### PR TITLE
Fix shower mist not going away on deconstruction

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -275,6 +275,9 @@
 
 /obj/machinery/shower/Destroy()
 	QDEL_NULL(soundloop)
+	var/obj/effect/mist/mist = locate() in loc
+	if(!QDELETED(mist))
+		QDEL_IN(mist, 25 SECONDS)
 	return ..()
 
 //add heat controls? when emagged, you can freeze to death in it?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

- Fixes shower mist not going away on deconstruction (closes #16232)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

https://tvtropes.org/pmwiki/pmwiki.php/Main/CensorSteam

## Changelog
:cl:
fix: Shower mist now eventually disappears on shower deconstruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
