### PR TITLE
Increases most radiation dose amounts

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -54,4 +54,4 @@ Ask ninjanomnom if they're around
 #define RAD_GEIGER_MEASURE_SMOOTHING 5
 #define RAD_GEIGER_GRACE_PERIOD 2
 
-#define RAD_DAMAGE_MULTIPLIER 10					// This brings pre-refactor rad values in line with the current danger values
+#define RAD_DOSAGE_MULTIPLIER 10					// This is used to increase radiation dosage taken during rad_act() calls

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -53,3 +53,5 @@ Ask ninjanomnom if they're around
 
 #define RAD_GEIGER_MEASURE_SMOOTHING 5
 #define RAD_GEIGER_GRACE_PERIOD 2
+
+#define RAD_DAMAGE_MULTIPLIER 10					// This brings pre-refactor rad values in line with the current danger values

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -87,7 +87,7 @@
 			Paralyse(effect * blocked)
 		if(IRRADIATE)
 			if(!HAS_TRAIT(src, TRAIT_RADIMMUNE))
-				radiation += max(effect * blocked, 0)
+				radiation += max((effect * RAD_DOSAGE_MULTIPLIER) * blocked, 0)
 		if(SLUR)
 			Slur(effect * blocked)
 		if(STUTTER)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1005,7 +1005,7 @@
 
 	amount -= RAD_BACKGROUND_RADIATION // This will always be at least 1 because of how skin protection is calculated
 
-	amount *= RAD_DAMAGE_MULTIPLIER
+	amount *= RAD_DOSAGE_MULTIPLIER
 
 	var/blocked = getarmor(null, "rad")
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1005,6 +1005,8 @@
 
 	amount -= RAD_BACKGROUND_RADIATION // This will always be at least 1 because of how skin protection is calculated
 
+	amount *= RAD_DAMAGE_MULTIPLIER
+
 	var/blocked = getarmor(null, "rad")
 
 	if(amount > RAD_BURN_THRESHOLD)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -312,7 +312,7 @@
 				//Hilariously enough, running into a closet should make you get hit the hardest.
 				var/mob/living/carbon/human/H = mob
 				H.hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1))))
-			var/rads = DETONATION_RADS * sqrt(1 / (get_dist(L, src) + 1)) * sqrt(power/5) / RAD_DAMAGE_MULTIPLIER
+			var/rads = (DETONATION_RADS * (sqrt(1 / (get_dist(L, src) + 1)) * sqrt(power / 5))) / (RAD_DAMAGE_MULTIPLIER * 0.25)
 			L.rad_act(rads)
 
 	var/turf/T = get_turf(src)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -312,7 +312,7 @@
 				//Hilariously enough, running into a closet should make you get hit the hardest.
 				var/mob/living/carbon/human/H = mob
 				H.hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1))))
-			var/rads = (DETONATION_RADS * (sqrt(1 / (get_dist(L, src) + 1)) * sqrt(power / 5))) / (RAD_DAMAGE_MULTIPLIER * 0.25)
+			var/rads = (DETONATION_RADS * (sqrt(1 / (get_dist(L, src) + 1)) * sqrt(power / 5))) / (RAD_DOSAGE_MULTIPLIER * 0.25)
 			L.rad_act(rads)
 
 	var/turf/T = get_turf(src)
@@ -525,7 +525,7 @@
 			l.hallucination += power * hallucination_power * D
 			l.hallucination = clamp(l.hallucination, 0, 200)
 	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))
-		var/rads = ((power / 10) * sqrt( 1 / max(get_dist(l, src), 1) )) / RAD_DAMAGE_MULTIPLIER //RAD_DAMAGE_MULTIPLIER division ensures consistency with other rad sources.
+		var/rads = ((power / 10) * sqrt( 1 / max(get_dist(l, src), 1) )) / RAD_DOSAGE_MULTIPLIER //RAD_DOSAGE_MULTIPLIER is used so that the SM doesn't absolutely murder you with rads
 		l.rad_act(rads)
 
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -312,7 +312,7 @@
 				//Hilariously enough, running into a closet should make you get hit the hardest.
 				var/mob/living/carbon/human/H = mob
 				H.hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1))))
-			var/rads = DETONATION_RADS * sqrt(1 / (get_dist(L, src) + 1))
+			var/rads = DETONATION_RADS * sqrt(1 / (get_dist(L, src) + 1)) * sqrt(power/5) / RAD_DAMAGE_MULTIPLIER
 			L.rad_act(rads)
 
 	var/turf/T = get_turf(src)
@@ -525,7 +525,7 @@
 			l.hallucination += power * hallucination_power * D
 			l.hallucination = clamp(l.hallucination, 0, 200)
 	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))
-		var/rads = (power / 10) * sqrt( 1 / max(get_dist(l, src), 1) )
+		var/rads = ((power / 10) * sqrt( 1 / max(get_dist(l, src), 1) )) / RAD_DAMAGE_MULTIPLIER //RAD_DAMAGE_MULTIPLIER division ensures consistency with other rad sources.
 		l.rad_act(rads)
 
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -159,7 +159,7 @@
 	taste_description = "the colour blue and regret"
 
 /datum/reagent/radium/on_mob_life(mob/living/M)
-	if(M.radiation < 80)
+	if(M.radiation < 800)
 		M.apply_effect(4, IRRADIATE)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes people take 10x as many rads from all sources bar the SM crystal. This is done by multiplying radiation by RAD_DOSAGE_MULTIPLIER (currently 10), this number is easy to tweak in future for balancing and affects all rad sources to keep them consistent.
The SM delamination rad dosage is now also 4-40x as powerful depending on the engine power (EER) at detonation.
This somewhat fixes #15819
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Since the rad refactor in #15331 most radiation sources give such trivial amounts of rads, you won't feel a thing. You could make a full uranium room and be fine.
This brings radiation values in line with the SM dosages, as that was the only source that was properly implemented into this new system with the rad refactor.
This does not mean that radiation leads to instant death, and it does not tweak the SM radiation doses as they are fine, but it does mean that radiation is no longer just a joke.

The 10x value comes from looking at how many rads you get from the SM, plus how many rads you currently get. In #15447 anti-rad chems were made 10 times more effective to deal with the SM rads.
Both these chems and old rad sources didn't get updated with the refactor, so the SM rad doses were nearly impossible to fix. The change to the chems however further invalidated other rad sources. This PR balances this all out.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Non-SM radiation doses are now stronger
tweak: SM delamination now more strongly irradiates the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
