### PR TITLE
(Hopefully) makes new players GC

### DIFF
--- a/code/controllers/subsystem/chat_pings.dm
+++ b/code/controllers/subsystem/chat_pings.dm
@@ -1,0 +1,16 @@
+SUBSYSTEM_DEF(chat_pings)
+	name = "Chat Pings"
+	flags = SS_NO_INIT
+	runlevels = RUNLEVEL_INIT | RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME // ALL OF THEM
+	wait = 30 SECONDS // Chat pings every 30 seconds
+	/// List of all held chat datums
+	var/list/datum/chatOutput/chat_datums = list() // Do NOT put this in Initialize(). You will cause issues.
+
+/datum/controller/subsystem/chat_pings/fire(resumed)
+	for(var/datum/chatOutput/CO as anything in chat_datums)
+		CO.updatePing()
+		if(MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/chat_pings/stat_entry()
+	..("P: [length(chat_datums)]")

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -225,7 +225,7 @@
 			to_chat(H, "<span class='danger'>Failed to locate a storage object on your mob, either you spawned with no hands free and no backpack or this is a bug.</span>")
 			qdel(G)
 
-		qdel(gear_leftovers)
+		gear_leftovers.Cut()
 
 	return 1
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -421,6 +421,7 @@
 		GLOB.admins -= src
 	GLOB.directory -= ckey
 	GLOB.clients -= src
+	QDEL_NULL(chatOutput)
 	if(movingmob)
 		movingmob.client_mobs_in_contents -= mob
 		UNSETEMPTY(movingmob.client_mobs_in_contents)

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -38,6 +38,7 @@ var/list/chatResources = list(
 	. = ..()
 
 	owner = C
+	SSchat_pings.chat_datums += src
 
 /datum/chatOutput/proc/start()
 	if(!owner)
@@ -124,14 +125,14 @@ var/list/chatResources = list(
 	if(owner.tos_consent)
 		sendClientData()
 
-	pingLoop()
+	updatePing()
 
-/datum/chatOutput/proc/pingLoop()
-	set waitfor = FALSE
-
-	while (owner)
-		ehjax_send(data = owner.is_afk(29 SECONDS) ? "softPang" : "pang") // SoftPang isn't handled anywhere but it'll always reset the opts.lastPang.
-		sleep(30 SECONDS)
+// PARADISE EDIT: This just updates the ping and is called from SSchat_pings
+/datum/chatOutput/proc/updatePing()
+	if(!owner)
+		qdel(src)
+		return
+	ehjax_send(data = owner.is_afk(29 SECONDS) ? "softPang" : "pang") // SoftPang isn't handled anywhere but it'll always reset the opts.lastPang.
 
 /datum/chatOutput/proc/ehjax_send(client/C = owner, window = "browseroutput", data)
 	if(islist(data))
@@ -222,6 +223,11 @@ var/list/chatResources = list(
   */
 /datum/chatOutput/proc/clear_syndicate_codes()
 	owner << output(null, "browseroutput:codewordsClear")
+
+/datum/chatOutput/Destroy(force)
+	SSchat_pings.chat_datums -= src
+	return ..()
+
 
 /client/verb/debug_chat()
 	set hidden = 1

--- a/paradise.dme
+++ b/paradise.dme
@@ -194,6 +194,7 @@
 #include "code\controllers\subsystem\atoms.dm"
 #include "code\controllers\subsystem\blackbox.dm"
 #include "code\controllers\subsystem\changelog.dm"
+#include "code\controllers\subsystem\chat_pings.dm"
 #include "code\controllers\subsystem\cleanup.dm"
 #include "code\controllers\subsystem\dbcore.dm"
 #include "code\controllers\subsystem\discord.dm"


### PR DESCRIPTION
## What Does This PR Do
Moves goonchat pings to a subsystem instead of an infinite spawn. This turns out to (hopefully) fix new players not GCing due to a tidbit fox gave me

```
Sleeping procs
Any proc that calls sleep(), spawn(), or some wrapper around that like walk() will hang references to any var inside it. This includes the usr it started from, the src it was called on, and any vars created as a part of processing
```

This then led to the realisation of goonchat loops. 

## Why It's Good For The Game
New players not GCing has been the bane of the GC for so long.

## Changelog
N/A