### PR TITLE
Fixes powersink not giving you a beacon on purchase.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1426,7 +1426,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Power Sink"
 	desc = "When screwed to wiring attached to an electric grid, then activated, this large device places excessive load on the grid, causing a stationwide blackout. The sink cannot be carried because of its excessive size. Ordering this sends you a small beacon that will teleport the power sink to your location on activation."
 	reference = "PS"
-	item = /obj/item/radio/beacon/syndicate/bomb/power_sink
+	item = /obj/item/radio/beacon/syndicate/power_sink
 	cost = 10
 
 /datum/uplink_item/device_tools/singularity_beacon

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1426,7 +1426,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Power Sink"
 	desc = "When screwed to wiring attached to an electric grid, then activated, this large device places excessive load on the grid, causing a stationwide blackout. The sink cannot be carried because of its excessive size. Ordering this sends you a small beacon that will teleport the power sink to your location on activation."
 	reference = "PS"
-	item = /obj/item/powersink
+	item = /obj/item/radio/beacon/syndicate/bomb/power_sink
 	cost = 10
 
 /datum/uplink_item/device_tools/singularity_beacon

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -89,6 +89,10 @@
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance EMP explosive to your location</i>."
 	bomb = /obj/machinery/syndicatebomb/emp
 
+/obj/item/radio/beacon/syndicate/bomb/power_sink //Yes it's not a bomb but this code works the way we want
+	desc = "A label on it reads: <i>Warning: Activating this device will send a power sink to your location</i>."
+	bomb = /obj/item/powersink
+
 /obj/item/radio/beacon/engine
 	desc = "A label on it reads: <i>Warning: This device is used for transportation of high-density objects used for high-yield power generation. Stay away!</i>."
 	anchored = 1		//Let's not move these around. Some folk might get the idea to use these for assassinations

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -74,12 +74,11 @@
 /obj/item/radio/beacon/syndicate/power_sink
 	name = "suspicious beacon"
 	desc = "A label on it reads: <i>Warning: Activating this device will send a power sink to your location</i>."
-	var/item_to_teleport = /obj/item/powersink
 
 /obj/item/radio/beacon/syndicate/power_sink/attack_self(mob/user)
 	if(user)
 		to_chat(user, "<span class='notice'>Locked In</span>")
-		new item_to_teleport(user.loc)
+		new /obj/item/powersink(user.loc)
 		playsound(src, 'sound/effects/pop.ogg', 100, TRUE, 1)
 		user.drop_item()
 		qdel(src)

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -71,6 +71,19 @@
 		user.drop_item()
 		qdel(src)
 
+/obj/item/radio/beacon/syndicate/power_sink
+	name = "suspicious beacon"
+	desc = "A label on it reads: <i>Warning: Activating this device will send a power sink to your location</i>."
+	var/item_to_teleport = /obj/item/powersink
+
+/obj/item/radio/beacon/syndicate/power_sink/attack_self(mob/user)
+	if(user)
+		to_chat(user, "<span class='notice'>Locked In</span>")
+		new item_to_teleport(user.loc)
+		playsound(src, 'sound/effects/pop.ogg', 100, 1, 1)
+		user.drop_item()
+		qdel(src)
+
 /obj/item/radio/beacon/syndicate/bomb
 	name = "suspicious beacon"
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance explosive to your location</i>."
@@ -88,10 +101,6 @@
 /obj/item/radio/beacon/syndicate/bomb/emp
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance EMP explosive to your location</i>."
 	bomb = /obj/machinery/syndicatebomb/emp
-
-/obj/item/radio/beacon/syndicate/bomb/power_sink //Yes it's not a bomb but this code works the way we want
-	desc = "A label on it reads: <i>Warning: Activating this device will send a power sink to your location</i>."
-	bomb = /obj/item/powersink
 
 /obj/item/radio/beacon/engine
 	desc = "A label on it reads: <i>Warning: This device is used for transportation of high-density objects used for high-yield power generation. Stay away!</i>."

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -80,7 +80,7 @@
 	if(user)
 		to_chat(user, "<span class='notice'>Locked In</span>")
 		new item_to_teleport(user.loc)
-		playsound(src, 'sound/effects/pop.ogg', 100, 1, 1)
+		playsound(src, 'sound/effects/pop.ogg', 100, TRUE, 1)
 		user.drop_item()
 		qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #16254
Gives you a teleporter beacon to call in the powersink later, as opposed to just giving you the item.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things should work as described, getting a powersink when you aren't ready for it because you are expecting a beacon is bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Uplink powersink purchase now properly gives you a beacon instead of the actual item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
