### PR TITLE
Fixes being unable to pickup the armblade nullrod on mining

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -366,6 +366,15 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
 
+/obj/item/nullrod/armblade/mining
+	flags = NODROP
+	reskin_selectable = FALSE //So 2 of the same nullrod doesnt show up.
+
+/obj/item/nullrod/armblade/mining/pickup(mob/living/user)
+	..()
+	flags += ABSTRACT
+	return FALSE
+
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"
 	desc = "An adorable stuffed toy that resembles the god of all carp. The teeth look pretty sharp. Activate it to recieve the blessing of Carp-Sie."

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -48,7 +48,7 @@
 		if(14)
 			new /obj/item/nullrod/scythe/talking(src)
 		if(15)
-			new /obj/item/nullrod/armblade(src)
+			new /obj/item/nullrod/armblade/mining(src)
 		if(16)
 			new /obj/item/guardiancreator(src)
 		if(17)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds a subtype of the armblade nullrod, that gains abstract on pickup, so it can be picked up, then behave normally afterwords. This is the one found in the lavaland chests.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad, loot being fixed is good.


## Changelog
:cl:
fix: Fixes the dark blessing nullrod from lavaland being unable to be picked up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
