### PR TITLE
Gives the Singularity Hammer a much needed buff. 

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -641,8 +641,8 @@
 	icon_state = "singulohammer0"
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
-	force = 15
-	force_unwielded = 15
+	force = 5
+	force_unwielded = 5
 	force_wielded = 40
 	throwforce = 15
 	throw_range = 1

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -641,15 +641,15 @@
 	icon_state = "singulohammer0"
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
-	force = 5
-	force_unwielded = 5
-	force_wielded = 20
+	force = 15
+	force_unwielded = 15
+	force_wielded = 40
 	throwforce = 15
 	throw_range = 1
 	w_class = WEIGHT_CLASS_HUGE
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	var/charged = 5
+	var/charged = 2
 	origin_tech = "combat=4;bluespace=4;plasmatech=7"
 
 /obj/item/twohanded/singularityhammer/New()
@@ -661,7 +661,7 @@
 	return ..()
 
 /obj/item/twohanded/singularityhammer/process()
-	if(charged < 5)
+	if(charged < 2)
 		charged++
 
 /obj/item/twohanded/singularityhammer/update_icon()  //Currently only here to fuck with the on-mob icons.
@@ -684,7 +684,7 @@
 				var/obj/item/clothing/shoes/magboots/M = H.shoes
 				if(M.magpulse)
 					continue
-			H.apply_effect(1, WEAKEN, 0)
+			H.Weaken(2)
 			step_towards(H, pull)
 			step_towards(H, pull)
 			step_towards(H, pull)
@@ -693,7 +693,7 @@
 	if(!proximity)
 		return
 	if(wielded)
-		if(charged == 5)
+		if(charged == 2)
 			charged = 0
 			if(isliving(A))
 				var/mob/living/Z = A


### PR DESCRIPTION
## What Does This PR Do
Exactly what it says on the tin, this PR gives the singularity hammer just a flat buff. It increases the damage of the hammer when wielded to 40 brute, reduces the charge time, and increases the weaken time to four seconds as opposed to two. 
## Why It's Good For The Game
The singularity hammer's description quite literally has "The pinnacle of close combat technology" written in it, yet it's damage is outclassed by virtually every weapon in the twohanded.dm folder, including a literal fire-axe and several other mundane one handed weapons like the meat cleaver. It goes virtually unpicked by every single wizard due to it's terrible combat performance and sharing the metaphorical love is a paramount change if we are to have some wizard variety. 

## Changelog
:cl:
tweak: Upped the brute damage from 20 to 40, decreased the charge time from ten to four seconds, and increased the stun time two to zero seconds to four seconds on the singularity hammer. 
fix: cleaned up some of the singularity hammer code in order for it to be more legible. 
/:cl: