### PR TITLE
Fix some off-station terminals showing up on engineer PDAs.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -2388,7 +2388,7 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
 "yf" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	name = "Engine Grid Power Monitoring Computer"
 	},
 /obj/structure/cable/yellow,
@@ -4114,7 +4114,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	name = "Output Grid Power Monitoring Computer"
 	},
 /turf/simulated/floor/plating,

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -133,7 +133,7 @@
 	},
 /area/derelict/bridge)
 "av" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -3697,7 +3697,7 @@
 	name = "Derelict Annex"
 	})
 "hD" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 5

--- a/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
+++ b/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
@@ -2536,7 +2536,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/awaymission/BMPship/Aft)

--- a/_maps/map_files/RandomZLevels/centcomAway.dmm
+++ b/_maps/map_files/RandomZLevels/centcomAway.dmm
@@ -2785,7 +2785,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -1308,7 +1308,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5160,7 +5160,7 @@
 /turf/simulated/floor/plating,
 /area/awaycontent/a7)
 "hm" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/awaycontent/a7)

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -7975,7 +7975,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	name = "primary power monitoring console"
 	},
 /obj/structure/sign/nosmoking_2{
@@ -10652,7 +10652,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaymission/UO71/outside)
 "vV" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/bridge)
 "vW" = (
@@ -11805,7 +11805,7 @@
 	},
 /area/awaymission/UO71/eng)
 "yc" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	name = "primary power monitoring console"
 	},
 /obj/structure/cable,

--- a/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
@@ -11078,7 +11078,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	name = "primary power monitoring console"
 	},
 /obj/structure/sign/nosmoking_2{
@@ -15909,7 +15909,7 @@
 	name = "UO45 Engineering"
 	})
 "xg" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	name = "primary power monitoring console"
 	},
 /obj/structure/cable,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #16217, where I had noticed that space base power monitors showed up on PDAs. It turned out that it applied to power monitors on gateway missions as well, so I changed those terminals too.

Replaces all off-station instances of `/obj/machinery/computer/monitor` with `/obj/machinery/computer/monitor/secret`, which is a sub-type of the power monitor with a flag that marks whether or not it shows up in power monitor lists (like the one generated by a Power-ON cart). It turns out this secret monitor already existed in the code and the flag was being checked for, but the monitors didn't seem to be in use.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a little immersion-breaking that the syndicate space base and away mission power terminals show up on station. Would it make sense that you can connect to the power computers through the gateway, or a (supposedly top-secret) syndicate base?

It also clutters up the menu for engineers who actually use the power monitor list, and can spoil the contents of the gateway from the start of the round.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Convert power monitors on the syndicate space base and gateway missions to /obj/machinery/computer/monitor/secret
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
