### PR TITLE
Gives nuke ops an ion carbine instead of an ion rifle

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -2971,7 +2971,7 @@
 /area/syndicate_mothership)
 "kL" = (
 /obj/structure/table,
-/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/ionrifle/carbine,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
 "kM" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> 

This PR swaps out the ion rifle in the nukie locker area, with an ion carbine. The only difference between the ion carbine and the rifle is a carbine is normal size, and thus fits in your bag.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Right now, there is no real point to taking the rifle. If anything, it's a noob trap. It's bulky, meaning you have to constantly hold it, or sacrifice your backpack. Some nukies take it thinking it is a fancy weapon, and then don't have space to hold a real one. Generally you need one EMP to cause a stun on cyborgs, which a grenade can do easier, or just using a normal gun shreds already. It might be useful for mechs, but its not worth sacrificing a backpack for it. This way, a nukie will actually be able to take an ion carbine and maybe possibly use it effectively, rather then it being left behind like usual.


## Changelog
:cl:
tweak: The ion rifle in the nuke ops base was replaced with an ion carbine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
