### PR TITLE
Adds warning to gluttony morph about not being an antag

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -246,5 +246,5 @@
 	stage3	= list("<span class='danger'>Your appendages are melting away.</span>", "<span class='danger'>Your limbs begin to lose their shape.</span>")
 	stage4	= list("<span class='danger'>You're ravenous.</span>")
 	stage5	= list("<span class='danger'>You have become a morph.</span>")
-	transformation_text = "<span class='userdanger'>You are NOT an antagonist, as such you should never eat steal objectives or the contents of the armory.</span>"
+	transformation_text = "<span class='userdanger'>This transformation does NOT make you an antagonist if you were not one already. If you were not an antagonist, you should not eat any steal objectives or the contents of the armory.</span>"
 	new_form = /mob/living/simple_animal/hostile/morph

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -40,13 +40,13 @@
 	if(istype(affected_mob, /mob/living/carbon) && affected_mob.stat != DEAD)
 		if(stage5)
 			to_chat(affected_mob, pick(stage5))
-		if(transformation_text)
-			to_chat(affected_mob, transformation_text)
 		if(jobban_isbanned(affected_mob, new_form))
 			affected_mob.death(1)
 			return
 		if(affected_mob.notransform)
 			return
+		if(transformation_text)
+			to_chat(affected_mob, transformation_text)
 		affected_mob.notransform = 1
 		affected_mob.canmove = 0
 		affected_mob.icon = null

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -15,6 +15,7 @@
 	var/list/stage3 = list("You feel utterly plain.")
 	var/list/stage4 = list("You feel white bread.")
 	var/list/stage5 = list("Oh the humanity!")
+	var/transformation_text = null
 	var/new_form = /mob/living/carbon/human
 
 /datum/disease/transformation/stage_act()
@@ -39,8 +40,8 @@
 	if(istype(affected_mob, /mob/living/carbon) && affected_mob.stat != DEAD)
 		if(stage5)
 			to_chat(affected_mob, pick(stage5))
-		if(name == "Gluttony's Blessing")
-			to_chat(affected_mob, "<span class='userdanger'>You are NOT an antagonist, as such you should never eat steal objectives or the contents of the armory.</span>")
+		if(transformation_text)
+			to_chat(affected_mob, transformation_text)
 		if(jobban_isbanned(affected_mob, new_form))
 			affected_mob.death(1)
 			return
@@ -245,4 +246,5 @@
 	stage3	= list("<span class='danger'>Your appendages are melting away.</span>", "<span class='danger'>Your limbs begin to lose their shape.</span>")
 	stage4	= list("<span class='danger'>You're ravenous.</span>")
 	stage5	= list("<span class='danger'>You have become a morph.</span>")
+	transformation_text = "<span class='userdanger'>You are NOT an antagonist, as such you should never eat steal objectives or the contents of the armory.</span>"
 	new_form = /mob/living/simple_animal/hostile/morph

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -39,6 +39,8 @@
 	if(istype(affected_mob, /mob/living/carbon) && affected_mob.stat != DEAD)
 		if(stage5)
 			to_chat(affected_mob, pick(stage5))
+		if(name == "Gluttony's Blessing")
+			to_chat(affected_mob, "<span class='userdanger'>You are NOT an antagonist, as such you should never eat steal objectives or the contents of the armory.</span>")
 		if(jobban_isbanned(affected_mob, new_form))
 			affected_mob.death(1)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a large chat message to morphs that transform from gluttony's blessing, saying: 
`You are NOT an antagonist, as such you should never eat steal objectives or the contents of the armory.`
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's not really all that clear to non-midround morphs that they can't do these things. This clears it up with a large chat message.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/12197162/121527660-8d9bd200-c9f2-11eb-9409-6bda772b4880.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Crew who become a morph via Gluttony's Blessing are now told they are not an antagonist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
