### PR TITLE
Fixes contractors removing ipc power cord

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -363,6 +363,9 @@
 		// Greys get to keep their implant
 		if(isgrey(H) && istype(I, /obj/item/organ/internal/cyberimp/brain/speech_translator))
 			continue
+		// IPCs keep this implant, free of charge!
+		if(ismachineperson(H) && istype(I, /obj/item/organ/internal/cyberimp/arm/power_cord))
+			continue
 		// Try removing it
 		I = I.remove(H)
 		if(I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds a check for if the target is a machine person in the syndicate contract stripping section so it will not remove the ipcs power cord implant.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Shockingly, IPCs need the IPC power cord. NT charges them a lot for it, and there is a lot of resistance to it being removed, people were being short about it. Thus, to avoid amping up the number of visits to robotics, this reduces the amount the syndicate applies battery to IPCs they kidnap, by not removing their power cord implant.

## Changelog
:cl:
fix: Fixes contractors removing IPCs power cord implant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
