### PR TITLE
Fixes borgs with stun batons being able to instantly recharge their cell to full in a cyborg recharger 

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -206,11 +206,6 @@
 		return TRUE
 	..()
 
-/obj/item/melee/baton/cyborg_recharge(coeff, emagged)
-	if(cell)
-		cell.charge = cell.maxcharge
-		update_icon()
-
 //Makeshift stun baton. Replacement for stun gloves.
 /obj/item/melee/baton/cattleprod
 	name = "stunprod"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
#15313 Made it so that if baton's are owned by cyborgs, the baton's cell is simply a reference to the cyborg's cell. I didn't really notice this change when #13527 was up, so this bug slipped through. The `cyborg_recharge()` proc was the culprit here, and it no longer needs to exist for batons, since the cyborg's baton cell charge is based off of their own cell charge.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes security borgs being able to instantly recharge their cell to full in a cyborg recharger 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
