### PR TITLE
Fixes VSC .dmi rendering

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,5 @@
 {
-	"workbench.editorAssociations": [
-		{
-			"filenamePattern": "*.dmi",
-			"viewType": "imagePreview.previewEditor"
-		}
-	]
+	"workbench.editorAssociations": {
+		"*.dmi": "imagePreview.previewEditor"
+	}
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
VSC has a new format for workbench editorAssociations. Fixing this sets our dmi files to open as images, not text.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why is this good?
VSC previews of dmi files are good.