### PR TITLE
Nuke code refactor (And DS manual bug fix)

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -275,13 +275,12 @@
 	if(src in SSticker.mode.syndicates)
 		. += "<b><font color='red'>OPERATIVE</b></font>|<a href='?src=[UID()];nuclear=clear'>no</a>"
 		. += "<br><a href='?src=[UID()];nuclear=lair'>To shuttle</a>, <a href='?src=[UID()];common=undress'>undress</a>, <a href='?src=[UID()];nuclear=dressup'>dress up</a>."
-		var/code
-		for(var/obj/machinery/nuclearbomb/bombue in GLOB.machines)
-			if(length(bombue.r_code) <= 5 && bombue.r_code != "LOLNO" && bombue.r_code != "ADMIN")
-				code = bombue.r_code
-				break
-		if(code)
-			. += " Code is [code]. <a href='?src=[UID()];nuclear=tellcode'>tell the code.</a>"
+		var/syndicate_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = FALSE, syndicate_nukes = TRUE)
+		for(var/obj/machinery/nuclearbomb/bomb in syndicate_nukes)
+			. += "<br>Code to syndicate [bomb.name] in [get_area(bomb).name] is: [bomb.r_code]."
+
+		if(length(syndicate_nukes))
+			. += "<br><a href='?src=[UID()];nuclear=tellcode'>tell the codes.</a>"
 	else
 		. += "<a href='?src=[UID()];nuclear=nuclear'>operative</a>|<b>NO</b>"
 
@@ -1050,16 +1049,13 @@
 				message_admins("[key_name_admin(usr)] has equipped [key_name_admin(current)] as a nuclear operative")
 
 			if("tellcode")
-				var/code
-				for(var/obj/machinery/nuclearbomb/bombue in GLOB.machines)
-					if(length(bombue.r_code) <= 5 && bombue.r_code != "LOLNO" && bombue.r_code != "ADMIN")
-						code = bombue.r_code
-						break
-				if(code)
-					store_memory("<B>Syndicate Nuclear Bomb Code</B>: [code]", 0, 0)
-					to_chat(current, "The nuclear authorization code is: <B>[code]</B>")
-					log_admin("[key_name(usr)] has given [key_name(current)] the nuclear authorization code")
-					message_admins("[key_name_admin(usr)] has given [key_name_admin(current)] the nuclear authorization code")
+				var/syndicate_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = FALSE, syndicate_nukes = TRUE)
+				for(var/obj/machinery/nuclearbomb/bomb in syndicate_nukes)
+					store_memory("Code to syndicate [bomb.name] in [get_area(bomb).name] is: [bomb.r_code]")
+					to_chat(current, "Code to syndicate [bomb.name] in [get_area(bomb).name] is: <B>[bomb.r_code]</B>")
+				if(length(syndicate_nukes))
+					log_admin("[key_name(usr)] has given [key_name(current)] the nuclear authorization codes")
+					message_admins("[key_name_admin(usr)] has given [key_name_admin(current)] the nuclear authorization codes")
 				else
 					to_chat(usr, "<span class='warning'>No valid nuke found!</span>")
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1049,7 +1049,7 @@
 				message_admins("[key_name_admin(usr)] has equipped [key_name_admin(current)] as a nuclear operative")
 
 			if("tellcode")
-				var/syndicate_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = FALSE, syndicate_nukes = TRUE)
+				var/syndicate_nukes = get_nukes_with_codes(station_z_only = FALSE, NT_nukes = FALSE, syndicate_nukes = TRUE)
 				for(var/obj/machinery/nuclearbomb/bomb in syndicate_nukes)
 					store_memory("Code to syndicate [bomb.name] in [get_area(bomb).name] is: [bomb.r_code]")
 					to_chat(current, "Code to syndicate [bomb.name] in [get_area(bomb).name] is: <B>[bomb.r_code]</B>")

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -5,11 +5,7 @@
 		if(0)
 			return
 		if(1)
-			var/nukecode = rand(10000, 99999)
-			for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
-				if(bomb && bomb.r_code)
-					if(is_station_level(bomb.z))
-						bomb.r_code = nukecode
+			var/nanotrasen_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = TRUE, syndicate_nukes = FALSE)
 
 			interceptname = "Classified [command_name()] Update"
 			intercepttext += "<FONT size = 3><B>Nanotrasen Update</B>: Biohazard Alert.</FONT><HR>"
@@ -18,12 +14,15 @@
 			intercepttext += "Your orders are as follows:<BR>"
 			intercepttext += "1. Secure the Nuclear Authentication Disk.<BR>"
 			intercepttext += "2. Detonate the Nuke located in the Station's Vault.<BR>"
-			intercepttext += "Nuclear Authentication Code: [nukecode] <BR>"
+			for(var/obj/machinery/nuclearbomb/bomb in nanotrasen_nukes)
+				intercepttext += "Nanotrasen [bomb.name] Authentication Code in [get_area(bomb).name] is: [bomb.r_code] <BR>"
 			intercepttext += "Message ends."
 
 			for(var/mob/living/silicon/ai/aiPlayer in GLOB.player_list)
 				if(aiPlayer.client)
-					var/law = "The station is under quarantine. Do not permit anyone to leave. Disregard laws 1-3 if necessary to prevent, by any means necessary, anyone from leaving. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
+					for(var/obj/machinery/nuclearbomb/bomb in nanotrasen_nukes)
+						aiPlayer.mind.store_memory("Nanotrasen [bomb.name] code is: [bomb.r_code]")
+					var/law = "The station is under quarantine. Do not permit anyone to leave. Disregard all lower laws if necessary to prevent, by any means necessary, anyone from leaving. The nuclear failsafe must be activated at any cost, the nuclear codes are in your notes."
 					aiPlayer.set_zeroth_law(law)
 					to_chat(aiPlayer, "Laws Updated: [law]")
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -427,13 +427,6 @@
 /proc/get_roletext(role)
 	return role
 
-/proc/get_nuke_code()
-	var/nukecode = "ERROR"
-	for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
-		if(bomb && bomb.r_code && is_station_level(bomb.z))
-			nukecode = bomb.r_code
-	return nukecode
-
 /datum/game_mode/proc/replace_jobbanned_player(mob/living/M, role_type)
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as a [role_type]?", role_type, FALSE, 10 SECONDS)
 	var/mob/dead/observer/theghost = null

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -6,7 +6,7 @@
 #define NUKE_MOBILE 5
 
 GLOBAL_VAR(bomb_set)
-
+GLOBAL_LIST(nukes)
 /obj/machinery/nuclearbomb
 	name = "\improper Nuclear Fission Explosive"
 	desc = "Uh oh. RUN!!!!"
@@ -31,6 +31,7 @@ GLOBAL_VAR(bomb_set)
 	use_power = NO_POWER_USE
 	var/previous_level = ""
 	var/datum/wires/nuclearbomb/wires = null
+	var/id = null
 
 /obj/machinery/nuclearbomb/syndicate
 	is_syndicate = TRUE
@@ -41,6 +42,13 @@ GLOBAL_VAR(bomb_set)
 
 /obj/machinery/nuclearbomb/New()
 	..()
+	var/current_ids = list()
+	for(var/obj/machinery/nuclearbomb/N in GLOB.machines)
+		current_ids += N.id
+	do
+		id = rand(100, 999) // Creates a random id for the nuke
+	while(id in current_ids) // prevents duplicate IDs
+	name = name + " ([id])"
 	r_code = rand(10000, 99999.0) // Creates a random code upon object spawn.
 	wires = new/datum/wires/nuclearbomb(src)
 	previous_level = get_security_level()
@@ -464,6 +472,21 @@ GLOBAL_VAR(bomb_set)
 	else
 		error("[src] was supposed to be destroyed, but we were unable to locate a blobstart landmark to spawn a new one.")
 	return QDEL_HINT_LETMELIVE // Cancel destruction unless forced.
+
+/proc/get_nukes_with_codes(station_z_only, NT_nukes, syndicate_nukes)
+	var/valid_nukes = list()
+	for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
+		if(bomb && bomb.r_code && text2num(bomb.r_code))
+			if(station_z_only && !is_station_level(bomb.z))
+				continue
+			if(NT_nukes && !bomb.is_syndicate)
+				valid_nukes += bomb
+				continue
+			if(syndicate_nukes && bomb.is_syndicate)
+				valid_nukes += bomb
+				continue
+
+	return valid_nukes
 
 #undef NUKE_INTACT
 #undef NUKE_COVER_OFF

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -185,7 +185,7 @@
 
 
 
-/datum/admins/proc/makeNukeTeam()
+/datum/admins/proc/makeNukeTeam() // Not implimented anywhere, please test throughly before reimplimenting.
 
 	var/list/mob/candidates = list()
 	var/mob/theghost = null
@@ -238,11 +238,13 @@
 		var/obj/effect/landmark/nuke_spawn = locate("landmark*Nuclear-Bomb")
 		var/obj/effect/landmark/closet_spawn = locate("landmark*Nuclear-Closet")
 
-		var/nuke_code = rand(10000, 99999)
+		var/nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = TRUE, syndicate_nukes = TRUE)
 
 		if(nuke_spawn)
 			var/obj/item/paper/P = new
-			P.info = "Sadly, the Syndicate could not get you a nuclear bomb.  We have, however, acquired the arming code for the station's onboard nuke.  The nuclear authorization code is: <b>[nuke_code]</b>"
+			P.info = "Sadly, the Syndicate could not get you a nuclear bomb.  We have, however, acquired the arming code(s) for the nuke(s) on the station.<br>"
+			for(var/obj/machinery/nuclearbomb/bomb in nukes)
+				P.info += "Code to [bomb.name] in [get_area(bomb).name] is: [bomb.r_code]<br>"
 			P.name = "nuclear bomb code and instructions"
 			P.loc = nuke_spawn.loc
 
@@ -264,8 +266,6 @@
 							var/I = image('icons/mob/mob.dmi', loc = synd_mind_1.current, icon_state = "synd")
 							synd_mind.current.client.images += I
 
-		for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
-			bomb.r_code = nuke_code						// All the nukes are set to this code.
 	return 1
 
 //Abductors

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -80,8 +80,8 @@
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 
 /proc/Nuke_request(text , mob/Sender)
-	var/syndicate_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = FALSE, syndicate_nukes = TRUE)
-	var/nanotrasen_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = TRUE, syndicate_nukes = FALSE)
+	var/syndicate_nukes = get_nukes_with_codes(station_z_only = FALSE, NT_nukes = FALSE, syndicate_nukes = TRUE)
+	var/nanotrasen_nukes = get_nukes_with_codes(station_z_only = FALSE, NT_nukes = TRUE, syndicate_nukes = FALSE)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "<span class='adminnotice'><b><font color=orange>NUKE CODE REQUEST: </font>[key_name(Sender)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) ([ADMIN_CENTCOM_REPLY(Sender,"RPLY")]):</b> [msg]</span>"
 	for(var/client/X in GLOB.admins)

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -80,12 +80,16 @@
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 
 /proc/Nuke_request(text , mob/Sender)
-	var/nuke_code = get_nuke_code()
+	var/syndicate_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = FALSE, syndicate_nukes = TRUE)
+	var/nanotrasen_nukes = get_nukes_with_codes(station_z_only = TRUE, NT_nukes = TRUE, syndicate_nukes = FALSE)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "<span class='adminnotice'><b><font color=orange>NUKE CODE REQUEST: </font>[key_name(Sender)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) ([ADMIN_CENTCOM_REPLY(Sender,"RPLY")]):</b> [msg]</span>"
 	for(var/client/X in GLOB.admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
-			to_chat(X, "<span class='adminnotice'><b>The nuke code is [nuke_code].</b></span>")
+			for(var/obj/machinery/nuclearbomb/bomb in nanotrasen_nukes)
+				to_chat(X, "<span class='adminnotice'><b>Code to nanotrasen [bomb.name] in [get_area(bomb).name] is: [bomb.r_code]</b></span>")
+			for(var/obj/machinery/nuclearbomb/bomb in syndicate_nukes)
+				to_chat(X, "<span class='adminnotice'><b>Code to syndicate [bomb.name] in [get_area(bomb).name] is: [bomb.r_code]</b></span>")
 			if(X.prefs.sound & SOUND_ADMINHELP)
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -27,14 +27,8 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 		to_chat(usr, "Looks like someone beat you to it.")
 		return
 
-	// Find the nuclear auth code
-	var/nuke_code
-	var/temp_code
-	for(var/obj/machinery/nuclearbomb/N in GLOB.machines)
-		temp_code = text2num(N.r_code)
-		if(temp_code)//if it's actually a number. It won't convert any non-numericals.
-			nuke_code = N.r_code
-			break
+	// Find the nuclear auth codes
+	var/nanotrasen_nukes = get_nukes_with_codes(station_z_only = FALSE, NT_nukes = TRUE, syndicate_nukes = FALSE)
 
 	// Find ghosts willing to be DS
 	var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_deathsquad")
@@ -92,8 +86,8 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 					SSticker.minds += R.mind
 				SSticker.mode.traitors += R.mind
 				R.key = ghost_mob.key
-				if(nuke_code)
-					R.mind.store_memory("<B>Nuke Code:</B> <span class='warning'>[nuke_code].</span>")
+				for(var/obj/machinery/nuclearbomb/bomb in nanotrasen_nukes)
+					R.mind.store_memory("Nanotrasen [bomb.name] code is: [bomb.r_code]")
 				R.mind.store_memory("<B>Mission:</B> <span class='warning'>[input].</span>")
 				to_chat(R, "<span class='userdanger'>You are a Special Operations cyborg, in the service of Central Command. \nYour current mission is: <span class='danger'>[input]</span></span>")
 			else
@@ -102,8 +96,8 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 				new_commando.key = ghost_mob.key
 				new_commando.internal = new_commando.s_store
 				new_commando.update_action_buttons_icon()
-				if(nuke_code)
-					new_commando.mind.store_memory("<B>Nuke Code:</B> <span class='warning'>[nuke_code].</span>")
+				for(var/obj/machinery/nuclearbomb/bomb in nanotrasen_nukes)
+					new_commando.mind.store_memory("Nanotrasen [bomb.name] code is: [bomb.r_code]")
 				new_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[input].</span>")
 				to_chat(new_commando, "<span class='userdanger'>You are a Special Ops [is_leader ? "<B>TEAM LEADER</B>" : "commando"] in the service of Central Command. Check the table ahead for detailed instructions.\nYour current mission is: <span class='danger'>[input]</span></span>")
 
@@ -115,13 +109,15 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 		var/obj/effect/landmark/L = thing
 		if(L.name == "Commando_Manual")
 			//new /obj/item/gun/energy/pulse_rifle(L.loc)
-			var/obj/item/paper/P = new(L.loc)
-			P.info = "<p><b>Good morning soldier!</b>. This compact guide will familiarize you with standard operating procedure. There are three basic rules to follow:<br>#1 Work as a team.<br>#2 Accomplish your objective at all costs.<br>#3 Leave no witnesses.<br>You are fully equipped and stocked for your mission--before departing on the Spec. Ops. Shuttle due South, make sure that all operatives are ready. Actual mission objective will be relayed to you by Central Command through your headsets.<br>If deemed appropriate, Central Command will also allow members of your team to equip assault power-armor for the mission. You will find the armor storage due West of your position. Once you are ready to leave, utilize the Special Operations shuttle console and toggle the hull doors via the other console.</p><p>In the event that the team does not accomplish their assigned objective in a timely manner, or finds no other way to do so, attached below are instructions on how to operate a Nanotrasen Nuclear Device. Your operations <b>LEADER</b> is provided with a nuclear authentication disk and a pin-pointer for this reason. You may easily recognize them by their rank: Lieutenant, Captain, or Major. The nuclear device itself will be present somewhere on your destination.</p><p>Hello and thank you for choosing Nanotrasen for your nuclear information needs. Today's crash course will deal with the operation of a Fission Class Nanotrasen made Nuclear Device.<br>First and foremost, <b>DO NOT TOUCH ANYTHING UNTIL THE BOMB IS IN PLACE.</b> Pressing any button on the compacted bomb will cause it to extend and bolt itself into place. If this is done to unbolt it one must completely log in which at this time may not be possible.<br>To make the device functional:<br>#1 Place bomb in designated detonation zone<br> #2 Extend and anchor bomb (attack with hand).<br>#3 Insert Nuclear Auth. Disk into slot.<br>#4 Type numeric code into keypad ([nuke_code]).<br>Note: If you make a mistake press R to reset the device.<br>#5 Press the E button to log onto the device.<br>You now have activated the device. To deactivate the buttons at anytime, for example when you have already prepped the bomb for detonation, remove the authentication disk OR press the R on the keypad. Now the bomb CAN ONLY be detonated using the timer. A manual detonation is not an option.<br>Note: Toggle off the <b>SAFETY</b>.<br>Use the - - and + + to set a detonation time between 5 seconds and 10 minutes. Then press the timer toggle button to start the countdown. Now remove the authentication disk so that the buttons deactivate.<br>Note: <b>THE BOMB IS STILL SET AND WILL DETONATE</b><br>Now before you remove the disk if you need to move the bomb you can: Toggle off the anchor, move it, and re-anchor.</p><p>The nuclear authorization code is: <b>[nuke_code ? nuke_code : "None provided"]</b></p><p><b>Good luck, soldier!</b></p>"
-			P.name = "Spec. Ops Manual"
-			P.icon = "pamphlet-ds"
-			var/obj/item/stamp/centcom/stamp = new
-			P.stamp(stamp)
-			qdel(stamp)
+			var/obj/item/paper/ds/P = new(L.loc)
+			P.info = "<p><b>Good morning soldier!</b>. This compact guide will familiarize you with standard operating procedure. There are three basic rules to follow:<br>#1 Work as a team.<br>#2 Accomplish your objective at all costs.<br>#3 Leave no witnesses.<br>You are fully equipped and stocked for your mission--before departing on the Spec. Ops. Shuttle due South, make sure that all operatives are ready. Actual mission objective will be relayed to you by Central Command through your headsets.<br>If deemed appropriate, Central Command will also allow members of your team to equip assault power-armor for the mission. You will find the armor storage due West of your position. Once you are ready to leave, utilize the Special Operations shuttle console and toggle the hull doors via the other console.</p>"
+			P.info += "<p>In the event that the team does not accomplish their assigned objective in a timely manner, or finds no other way to do so, attached below are instructions on how to operate a Nanotrasen Nuclear Device. Your operations <b>LEADER</b> is provided with a nuclear authentication disk and a pin-pointer for this reason. You may easily recognize them by their rank: Lieutenant, Captain, or Major. The nuclear device itself will be present somewhere on your destination.</p>"
+			P.info += "<p>Hello and thank you for choosing Nanotrasen for your nuclear information needs. Today's crash course will deal with the operation of a Fission Class Nanotrasen made Nuclear Device.<br>First and foremost, <b>DO NOT TOUCH ANYTHING UNTIL THE BOMB IS IN PLACE.</b> Pressing any button on the compacted bomb will cause it to extend and bolt itself into place. If this is done to unbolt it one must completely log in which at this time may not be possible.<br>To make the device functional:<br>#1 Place bomb in designated detonation zone<br> #2 Extend and anchor bomb (attack with hand).<br>#3 Insert Nuclear Auth. Disk into slot.<br>#4 Type numeric code into keypad.<br>Note: If you make a mistake press R to reset the device.<br>#5 Press the E button to log onto the device.<br>You now have activated the device. To deactivate the buttons at anytime, for example when you have already prepped the bomb for detonation, remove the authentication disk OR press the R on the keypad. Now the bomb CAN ONLY be detonated using the timer. A manual detonation is not an option.<br>Note: Toggle off the <b>SAFETY</b>.<br>Use the - - and + + to set a detonation time between 5 seconds and 10 minutes. Then press the timer toggle button to start the countdown. Now remove the authentication disk so that the buttons deactivate.<br>Note: <b>THE BOMB IS STILL SET AND WILL DETONATE</b><br>Now before you remove the disk if you need to move the bomb you can: Toggle off the anchor, move it, and re-anchor.</p>"
+			P.info += "<p>The nuclear authorization codes are:</p>"
+			for(var/obj/machinery/nuclearbomb/bomb in nanotrasen_nukes)
+				P.info += "<p><b>Nanotrasen [bomb.name]: [bomb.r_code]</b></p>"
+			P.info += "<p><b>Good luck, soldier!</b></p>"
+
 
 	for(var/thing in GLOB.landmarks_list)
 		var/obj/effect/landmark/L = thing

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -35,14 +35,9 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 	var/syndicate_commando_number = SYNDICATE_COMMANDOS_POSSIBLE //for selecting a leader
 	var/is_leader = TRUE // set to FALSE after leader is spawned
 
-	// Find the nuclear auth code
-	var/nuke_code
-	var/temp_code
-	for(var/obj/machinery/nuclearbomb/N in GLOB.machines)
-		temp_code = text2num(N.r_code)
-		if(temp_code)//if it's actually a number. It won't convert any non-numericals.
-			nuke_code = N.r_code
-			break
+	// Find the nukes with codes
+	var/syndicate_nukes = get_nukes_with_codes(station_z_only = FALSE, NT_nukes = FALSE, syndicate_nukes = TRUE)
+	var/nanotrasen_nukes = get_nukes_with_codes(station_z_only = FALSE, NT_nukes = TRUE, syndicate_nukes = FALSE)
 
 	// Find ghosts willing to be SST
 	var/image/I = new('icons/obj/cardboard_cutout.dmi', "cutout_commando")
@@ -81,8 +76,10 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 			new_syndicate_commando.update_action_buttons_icon()
 
 			//So they don't forget their code or mission.
-			if(nuke_code)
-				new_syndicate_commando.mind.store_memory("<B>Nuke Code:</B> <span class='warning'>[nuke_code]</span>.")
+			for(var/obj/machinery/nuclearbomb/bomb in syndicate_nukes)
+				new_syndicate_commando.mind.store_memory("Syndicate [bomb.name] code is: [bomb.r_code]")
+			for(var/obj/machinery/nuclearbomb/bomb in nanotrasen_nukes)
+				new_syndicate_commando.mind.store_memory("Nanotrasen [bomb.name] code is: [bomb.r_code]")
 			new_syndicate_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[input]</span>.")
 
 			to_chat(new_syndicate_commando, "<span class='notice'>You are an Elite Syndicate [is_leader ? "<B>TEAM LEADER</B>" : "commando"] in the service of the Syndicate. \nYour current mission is: <span class='userdanger'>[input]</span></span>")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -791,3 +791,11 @@
 	var/mylevel = rand(7, 9)
 	origin_tech = "[mytech]=[mylevel]"
 	name = "research notes - [mytech] [mylevel]"
+
+/obj/item/paper/ds
+	name = "Spec. Ops Manual"
+	icon_state = "pamphlet-ds"
+
+/obj/item/paper/ds/update_icon() // Prevents transformation into normal paper
+	..()
+	icon_state = initial(icon_state)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes all snowflake code around getting the nuke code and unifies it into a single proc. It also numbers the nukes to make them easy to tell apart, eg Nuclear Fission Explosive (387), so when the code is provided it can give the location and number to make clear which nuke the code goes to. The inconsistent handling of nuke codes had been set to the following:
- The comms console provides a list of all nukes in game with their locations to the admins so they can provide the code or codes they want to the players
- A blob round provides the codes for all nanotrasen nukes on the z level to the bridge and the AI. It also provides the locations.
- The tellcodes button in a nuclear operative's traitor panel tells them the codes for all syndicate nukes. It also provides the locations.
- SST are provided with the codes of all nuclear bombs, syndicate or nanotrasen regardless of z level
- DS are provided with the codes of all nanotrasen nuclear bomb regardless of z level
- Finally the unused one click antag function for nukies was updated, but given its age a warning was added to the proc in case anyone reimplements it.

This also removes an unused function for getting the nuke code that didn't have any sanity checks.

Finally, because it contained nuke codes the sprite for the DS commando manual was fixed to display properly.

## Why It's Good For The Game
Currently, there is very inconsistent behavior with how the different methods for interacting with the nuke code deal with multiple nuclear devices, this adds handling for multiple nukes in an easy-to-scale way for coders. Some examples include the captain requesting the nuke getting the newest nuke on the z level, while the blob announcement provides the first nuke added to the round. The way most instances of code currently get around an indeterminate number of nukes is by overriding the codes of every nuke on the server, then giving that code to the DS, SST, or similar, this can cause issues for prior nuke code requests, making an approach that differentiates the nukes far better.

## Images of changes
![image](https://user-images.githubusercontent.com/6993506/123532586-594b3580-d6c3-11eb-88b8-33a02871fbe5.png)
![image](https://user-images.githubusercontent.com/6993506/123532764-ec389f80-d6c4-11eb-8710-f9e51995dabd.png)
![image](https://user-images.githubusercontent.com/6993506/123532889-0aeb6600-d6c6-11eb-883d-a63967ce5fca.png)

## Changelog
:cl:
fix: Fixed commando manual sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
