### PR TITLE
Fixes secborg batons

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -29,12 +29,22 @@
 	return ..()
 
 /obj/item/melee/baton/Destroy()
-	QDEL_NULL(cell)
+	if(cell?.loc == src)
+		QDEL_NULL(cell)
 	return ..()
 
-// Should only be called on Initialize(), or if a borg has their cell replaced.
-/obj/item/melee/baton/proc/link_new_cell()
-	if(isrobot(loc.loc)) // First loc is the module
+/**
+ * Updates the linked power cell on the baton.
+ *
+ * If the baton is held by a cyborg, link it to their internal cell.
+ * Else, spawn a new cell and use that instead.
+ * Arguments:
+ * * unlink - If TRUE, sets the `cell` variable to `null` rather than linking it to a new one.
+ */
+/obj/item/melee/baton/proc/link_new_cell(unlink = FALSE)
+	if(unlink)
+		cell = null
+	else if(isrobot(loc.loc)) // First loc is the module
 		var/mob/living/silicon/robot/R = loc.loc
 		cell = R.cell
 	else

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -25,16 +25,20 @@
 	update_icon()
 
 /obj/item/melee/baton/loaded/Initialize(mapload) //this one starts with a cell pre-installed.
-	if(isrobot(loc.loc)) // First loc would be the module
-		var/mob/living/silicon/robot/R = loc.loc
-		cell = R.cell
-	else
-		cell = new(src)
+	link_new_cell()
 	return ..()
 
 /obj/item/melee/baton/Destroy()
 	QDEL_NULL(cell)
 	return ..()
+
+// Should only be called on Initialize(), or if a borg has their cell replaced.
+/obj/item/melee/baton/proc/link_new_cell()
+	if(isrobot(loc.loc)) // First loc is the module
+		var/mob/living/silicon/robot/R = loc.loc
+		cell = R.cell
+	else
+		cell = new(src)
 
 /obj/item/melee/baton/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting the live [name] in [user.p_their()] mouth! It looks like [user.p_theyre()] trying to commit suicide.</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -757,7 +757,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			//This will mean that removing and replacing a power cell will repair the mount, but I don't care at this point. ~Z
 			C.brute_damage = 0
 			C.electronics_damage = 0
-			module.update_cells(W)
+			module?.update_cells()
 			diag_hud_set_borgcell()
 
 	else if(istype(W, /obj/item/encryptionkey/) && opened)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -757,6 +757,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			//This will mean that removing and replacing a power cell will repair the mount, but I don't care at this point. ~Z
 			C.brute_damage = 0
 			C.electronics_damage = 0
+			module.update_cells(W)
 			diag_hud_set_borgcell()
 
 	else if(istype(W, /obj/item/encryptionkey/) && opened)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -47,6 +47,7 @@
 			var/datum/robot_component/C = components["power cell"]
 			C.installed = 0
 			C.uninstall()
+			module?.update_cells(TRUE)
 			diag_hud_set_borgcell()
 
 	if(!opened)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -191,11 +191,11 @@
 /**
  * Called when the robot owner of this module has their power cell replaced.
  *
- * Changes the linked power cell for module items to the newly inserted cell.
+ * Changes the linked power cell for module items to the newly inserted cell, or to `null`.
  * Arguments:
- * * new_cell - The replacement [/obj/item/stock_parts/cell] which will be linked to the items.
+ * * unlink_cell - If TRUE, set the item's power cell variable to `null` rather than linking it to a new one.
  */
-/obj/item/robot_module/proc/update_cells(obj/item/stock_parts/cell/new_cell)
+/obj/item/robot_module/proc/update_cells(unlink_cell = FALSE)
 	return
 
 /**
@@ -418,10 +418,10 @@
 	emag_modules = list(/obj/item/gun/energy/laser/cyborg)
 	special_rechargables = list(/obj/item/melee/baton/loaded, /obj/item/gun/energy/disabler/cyborg)
 
-/obj/item/robot_module/security/update_cells()
+/obj/item/robot_module/security/update_cells(unlink_cell = FALSE)
 	var/obj/item/melee/baton/B = locate(/obj/item/melee/baton/loaded) in modules
 	if(B)
-		B.link_new_cell()
+		B.link_new_cell(unlink_cell)
 
 // Janitor cyborg module.
 /obj/item/robot_module/janitor

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -189,6 +189,16 @@
 		I.cyborg_recharge(coeff, R.emagged)
 
 /**
+ * Called when the robot owner of this module has their power cell replaced.
+ *
+ * Changes the linked power cell for module items to the newly inserted cell.
+ * Arguments:
+ * * new_cell - The replacement [/obj/item/stock_parts/cell] which will be linked to the items.
+ */
+/obj/item/robot_module/proc/update_cells(obj/item/stock_parts/cell/new_cell)
+	return
+
+/**
  * Called when the robot owner of this module has the `unemag()` proc called on them, which is only via admin means.
  *
  * Deletes this module's emag items, and recreates them.
@@ -407,6 +417,11 @@
 	)
 	emag_modules = list(/obj/item/gun/energy/laser/cyborg)
 	special_rechargables = list(/obj/item/melee/baton/loaded, /obj/item/gun/energy/disabler/cyborg)
+
+/obj/item/robot_module/security/update_cells()
+	var/obj/item/melee/baton/B = locate(/obj/item/melee/baton/loaded) in modules
+	if(B)
+		B.link_new_cell()
 
 // Janitor cyborg module.
 /obj/item/robot_module/janitor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes #16179.
This was caused by the secborg module's stunbaton only linking to the cyborg's cell on `Initialize()`. So if the borg had their power cell replaced, the baton would stay connected to the original cell and ignore the new one.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Secborgs should be able to use their stunbaton.
*(Also this was probably caused by me in #15313 so...)*

## Changelog
:cl:
fix: Fixed secborg batons staying linked to the old cell if the borg had a new one installed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
