### PR TITLE
Prevents final summon rune by being cleaned by normal methods

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -22,8 +22,6 @@
 
 #define iseffect(A) (istype(A, /obj/effect))
 
-#define is_cleanable(A) (istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/rune) && !istype(A, /obj/effect/rune/narsie)) //if something is cleanable
-
 #define isclothing(A) (istype(A, /obj/item/clothing))
 
 #define is_pen(W) (istype(W, /obj/item/pen))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -22,7 +22,7 @@
 
 #define iseffect(A) (istype(A, /obj/effect))
 
-#define is_cleanable(A) (istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/rune)) //if something is cleanable
+#define is_cleanable(A) (istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/rune) && !istype(A, /obj/effect/rune/narsie)) //if something is cleanable
 
 #define isclothing(A) (istype(A, /obj/item/clothing))
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -130,6 +130,9 @@ To draw a rune, use a ritual dagger.
 	visible_message("<span class='danger'>[src] suddenly appears!</span>")
 	alpha = initial(alpha)
 
+/obj/effect/rune/is_cleanable()
+	return TRUE
+
 
 /*
 There are a few different procs each rune runs through when a cultist activates it.
@@ -990,6 +993,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 /obj/effect/rune/narsie/cult_conceal() //can't hide this, and you wouldn't want to
 	return
+
+/obj/effect/rune/narsie/is_cleanable() //No, you can't just yeet a cleaning grenade to remove it.
+	return FALSE
 
 /obj/effect/rune/narsie/invoke(list/invokers)
 	if(used)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -53,6 +53,9 @@
 /obj/effect/decal/cleanable/proc/can_bloodcrawl_in()
 	return FALSE
 
+/obj/effect/decal/cleanable/is_cleanable()
+	return TRUE
+
 /obj/effect/decal/cleanable/Initialize(mapload)
 	. = ..()
 	if(loc && isturf(loc))

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -25,6 +25,9 @@
 /obj/effect/acid_act()
 	return
 
+/obj/effect/proc/is_cleanable() //Called when you want to clean something, and usualy delete it after
+	return FALSE
+
 /obj/effect/mech_melee_attack(obj/mecha/M)
 	return 0
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -28,7 +28,7 @@
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("cleaner", 1) || reagents.has_reagent("holywater", 1))
 		A.clean_blood()
 		for(var/obj/effect/O in A)
-			if(is_cleanable(O))
+			if(O.is_cleanable())
 				qdel(O)
 	reagents.reaction(A, REAGENT_TOUCH, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -52,7 +52,7 @@
 /obj/item/soap/proc/clean_turf(turf/simulated/T)
 	T.clean_blood()
 	for(var/obj/effect/O in T)
-		if(is_cleanable(O))
+		if(O.is_cleanable())
 			qdel(O)
 
 /obj/item/soap/attack(mob/target as mob, mob/user as mob)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -363,6 +363,9 @@ a {
 /obj/proc/cult_reveal() //Called by cult reveal spell and chaplain's bible
 	return
 
+/obj/proc/is_cleanable() //Called when you want to clean something, and usualy delete it after
+	return FALSE
+
 /obj/proc/force_eject_occupant(mob/target)
 	// This proc handles safely removing occupant mobs from the object if they must be teleported out (due to being SSD/AFK, by admin teleport, etc) or transformed.
 	// In the event that the object doesn't have an overriden version of this proc to do it, log a runtime so one can be added.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -363,8 +363,6 @@ a {
 /obj/proc/cult_reveal() //Called by cult reveal spell and chaplain's bible
 	return
 
-/obj/proc/is_cleanable() //Called when you want to clean something, and usualy delete it after
-	return FALSE
 
 /obj/proc/force_eject_occupant(mob/target)
 	// This proc handles safely removing occupant mobs from the object if they must be teleported out (due to being SSD/AFK, by admin teleport, etc) or transformed.

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -401,7 +401,7 @@
 			tile.water_act(100, convertHeat(), src)
 			tile.clean_blood(radiation_clean = TRUE)
 			for(var/obj/effect/E in tile)
-				if(is_cleanable(E))
+				if(E.is_cleanable())
 					qdel(E)
 		for(var/A in loc)
 			wash(A)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1201,12 +1201,13 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 				var/floor_only = TRUE
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
-						if(is_cleanable(A))
-							var/obj/effect/decal/cleanable/blood/B = A
+						var/obj/effect/E = A
+						if(E.is_cleanable())
+							var/obj/effect/decal/cleanable/blood/B = E
 							if(istype(B) && B.off_floor)
 								floor_only = FALSE
 							else
-								qdel(A)
+								qdel(E)
 					else if(istype(A, /obj/item))
 						var/obj/item/cleaned_item = A
 						cleaned_item.clean_blood()

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -57,7 +57,7 @@
 	taste_description = "floor cleaner"
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, volume)
-	if(is_cleanable(O))
+	if(O.is_cleanable())
 		var/obj/effect/decal/cleanable/blood/B = O
 		if(!(istype(B) && B.off_floor))
 			qdel(O)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -57,10 +57,12 @@
 	taste_description = "floor cleaner"
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, volume)
-	if(O.is_cleanable())
-		var/obj/effect/decal/cleanable/blood/B = O
-		if(!(istype(B) && B.off_floor))
-			qdel(O)
+	if(istype(O, /obj/effect))
+		var/obj/effect/E = O
+		if(E.is_cleanable())
+			var/obj/effect/decal/cleanable/blood/B = E
+			if(!(istype(B) && B.off_floor))
+				qdel(E)
 	else
 		if(O.simulated)
 			O.color = initial(O.color)

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -49,9 +49,9 @@
 		var/turf/tile = loc
 		if(isturf(tile))
 			tile.clean_blood()
-			for(var/A in tile)
-				if(is_cleanable(A))
-					qdel(A)
+			for(var/obj/effect/E in tile)
+				if(E.is_cleanable())
+					qdel(E)
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Makes Narsie summon rune not pass the is_cleanable check, meaning soap, mops, janiborgs, spray cleaner, and cleaning foam can not remove the rune. Rune can still be removed with a null rod.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Cult summoning is supposed to be hard. However, it is a bit unfair to expect in order for a cult to summon, they must prevent _ANY_ cleaning grenade from going off in a 7 tile radius around the summon rune, or anyone else with a spray cleaner or a chem grenade. The rune is still removable, by the normal methods, using a null rod as a chaplain, or cult dagger as a cultist.


## Changelog
:cl:
tweak: Narsie summon rune can now only be removed by null rod or dagger, and not normal cleaning methods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
