### PR TITLE
Refactors AI slipping machines

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -215,11 +215,3 @@
 	if(!ai_control_check(user))
 		return
 	toggle_light(user)
-
-// AI-CONTROLLED SLIP GENERATOR IN AI CORE
-
-/obj/machinery/ai_slipper/AICtrlClick(mob/living/silicon/ai/user) //Turns liquid dispenser on or off
-	ToggleOn()
-
-/obj/machinery/ai_slipper/AIAltClick() //Dispenses liquid if on
-	Activate()

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -169,16 +169,6 @@
 /obj/machinery/power/apc/BorgCtrlClick(mob/living/silicon/robot/user) // turns off/on APCs. Forwards to AI code.
 	AICtrlClick(user)
 
-
-// AI SLIPPER
-
-/obj/machinery/ai_slipper/BorgCtrlClick(mob/living/silicon/robot/user) //Turns liquid dispenser on or off
-	ToggleOn()
-
-/obj/machinery/ai_slipper/BorgAltClick(mob/living/silicon/robot/user) //Dispenses liquid if on
-	Activate()
-
-
 // TURRETCONTROL
 
 /obj/machinery/turretid/BorgCtrlClick(mob/living/silicon/robot/user) //turret control on/off. Forwards to AI code.

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -14,7 +14,7 @@
 
 /obj/machinery/ai_slipper/examine(mob/user)
 	. = ..()
-	. += "A small counter shows it has: <B><U>[uses]</U></B> uses remaining."
+	. += "<span class='notice'>A small counter shows it has: [uses] uses remaining.</span>"
 
 /obj/machinery/ai_slipper/power_change()
 	if(powered())
@@ -33,10 +33,10 @@
 
 /obj/machinery/ai_slipper/attack_hand(mob/user)
 	if(stat & (NOPOWER|BROKEN))
-		to_chat(user, "[src] has no power or is broken!")
+		to_chat(user, "<span class='warning'>[src] has no power or is broken!</span>")
 		return
 	if(!allowed(user))
-		to_chat(user, "Access denied.")
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	Activate(user)
 
@@ -44,10 +44,10 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	if(!uses)
-		to_chat(user, "[src] is empty!")
+		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return
 	if(cooldown_on)
-		to_chat(user, "[src] is still recharging!")
+		to_chat(user, "<span class='warning'>[src] is still recharging!</span>")
 		return
 	else
 		new /obj/effect/particle_effect/foam(loc)

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -14,7 +14,7 @@
 
 /obj/machinery/ai_slipper/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>A small counter shows it has: [uses] uses remaining.</span>"
+	. += "<span class='notice'>A small counter shows it has: [uses] use\s remaining.</span>"
 
 /obj/machinery/ai_slipper/power_change()
 	if(powered())

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -4,133 +4,66 @@
 	icon_state = "liquid_dispenser"
 	layer = 3
 	plane = FLOOR_PLANE
-	anchored = 1.0
+	anchored = TRUE
 	max_integrity = 200
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 30)
 	var/uses = 20
-	var/disabled = TRUE
-	var/lethal = 0
-	var/locked = TRUE
-	var/cooldown_time = 0
-	var/cooldown_timeleft = 0
+	var/cooldown_time = 10 SECONDS
 	var/cooldown_on = FALSE
 	req_access = list(ACCESS_AI_UPLOAD)
 
+/obj/machinery/ai_slipper/examine(mob/user)
+	. = ..()
+	. += "A small counter shows it has: <B><U>[uses]</U></B> uses remaining."
+
 /obj/machinery/ai_slipper/power_change()
-	if(stat & BROKEN)
-		update_icon()
+	if(powered())
+		stat &= ~NOPOWER
 	else
-		if( powered() )
-			stat &= ~NOPOWER
-		else
-			stat |= NOPOWER
-			disabled = TRUE
-		update_icon()
-
-/obj/machinery/ai_slipper/proc/setState(enabled, uses)
-	disabled = disabled
-	uses = uses
-	power_change()
-
-/obj/machinery/ai_slipper/attackby(obj/item/W, mob/user, params)
-	if(stat & (NOPOWER|BROKEN))
-		return
-	if(istype(user, /mob/living/silicon))
-		return attack_hand(user)
-	if(allowed(usr)) // trying to unlock the interface
-		locked = !locked
-		to_chat(user, "You [locked ? "lock" : "unlock"] the device.")
-		if(locked)
-			if(user.machine == src)
-				user.unset_machine()
-				user << browse(null, "window=ai_slipper")
-		else
-			if(user.machine == src)
-				attack_hand(usr)
-		return
-	return ..()
-
-/obj/machinery/ai_slipper/proc/ToggleOn()
-	if(stat & (NOPOWER|BROKEN))
-		return
-	disabled = !disabled
+		stat |= NOPOWER
 	update_icon()
 
-/obj/machinery/ai_slipper/proc/Activate()
+/obj/machinery/ai_slipper/attack_ai(mob/user)
+	add_hiddenprint(user)
+	return attack_hand(user)
+
+/obj/machinery/ai_slipper/attack_ghost(mob/user)
+	if(user.can_advanced_admin_interact())
+		Activate(user)
+
+/obj/machinery/ai_slipper/attack_hand(mob/user)
+	if(stat & (NOPOWER|BROKEN))
+		to_chat(user, "[src] has no power or is broken!")
+		return
+	if(!allowed(user))
+		to_chat(user, "Access denied.")
+		return
+	Activate(user)
+
+/obj/machinery/ai_slipper/proc/Activate(mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if(cooldown_on || disabled)
+	if(!uses)
+		to_chat(user, "[src] is empty!")
+		return
+	if(cooldown_on)
+		to_chat(user, "[src] is still recharging!")
 		return
 	else
 		new /obj/effect/particle_effect/foam(loc)
 		uses--
 		cooldown_on = TRUE
-		cooldown_time = world.timeofday + 100
-		slip_process()
+		power_change()
+		addtimer(CALLBACK(src, .proc/recharge), cooldown_time)
 
 /obj/machinery/ai_slipper/update_icon()
-	if(stat & (NOPOWER|BROKEN) || disabled)
+	if(stat & (NOPOWER|BROKEN) || cooldown_on || !uses)
 		icon_state = "liquid_dispenser"
 	else
 		icon_state = "liquid_dispenser_on"
 
-/obj/machinery/ai_slipper/attack_ai(mob/user)
-	return attack_hand(user)
-
-/obj/machinery/ai_slipper/attack_ghost(mob/user)
-	return attack_hand(user)
-
-/obj/machinery/ai_slipper/attack_hand(mob/user)
-	if(stat & (NOPOWER|BROKEN))
+/obj/machinery/ai_slipper/proc/recharge()
+	if(!uses)
 		return
-
-	if(get_dist(src, user) > 1 && (!issilicon(user) && !user.can_admin_interact()))
-		to_chat(user, "<span class='warning'>Too far away.</span>")
-		user.unset_machine()
-		user << browse(null, "window=ai_slipper")
-		return
-
-	user.set_machine(src)
-	var/area/myarea = get_area(src)
-	var/t = "<TT><B>AI Liquid Dispenser</B> ([myarea.name])<HR>"
-
-	if(locked && (!issilicon(user) && !user.can_admin_interact()))
-		t += "<I>(Swipe ID card to unlock control panel.)</I><BR>"
-	else
-		t += text("Dispenser [] - <A href='?src=[UID()];toggleOn=1'>[]?</a><br>\n", disabled ? "deactivated" : "activated", disabled ? "Enable" : "Disable")
-		t += text("Uses Left: [uses]. <A href='?src=[UID()];toggleUse=1'>Activate the dispenser?</A><br>\n")
-
-	user << browse(t, "window=computer;size=575x450")
-	onclose(user, "computer")
-
-/obj/machinery/ai_slipper/Topic(href, href_list)
-	if(..())
-		return 1
-
-	if(locked && (!issilicon(usr) && !usr.can_admin_interact()))
-		to_chat(usr, "Control panel is locked!")
-		return 1
-
-	if(href_list["toggleOn"])
-		ToggleOn()
-
-	if(href_list["toggleUse"])
-		Activate()
-
-	attack_hand(usr)
-
-/obj/machinery/ai_slipper/proc/slip_process()
-	while(cooldown_time - world.timeofday > 0)
-		var/ticksleft = cooldown_time - world.timeofday
-
-		if(ticksleft > 1e5)
-			cooldown_time = world.timeofday + 10	// midnight rollover
-
-
-		cooldown_timeleft = (ticksleft / 10)
-		sleep(5)
-	if(uses <= 0)
-		return
-	if(uses >= 0)
-		cooldown_on = FALSE
+	cooldown_on = FALSE
 	power_change()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR removes the useless browser interface for the AI slippers that allowed them to be locked and unlocked and activated.
They are now either on or off. Clicking them while on will dispense foam if you have access (AI upload access) or are a silicon.
Inspect text added to show uses remaining.
Chat messages added to various interactions: Clicking while power off, clicking while empty, clicking while recharging.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Old bad code is bad.
Simple devices should be simple to use.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked the AI slipping machines to be click-interaction only.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
