### PR TITLE
Fixes a runtime with the cyborg rename module

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -71,7 +71,7 @@
 		if(replacement_type in special_rechargables)
 			R.module.special_rechargables += replacement
 
-	R.module.rebuild_modules()
+	R.module?.rebuild_modules()
 	return TRUE
 
 /obj/item/borg/upgrade/reset


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
After the cyborg rename module (and possibly other modules) are applied to a module-less cyborg, the `rebuild_modules()` proc is called on the cyborgs module. In the case of module-less cyborgs, this was null, so this just adds a null check before calling the proc.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes a runtime with the rename cyborg upgrade module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
