### PR TITLE
Fixes soulstones kicking players to the lobby

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -262,7 +262,8 @@
 	switch(choice)
 		if("FORCE")
 			var/mob/living/T = target
-			if(T.client && T.ghost_can_reenter()) // Haven't DC'd or ahudded
+			T.grab_ghost(FALSE) // If they haven't DC'd or ahudded, put them back in their body
+			if(T.client) // If there's someone in the body
 				init_shade(T, user)
 			else // Poll ghosts
 				to_chat(user, "<span class='userdanger'>Capture failed!</span> The soul has already fled its mortal frame. You attempt to bring it back...")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes `Runtime in soulstone.dm,98: Cannot read null.offstation_role`, by forcing the player's ghost back into their body if they're able to reenter it, since otherwise the player's `key` would be overridden by that of a polled ghost, potentially crashing both of them and kicking one to the lobby.

<details>
<summary><b>Steps to reproduce the bug:</b></summary>

1. Join the game with two accounts, one playing and one observing.
2. Kill the living one and ghost out of it with the first account.
3. Mark the corpse in VV, spawn a soulstone, and call `transfer_soul("FORCE", marked_datum, mob_reference)`
(Same as a rune sacrifice, just skips a step)
4. The body will be polled to ghosts, despite the original player still being able to re-enter.
5. Sign up for the poll on the second observer account.
6. Re-enter the corpse on the first account.
7. Wait a few seconds, and both clients crash.
8. Rejoin the server and see that one client is inside the corpse, and one is kicked out to the lobby.

</details>

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Semi-major bugfix.

## Changelog
:cl:
fix: Fixed soulstones sending players to the lobby in some circumstances.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
