### PR TITLE
Digital Camouflage does no longer out you as a changeling.

### DIFF
--- a/code/game/gamemodes/changeling/powers/digitalcamo.dm
+++ b/code/game/gamemodes/changeling/powers/digitalcamo.dm
@@ -1,11 +1,11 @@
 /datum/action/changeling/digitalcamo
 	name = "Digital Camouflage"
 	desc = "By evolving the ability to distort our form and proprotions, we defeat common altgorithms used to detect lifeforms on cameras."
-	helptext = "We cannot be tracked by camera while using this skill. However, humans looking at us will find us... uncanny."
+	helptext = "We cannot be tracked by camera while using this skill."
 	button_icon_state = "digital_camo"
 	dna_cost = 1
 
-//Prevents AIs tracking you but makes you easily detectable to the human-eye.
+//Prevents AIs tracking you.
 /datum/action/changeling/digitalcamo/sting_action(mob/user)
 
 	if(user.digitalcamo)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -332,9 +332,6 @@
 				else if(!client)
 					msg += "[p_they(TRUE)] [p_have()] suddenly fallen asleep, suffering from Space Sleep Disorder. [p_they(TRUE)] may wake up soon.\n"
 
-		if(digitalcamo)
-			msg += "[p_they(TRUE)] [p_are()] moving [p_their()] body in an unnatural and blatantly inhuman manner.\n"
-
 	if(!(skipface || ( wear_mask && ( wear_mask.flags_inv & HIDEFACE || wear_mask.flags_cover & MASKCOVERSMOUTH) ) ) && is_thrall(src) && in_range(user,src))
 		msg += "Their features seem unnaturally tight and drawn.\n"
 


### PR DESCRIPTION
## What Does This PR Do
Removes the "X is moving in an unnatural manner" examine message that changelings with the digital camouflage ability get.

## Why It's Good For The Game
This ability is /very/ limited, as it currently stands, it does the following:
- Prevents yourself from being tracked by the AI.
- Does not prevent yourself from being visible to the AI.
- Outs you as a changeling while active.

I believe this is a bit underpowered as an ability, as it's attempt to protect you from the AI is situational, and it's downside will affect you a lot more.

## Changelog
:cl:
tweak: Changeling's Digital Camouflage ability no longer has an examine message that outs you as changeling.
/:cl: