### PR TITLE
table climbing fix

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -108,27 +108,27 @@
 
 /obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height == 0)
-		return 1
+		return TRUE
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
 	if(ismob(mover))
 		var/mob/M = mover
 		if(M.flying)
-			return 1
+			return TRUE
 	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
+		return TRUE
 	if(mover.throwing)
-		return 1
+		return TRUE
 	if(length(get_atoms_of_type(get_turf(mover), /obj/structure/table) - mover))
 		var/obj/structure/table/T = locate(/obj/structure/table) in get_turf(mover)
 		if(!T.flipped)
-			return 1
+			return TRUE
 	if(flipped)
 		if(get_dir(loc, target) == dir)
 			return !density
 		else
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /obj/structure/table/CanAStarPass(ID, dir, caller)
 	. = !density

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -120,7 +120,9 @@
 	if(mover.throwing)
 		return 1
 	if(length(get_atoms_of_type(get_turf(mover), /obj/structure/table) - mover))
-		return 1
+		var/obj/structure/table/T = locate(/obj/structure/table) in get_turf(mover)
+		if(!T.flipped)
+			return 1
 	if(flipped)
 		if(get_dir(loc, target) == dir)
 			return !density


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
you can no longer use flipped tables to climb onto tables instantly.
fixes #16199 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
bugs bad. can be exploited aswell for making one way barriers

## Images of changes
**NOTE** tables still smooth with flipped tables. that is a bug for another day.



## Changelog
:cl:
fix: you can no longer use flipped tables to climb onto tables instantly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
