### PR TITLE
Standardizes Sec Bomber Jacket Armor And Adds To Loadout

### DIFF
--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -108,6 +108,11 @@
 	path = /obj/item/clothing/suit/armor/secjacket
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer", "Security Pod Pilot")
 
+/datum/gear/suit/secbomberjacket
+	display_name = "security bomber jacket"
+	path = /obj/item/clothing/suit/jacket/pilot
+	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer", "Security Pod Pilot")
+
 /datum/gear/suit/ianshirt
 	display_name = "Ian Shirt"
 	path = /obj/item/clothing/suit/ianshirt

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -803,7 +803,7 @@
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	strip_delay = 60
 	put_on_delay = 40
-	armor = list(melee = 25, bullet = 15, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0, fire = 50, acid = 50)
+	armor = list(melee = 15, bullet = 5, laser = 15, energy = 5, bomb = 15, bio = 0, rad = 0, fire = 30, acid = 30)
 	//End of inheritance from Security armour.
 
 /obj/item/clothing/suit/jacket/leather


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR standardizes the security bomber jacket's armor to be in line with the standard security jacket, also adds the bomber jacket to the loadout menu
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
First off, why does the sec bomber jacket have more armor? It's "exclusive" to pod pilot? I disagree with this as the pod pilot already has a number of unique things to their job and the bomber jacket itself has no indication it would be stronger than the security jacket, bringing it in line with the security jacket creates a slightly more consistent choice in regards to armor. For reference the current security jacket has an armor of 
"(melee = 15, bullet = 10, laser = 15, energy = 5, bomb = 15, bio = 0, rad = 0, fire = 30, acid = 30)" 
while the bomber jacket has 
"(melee = 25, bullet = 15, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0, fire = 50, acid = 50)".
The addition of the bomber jacket to the loadout is simple, it's a rather stylish piece of equipment allowing for officers to maintain an amount of style alongside their standard protection.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The security bomber jacket is now available in the loadout menu for security staff
tweak: Reduced the armor values of the bomber jacket to bring it in line with the standard security jacket
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
