### PR TITLE
Fixes RPD eating TEG circulators

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -145,6 +145,8 @@
 	else if(our_rpd.mode == RPD_FLIP_MODE)
 		flip()
 	else if(our_rpd.mode == RPD_DELETE_MODE)
+		if(pipe_type == PIPE_CIRCULATOR) //Skip TEG heat circulators, they aren't really pipes
+			return ..()
 		our_rpd.delete_single_pipe(user, src)
 	else
 		return ..()

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -142,6 +142,8 @@
 /obj/item/rpd/proc/delete_all_pipes(mob/user, turf/T) //Delete all pipes on a turf
 	var/eaten
 	for(var/obj/item/pipe/P in T)
+		if(P.pipe_type == PIPE_CIRCULATOR) //Skip TEG heat circulators, they aren't really pipes
+			continue
 		QDEL_NULL(P)
 		eaten = TRUE
 	for(var/obj/item/pipe_gsensor/G in T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #16231 so that RPDs cant eat TEG heat circulators. This happened because they are technically pipes in the code (even though they aren't really, but need to behave like them)
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
TEG circulators should not be eaten by an RPD, they are expensive and you wouldn't expect them to get eaten.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed RPD eating TEG circulators
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
