### PR TITLE
Fix nullspaced GPS causing runtime on display

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	for(var/g in GLOB.GPS_list)
 		var/obj/item/gps/G = g
 		var/turf/GT = get_turf(G)
-		if(!G.tracking || G == src)
+		if(isnull(GT) || !G.tracking || G == src)
 			continue
 		if((G.local || same_z) && (GT.z != T.z))
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Fixes GPS TGUI not working when there is a nullspaced GPS existing (e.g. cavity implant).

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- Being able to use GPS at all times is good.

## Changelog
:cl:
fix: Fix not being able to view GPS signals if any one of them is nullspaced (e.g. cavity implant)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
