### PR TITLE
Fixes broken shuttle and escape pod rotation

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -6,6 +6,7 @@
 	armor = list(melee = 100, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70) //default + ignores melee
 
 /obj/structure/shuttle/shuttleRotate(rotation)
+	return //This call is needed to properly rotate the object when on a shuttle that is rotated.
 
 /obj/structure/shuttle/engine
 	name = "engine"

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -6,7 +6,7 @@
 	armor = list(melee = 100, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70) //default + ignores melee
 
 /obj/structure/shuttle/shuttleRotate(rotation)
-	return //This call is needed to properly rotate the object when on a shuttle that is rotated.
+	return //This override is needed to properly rotate the object when on a shuttle that is rotated.
 
 /obj/structure/shuttle/engine
 	name = "engine"

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -6,10 +6,6 @@
 	armor = list(melee = 100, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70) //default + ignores melee
 
 /obj/structure/shuttle/shuttleRotate(rotation)
-	..()
-	var/matrix/M = transform
-	M.Turn(rotation)
-	transform = M
 
 /obj/structure/shuttle/engine
 	name = "engine"
@@ -30,14 +26,11 @@
 	opacity = 1
 
 /obj/structure/shuttle/engine/propulsion/burst
-	name = "burst"
 
 /obj/structure/shuttle/engine/propulsion/burst/left
-	name = "left"
 	icon_state = "burst_l"
 
 /obj/structure/shuttle/engine/propulsion/burst/right
-	name = "right"
 	icon_state = "burst_r"
 
 /obj/structure/shuttle/engine/router

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -8,7 +8,7 @@
 	smooth = SMOOTH_TRUE
 
 /turf/simulated/wall/mineral/shuttleRotate(rotation)
-	return //This call is needed to properly rotate the object when on a shuttle that is rotated.
+	return //This override is needed to properly rotate the object when on a shuttle that is rotated.
 
 /turf/simulated/wall/mineral/gold
 	name = "gold wall"

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -8,6 +8,7 @@
 	smooth = SMOOTH_TRUE
 
 /turf/simulated/wall/mineral/shuttleRotate(rotation)
+	return //This call is needed to properly rotate the object when on a shuttle that is rotated.
 
 /turf/simulated/wall/mineral/gold
 	name = "gold wall"

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -7,6 +7,8 @@
 	canSmoothWith = null
 	smooth = SMOOTH_TRUE
 
+/turf/simulated/wall/mineral/shuttleRotate(rotation)
+
 /turf/simulated/wall/mineral/gold
 	name = "gold wall"
 	desc = "A wall with gold plating. Swag!"

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -56,6 +56,9 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 		d2 = temp
 	update_icon()
 
+/obj/structure/shuttle/engine/shuttleRotate(rotation, params)
+	setDir(angle2dir(rotation+dir2angle(dir)))
+
 //Fixes dpdir on shuttle rotation
 /obj/structure/disposalpipe/shuttleRotate(rotation, params)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes a bug that was introduced in #15454 that caused incorrect shuttle wall and engine dirs when the shuttle was rotated.
I also removed the names "burst", "left", and "right" from shuttle engines, because that got confusing with rotation.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shuttles and escape pods should never look like a garbled mess.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![2021-06-11 15_30_02-Window](https://user-images.githubusercontent.com/12197162/121703666-fa829b00-caca-11eb-9404-607fe5dd9133.png)
![2021-06-11 15_32_03-Window](https://user-images.githubusercontent.com/12197162/121703673-fb1b3180-caca-11eb-8a66-791e5c000efd.png)
![2021-06-11 15_32_22-Window](https://user-images.githubusercontent.com/12197162/121703676-fb1b3180-caca-11eb-9689-cc6d242a455e.png)
![2021-06-11 15_32_29-Window](https://user-images.githubusercontent.com/12197162/121703677-fbb3c800-caca-11eb-8c8d-5c4472530197.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Fixed a bug causing shuttle rotation to be broken
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
