### PR TITLE
Prevents ghosts from setting off mousetraps

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -164,9 +164,10 @@
 	if(!user.client)
 		return
 	if(user.s_active != src) // Switching from another container
-		for(var/obj/item/I in src)
-			if(I.on_found(user)) // For mouse traps and such
-				return // If something triggered, don't open the UI
+		if(!isobserver(user)) //Don't want ghosts setting off the fun stuff
+			for(var/obj/item/I in src)
+				if(I.on_found(user)) // For mouse traps and such
+					return // If something triggered, don't open the UI
 	orient2hud(user) // this only needs to happen to make .contents show properly as screen objects.
 	if(user.s_active)
 		user.s_active.hide_from(user) // If there's already an interface open, close it.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -164,10 +164,9 @@
 	if(!user.client)
 		return
 	if(user.s_active != src && !isobserver(user))
-		if(!isobserver(user)) //Don't want ghosts setting off the fun stuff
-			for(var/obj/item/I in src)
-				if(I.on_found(user)) // For mouse traps and such
-					return // If something triggered, don't open the UI
+		for(var/obj/item/I in src)
+			if(I.on_found(user)) // For mouse traps and such
+				return // If something triggered, don't open the UI
 	orient2hud(user) // this only needs to happen to make .contents show properly as screen objects.
 	if(user.s_active)
 		user.s_active.hide_from(user) // If there's already an interface open, close it.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -163,7 +163,7 @@
 /obj/item/storage/proc/show_to(mob/user)
 	if(!user.client)
 		return
-	if(user.s_active != src) // Switching from another container
+	if(user.s_active != src && !isobserver(user))
 		if(!isobserver(user)) //Don't want ghosts setting off the fun stuff
 			for(var/obj/item/I in src)
 				if(I.on_found(user)) // For mouse traps and such


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds an isobserver check to inventory code, that prevents each item trying isfound against the ghost when a storage container is open.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ghosts should not be able to remotely set off moustraps / facehuggers / mousetrap bombs.


## Changelog
:cl:
fix: Ghosts can no longer set off mousetrap assemblies and facehuggers in storage containers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
