### PR TITLE
Respawning using anomalous crystal exploit fixes

### DIFF
--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -232,8 +232,20 @@
 /obj/machinery/anomalous_crystal/helpers/attack_ghost(mob/dead/observer/user)
 	..()
 	if(ready_to_deploy)
+		if(!istype(user)) // No revs allowed
+			return
+		if(cannotPossess(user))
+			to_chat(user, "<span class='warning'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
+			return
+		if(!user.can_reenter_corpse)
+			to_chat(user, "<span class='warning'>You have forfeited the right to respawn.</span>")
+			return
 		var/be_helper = alert("Become a Lightgeist? (Warning, You can no longer be cloned!)",,"Yes","No")
 		if(be_helper == "No")
+			return
+		if(!loc || QDELETED(src) || QDELETED(user))
+			if(user)
+				to_chat(user, "<span class='warning'>[src] is no longer usable!</span>")
 			return
 		var/mob/living/simple_animal/hostile/lightgeist/W = new /mob/living/simple_animal/hostile/lightgeist(get_turf(loc))
 		W.key = user.key

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -231,8 +231,6 @@
 
 /obj/machinery/anomalous_crystal/helpers/attack_ghost(mob/dead/observer/user)
 	..()
-	if(cannotPossess(user))
-		return
 	if(ready_to_deploy)
 		if(!istype(user)) // No revs allowed
 			return


### PR DESCRIPTION
## What Does This PR Do
Makes it so that you can't get around ahud enabling or other reasons that should disallow you from respawning using the anomalous helper crystal
Further Fixes #16163
Also fixes revs being able to spawn as lightgeists

## Why It's Good For The Game
Exploits b gone

## Changelog
:cl:
fix: The anomalous crystal now properly checks if you have respawn rights
/:cl: