### PR TITLE
Remove mouse ears from Donor items

### DIFF
--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -63,10 +63,6 @@
 	display_name = "Fur Cap"
 	path = /obj/item/clothing/head/furcap
 
-/datum/gear/donor/mouse
-	display_name = "Mouse Headband"
-	path = /obj/item/clothing/head/kitty/mouse
-
 /datum/gear/donor/fawkes
 	display_name = "Guy Fawkes mask"
 	path = /obj/item/clothing/mask/fawkes


### PR DESCRIPTION
Mouse ears were originally the vanity/flair item made for me that somehow made their way into the autodrobe, then out of the autodrobe and into donator items. I'd like to reclaim my vanity item please, and thus remove it from donor availability.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the referece to mouse ears from the list of donor loadout items.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unique vanity items should stay as such unless both creator and holder agree that it should be genericized.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed mouse ears from the donor loadout options.
/:cl: