### PR TITLE
Prevents vents / scrubbers from making air from walls

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -23,6 +23,10 @@
 	if(!node)
 		return 0
 
+	var/turf/T = loc
+	if(T.density) //No, you should not be able to get free air from walls
+		return
+
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/pressure_delta = air_contents.return_pressure() - environment.return_pressure()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -128,6 +128,9 @@
 	..()
 	if(stat & (NOPOWER|BROKEN))
 		return FALSE
+	var/turf/T = loc
+	if(T.density) //No, you should not be able to get free air from walls
+		return
 	if(!node)
 		on = FALSE
 	//broadcast_status() // from now air alarm/control computer should request update purposely --rastaf0

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -193,6 +193,10 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
+	var/turf/T = loc
+	if(T.density) //No, you should not be able to get free air from walls
+		return
+
 	if(!node)
 		on = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds a check to active, passive vents, and scrubbers, during their process atmos step, to check if the turf they are on is dense. If they are dense, they will not do anything, similar to being broken, welded, or off.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to get air from walls is not something you should be able to do. Doesn't make sense, and you should not be able to get something from nothing.

Fixes #14917

## Changelog
:cl:
tweak: Atmos vents and scrubbers no longer works in walls / dense turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
