### PR TITLE
Prevents built APCs from being hacked, Prevents AI from loosing points from apc destruction

### DIFF
--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -28,5 +28,5 @@
 	return TRUE
 
 /obj/item/mounted/frame/apc_frame/do_build(turf/on_wall, mob/user)
-	new /obj/machinery/power/apc(get_turf(src), get_dir(user, on_wall), 1)
+	new /obj/machinery/power/apc/constructed(get_turf(src), get_dir(user, on_wall), 1)
 	qdel(src)

--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -28,5 +28,5 @@
 	return TRUE
 
 /obj/item/mounted/frame/apc_frame/do_build(turf/on_wall, mob/user)
-	new /obj/machinery/power/apc/constructed(get_turf(src), get_dir(user, on_wall), 1)
+	new /obj/machinery/power/apc(get_turf(src), get_dir(user, on_wall), TRUE)
 	qdel(src)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -105,6 +105,7 @@
 	var/global/list/status_overlays_environ
 	var/indestructible = 0 // If set, prevents aliens from destroying it
 	var/keep_preset_name = 0
+	var/constructed = FALSE //Was this APC built instead of already existing? Used for malfhack to keep borgs from building apcs in space
 
 	var/report_power_alarm = TRUE
 
@@ -130,6 +131,9 @@
 	req_access = list(ACCESS_SYNDICATE)
 	report_power_alarm = FALSE
 
+
+/obj/machinery/power/apc/constructed // APCS the crew builds
+	constructed = TRUE
 /obj/item/apc_electronics
 	name = "power control module"
 	desc = "Heavy-duty switching circuits for power control."
@@ -177,8 +181,6 @@
 /obj/machinery/power/apc/Destroy()
 	SStgui.close_uis(wires)
 	GLOB.apcs -= src
-	if(malfai && operating)
-		malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10,0,1000)
 	area.power_light = 0
 	area.power_equip = 0
 	area.power_environ = 0
@@ -972,6 +974,9 @@
 		return
 	if(malf.malfhacking)
 		to_chat(malf, "You are already hacking an APC.")
+		return
+	if(constructed)
+		to_chat(malf, "<span class='warning'>This APC was reciently constructed, and not fully linked to station systems, and is of no use to hack.")
 		return
 	to_chat(malf, "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.")
 	malf.malfhack = src

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -131,9 +131,6 @@
 	req_access = list(ACCESS_SYNDICATE)
 	report_power_alarm = FALSE
 
-/obj/machinery/power/apc/constructed // APCS the crew builds
-	constructed = TRUE
-
 /obj/item/apc_electronics
 	name = "power control module"
 	desc = "Heavy-duty switching circuits for power control."
@@ -175,6 +172,7 @@
 		operating = 0
 		name = "[area.name] APC"
 		stat |= MAINT
+		constructed = TRUE
 		update_icon()
 		addtimer(CALLBACK(src, .proc/update), 5)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -131,9 +131,9 @@
 	req_access = list(ACCESS_SYNDICATE)
 	report_power_alarm = FALSE
 
-
 /obj/machinery/power/apc/constructed // APCS the crew builds
 	constructed = TRUE
+
 /obj/item/apc_electronics
 	name = "power control module"
 	desc = "Heavy-duty switching circuits for power control."

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -974,7 +974,7 @@
 		to_chat(malf, "You are already hacking an APC.")
 		return
 	if(constructed)
-		to_chat(malf, "<span class='warning'>This APC was reciently constructed, and not fully linked to station systems, and is of no use to hack.</span>")
+		to_chat(malf, "<span class='warning'>This APC was only recently constructed, and is not fully linked to station systems. Hacking it would be pointless.</span>")
 		return
 	to_chat(malf, "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.")
 	malf.malfhack = src

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -976,7 +976,7 @@
 		to_chat(malf, "You are already hacking an APC.")
 		return
 	if(constructed)
-		to_chat(malf, "<span class='warning'>This APC was reciently constructed, and not fully linked to station systems, and is of no use to hack.")
+		to_chat(malf, "<span class='warning'>This APC was reciently constructed, and not fully linked to station systems, and is of no use to hack.</span>")
 		return
 	to_chat(malf, "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.")
 	malf.malfhack = src

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -105,7 +105,8 @@
 	var/global/list/status_overlays_environ
 	var/indestructible = 0 // If set, prevents aliens from destroying it
 	var/keep_preset_name = 0
-	var/constructed = FALSE //Was this APC built instead of already existing? Used for malfhack to keep borgs from building apcs in space
+	/// Was this APC built instead of already existing? Used for malfhack to keep borgs from building apcs in space
+	var/constructed = FALSE
 
 	var/report_power_alarm = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

This PR makes a subtype of APC, constructed apcs, which can not be hacked by malf AIs. They can still have lights overloaded, power turned off, locked, ect, just like a normal AI would do to the APC
Makes it so deconstructing a malf hacked APC does not cost the malf AI points.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

After discussing with a maintainer, it was decided that malf AI should be tweaked to prevent a malf AI from gaining all its points from space built APCs. We are aware however, with the limited APCs on station and off station, so with this PR it is tweaked that if crew deconstructs APCs the malf AI has hacked, they will no longer loose points, meaning once the AI starts going loud with the APC hacking, crew will not be able to destroy APCs the malf AI has hacked to subtract points from them.

For those wondering if command will start deconstructing and repairing the APC on the bridge so the AI can't malfhack it when it turns out the AI is malf, you could already cut the AI control wire to prevent this.


## Changelog
:cl:
tweak: Malf AI can no longer hack APCs that are built by crew / borgs. This does not prevent the AI from interfacing with them like normal.
tweak: Malf AI no longer looses points when Malfhacked APCs are destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
