### PR TITLE
Improves our map rendering

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -10,3 +10,22 @@ use_typepath_names = true
 
 [debugger]
 engine = "auxtools"
+
+[map_renderer.render_passes]
+smart-cables = false
+icon-smoothing = false
+icon-smoothing-2016 = true
+
+[map_renderer.fancy_layers]
+"/turf/simulated/floor/plating" = -10
+"/turf/space" = -10
+"/turf/simulated/floor/plasteel" = -2
+"/turf/simulated/floor/engine" = -2
+"/turf/simulated/floor/wood" = -2
+"/turf/simulated/floor/bluegrid" = -2
+"/turf/simulated/floor/carpet" = -2
+"/turf/simulated/wall" = -2
+# Stuff here should be invisible. So set it to layer -20
+"/obj/effect/mapping_helpers" = -20
+"/obj/effect/landmark" = -20
+"/obj/effect/spawner/random_spawners" = -20

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -12,9 +12,10 @@ use_typepath_names = true
 engine = "auxtools"
 
 [map_renderer]
-force_hide_types = [
-    "/obj/effect/mapping_helpers",
+hide_invisible = [
     "/obj/effect/landmark",
+    "/obj/effect/mapping_helpers",
+	"/obj/effect/spawner/random_barrier",
     "/obj/effect/spawner/random_spawners",
 ]
 

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -13,10 +13,10 @@ engine = "auxtools"
 
 [map_renderer]
 hide_invisible = [
-    "/obj/effect/landmark",
-    "/obj/effect/mapping_helpers",
+	"/obj/effect/landmark",
+	"/obj/effect/mapping_helpers",
 	"/obj/effect/spawner/random_barrier",
-    "/obj/effect/spawner/random_spawners",
+	"/obj/effect/spawner/random_spawners",
 ]
 
 [map_renderer.render_passes]

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -11,6 +11,13 @@ use_typepath_names = true
 [debugger]
 engine = "auxtools"
 
+[map_renderer]
+force_hide_types = [
+    "/obj/effect/mapping_helpers",
+    "/obj/effect/landmark",
+    "/obj/effect/spawner/random_spawners",
+]
+
 [map_renderer.render_passes]
 smart-cables = false
 icon-smoothing = false
@@ -25,7 +32,3 @@ icon-smoothing-2016 = true
 "/turf/simulated/floor/bluegrid" = -2
 "/turf/simulated/floor/carpet" = -2
 "/turf/simulated/wall" = -2
-# Stuff here should be invisible. So set it to layer -20
-"/obj/effect/mapping_helpers" = -20
-"/obj/effect/landmark" = -20
-"/obj/effect/spawner/random_spawners" = -20

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,15 +1,16 @@
-[langserver]
-dreamchecker = true
-
+# Keep the keys in this file alphabetical please
 [code_standards]
-disallow_relative_type_definitions = true
 disallow_relative_proc_definitions = true
+disallow_relative_type_definitions = true
+
+[debugger]
+engine = "auxtools"
 
 [dmdoc]
 use_typepath_names = true
 
-[debugger]
-engine = "auxtools"
+[langserver]
+dreamchecker = true
 
 [map_renderer]
 hide_invisible = [
@@ -19,17 +20,19 @@ hide_invisible = [
 	"/obj/effect/spawner/random_spawners",
 ]
 
-[map_renderer.render_passes]
-smart-cables = false
-icon-smoothing = false
-icon-smoothing-2016 = true
-
 [map_renderer.fancy_layers]
+# -10
 "/turf/simulated/floor/plating" = -10
 "/turf/space" = -10
-"/turf/simulated/floor/plasteel" = -2
-"/turf/simulated/floor/engine" = -2
-"/turf/simulated/floor/wood" = -2
+# -2
 "/turf/simulated/floor/bluegrid" = -2
 "/turf/simulated/floor/carpet" = -2
+"/turf/simulated/floor/engine" = -2
+"/turf/simulated/floor/plasteel" = -2
+"/turf/simulated/floor/wood" = -2
 "/turf/simulated/wall" = -2
+
+[map_renderer.render_passes]
+icon-smoothing = false
+icon-smoothing-2016 = true
+smart-cables = false


### PR DESCRIPTION
## What Does This PR Do
Adds new options to our `SpacemanDMM.toml` to account for features coming soon in the map renderer.

Coming soon is the ability to configure dedicated render passes and layer filters on a config-file basis instead of me having to modify the executable for the webmap. This also means we can tweak turf values easily, as well as get better renders on MapDiffBot, since thats designed for TG pathtypes, and TG render stuff.

PR is WIP till this is finalised, as I still have extra things to add. This is just me putting the relevant changes up now. 

## Why It's Good For The Repo
Renders on the webmap and MapDiffBot should look better than they do.


## Changelog
N/A