### PR TITLE
Fix: check mapload on loot spawn

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -27,7 +27,7 @@
 // Please dont override this unless you absolutely have to
 /obj/structure/closet/Initialize(mapload)
 	. = ..()
-	if(!opened)
+	if(mapload && !opened)
 		// Youre probably asking, why is this a 0 seconds timer AA?
 		// Well, I will tell you. One day, all /obj/effect/spawner will use Initialize
 		// This includes maint loot spawners. The problem with that is if a closet loads before a spawner,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes this runtime
`[2021-05-16T16:37:46] Runtime in timer.dm,134: Invalid timer: Timer: Timer: -1 ([0x2103a002]), TTR: 76011.7, Flags: , callBack: [0x2103599f], callBack.object: the necropolis chest[0x2036aea](/obj/structure/closet/crate/necropolis/tendril), callBack.delegate:/obj/structure/closet/proc/take_contents()Prev: NULL, Next: NULL, SPENT(76496.9), QDELETED, NO CALLBACK world.time: 76611.3, head_offset: 76200.5, practical_offset: 1028`
`## WARNING: Invalid timer: Timer: Timer: -1 ([0x2103a002]), TTR: 76011.7, Flags: , callBack: [0x2103599f], callBack.object: the necropolis chest[0x2036aea](/obj/structure/closet/crate/necropolis/tendril), callBack.delegate:/obj/structure/closet/proc/take_contents()Prev: NULL, Next: NULL, SPENT(76496.9), QDELETED, NO CALLBACK world.time: 76611.7, head_offset: 76011.7, practical_offset: 1 in code/controllers/subsystem/timer.dm at line 283 src: Timer usr: .
`
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less runtimes and SStimer crashes
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Semoro
fix: check mapload on loot spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
