### PR TITLE
Fixes syndie duffels mob sprite being invisible

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -340,7 +340,7 @@
 /obj/item/storage/backpack/duffel/syndie
 	name = "suspicious looking duffelbag"
 	desc = "A large duffelbag for holding extra tactical supplies."
-	icon_state = "duffel-syndie"
+	icon_state = "duffel-syndimed"
 	item_state = "duffel-syndimed"
 	origin_tech = "syndicate=1"
 	silent = TRUE
@@ -350,8 +350,6 @@
 /obj/item/storage/backpack/duffel/syndie/med
 	name = "suspicious duffelbag"
 	desc = "A black and red duffelbag with a red and white cross sewn onto it."
-	icon_state = "duffel-syndimed"
-	item_state = "duffel-syndimed"
 
 /obj/item/storage/backpack/duffel/syndie/ammo
 	name = "suspicious duffelbag"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes X4 C4 duffel sprite being invisible when worn.

## Why It's Good For The Game
bugs bad. this sprite doesn't even exist.

## Images of changes
it uses the syndie medi duffel sprite like the item state. If pictures are needed i can get them.

## Changelog
:cl:
Fix: syndie duffel worn sprites are no longer invisible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
