### PR TITLE
Hand tele portals malfunctions teleport to random Z levels

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -401,7 +401,7 @@
 		if(!calibrated && com.cc_beacon)
 			visible_message("<span class='alert'>Cannot lock on target. Please calibrate the teleporter before attempting long range teleportation.</span>")
 		else if(!calibrated && prob(25 - ((accurate) * 10)) && !com.cc_beacon) //oh dear a problem
-			var/list/target_z = levels_by_trait(REACHABLE)
+			var/list/target_z = levels_by_trait(SPAWN_RUINS)
 			target_z -= M.z //Where to sir? Anywhere but here.
 			. = do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), pick(target_z)), 2, bypass_area_flag = com.area_bypass)
 		else

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -101,7 +101,7 @@
 
 	if(prob(failchance))
 		icon_state = fail_icon
-		var/list/target_z = levels_by_trait(REACHABLE)
+		var/list/target_z = levels_by_trait(SPAWN_RUINS)
 		target_z -= M.z
 		if(!do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), pick(target_z)), 0, bypass_area_flag = ignore_tele_proof_area_setting)) // Try to send them to deep space.
 			invalid_teleport()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -101,7 +101,9 @@
 
 	if(prob(failchance))
 		icon_state = fail_icon
-		if(!do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0, bypass_area_flag = ignore_tele_proof_area_setting)) // Try to send them to deep space.
+		var/list/target_z = levels_by_trait(REACHABLE)
+		target_z -= M.z
+		if(!do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), pick(target_z)), 0, bypass_area_flag = ignore_tele_proof_area_setting)) // Try to send them to deep space.
 			invalid_teleport()
 			return FALSE
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Hand tele portals and the teleporter machine malfunctions teleport to random Z levels (not lavaland) instead of always Z 3

## Why It's Good For The Game
Hand tele portals should follow the same behaviour as regular teleporters for consistency.

likely an oversight from #15674 

teleporting to lavaland gets people stuck in indestructible inescapable walls and makes people ahelp, which isn't exactly ideal.

## Changelog
:cl:
tweak: hand tele malfunctions now send you to random Z levels instead of Z 3 (not lavaland).
tweak: teleporter machine malfunctions won't send you to lavaland anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
