### PR TITLE
Fixes maintenance drone suicide softlock

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -239,7 +239,7 @@
 		health = 35
 		stat = CONSCIOUS
 		return
-	health = 35 - (getBruteLoss() + getFireLoss())
+	health = 35 - (getBruteLoss() + getFireLoss() + getOxyLoss())
 	update_stat("updatehealth([reason])")
 
 /mob/living/silicon/robot/drone/death(gibbed)

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -114,7 +114,8 @@
 			var/mob/living/silicon/robot/drone/D = locateUID(params["uid"])
 			if(D)
 				to_chat(usr, "<span class='warning'>You issue a kill command for the unfortunate drone.</span>")
-				message_admins("[key_name_admin(usr)] issued kill order for drone [key_name_admin(D)] from control console.")
+				if(D != usr) // Don't need to bug admins about a suicide
+					message_admins("[key_name_admin(usr)] issued kill order for drone [key_name_admin(D)] from control console.")
 				log_game("[key_name(usr)] issued kill order for [key_name(D)] from control console.")
 				D.shut_down()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes maintenance drones not actually being able to commit suicide, and just being stuck softlocked until they ahelp or ghost.
This was because silicons suiciding gives oxyloss damage, but the maintenance drone health override doesn't include that so they never actually died.
Also disables the admin message from drone control consoles if a maint drone tries to deactivate themselves.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Players shouldn't be forced to give up respawnability if they want to stop playing as a drone and suicide, and admins shouldn't get spammed if they do it via the control console.

## Changelog
:cl:
tweak: Made the admin message for remotely shutting down a drone not show if the drone in question is doing it.
fix: Fixed maintenance drones getting softlocked when committing suicide.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
