### PR TITLE
Replaces between() With Native clamp()

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -538,10 +538,6 @@ Returns 1 if the chain up to the area contains the given typepath
 	var/y = min(world.maxy, max(1, A.y + dy))
 	return locate(x,y,A.z)
 
-//Makes sure MIDDLE is between LOW and HIGH. If not, it adjusts it. Returns the adjusted value.
-/proc/between(low, middle, high)
-	return max(min(middle, high), low)
-
 //returns random gauss number
 /proc/GaussRand(sigma)
   var/x,y,rsq

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -549,7 +549,7 @@
 	if(href_list["out_set_pressure"])
 		var/response=input(usr,"Set new pressure, in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
 		pressure_setting = text2num(response)
-		pressure_setting = between(0, pressure_setting, 50*ONE_ATMOSPHERE)
+		pressure_setting = clamp(pressure_setting, 0, 50*ONE_ATMOSPHERE)
 
 	if(!radio_connection)
 		return 0

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -34,7 +34,7 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 			return
 	var/tctext = input(src, "How much TC do you want to give each team member? Suggested: 20-30. They cannot trade TC.") as num
 	var/tcamount = text2num(tctext)
-	tcamount = between(0, tcamount, 1000)
+	tcamount = clamp(tcamount, 0, 1000)
 	if(GLOB.sent_syndicate_infiltration_team == 1)
 		if(alert("A Syndicate Infiltration Team has already been sent. Sure you want to send another?",,"Yes","No")=="No")
 			return

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -206,23 +206,23 @@
 		pump_direction = 1
 
 	if(signal.data["set_input_pressure"] != null)
-		input_pressure_min = between(
-			0,
+		input_pressure_min = clamp(
 			text2num(signal.data["set_input_pressure"]),
+			0,
 			ONE_ATMOSPHERE*50
 		)
 
 	if(signal.data["set_output_pressure"] != null)
-		output_pressure_max = between(
-			0,
+		output_pressure_max = clamp(
 			text2num(signal.data["set_output_pressure"]),
+			0,
 			ONE_ATMOSPHERE*50
 		)
 
 	if(signal.data["set_external_pressure"] != null)
-		external_pressure_bound = between(
-			0,
+		external_pressure_bound = clamp(
 			text2num(signal.data["set_external_pressure"]),
+			0,
 			ONE_ATMOSPHERE*50
 		)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -100,9 +100,9 @@
 		on = !on
 
 	if("set_output_pressure" in signal.data)
-		target_pressure = between(
-			0,
+		target_pressure = clamp(
 			text2num(signal.data["set_output_pressure"]),
+			0,
 			ONE_ATMOSPHERE*50
 		)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -155,9 +155,9 @@ Thus, the two variables affect pump operation are set in New():
 		on = !on
 
 	if(signal.data["set_output_pressure"])
-		target_pressure = between(
-			0,
+		target_pressure = clamp(
 			text2num(signal.data["set_output_pressure"]),
+			0,
 			ONE_ATMOSPHERE*50
 		)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -153,9 +153,9 @@ Thus, the two variables affect pump operation are set in New():
 		on = !on
 
 	if(signal.data["set_transfer_rate"])
-		transfer_rate = between(
-			0,
+		transfer_rate = clamp(
 			text2num(signal.data["set_transfer_rate"]),
+			0,
 			air1.volume
 		)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -135,7 +135,7 @@
 
 	if(signal.data["set_volume_rate"] != null)
 		var/number = text2num(signal.data["set_volume_rate"])
-		volume_rate = between(0, number, air_contents.volume)
+		volume_rate = clamp(number, 0, air_contents.volume)
 
 	if(signal.data["status"])
 		broadcast_status()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -222,7 +222,7 @@
 	//or if it is already above upper_limit, limit the increase to 0.
 	var/inc_limit = max(upper_limit - temperature, 0)
 	var/dec_limit = min(temperature - lower_limit, 0)
-	temperature += between(dec_limit, rand(-7 + bias, 7 + bias), inc_limit)
+	temperature += clamp(rand(-7 + bias, 7 + bias), dec_limit, inc_limit)
 
 	if(temperature > max_temperature)
 		overheat()
@@ -239,7 +239,7 @@
 
 	if(temperature > cooling_temperature)
 		var/temp_loss = (temperature - cooling_temperature)/TEMPERATURE_DIVISOR
-		temp_loss = between(2, round(temp_loss, 1), TEMPERATURE_CHANGE_MAX)
+		temp_loss = clamp(round(temp_loss, 1), 2, TEMPERATURE_CHANGE_MAX)
 		temperature = max(temperature - temp_loss, cooling_temperature)
 		SStgui.update_uis(src)
 

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -164,7 +164,7 @@
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
 		var/fever_temperature = (owner.dna.species.heat_level_1 - owner.dna.species.body_temperature - 5) * min(germ_level / INFECTION_LEVEL_TWO, 1) + owner.dna.species.body_temperature
-		owner.bodytemperature += between(0, (fever_temperature - T20C) / BODYTEMP_COLD_DIVISOR + 1, fever_temperature - owner.bodytemperature)
+		owner.bodytemperature += clamp((fever_temperature - T20C) / BODYTEMP_COLD_DIVISOR + 1, 0, fever_temperature - owner.bodytemperature)
 
 	if(germ_level >= INFECTION_LEVEL_TWO)
 		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
@@ -208,7 +208,7 @@
 /obj/item/organ/proc/receive_damage(amount, silent = 0)
 	if(tough)
 		return
-	damage = between(0, damage + amount, max_damage)
+	damage = clamp(damage + amount, 0, max_damage)
 
 	//only show this if the organ is not robotic
 	if(owner && parent_organ && amount > 0)


### PR DESCRIPTION
## What Does This PR Do
Replaces a global proc with a native proc that does the same thing.
Removes the global proc.

## Why It's Good For The Game
There's absolutely no reason for between() to exist.