### PR TITLE
Fixes duping rods with repairing grills under windows

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -126,11 +126,12 @@
 		return ..()
 
 /obj/structure/grille/proc/repair(mob/user, obj/item/stack/rods/R)
-	user.visible_message("<span class='notice'>[user] rebuilds the broken grille.</span>",
-		"<span class='notice'>You rebuild the broken grille.</span>")
-	new grille_type(loc)
-	R.use(1)
-	qdel(src)
+	if(R.get_amount() >= 1)
+		user.visible_message("<span class='notice'>[user] rebuilds the broken grille.</span>",
+			"<span class='notice'>You rebuild the broken grille.</span>")
+		new grille_type(loc)
+		R.use(1)
+		qdel(src)
 
 /obj/structure/grille/wirecutter_act(mob/user, obj/item/I)
 	. = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Before you could start to repair a bunch of grills under windows with one rod and it would repair them all, this is no longer possible

## Why It's Good For The Game
bugs bad

## Changelog
:cl:
fix: you can no longer dupe rods by repairing grills under windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
