### PR TITLE
tweaks some things with energy bolas

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -123,29 +123,6 @@
 				L.apply_damage(trap_damage, BRUTE)
 	..()
 
-/obj/item/restraints/legcuffs/beartrap/energy
-	name = "energy snare"
-	armed = 1
-	icon_state = "e_snare"
-	trap_damage = 0
-	flags = DROPDEL
-	breakouttime = 6 SECONDS
-
-/obj/item/restraints/legcuffs/beartrap/energy/New()
-	..()
-	addtimer(CALLBACK(src, .proc/dissipate), 100)
-
-/obj/item/restraints/legcuffs/beartrap/energy/proc/dissipate()
-	if(!ismob(loc))
-		do_sparks(1, 1, src)
-		qdel(src)
-
-/obj/item/restraints/legcuffs/beartrap/energy/attack_hand(mob/user)
-	Crossed(user) //honk
-
-/obj/item/restraints/legcuffs/beartrap/energy/cyborg
-	breakouttime = 20 // Cyborgs shouldn't have a strong restraint
-
 /obj/item/restraints/legcuffs/bola
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
@@ -189,11 +166,4 @@
 	icon_state = "ebola"
 	hitsound = 'sound/weapons/tase.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	breakouttime = 60
-
-/obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom)
-	if(iscarbon(hit_atom))
-		var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy(get_turf(hit_atom))
-		B.Crossed(hit_atom, null)
-		qdel(src)
-	..()
+	breakouttime = 6 SECONDS

--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -131,7 +131,10 @@
 	gender = NEUTER
 	origin_tech = "engineering=3;combat=1"
 	hitsound = 'sound/effects/snap.ogg'
+	///how much it weakens for
 	var/weaken = 0
+	///if it gets deleted when removed
+	var/one_use = FALSE
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	playsound(loc,'sound/weapons/bolathrow.ogg', 50, TRUE)
@@ -151,6 +154,8 @@
 		to_chat(C, "<span class='userdanger'>[src] ensnares you!</span>")
 		C.Weaken(weaken)
 		playsound(loc, hitsound, 50, TRUE)
+		if(one_use)
+			flags |= DROPDEL
 
 /obj/item/restraints/legcuffs/bola/tactical //traitor variant
 	name = "reinforced bola"
@@ -167,3 +172,4 @@
 	hitsound = 'sound/weapons/tase.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 	breakouttime = 6 SECONDS
+	one_use = TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -883,8 +883,6 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 				legcuffed = null
 				toggle_move_intent()
 				update_inv_legcuffed()
-				if(istype(I, /obj/item/restraints/legcuffs/bola/energy))
-					qdel(I)
 				return
 			else
 				unEquip(I)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -883,6 +883,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 				legcuffed = null
 				toggle_move_intent()
 				update_inv_legcuffed()
+				if(istype(I, /obj/item/restraints/legcuffs/bola/energy))
+					qdel(I)
 				return
 			else
 				unEquip(I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
E-bolas behave more like standard bolas. They no longer magically pass through shielded hardsuits/riot shield, they can now be caught and they now actually play their hitsound.

Hitting someone with a bola who is already hit with a bola no longer creates an e-beartrap at their feet

Also removed e-beartraps because they are unused and they cannot even be used as they delete themselves on the floor.

## Why It's Good For The Game
shields should block things, intended sounds should be played.

also `new`ing a beartrap and forcing them to walk over it is also kinda gross, it means that the breakout time on the actual item didn't actually affect anything resulting in confusion. 


## Changelog
:cl:
tweak: energy bolas can now be caught and blocked by shields.
fix: energy bolas now play their sound on hit.
fix: hitting someone with an e-bola who is already snared no longer drops an e-beartrap at their feet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
