### PR TITLE
Rebalences teslium blob slightly

### DIFF
--- a/code/modules/reagents/chemistry/reagents/blob.dm
+++ b/code/modules/reagents/chemistry/reagents/blob.dm
@@ -181,11 +181,11 @@
 		volume = ..()
 		M.apply_damage(0.4 * volume, BURN)
 		if(M.reagents)
-			if(M.reagents.has_reagent("teslium") && prob(0.6 * volume))
+			if(M.reagents.has_reagent("blob_teslium") && prob(0.6 * volume))
 				M.electrocute_act((0.5 * volume), "the blob's electrical discharge", 1, SHOCK_NOGLOVES)
-				M.reagents.del_reagent("teslium")
+				M.reagents.del_reagent("blob_teslium")
 				return //don't add more teslium after you shock it out of someone.
-			M.reagents.add_reagent("teslium", 0.125 * volume)  // a little goes a long way
+			M.reagents.add_reagent("blob_teslium", 0.125 * volume)  // a little goes a long way
 
 /datum/reagent/blob/proc/send_message(mob/living/M)
 	var/totalmessage = message

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1228,17 +1228,19 @@
 	color = "#20324D" //RGB: 32, 50, 77
 	metabolization_rate = 0.2
 	var/shock_timer = 0
-	var/normal_teslium = TRUE //Is this the base teslium, or the blob teslium. Used so it can be a subtype of teslium without inheriting the random shock from normal teslium as well as it's own
+
+	//The random values assigned to the high and low number for the random time for shocks
+	var/shock_high = 30
+	var/shock_low = 5
+	var/use_chaotic_random = TRUE //Do you change the random number every cycle, or after shock is triggered
+	var/chosen_timer = 15 //The timer chosen last cycle, or every time they are shocked
+
 	process_flags = ORGANIC | SYNTHETIC
 	taste_description = "electricity"
 
 /datum/reagent/teslium/on_mob_life(mob/living/M)
-	if(normal_teslium)
-		shock_timer++
-		if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
-			shock_timer = 0
-			M.electrocute_act(rand(5, 20), "Teslium in their body", 1, SHOCK_NOGLOVES) //Override because it's caused from INSIDE of you
-			playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	shock_timer++
+	shock_proc(M)
 	return ..()
 
 /datum/reagent/teslium/on_mob_add(mob/living/M)
@@ -1253,25 +1255,22 @@
 		H.physiology.siemens_coeff *= 0.5
 	..()
 
-/datum/reagent/teslium/blob //This version has it's shocks much less frequently, while retaining the shock multiplier
-	id = "blob_teslium"
-	normal_teslium = FALSE
-	var/chosen_timer = 15
-
-/datum/reagent/teslium/blob/on_mob_life(mob/living/M)
-	shock_timer++
-	if(shock_timer >= chosen_timer) //Random shocks are wildly unpredictable
+/datum/reagent/teslium/proc/shock_proc(mob/living/M)
+	if(use_chaotic_random)
+		chosen_timer = rand(shock_low, shock_high)
+	if(shock_timer >= chosen_timer)
 		shock_timer = 0
-		chosen_timer = rand(10, 30)
 		M.electrocute_act(rand(5, 20), "Teslium in their body", 1, SHOCK_NOGLOVES) //Override because it's caused from INSIDE of you
 		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	return ..()
+		chosen_timer = rand(shock_low, shock_high) //It needs to be randomised here for blob teslium, and randoming it here doesn't affect normal
+
+/datum/reagent/teslium/blob //This version has it's shocks much less frequently, while retaining the shock multiplier
+	id = "blob_teslium"
+	shock_low = 10
+	use_chaotic_random = FALSE
 
 /datum/reagent/teslium/blob/on_mob_add(mob/living/M)
 	..()
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.physiology.siemens_coeff *= 2
 	chosen_timer = rand(10, 30)
 
 /datum/reagent/gluttonytoxin

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1228,16 +1228,18 @@
 	color = "#20324D" //RGB: 32, 50, 77
 	metabolization_rate = 0.2
 	var/shock_timer = 0
+	var/normal_teslium = TRUE //Is this the base teslium, or the blob teslium. Used so it can be a subtype of teslium without inheriting the random shock from normal teslium as well as it's own
 	process_flags = ORGANIC | SYNTHETIC
 	taste_description = "electricity"
 
 /datum/reagent/teslium/on_mob_life(mob/living/M)
-	shock_timer++
-	if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
-		shock_timer = 0
-		M.electrocute_act(rand(5, 20), "Teslium in their body", 1, SHOCK_NOGLOVES) //Override because it's caused from INSIDE of you
-		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	return ..()
+	if(normal_teslium)
+		shock_timer++
+		if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
+			shock_timer = 0
+			M.electrocute_act(rand(5, 20), "Teslium in their body", 1, SHOCK_NOGLOVES) //Override because it's caused from INSIDE of you
+			playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		return ..()
 
 /datum/reagent/teslium/on_mob_add(mob/living/M)
 	..()
@@ -1253,19 +1255,24 @@
 
 /datum/reagent/teslium/blob //This version has it's shocks much less frequently, while retaining the shock multiplier
 	id = "blob_teslium"
+	normal_teslium = FALSE
 	var/chosen_timer = 15
-
-/datum/reagent/teslium/blob/reaction_mob/(mob/living/M)
-	chosen_timer = rand(5, 30)
 
 /datum/reagent/teslium/blob/on_mob_life(mob/living/M)
 	shock_timer++
 	if(shock_timer >= chosen_timer) //Random shocks are wildly unpredictable
 		shock_timer = 0
-		chosen_timer = rand(5, 30)
+		chosen_timer = rand(10, 30)
 		M.electrocute_act(rand(5, 20), "Teslium in their body", 1, SHOCK_NOGLOVES) //Override because it's caused from INSIDE of you
 		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return ..()
+
+/datum/reagent/teslium/blob/on_mob_add(mob/living/M)
+	..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.physiology.siemens_coeff *= 2
+	chosen_timer = rand(10, 30)
 
 /datum/reagent/gluttonytoxin
 	name = "Gluttony's Blessing"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1251,6 +1251,22 @@
 		H.physiology.siemens_coeff *= 0.5
 	..()
 
+/datum/reagent/teslium/blob //This version has it's shocks much less frequently, while retaining the shock multiplier
+	id = "blob_teslium"
+	var/chosen_timer = 15
+
+/datum/reagent/teslium/blob/reaction_mob/(mob/living/M)
+	chosen_timer = rand(5, 30)
+
+/datum/reagent/teslium/blob/on_mob_life(mob/living/M)
+	shock_timer++
+	if(shock_timer >= chosen_timer) //Random shocks are wildly unpredictable
+		shock_timer = 0
+		chosen_timer = rand(5, 30)
+		M.electrocute_act(rand(5, 20), "Teslium in their body", 1, SHOCK_NOGLOVES) //Override because it's caused from INSIDE of you
+		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	return ..()
+
 /datum/reagent/gluttonytoxin
 	name = "Gluttony's Blessing"
 	id = "gluttonytoxin"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1239,7 +1239,7 @@
 			shock_timer = 0
 			M.electrocute_act(rand(5, 20), "Teslium in their body", 1, SHOCK_NOGLOVES) //Override because it's caused from INSIDE of you
 			playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		return ..()
+	return ..()
 
 /datum/reagent/teslium/on_mob_add(mob/living/M)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Adds a new teslium subtype, blob teslium, which has a much more stable reaction in someones body, shocking them much less.


## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Currently, teslium blob gets people wired, generating a shocking ammount of salt (Sorry, had to make the joke.)

In all honesty, it did need a re-balance, so I have made a tweak to the likelihood of the teslium from the blob shocking the person while it is in their user. 

Before, on average, you would be stunned every _18 seconds, or 9 cycles_, from teslium, with a 80% chance to be stunned after 12 cycles. This was too strong, and thus the subtype teslium the blob gives is heavily nerfed. Now, its a 50/50 chance you will be stunned every 20 cycles, or 40 seconds. It can be higher or lower, but on average that is how long it will be.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

For those curious as well, here are the current probabilities for teslium blob and spore stunning you when attacking you. Note that the first attack can not stun currently. (sorry for not rounding)

![image](https://user-images.githubusercontent.com/52090703/120241254-5f6b0500-c230-11eb-9f01-e82fc7537182.png)

By the time it is 50/50 blob attacks stun you, you will have already have taken 90 damage anyway, where other blob types would have put you in crit. That is also the blob spending 25-30 chemicals on one person. Just in case anyone was curious about those chances.

## Changelog
:cl:
tweak: Teslium blob now uses a subtype of the teslium reagent, which stuns much less frequently.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
