### PR TITLE
Maintenance drone mind fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -300,11 +300,7 @@
 	if(!player)
 		return
 
-	if(player.mob?.mind)
-		player.mob.mind.transfer_to(src)
-		player.mob.mind.assigned_role = "Drone"
-	else
-		ckey = player.ckey
+	ckey = player.ckey
 
 	to_chat(src, "<b>Systems rebooted</b>. Loading base pattern maintenance protocol... <b>loaded</b>.")
 	full_law_reset()

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -37,7 +37,7 @@
 
 	icon_state = "drone_fab_active"
 	var/elapsed = world.time - time_last_drone
-	drone_progress = round((elapsed / config.drone_build_time) * 100)
+	drone_progress = clamp(round((elapsed / config.drone_build_time) * 100), 0, 100)
 
 	if(drone_progress >= 100)
 		visible_message("[src] voices a strident beep, indicating a drone chassis is prepared.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
1. Fixes the maintenance drone fabricator not properly transferring the player's mind into the new drone. (Fixes #16103)
2. Fixes maintenance drones taking on the AntagHUD roles that their player had beforehand. (Fixes #15595)
3. Fixes the maintenance drone fabricator showing above 100% construction progress.

Closes #13004 (Fixed in #15873)
Closes #11609 (Fixed in #16128)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This really shouldn't be happening:
![image](https://user-images.githubusercontent.com/57483089/122845616-01e04a80-d2fc-11eb-81b7-65e809d3b4a4.png)

## Changelog
:cl:
fix: Fixed the maintenance drone fabricator not properly transferring the player's mind into the new drone.
fix: Fixed the maintenance drone fabricator showing above 100% construction progress.
fix: Fixed maintenance drones taking on the AntagHUD roles that their player had beforehand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
