### PR TITLE
[MDB IGNORE] Map variable sanitisation

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -17,8 +17,8 @@
 "ad" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -194,8 +194,8 @@
 /obj/item/bodybag,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -271,8 +271,8 @@
 /area/ruin/powered/animal_hospital)
 "aJ" = (
 /turf/simulated/floor/plasteel/grimy{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -655,24 +655,24 @@
 /area/ruin/powered/animal_hospital)
 "bL" = (
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
 "bM" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
 "bO" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -743,8 +743,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -753,8 +753,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -763,8 +763,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -773,16 +773,16 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
 "cb" = (
 /obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -861,8 +861,8 @@
 "cn" = (
 /obj/machinery/light,
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -932,8 +932,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -964,8 +964,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
@@ -975,8 +975,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -269,7 +269,6 @@
 /area/ruin/unpowered/ash_walkers)
 "aO" = (
 /obj/structure/stone_tile/surrounding/cracked{
-	icon_state = "cracked_surrounding1";
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -999,7 +998,6 @@
 /area/ruin/unpowered/ash_walkers)
 "cA" = (
 /obj/structure/stone_tile/slab/cracked{
-	icon_state = "cracked_slab1";
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -4,8 +4,8 @@
 /area/template_noop)
 "b" = (
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -26,8 +26,8 @@
 "g" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -39,8 +39,8 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -48,8 +48,8 @@
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -58,16 +58,16 @@
 /obj/item/clothing/shoes/cult,
 /obj/item/clothing/suit/hooded/cultrobes,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -90,8 +90,8 @@
 	name = "ohfuck"
 	},
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -101,8 +101,8 @@
 /obj/item/clothing/suit/hooded/cultrobes,
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
 	nitrogen = 23;
+	oxygen = 24;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dead_ratvar.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dead_ratvar.dmm
@@ -16,8 +16,8 @@
 "e" = (
 /obj/item/stack/tile/brass,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -30,8 +30,8 @@
 /area/lavaland/surface/outdoors/unexplored)
 "h" = (
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -45,8 +45,8 @@
 "k" = (
 /obj/item/clockwork/alloy_shards/small,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -68,8 +68,8 @@
 "p" = (
 /obj/item/clockwork/alloy_shards/medium,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -84,8 +84,8 @@
 "s" = (
 /obj/item/clockwork/alloy_shards/large,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -96,8 +96,8 @@
 "u" = (
 /obj/structure/grille/ratvar,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -109,8 +109,8 @@
 "w" = (
 /obj/structure/grille/ratvar/broken,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -118,48 +118,48 @@
 /obj/structure/clockwork/wall_gear,
 /obj/item/stack/tile/brass,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
 "y" = (
 /obj/item/clockwork/component/geis_capacitor/fallen_armor,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
 "z" = (
 /obj/structure/clockwork/wall_gear,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
 "A" = (
 /obj/item/clockwork/alloy_shards/clockgolem_remains,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
 "B" = (
 /obj/item/clockwork/weapon/ratvarian_spear,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
 "C" = (
 /obj/item/clockwork/alloy_shards/medium/gear_bit,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)
@@ -174,8 +174,8 @@
 "F" = (
 /obj/structure/dead_ratvar,
 /turf/simulated/floor/clockwork{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors/unexplored)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -13,10 +13,10 @@
 /area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /obj/structure/mirror{
+	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_x = -28;
-	broken = 1
+	pixel_x = -28
 	},
 /obj/item/clothing/suit/bloated_human,
 /obj/effect/decal/cleanable/blood,
@@ -25,20 +25,20 @@
 /area/ruin/unpowered/misc_lavaruin)
 "f" = (
 /obj/structure/mirror{
+	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_x = 28;
-	broken = 1
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating/burnt,
 /area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/mirror{
+	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_x = -28;
-	broken = 1
+	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/misc_lavaruin)
@@ -55,29 +55,29 @@
 /area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /obj/structure/mirror{
+	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_y = 28;
-	broken = 1
+	pixel_y = 28
 	},
 /obj/item/kitchen/knife/envy,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/misc_lavaruin)
 "l" = (
 /obj/structure/mirror{
+	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_x = 28;
-	broken = 1
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/structure/mirror{
+	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_x = -28;
-	broken = 1
+	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/misc_lavaruin)
@@ -86,10 +86,10 @@
 /area/ruin/unpowered/misc_lavaruin)
 "o" = (
 /obj/structure/mirror{
+	broken = 1;
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_x = -28;
-	broken = 1
+	pixel_x = -28
 	},
 /turf/simulated/floor/plating/damaged,
 /area/ruin/unpowered/misc_lavaruin)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -28,7 +28,6 @@
 /area/shuttle/freegolem)
 "h" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -105,8 +104,7 @@
 	name = "statue of the Liberator"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/purple,
 /area/shuttle/freegolem)
@@ -153,8 +151,7 @@
 /area/shuttle/freegolem)
 "C" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/item/bedsheet/rd/royal_cape{
@@ -172,7 +169,6 @@
 "D" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/purp{
-	icon_state = "comfychair";
 	dir = 1
 	},
 /turf/simulated/floor/mineral/titanium/purple,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -170,8 +170,8 @@
 "J" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/powered)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hierophant.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hierophant.dmm
@@ -7,8 +7,8 @@
 /area/ruin/unpowered/hierophant)
 "c" = (
 /obj/effect/light_emitter{
-	light_range = 3;
-	light_power = 5
+	light_power = 5;
+	light_range = 3
 	},
 /turf/simulated/floor/indestructible/hierophant,
 /area/ruin/unpowered/hierophant)
@@ -21,8 +21,8 @@
 /area/ruin/unpowered/hierophant)
 "f" = (
 /obj/effect/light_emitter{
-	light_range = 3;
-	light_power = 5
+	light_power = 5;
+	light_range = 3
 	},
 /turf/simulated/floor/indestructible/hierophant/two,
 /area/ruin/unpowered/hierophant)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -15,8 +15,8 @@
 "e" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -24,8 +24,8 @@
 /obj/structure/table/wood,
 /obj/item/storage/box/cups,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -33,16 +33,16 @@
 /obj/structure/reagent_dispensers/water_cooler/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -50,8 +50,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -59,8 +59,8 @@
 /obj/item/reagent_containers/food/snacks/mushroompizzaslice,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -69,8 +69,8 @@
 /obj/effect/spawner/lootdrop/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -83,8 +83,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -92,8 +92,8 @@
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -101,8 +101,8 @@
 /obj/structure/glowshroom/single,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -110,8 +110,8 @@
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -119,8 +119,8 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -128,8 +128,8 @@
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -141,15 +141,15 @@
 	name = "party hat"
 	},
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "s" = (
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -157,16 +157,16 @@
 /obj/structure/chair/wood/wings,
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "u" = (
 /obj/structure/glowshroom/single,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -179,8 +179,8 @@
 /obj/item/kitchen/utensil/fork,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -188,8 +188,8 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/pizzaparty,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -197,8 +197,8 @@
 /obj/structure/table/wood,
 /obj/item/trash/plate,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -207,8 +207,8 @@
 /obj/structure/glowshroom/single,
 /obj/item/a_gift,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -217,16 +217,16 @@
 /obj/item/trash/plate,
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "B" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -236,8 +236,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -246,8 +246,8 @@
 /obj/item/reagent_containers/food/snacks/margheritaslice,
 /obj/item/trash/plate,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -255,8 +255,8 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meatpizzaslice,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -264,24 +264,24 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/sliceable/birthdaycake,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "G" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "H" = (
 /obj/item/chair/wood/wings,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -289,8 +289,8 @@
 /obj/item/kitchen/utensil/fork,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -298,8 +298,8 @@
 /obj/structure/glowshroom/single,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -310,8 +310,8 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -319,8 +319,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -328,8 +328,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/a_gift,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -342,8 +342,8 @@
 /obj/item/kitchen/knife,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -353,15 +353,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "Q" = (
 /turf/simulated/floor/plating{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -8,13 +8,11 @@
 "c" = (
 /obj/item/paper/fluff/stations/lavaland/sloth/note,
 /turf/simulated/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -22,7 +20,6 @@
 /obj/machinery/door/airlock/wood,
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -30,7 +27,6 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
 /turf/simulated/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -38,14 +34,12 @@
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/simulated/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered/misc_lavaruin)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
@@ -10,8 +10,8 @@
 /area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/floor/mineral/plastitanium/red{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
@@ -24,16 +24,16 @@
 "f" = (
 /mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon,
 /turf/simulated/floor/mineral/plastitanium/red{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/mineral/plastitanium/red{
-	oxygen = 14;
 	nitrogen = 23;
+	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered/misc_lavaruin)

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -9,8 +9,8 @@
 	power = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
@@ -20,8 +20,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
@@ -32,8 +31,8 @@
 	power = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -55,8 +54,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
@@ -93,8 +92,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
@@ -160,7 +158,6 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/razor,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -178,8 +175,7 @@
 	},
 /obj/item/storage/box/beakers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -202,8 +198,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Bio Containment";
@@ -220,14 +215,13 @@
 	power = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -246,8 +240,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/ruin/unpowered)
@@ -256,8 +249,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/gun/energy/floragun,
 /turf/simulated/floor/plasteel{
@@ -268,8 +260,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -279,8 +270,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -295,8 +285,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -325,8 +314,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/ruin/unpowered)
@@ -368,12 +356,11 @@
 "aS" = (
 /obj/machinery/power/apc/worn_out{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/rack,
 /obj/item/melee/baton/cattleprod,
@@ -391,8 +378,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/medical,
@@ -478,8 +464,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -488,8 +473,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -508,8 +492,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -586,8 +569,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -626,8 +608,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -637,8 +618,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -692,7 +672,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
@@ -54,15 +54,14 @@
 /area/ruin/tcommsat)
 "an" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Worn-out APC";
 	pixel_x = 1;
 	pixel_y = 26
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/tcommsat)
@@ -114,8 +113,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/tcommsat)

--- a/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
@@ -7,9 +7,8 @@
 /area/space/nearstation)
 "c" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -107,9 +106,8 @@
 /area/space/nearstation)
 "A" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (EAST)";
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8

--- a/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
@@ -101,7 +101,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/burnt,

--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -113,7 +113,6 @@
 "aj" = (
 /obj/structure/closet/cardboard,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/flashlight/flare,
@@ -173,8 +172,7 @@
 "ao" = (
 /obj/structure/closet/cardboard,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/ammo_box/c9mm,
 /obj/item/ammo_box/c9mm,
@@ -234,9 +232,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -256,8 +252,7 @@
 	pixel_y = 6
 	},
 /obj/item/gun/projectile/automatic/wt550{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
@@ -342,14 +337,14 @@
 "aH" = (
 /obj/machinery/vending/clothing,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/ruin/unpowered)
 "aI" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken2";
-	icon_state = "wood-broken2"
+	icon_state = "wood-broken2";
+	tag = "icon-wood-broken2"
 	},
 /area/ruin/unpowered)
 "aJ" = (
@@ -391,7 +386,6 @@
 "aO" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -404,16 +398,15 @@
 /obj/item/reagent_containers/food/drinks/cans/cola,
 /obj/item/reagent_containers/food/drinks/cans/cola,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "aQ" = (
 /obj/structure/closet/wardrobe/pink,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken2";
-	icon_state = "wood-broken2"
+	icon_state = "wood-broken2";
+	tag = "icon-wood-broken2"
 	},
 /area/ruin/unpowered)
 "aR" = (
@@ -422,8 +415,8 @@
 "aS" = (
 /obj/structure/bed,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/ruin/unpowered)
 "aT" = (
@@ -475,15 +468,15 @@
 /area/ruin/unpowered)
 "aZ" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/ruin/unpowered)
 "ba" = (
 /obj/structure/bed,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken2";
-	icon_state = "wood-broken2"
+	icon_state = "wood-broken2";
+	tag = "icon-wood-broken2"
 	},
 /area/ruin/unpowered)
 "bb" = (
@@ -519,15 +512,14 @@
 /area/ruin/unpowered)
 "bf" = (
 /obj/structure/closet/fireaxecabinet{
-	tag = "icon-fireaxe0130";
 	icon_state = "fireaxe0130";
-	pixel_y = 28
+	pixel_y = 28;
+	tag = "icon-fireaxe0130"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "bg" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper-open";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -550,7 +542,6 @@
 /area/ruin/unpowered)
 "bj" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper-open";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -593,8 +584,8 @@
 /area/ruin/unpowered)
 "br" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
@@ -637,7 +628,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -650,30 +640,30 @@
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bB" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bC" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bE" = (
@@ -681,8 +671,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bF" = (
@@ -692,14 +682,13 @@
 "bG" = (
 /obj/machinery/power/apc/noalarm{
 	dir = 8;
-	name = "Bunker APC";
 	keep_preset_name = 1;
-	pixel_x = -24;
-	pixel_y = 0
+	name = "Bunker APC";
+	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -708,7 +697,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -730,23 +718,23 @@
 /obj/structure/table,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bL" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bM" = (
 /obj/structure/table,
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bN" = (
@@ -759,9 +747,8 @@
 /area/ruin/unpowered)
 "bP" = (
 /obj/structure/chair/office/dark{
-	tag = "icon-officechair_dark (EAST)";
-	icon_state = "officechair_dark";
-	dir = 4
+	dir = 4;
+	tag = "icon-officechair_dark (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -772,15 +759,15 @@
 "bR" = (
 /obj/machinery/smartfridge,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bS" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bar";
-	icon_state = "bar"
+	icon_state = "bar";
+	tag = "icon-bar"
 	},
 /area/ruin/unpowered)
 "bT" = (
@@ -809,7 +796,6 @@
 	dir = 1;
 	name = "Bunker Entrance";
 	network = list("Bunker1");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
@@ -4,9 +4,8 @@
 /area/template_noop)
 "b" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/template_noop,
 /area/space/nearstation)
@@ -16,22 +15,19 @@
 /area/ruin/powered)
 "d" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (WEST)";
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/template_noop,
 /area/space/nearstation)
 "e" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (WEST)";
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/powered)
@@ -45,9 +41,8 @@
 /area/ruin/powered)
 "h" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered)
@@ -56,9 +51,8 @@
 /area/ruin/powered)
 "j" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered)
@@ -69,17 +63,15 @@
 "l" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/powered)
 "m" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel,
@@ -99,26 +91,23 @@
 /area/ruin/powered)
 "o" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered)
 "p" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/template_noop,
 /area/space/nearstation)
 "q" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
@@ -26,9 +26,8 @@
 /area/ruin/unpowered)
 "i" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (WEST)";
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/titanium/blue/airless,
@@ -44,7 +43,6 @@
 "l" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -76,9 +74,8 @@
 /area/ruin/unpowered)
 "r" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (WEST)";
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1

--- a/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
@@ -160,8 +160,8 @@
 	},
 /obj/machinery/tcomms/relay/ruskie,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/djstation)
 "av" = (
@@ -282,16 +282,16 @@
 /area/djstation)
 "aG" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/smes/magical{
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
 	name = "power storage unit"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/djstation)
 "aH" = (
@@ -342,8 +342,8 @@
 /area/djstation)
 "aM" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 0;
@@ -398,9 +398,7 @@
 /turf/simulated/floor/plating,
 /area/djstation)
 "aR" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "rampbottom";
@@ -467,8 +465,8 @@
 	},
 /obj/structure/table,
 /obj/item/paper/djstation{
-	name = "communications update";
-	info = "Station has stopped responding to my reports for about the past month. I assume Vostok just has his knickers in a twist.<br><br>Hell, not my problem. Got all the vodka and cigarettes I need to last me a year."
+	info = "Station has stopped responding to my reports for about the past month. I assume Vostok just has his knickers in a twist.<br><br>Hell, not my problem. Got all the vodka and cigarettes I need to last me a year.";
+	name = "communications update"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -661,20 +659,19 @@
 /obj/structure/table,
 /obj/item/radio/intercom/pirate,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/djstation)
 "by" = (
 /obj/structure/table,
 /obj/item/paper/djstation{
+	info = "<B>Welcome new owner!</B><BR><BR>You have purchased the latest in listening equipment. The telecommunication setup we created is the best in listening to common and private radio fequencies. Here is a step by step guide to start listening in on those saucy radio channels:<br><ol><li>Equip yourself with a multi-tool</li><li>Use the multitool on each machine, that is the broadcaster, receiver and the relay.</li><li>Turn all the machines on, it has already been configured for you to listen on.</li></ol> Simple as that. Now to listen to the private channels, you'll have to configure the intercoms, located on the front desk. Here is a list of frequencies for you to listen on.<br><ul><li>145.7 - Common Channel</li><li>144.7 - Private AI Channel</li><li>135.9 - Security Channel</li><li>135.7 - Engineering Channel</li><li>135.5 - Medical Channel</li><li>135.3 - Command Channel</li><li>135.1 - Science Channel</li><li>134.7 - Supply Channel</li>";
 	pixel_x = 5;
-	pixel_y = 17;
-	info = "<B>Welcome new owner!</B><BR><BR>You have purchased the latest in listening equipment. The telecommunication setup we created is the best in listening to common and private radio fequencies. Here is a step by step guide to start listening in on those saucy radio channels:<br><ol><li>Equip yourself with a multi-tool</li><li>Use the multitool on each machine, that is the broadcaster, receiver and the relay.</li><li>Turn all the machines on, it has already been configured for you to listen on.</li></ol> Simple as that. Now to listen to the private channels, you'll have to configure the intercoms, located on the front desk. Here is a list of frequencies for you to listen on.<br><ul><li>145.7 - Common Channel</li><li>144.7 - Private AI Channel</li><li>135.9 - Security Channel</li><li>135.7 - Engineering Channel</li><li>135.5 - Medical Channel</li><li>135.3 - Command Channel</li><li>135.1 - Science Channel</li><li>134.7 - Supply Channel</li>"
+	pixel_y = 17
 	},
 /obj/item/phone{
-	name = "spin-dial phone";
 	desc = "An old Russian phone. The dial tone is still humming.";
+	name = "spin-dial phone";
 	pixel_x = 1;
 	pixel_y = 1
 	},
@@ -711,17 +708,14 @@
 	},
 /area/djstation)
 "bD" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/djstation)
 "bE" = (
 /obj/machinery/door/airlock{
-	name = "Restroom";
-	req_access_txt = "0"
+	name = "Restroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -735,7 +729,6 @@
 /area/djstation)
 "bG" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/djstation)
@@ -752,9 +745,8 @@
 "bI" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -786,8 +778,7 @@
 	master_tag = "dj_station_airlock";
 	name = "interior access button";
 	pixel_x = 25;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -800,8 +791,8 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/djstation)
 "bO" = (
@@ -815,7 +806,6 @@
 	pixel_x = -32
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -866,8 +856,7 @@
 	id_tag = "dj_station_inner";
 	locked = 1;
 	name = "DJ Station Interior Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
@@ -888,7 +877,6 @@
 	frequency = 1479;
 	id_tag = "dj_station_airlock";
 	pixel_x = -25;
-	req_access_txt = "0";
 	tag_airpump = "dj_station_pump";
 	tag_chamber_sensor = "dj_station_sensor";
 	tag_exterior_door = "dj_station_outer";
@@ -906,8 +894,7 @@
 	id_tag = "dj_station_outer";
 	locked = 1;
 	name = "DJ Station External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /turf/simulated/floor/plating,
 /area/djstation)
@@ -921,8 +908,7 @@
 	master_tag = "dj_station_airlock";
 	name = "exterior access button";
 	pixel_x = 23;
-	pixel_y = 35;
-	req_access_txt = "0"
+	pixel_y = 35
 	},
 /turf/template_noop,
 /area/djstation)

--- a/_maps/map_files/RandomRuins/SpaceRuins/druglab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/druglab.dmm
@@ -77,9 +77,9 @@
 /area/exploration/methlab)
 "p" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 4;

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -16,18 +16,17 @@
 /obj/structure/bed,
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 8
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "e" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 4
+	dir = 4;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "f" = (
@@ -40,8 +39,8 @@
 /obj/structure/bed,
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 8
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "g" = (
@@ -53,31 +52,30 @@
 	},
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 8
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "h" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 4
+	dir = 4;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "i" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 8
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "j" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/outlet_injector,
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 4
+	dir = 4;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "k" = (
@@ -85,15 +83,15 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 8
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "l" = (
 /obj/machinery/atmospherics/unary/outlet_injector,
 /turf/simulated/floor/plasteel{
-	icon_state = "warndark";
-	dir = 4
+	dir = 4;
+	icon_state = "warndark"
 	},
 /area/ruin/unpowered)
 "m" = (
@@ -124,10 +122,8 @@
 "p" = (
 /obj/machinery/power/apc/worn_out{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0;
-	cell_type = 2500;
-	operating = 1
+	operating = 1;
+	pixel_x = -24
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -171,8 +167,7 @@
 /area/ruin/unpowered)
 "v" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -263,8 +258,7 @@
 /area/ruin/unpowered)
 "I" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/structure/table,

--- a/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -8,7 +8,6 @@
 "e" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -18,9 +17,8 @@
 	dir = 4
 	},
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered)
@@ -107,10 +105,9 @@
 /area/ruin/powered)
 "x" = (
 /obj/machinery/door_control{
+	id = "strange ship";
 	name = "Strange Ship Door Control";
-	pixel_x = 6;
-	pixel_y = 0;
-	id = "strange ship"
+	pixel_x = 6
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/ruin/powered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -251,9 +251,8 @@
 /area/ruin/powered)
 "Q" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -266,9 +265,8 @@
 /area/ruin/powered)
 "S" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (WEST)";
-	icon_state = "toilet00";
-	dir = 8
+	dir = 8;
+	tag = "icon-toilet00 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"

--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -145,7 +145,6 @@
 /area/ruin/space/ancientstation/hivebot)
 "ay" = (
 /obj/structure/shuttle/engine/large{
-	icon_state = "large_engine";
 	dir = 4
 	},
 /turf/simulated/wall,
@@ -257,8 +256,8 @@
 "aO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrivalcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "arrivalcorner"
 	},
 /area/ruin/space/ancientstation/comm)
 "aP" = (
@@ -412,8 +411,8 @@
 	name = "Broken Computer"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/ruin/space/ancientstation/comm)
 "bj" = (
@@ -423,8 +422,8 @@
 	name = "Broken Computer"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/ruin/space/ancientstation/comm)
 "bk" = (
@@ -436,8 +435,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/ruin/space/ancientstation/comm)
 "bl" = (
@@ -688,7 +687,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -921,7 +919,6 @@
 /area/template_noop)
 "cD" = (
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -965,7 +962,6 @@
 /area/ruin/space/ancientstation/thetacorridor)
 "cJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1116,8 +1112,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/ruin/space/ancientstation/comm)
 "dd" = (
@@ -1208,7 +1204,6 @@
 "dp" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -1219,7 +1214,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1372,8 +1366,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/ruin/space/ancientstation/comm)
 "dM" = (
@@ -1470,9 +1464,9 @@
 /area/ruin/space/ancientstation)
 "dX" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -1495,8 +1489,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "ea" = (
@@ -1557,7 +1551,6 @@
 /area/ruin/space/ancientstation/rnd)
 "eg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1597,8 +1590,8 @@
 /obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "em" = (
@@ -1741,7 +1734,6 @@
 /area/ruin/space/ancientstation/engi)
 "eD" = (
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -1753,9 +1745,9 @@
 /area/ruin/space/ancientstation/engi)
 "eE" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/smes/engineering{
 	charge = 0
@@ -1792,8 +1784,8 @@
 "eI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/ruin/space/ancientstation/sec)
 "eJ" = (
@@ -1822,7 +1814,6 @@
 /area/template_noop)
 "eL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1835,8 +1826,8 @@
 	report_danger_level = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/ruin/space/ancientstation/comm)
 "eM" = (
@@ -1870,8 +1861,8 @@
 "eR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "eS" = (
@@ -1993,8 +1984,8 @@
 /obj/item/book/manual/security_space_law,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "fh" = (
@@ -2065,7 +2056,6 @@
 /area/ruin/space/ancientstation/rnd)
 "fp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2377,8 +2367,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 5
+	dir = 5;
+	icon_state = "yellow"
 	},
 /area/ruin/space/ancientstation/engi)
 "fQ" = (
@@ -2576,22 +2566,21 @@
 "ge" = (
 /obj/structure/table,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Charlie Security APC";
 	pixel_x = -24;
 	report_power_alarm = 0;
-	shock_proof = 0;
 	start_charge = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "gf" = (
@@ -2712,8 +2701,8 @@
 /obj/item/flash,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "gw" = (
@@ -2842,8 +2831,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "gO" = (
@@ -2874,8 +2863,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/ruin/space/ancientstation/sec)
 "gR" = (
@@ -2907,7 +2896,6 @@
 /area/ruin/space/ancientstation/thetacorridor)
 "gU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2990,8 +2978,8 @@
 "he" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "hf" = (
@@ -3012,7 +3000,6 @@
 "hh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/ruin/space/ancientstation/rnd)
@@ -3077,8 +3064,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 8
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/ruin/space/ancientstation/engi)
 "hp" = (
@@ -3239,15 +3226,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 8
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/ruin/space/ancientstation)
 "hD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/ruin/space/ancientstation/hydroponics)
 "hE" = (
@@ -3267,16 +3254,16 @@
 "hF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/ruin/space/ancientstation/hydroponics)
 "hG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "cautioncorner";
-	dir = 4
+	dir = 4;
+	icon_state = "cautioncorner"
 	},
 /area/ruin/space/ancientstation/engi)
 "hH" = (
@@ -3323,8 +3310,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "hL" = (
@@ -3348,8 +3335,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/ruin/space/ancientstation/hydroponics)
 "hN" = (
@@ -3499,9 +3486,9 @@
 /area/ruin/space/ancientstation/kitchen)
 "id" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -3591,7 +3578,6 @@
 /area/ruin/space/ancientstation/rnd)
 "im" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3618,7 +3604,6 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -3627,9 +3612,9 @@
 /area/ruin/space/ancientstation/engi)
 "ir" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/smes/engineering{
 	charge = 0
@@ -3669,7 +3654,6 @@
 /area/ruin/space/ancientstation)
 "iw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4111,8 +4095,7 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/ruin/space/ancientstation/proto)
 "jv" = (
@@ -4123,8 +4106,7 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/ruin/space/ancientstation/proto)
 "jw" = (
@@ -4202,7 +4184,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Charlie Kitchen APC";
 	pixel_y = -24;
 	report_power_alarm = 0;
@@ -4380,7 +4361,6 @@
 "jY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/paper/fluff/ruins/oldstation/protosing,
@@ -4560,7 +4540,6 @@
 "kt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/paper/fluff/ruins/oldstation/protogun,
@@ -4669,7 +4648,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -4907,13 +4885,12 @@
 "lj" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "greencorner";
-	dir = 8
+	dir = 8;
+	icon_state = "greencorner"
 	},
 /area/ruin/space/ancientstation/hydroponics)
 "lk" = (
@@ -4922,8 +4899,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/ruin/space/ancientstation/hydroponics)
 "ll" = (
@@ -4938,8 +4915,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "ln" = (
@@ -4961,8 +4938,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "lp" = (
@@ -4973,7 +4950,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/ruin/space/ancientstation/engi)
@@ -5009,8 +4985,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 8
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/ruin/space/ancientstation/engi)
 "lt" = (
@@ -5047,8 +5023,8 @@
 /obj/item/storage/backpack/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "lw" = (
@@ -5168,7 +5144,6 @@
 "lG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/ruin/space/ancientstation/sec)
@@ -5185,8 +5160,8 @@
 /obj/item/clothing/mask/gas,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "lJ" = (
@@ -5220,8 +5195,8 @@
 /obj/item/clothing/head/helmet/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/ruin/space/ancientstation/sec)
 "lN" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -35,7 +35,6 @@
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/cut{
 	amount = 2;
-	dir = 2;
 	icon_state = "coil_red2"
 	},
 /turf/template_noop,
@@ -78,14 +77,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "am" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "an" = (
@@ -96,8 +95,8 @@
 	},
 /obj/item/storage/firstaid/fire,
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "ao" = (
@@ -172,14 +171,13 @@
 "aA" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "aB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/storage/firstaid/brute{
@@ -188,8 +186,8 @@
 	},
 /obj/item/storage/firstaid,
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "aC" = (
@@ -233,8 +231,8 @@
 "aJ" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "aK" = (
@@ -245,8 +243,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "aL" = (
@@ -257,7 +255,6 @@
 /obj/machinery/power/apc/noalarm{
 	keep_preset_name = 1;
 	name = "Hallway APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -380,8 +377,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "aW" = (
@@ -419,8 +416,8 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/ruin/onehalf/dorms_med)
 "aZ" = (
@@ -472,13 +469,11 @@
 /area/ruin/onehalf/hallway)
 "be" = (
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (EAST)";
-	icon_state = "pipe-b";
-	dir = 4
+	dir = 4;
+	tag = "icon-pipe-b (EAST)"
 	},
 /obj/item/stack/cable_coil/cut{
 	amount = 2;
-	dir = 2;
 	icon_state = "coil_red2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -498,9 +493,8 @@
 /area/ruin/onehalf/hallway)
 "bg" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -530,9 +524,8 @@
 /area/ruin/onehalf/hallway)
 "bi" = (
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (EAST)";
-	icon_state = "pipe-b";
-	dir = 4
+	dir = 4;
+	tag = "icon-pipe-b (EAST)"
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
@@ -556,7 +549,6 @@
 /area/ruin/onehalf/hallway)
 "bk" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -608,9 +600,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/onehalf/drone_bay)
 "bp" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "maintenance hatch"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -627,8 +617,8 @@
 /area/ruin/onehalf/drone_bay)
 "br" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/onehalf/drone_bay)
@@ -712,8 +702,7 @@
 /area/ruin/onehalf/drone_bay)
 "bD" = (
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/onehalf/drone_bay)
@@ -818,9 +807,8 @@
 /area/ruin/onehalf/hallway)
 "bZ" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
-	icon_state = "pipe-j1";
-	dir = 1
+	dir = 1;
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /obj/item/shard,
 /obj/effect/landmark/damageturf,
@@ -915,8 +903,8 @@
 	dir = 4
 	},
 /obj/item/shard{
-	tag = "icon-small";
-	icon_state = "small"
+	icon_state = "small";
+	tag = "icon-small"
 	},
 /turf/template_noop,
 /area/space/nearstation)
@@ -943,9 +931,8 @@
 /area/ruin/onehalf/bridge)
 "cq" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/onehalf/bridge)
@@ -954,9 +941,8 @@
 /area/ruin/onehalf/bridge)
 "cs" = (
 /obj/structure/chair{
-	tag = "icon-chair (NORTH)";
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	tag = "icon-chair (NORTH)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/onehalf/bridge)
@@ -1014,8 +1000,8 @@
 "cy" = (
 /obj/structure/lattice,
 /obj/item/shard{
-	tag = "icon-medium";
-	icon_state = "medium"
+	icon_state = "medium";
+	tag = "icon-medium"
 	},
 /turf/template_noop,
 /area/ruin/onehalf/hallway)
@@ -1081,14 +1067,12 @@
 "cH" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (NORTH)";
-	icon_state = "pipe-b";
-	dir = 1
+	dir = 1;
+	tag = "icon-pipe-b (NORTH)"
 	},
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (WEST)";
-	icon_state = "pipe-b";
-	dir = 8
+	dir = 8;
+	tag = "icon-pipe-b (WEST)"
 	},
 /turf/template_noop,
 /area/ruin/onehalf/hallway)
@@ -1129,9 +1113,8 @@
 /area/ruin/onehalf/bridge)
 "cN" = (
 /obj/structure/chair/comfy/black{
-	tag = "icon-comfychair (EAST)";
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	tag = "icon-comfychair (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/onehalf/bridge)
@@ -1139,7 +1122,6 @@
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/cut{
 	amount = 2;
-	dir = 2;
 	icon_state = "coil_red2"
 	},
 /turf/template_noop,
@@ -1183,7 +1165,6 @@
 /obj/machinery/door_control{
 	id = "onehalf bridge";
 	name = "Bridge Lockdown";
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel,
@@ -1340,8 +1321,8 @@
 	tag = ""
 	},
 /obj/item/shard{
-	tag = "icon-medium";
-	icon_state = "medium"
+	icon_state = "medium";
+	tag = "icon-medium"
 	},
 /turf/template_noop,
 /area/space/nearstation)

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -252,9 +252,8 @@
 	})
 "aU" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered{
@@ -268,9 +267,8 @@
 	})
 "aW" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered{
@@ -278,7 +276,6 @@
 	})
 "aX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -349,9 +346,7 @@
 "bh" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -363,7 +358,6 @@
 "bi" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -4,12 +4,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -91,7 +89,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -161,7 +158,6 @@
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/ruin/unpowered/syndicate_space_base/cargo)
@@ -243,8 +239,7 @@
 /area/ruin/unpowered/syndicate_space_base/virology)
 "cB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -255,7 +250,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light,
@@ -266,8 +260,7 @@
 "cD" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
@@ -292,8 +285,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
@@ -330,8 +322,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -413,7 +404,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -465,7 +455,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -482,7 +471,6 @@
 /obj/machinery/kitchen_machine/microwave,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -533,7 +521,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -551,7 +538,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/engine,
@@ -597,7 +583,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -636,7 +621,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -687,8 +671,7 @@
 "gZ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -725,8 +708,7 @@
 /area/ruin/unpowered/syndicate_space_base/chemistry)
 "hq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -778,8 +760,7 @@
 "hR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -791,12 +772,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -808,14 +787,12 @@
 "hX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -864,7 +841,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -875,7 +851,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -1018,8 +993,7 @@
 "jS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel{
@@ -1147,7 +1121,6 @@
 /obj/machinery/optable,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -1221,7 +1194,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -1273,9 +1245,7 @@
 "mX" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1292,7 +1262,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1313,7 +1282,6 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -1353,7 +1321,6 @@
 /area/ruin/unpowered/syndicate_space_base/testlab)
 "ny" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -1378,7 +1345,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -1412,8 +1378,7 @@
 "ob" = (
 /obj/machinery/door/airlock/hatch/syndicate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1428,12 +1393,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1492,8 +1455,7 @@
 	tag = "90Curve"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_space_base/cargo)
@@ -1530,7 +1492,6 @@
 /obj/machinery/light,
 /obj/machinery/cryopod/offstation,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
@@ -1542,26 +1503,13 @@
 /area/ruin/unpowered/syndicate_space_base/bar)
 "pA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/engineering)
-"pG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ruin/unpowered/syndicate_space_base/main)
 "pI" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
@@ -1586,7 +1534,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -1604,7 +1551,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/operating,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -1627,8 +1573,7 @@
 "qN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -1668,7 +1613,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -1681,12 +1625,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1720,8 +1662,7 @@
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1770,13 +1711,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"sw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/engine,
-/area/ruin/unpowered/syndicate_space_base/testlab)
 "sz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/navbeacon/invisible{
@@ -1787,7 +1721,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1816,14 +1749,12 @@
 /area/ruin/unpowered/syndicate_space_base/telecomms)
 "tf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/alarm/syndicate{
@@ -1848,7 +1779,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1867,8 +1797,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1966,7 +1895,6 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "uJ" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -1992,13 +1920,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
@@ -2008,7 +1934,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -2033,7 +1958,6 @@
 "vk" = (
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -2057,7 +1981,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -2155,8 +2078,7 @@
 "wc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
@@ -2192,7 +2114,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2268,8 +2189,7 @@
 /obj/effect/turf_decal/caution/red,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel{
@@ -2280,21 +2200,18 @@
 /obj/item/kitchen/rollingpin,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/ruin/unpowered/syndicate_space_base/bar)
 "wX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -2382,7 +2299,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -2398,14 +2314,12 @@
 /area/ruin/unpowered/syndicate_space_base/main)
 "xN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2436,7 +2350,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -2448,7 +2361,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -2514,9 +2426,7 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/telecomms)
 "zs" = (
-/obj/structure/sign/biohazard{
-	pixel_y = 0
-	},
+/obj/structure/sign/biohazard,
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_space_base/virology)
 "zG" = (
@@ -2650,8 +2560,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
@@ -2704,7 +2613,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2723,8 +2631,7 @@
 /area/ruin/unpowered/syndicate_space_base/main)
 "Ce" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2738,15 +2645,13 @@
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "Cj" = (
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -2802,7 +2707,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -2811,8 +2715,7 @@
 "Dp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -2842,7 +2745,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
@@ -2854,7 +2756,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -2892,7 +2793,6 @@
 /obj/item/clothing/gloves/combat,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/ruin/unpowered/syndicate_space_base/cargo)
@@ -2906,8 +2806,7 @@
 /area/ruin/unpowered/syndicate_space_base/virology)
 "El" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2930,7 +2829,6 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -2955,7 +2853,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -3027,7 +2924,6 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "EX" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkbluecorners"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
@@ -3069,7 +2965,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3088,7 +2983,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
@@ -3147,7 +3041,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3161,12 +3054,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3201,7 +3092,6 @@
 "Go" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -3219,8 +3109,7 @@
 /area/ruin/unpowered/syndicate_space_base/dormitories)
 "GJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -3230,7 +3119,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3255,7 +3143,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -3271,8 +3158,7 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "GY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -3309,7 +3195,6 @@
 "HB" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -3385,8 +3270,7 @@
 /area/ruin/unpowered/syndicate_space_base/bar)
 "Iv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_space_base/cargo)
@@ -3405,7 +3289,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -3508,7 +3391,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3522,7 +3404,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3575,7 +3456,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3609,7 +3489,6 @@
 /obj/machinery/processor,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -3709,7 +3588,6 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -3734,7 +3612,6 @@
 	shock_proof = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -3751,7 +3628,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3762,8 +3638,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -3856,14 +3731,12 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "Mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3913,7 +3786,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4000,7 +3872,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4030,12 +3901,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4047,7 +3916,6 @@
 "Ot" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
@@ -4122,7 +3990,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -4165,7 +4032,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -4179,8 +4045,7 @@
 "QO" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4244,7 +4109,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4295,7 +4159,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4349,8 +4212,7 @@
 /area/ruin/unpowered/syndicate_space_base/dormitories)
 "SQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
@@ -4414,8 +4276,7 @@
 "Tl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
@@ -4489,7 +4350,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/alarm/syndicate{
@@ -4514,8 +4374,7 @@
 /area/ruin/unpowered/syndicate_space_base/cargo)
 "Us" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -4559,7 +4418,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4630,14 +4488,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
 "VQ" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/item/soap/syndie,
@@ -4653,7 +4509,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -4663,7 +4518,6 @@
 "Wi" = (
 /obj/machinery/kitchen_machine/candy_maker,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -4690,8 +4544,6 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "Wz" = (
 /obj/structure/sign/lifestar{
-	desc = "The Star of Life, a symbol of Medical Aid.";
-	icon_state = "lifestar";
 	name = "Medbay"
 	},
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
@@ -4702,7 +4554,6 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -4742,7 +4593,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4791,7 +4641,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -4802,20 +4651,17 @@
 /area/ruin/unpowered/syndicate_space_base/chemistry)
 "Ya" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4826,7 +4672,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -4890,7 +4735,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -6796,7 +6640,7 @@ El
 uk
 uk
 yz
-pG
+ZB
 uk
 uk
 uk
@@ -7117,7 +6961,7 @@ TD
 Rn
 Vl
 Vl
-sw
+Ri
 Vc
 Vl
 Vl
@@ -7179,7 +7023,7 @@ TD
 Vl
 Vl
 Vl
-sw
+Ri
 Vc
 Vl
 Vl
@@ -7241,7 +7085,7 @@ TD
 Vl
 Vl
 Vl
-sw
+Ri
 Vc
 Vl
 Vl
@@ -7303,7 +7147,7 @@ TD
 Vl
 Vl
 Vl
-sw
+Ri
 Vc
 Vl
 Vl

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
@@ -178,7 +178,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -331,7 +330,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -345,7 +343,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -512,7 +509,6 @@
 "TM" = (
 /obj/structure/chair/office/dark{
 	dir = 4;
-	icon_state = "officechair_dark";
 	tag = "icon-officechair_dark (EAST)"
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -55,9 +55,8 @@
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -76,15 +75,15 @@
 "r" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "s" = (
 /obj/item/rack_parts,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "t" = (
@@ -93,8 +92,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "u" = (
@@ -107,9 +106,8 @@
 /area/ruin/unpowered)
 "w" = (
 /obj/machinery/power/apc/noalarm{
-	dir = 2;
-	name = "Outpost APC";
 	keep_preset_name = 1;
+	name = "Outpost APC";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
@@ -157,16 +155,15 @@
 /obj/structure/rack,
 /obj/item/ammo_box/c9mm,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "E" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -174,8 +171,8 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/swat,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "G" = (
@@ -183,8 +180,8 @@
 /obj/item/crowbar/red,
 /obj/item/paper/crumpled,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "H" = (
@@ -249,23 +246,22 @@
 /obj/item/storage/belt/military,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "R" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/riot,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/ruin/unpowered)
 "S" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/rawcutlet,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -78,9 +78,7 @@
 /turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
 /area/derelict/bridge)
 "ap" = (
-/obj/effect/landmark/damageturf{
-	layer = 3
-	},
+/obj/effect/landmark/damageturf,
 /obj/effect/landmark/burnturf,
 /turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
 /area/derelict/bridge)
@@ -237,16 +235,14 @@
 "aG" = (
 /obj/structure/safe/floor,
 /obj/item/paper/djstation{
+	info = "<i>To my darling Sergei,<br><br>I will never forget those nights we spent on Cygni, or all the times you took me around in your 2452 Vincent. The way you looked at me that one night, that was the night I knew that you and I were of the same soul.<br><br>I know they made you sell your Vincent when you were reassigned, but I could not let such a beautiful thing go to rust. I have made arrangements and it is here, waiting for you.<br><br>I have enclosed the keys. Please, let them serve as a reminder always of our love and a reason to return. I beg of you, do not let our love go softly into the night.</i>";
+	layer = 2.9;
 	name = "love letter";
 	pixel_x = -5;
-	pixel_y = -3;
-	layer = 2.9;
-	info = "<i>To my darling Sergei,<br><br>I will never forget those nights we spent on Cygni, or all the times you took me around in your 2452 Vincent. The way you looked at me that one night, that was the night I knew that you and I were of the same soul.<br><br>I know they made you sell your Vincent when you were reassigned, but I could not let such a beautiful thing go to rust. I have made arrangements and it is here, waiting for you.<br><br>I have enclosed the keys. Please, let them serve as a reminder always of our love and a reason to return. I beg of you, do not let our love go softly into the night.</i>"
+	pixel_y = -3
 	},
 /obj/item/key{
-	name = "Vincent '52 Key";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Vincent '52 Key"
 	},
 /obj/item/trash/tapetrash{
 	desc = "A bundle of severely yellowed and highly pretentious looking documents. Unfortunately they appear to be written in cyrillic and encrypted with a cypher.";
@@ -267,9 +263,8 @@
 /area/derelict/bridge)
 "aI" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -338,7 +333,6 @@
 /obj/effect/landmark/damageturf,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
@@ -347,9 +341,8 @@
 /area/derelict/bridge)
 "aR" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -376,9 +369,8 @@
 "aU" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -459,7 +451,6 @@
 /area/derelict/bridge)
 "bf" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
@@ -516,7 +507,6 @@
 "bl" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -721,12 +711,10 @@
 /area/derelict/arrival)
 "bF" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/derelict/arrival)
@@ -743,9 +731,8 @@
 /area/derelict/arrival)
 "bH" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -839,7 +826,6 @@
 /area/derelict/crew_quarters)
 "bS" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/derelict/arrival)
@@ -861,8 +847,8 @@
 /area/derelict/arrival)
 "bV" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/derelict/bridge)
 "bW" = (
@@ -876,7 +862,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/cups,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
@@ -884,21 +869,18 @@
 /obj/structure/table/reinforced,
 /obj/item/ashtray/bronze,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
 "bZ" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
 "ca" = (
 /obj/structure/coatrack,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
@@ -906,14 +888,12 @@
 /obj/structure/table/reinforced,
 /obj/item/folder,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
 "cc" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
@@ -951,9 +931,8 @@
 /area/derelict/bridge)
 "ch" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -977,9 +956,8 @@
 /area/derelict/crew_quarters)
 "ck" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -995,13 +973,11 @@
 	name = "armoured helmet"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/derelict/arrival)
 "cm" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/derelict/arrival)
@@ -1086,14 +1062,12 @@
 "cx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
 "cy" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -1246,7 +1220,6 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	pixel_x = 5;
 	tag = "icon-shower (EAST)"
 	},
@@ -1258,7 +1231,6 @@
 	},
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1319,7 +1291,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/bridge)
@@ -1369,8 +1340,8 @@
 /obj/item/bedsheet/blue,
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/derelict/crew_quarters)
 "dd" = (
@@ -1426,9 +1397,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
@@ -1440,8 +1410,8 @@
 /obj/item/bedsheet/blue,
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/derelict/crew_quarters)
 "dl" = (
@@ -1488,7 +1458,6 @@
 "dr" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -1501,16 +1470,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/derelict/arrival)
 "dt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1534,8 +1501,8 @@
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/derelict/crew_quarters)
 "dw" = (
@@ -1556,8 +1523,8 @@
 /obj/item/bedsheet/blue,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 6
+	dir = 6;
+	icon_state = "blue"
 	},
 /area/derelict/crew_quarters)
 "dz" = (
@@ -1597,7 +1564,6 @@
 	name = "recommendation for commendation"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/derelict/arrival)
@@ -1609,7 +1575,6 @@
 	name = "Bridge Lockdown"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/derelict/arrival)
@@ -1692,9 +1657,8 @@
 "dN" = (
 /obj/structure/closet,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/item/clothing/head/ushanka,
 /obj/item/clothing/head/ushanka,
@@ -1722,8 +1686,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
@@ -1738,9 +1701,8 @@
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1876,9 +1838,8 @@
 	})
 "eh" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -1902,9 +1863,8 @@
 	})
 "ej" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants,
@@ -1925,9 +1885,9 @@
 /area/derelict/crew_quarters)
 "el" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/piano,
 /obj/machinery/power/apc/noalarm{
@@ -1942,7 +1902,6 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/effect/decal/cleanable/blood,
@@ -1963,7 +1922,6 @@
 "eo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/derelict/arrival)
@@ -1977,7 +1935,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/derelict/arrival)
@@ -1996,7 +1953,6 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/machinery/light/spot{
-	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -2023,7 +1979,6 @@
 	})
 "eu" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "rampbottom";
 	tag = "icon-stage_stairs"
 	},
@@ -2037,7 +1992,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "rampbottom";
 	tag = "icon-stage_stairs"
 	},
@@ -2047,7 +2001,6 @@
 "ew" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "rampbottom";
 	tag = "icon-stage_stairs"
 	},
@@ -2081,8 +2034,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -2110,8 +2063,8 @@
 "eC" = (
 /obj/structure/chair/wood,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/derelict/crew_quarters)
 "eD" = (
@@ -2128,9 +2081,8 @@
 "eF" = (
 /obj/structure/chair/sofa/left,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/sign/poster/contraband/rebels_unite{
 	pixel_x = -1;
@@ -2147,8 +2099,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/derelict/crew_quarters)
 "eH" = (
@@ -2304,13 +2256,12 @@
 	})
 "eV" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/eva{
@@ -2346,8 +2297,8 @@
 /obj/structure/engineeringcart,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -2418,7 +2369,6 @@
 "fg" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
@@ -2473,7 +2423,6 @@
 	name = "Science Wing"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/derelict/eva{
@@ -2534,7 +2483,6 @@
 	name = "Engineering Wing"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/derelict/eva{
@@ -2600,8 +2548,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -2611,7 +2559,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
@@ -2623,8 +2570,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/derelict/crew_quarters)
 "fx" = (
@@ -2649,8 +2596,8 @@
 "fz" = (
 /obj/structure/mopbucket,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
 	},
 /area/derelict/crew_quarters)
 "fA" = (
@@ -2702,7 +2649,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
@@ -2799,9 +2745,8 @@
 	})
 "fP" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2833,8 +2778,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -2872,7 +2817,6 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/effect/decal/cleanable/blood,
@@ -2913,7 +2857,6 @@
 "ga" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "gnawed bones"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -2981,7 +2924,6 @@
 /obj/structure/table/wood,
 /obj/item/ashtray/plastic,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/derelict/eva{
@@ -3016,13 +2958,13 @@
 	track = 2
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -3049,8 +2991,8 @@
 "gn" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/derelict/crew_quarters)
 "go" = (
@@ -3106,7 +3048,6 @@
 "gu" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/derelict/eva{
@@ -3127,7 +3068,6 @@
 	})
 "gw" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/derelict/eva{
@@ -3138,9 +3078,8 @@
 	dir = 1
 	},
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -3167,7 +3106,6 @@
 	})
 "gA" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/derelict/eva{
@@ -3190,9 +3128,9 @@
 	})
 "gC" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
@@ -3211,13 +3149,12 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -3358,8 +3295,8 @@
 /obj/item/clothing/under/retro/engineering,
 /obj/structure/closet,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -3378,7 +3315,6 @@
 	},
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
@@ -3389,9 +3325,8 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -3410,9 +3345,9 @@
 	id = "russolar"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -3435,7 +3370,6 @@
 /obj/item/storage/box/cups,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/derelict/arrival)
@@ -3523,8 +3457,8 @@
 	})
 "hl" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -3608,7 +3542,6 @@
 	name = "Security Wing"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "ramptop";
 	tag = "icon-stage_stairs"
 	},
@@ -3623,14 +3556,12 @@
 	name = "Security Wing"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "ramptop";
 	tag = "icon-stage_stairs"
 	},
 /area/derelict/arrival)
 "hw" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -3645,7 +3576,6 @@
 "hx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/derelict/eva{
@@ -3684,7 +3614,6 @@
 /obj/effect/landmark/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/derelict/eva{
@@ -3699,8 +3628,8 @@
 "hD" = (
 /obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -3715,8 +3644,8 @@
 	name = "Eastern Annex"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_stairs";
-	icon_state = "stage_stairs"
+	icon_state = "stage_stairs";
+	tag = "icon-stage_stairs"
 	},
 /area/derelict/crew_quarters)
 "hF" = (
@@ -3728,8 +3657,8 @@
 	name = "Eastern Annex"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_stairs";
-	icon_state = "stage_stairs"
+	icon_state = "stage_stairs";
+	tag = "icon-stage_stairs"
 	},
 /area/derelict/crew_quarters)
 "hI" = (
@@ -3786,7 +3715,6 @@
 /area/derelict/arrival)
 "hN" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -3839,8 +3767,8 @@
 "hR" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -3917,9 +3845,8 @@
 /area/derelict/arrival)
 "ib" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/structure/closet/l3closet/scientist,
 /obj/item/clothing/glasses/science,
@@ -3999,8 +3926,8 @@
 	name = "Cosmonaut Engineering Suit"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -4083,9 +4010,8 @@
 /area/derelict/arrival)
 "iz" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -4114,7 +4040,6 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/derelict/eva{
@@ -4227,7 +4152,6 @@
 "iQ" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -4322,7 +4246,6 @@
 /obj/effect/landmark/damageturf,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plating/airless,
@@ -4356,8 +4279,8 @@
 	name = "Engineering Wing"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -4391,9 +4314,8 @@
 /area/derelict/crew_quarters)
 "jg" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -4434,11 +4356,9 @@
 /area/derelict/arrival)
 "jm" = (
 /obj/machinery/door/airlock/external{
-	name = "Docking Port";
-	req_access_txt = "0"
+	name = "Docking Port"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/derelict/arrival)
@@ -4601,8 +4521,8 @@
 	})
 "jF" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -4620,8 +4540,8 @@
 "jH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -4649,8 +4569,7 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1502;
 	id_tag = "rus_inner_2";
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4658,8 +4577,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/derelict/crew_quarters)
@@ -4687,8 +4605,7 @@
 	frequency = 1502;
 	id_tag = "rus_outer_2";
 	locked = 1;
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/derelict/crew_quarters)
@@ -4932,7 +4849,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
@@ -4954,8 +4870,7 @@
 	})
 "kl" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/eva{
@@ -4973,8 +4888,7 @@
 	})
 "kn" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/engine,
 /area/derelict/eva{
@@ -5013,8 +4927,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/engine,
 /area/derelict/eva{
@@ -5037,8 +4950,7 @@
 	})
 "kt" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5251,8 +5163,7 @@
 	frequency = 1502;
 	master_tag = "rus_airlock_2";
 	name = "exterior access button";
-	pixel_x = -25;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /turf/template_noop,
 /area/derelict/crew_quarters)
@@ -5443,7 +5354,6 @@
 "lf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/derelict/eva{
@@ -5456,7 +5366,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/derelict/eva{
@@ -5519,8 +5428,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -5534,14 +5442,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1502;
 	id_tag = "rus_inner_2";
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/derelict/crew_quarters)
@@ -5563,7 +5469,6 @@
 	frequency = 1502;
 	id_tag = "rus_airlock_2";
 	pixel_y = -25;
-	req_access_txt = "0";
 	tag_airpump = "rus_pump_2";
 	tag_chamber_sensor = "rus_sensor_2";
 	tag_exterior_door = "rus_outer_2";
@@ -5581,8 +5486,7 @@
 	frequency = 1502;
 	id_tag = "rus_outer_2";
 	locked = 1;
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5629,8 +5533,7 @@
 /area/derelict/arrival)
 "lu" = (
 /obj/machinery/door/airlock/external{
-	name = "Docking Port";
-	req_access_txt = "0"
+	name = "Docking Port"
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/arrival)
@@ -5638,7 +5541,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel,
@@ -5671,8 +5573,8 @@
 	welded = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -5683,8 +5585,8 @@
 	welded = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/derelict/eva{
 	name = "Derelict Annex"
@@ -5745,17 +5647,15 @@
 	})
 "lG" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1502;
 	master_tag = "rus_airlock_2";
 	name = "interior access button";
-	pixel_x = 25;
-	req_access_txt = "0"
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
@@ -5799,7 +5699,6 @@
 	name = "2maintenance loot spawner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/derelict/arrival)
@@ -5890,9 +5789,8 @@
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/item/trash/tastybread,
 /obj/effect/decal/cleanable/dirt,
@@ -5961,9 +5859,8 @@
 /area/derelict/solar_control)
 "mc" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -6097,13 +5994,11 @@
 "mv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/derelict/arrival)
 "mw" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/derelict/arrival)
@@ -6395,9 +6290,8 @@
 	})
 "ne" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -6506,9 +6400,8 @@
 	})
 "ns" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/open/shower,
 /obj/structure/window/reinforced,
@@ -6593,7 +6486,6 @@
 "nC" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12;
 	pixel_y = 2
 	},
@@ -6615,9 +6507,8 @@
 /obj/structure/rack,
 /obj/item/beach_ball/holoball,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -6661,7 +6552,6 @@
 "nJ" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel/airless{
@@ -6776,7 +6666,6 @@
 /area/derelict/crew_quarters)
 "nV" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangefull"
 	},
 /area/derelict/crew_quarters)
@@ -6923,7 +6812,6 @@
 "op" = (
 /obj/item/stack/ore/iron,
 /turf/simulated/floor/plasteel/airless{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/derelict/eva{
@@ -6934,7 +6822,6 @@
 	icon_state = "medium"
 	},
 /turf/simulated/floor/plasteel/airless{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/derelict/eva{
@@ -6950,7 +6837,6 @@
 "os" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -7122,7 +7008,6 @@
 	})
 "oL" = (
 /turf/simulated/floor/plasteel/airless{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/derelict/eva{
@@ -7180,7 +7065,6 @@
 "oR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orange"
 	},
 /area/derelict/crew_quarters)
@@ -7196,7 +7080,6 @@
 /obj/item/hatchet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/derelict/eva{
@@ -7298,7 +7181,6 @@
 "pd" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
-	icon_state = "pinonfar";
 	id = "whiteship_ussp";
 	name = "USSP"
 	},
@@ -7314,9 +7196,8 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -7327,7 +7208,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangefull"
 	},
 /area/derelict/crew_quarters)
@@ -7337,13 +7217,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orange"
 	},
 /area/derelict/crew_quarters)
 "pi" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orange"
 	},
 /area/derelict/crew_quarters)
@@ -7414,15 +7292,14 @@
 "pt" = (
 /obj/structure/closet/jcloset,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/derelict/crew_quarters)
 "pu" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/rack,
 /obj/item/mop,
@@ -7432,8 +7309,8 @@
 /obj/item/storage/bag/trash,
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/derelict/crew_quarters)
 "pv" = (
@@ -7451,7 +7328,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/spider/cocoon,
@@ -7467,8 +7343,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/derelict/crew_quarters)
 "pA" = (
@@ -7493,21 +7368,20 @@
 	})
 "pC" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/derelict/crew_quarters)
 "pD" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/rack,
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/derelict/crew_quarters)
 "pE" = (
@@ -7523,8 +7397,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/derelict/crew_quarters)
 "pH" = (
@@ -7537,9 +7410,8 @@
 "pI" = (
 /obj/effect/landmark/burnturf,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "white"
@@ -7556,35 +7428,34 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/derelict/crew_quarters)
 "pL" = (
 /obj/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/derelict/crew_quarters)
 "pM" = (
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/derelict/crew_quarters)
 "pN" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/derelict/crew_quarters)
 "pO" = (
@@ -7661,9 +7532,8 @@
 /area/derelict/crew_quarters)
 "pX" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -7703,9 +7573,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/eva{
@@ -7726,9 +7595,8 @@
 /area/derelict/crew_quarters)
 "qe" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -7755,7 +7623,6 @@
 "qi" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -7763,7 +7630,6 @@
 "qj" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -7779,7 +7645,6 @@
 	slogan_list = list("Just remember! No capitalist.","Best enjoyed with Vodka!.","Smoke!","Nine out of ten USSP scientists agree, smoking reduces stress!","There's no cigarette like a Russian cigarette!","Cigarettes! Now with 100% less capitalism.")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -7787,7 +7652,6 @@
 "qm" = (
 /obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -7805,9 +7669,8 @@
 "qo" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/kitchenspike,
 /turf/simulated/floor/plasteel{
@@ -7824,9 +7687,9 @@
 /area/derelict/arrival)
 "qr" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "floorscorched2"
@@ -7838,27 +7701,26 @@
 /area/derelict/arrival)
 "qt" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "qu" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "qv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "qw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -7876,16 +7738,14 @@
 /area/derelict/arrival)
 "qy" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/derelict/arrival)
 "qz" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -7894,8 +7754,8 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "qA" = (
@@ -7946,14 +7806,13 @@
 /area/derelict/arrival)
 "qF" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "qG" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -7965,7 +7824,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -7979,7 +7837,6 @@
 	list_reagents = list("charcoal" = 13, "salmonella" = 2)
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8011,12 +7868,10 @@
 /area/derelict/arrival)
 "qN" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8037,9 +7892,8 @@
 "qQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/leafybush,
@@ -8048,14 +7902,14 @@
 /area/derelict/arrival)
 "qR" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/derelict/arrival)
 "qS" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/derelict/arrival)
 "qT" = (
@@ -8075,9 +7929,8 @@
 "qV" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
@@ -8113,9 +7966,8 @@
 /area/derelict/arrival)
 "ra" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -8167,8 +8019,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "rg" = (
@@ -8178,7 +8030,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8190,8 +8041,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "ri" = (
@@ -8238,8 +8089,7 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/derelict/crew_quarters)
 "rn" = (
@@ -8256,8 +8106,8 @@
 /area/derelict/arrival)
 "rq" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "rr" = (
@@ -8302,16 +8152,15 @@
 	layer = 2.9
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/grass,
 /area/derelict/arrival)
 "ru" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "rv" = (
@@ -8319,7 +8168,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8327,7 +8175,6 @@
 "rw" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8383,9 +8230,8 @@
 	pixel_y = 5
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/grass,
@@ -8405,7 +8251,6 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8417,8 +8262,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/derelict/arrival)
 "rF" = (
@@ -8432,7 +8277,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8441,7 +8285,6 @@
 /obj/structure/table/wood/poker,
 /obj/item/deck/cards,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8451,7 +8294,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8469,7 +8311,6 @@
 	name = "worn paper"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8500,9 +8341,8 @@
 	layer = 2.9
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -8517,7 +8357,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8525,8 +8364,7 @@
 "rO" = (
 /obj/machinery/light/spot,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
@@ -8560,16 +8398,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1501;
 	master_tag = "rus_airlock_1";
 	name = "interior access button";
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
@@ -8607,7 +8443,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8634,9 +8469,8 @@
 /area/derelict/arrival)
 "rW" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -8649,7 +8483,6 @@
 /obj/structure/table,
 /obj/machinery/computer/library/public,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -8666,8 +8499,7 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1501;
 	id_tag = "rus_inner_1";
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8687,8 +8519,7 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1501;
 	id_tag = "rus_inner_1";
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/derelict/arrival)
@@ -8699,9 +8530,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -8718,7 +8548,6 @@
 	frequency = 1501;
 	id_tag = "rus_airlock_1";
 	pixel_x = -25;
-	req_access_txt = "0";
 	tag_airpump = "rus_pump_1";
 	tag_chamber_sensor = "rus_sensor_1";
 	tag_exterior_door = "rus_outer_1";
@@ -8752,8 +8581,7 @@
 	frequency = 1501;
 	id_tag = "rus_outer_1";
 	locked = 1;
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/derelict/arrival)
@@ -8762,8 +8590,7 @@
 	frequency = 1501;
 	id_tag = "rus_outer_1";
 	locked = 1;
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8774,8 +8601,7 @@
 /area/derelict/arrival)
 "sg" = (
 /obj/item/stack/cable_coil{
-	amount = 1;
-	max_amount = 30
+	amount = 1
 	},
 /turf/template_noop,
 /area/space/nearstation)
@@ -8788,8 +8614,7 @@
 	frequency = 1501;
 	master_tag = "rus_airlock_1";
 	name = "exterior access button";
-	pixel_y = 25;
-	req_access_txt = "0"
+	pixel_y = 25
 	},
 /turf/template_noop,
 /area/derelict/arrival)

--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -9,9 +9,7 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "af" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/sleeper,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -40,9 +38,8 @@
 /area/shuttle/abandoned)
 "aq" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (EAST)";
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -52,7 +49,6 @@
 "ar" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -132,7 +128,6 @@
 	},
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
-	icon_state = "pinonfar";
 	id = "whiteship_away";
 	name = "Deep Space"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -17,8 +17,8 @@
 	icon_state = "small"
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/ruin/unpowered)
 "ae" = (
@@ -27,14 +27,14 @@
 "af" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/ruin/unpowered)
 "ag" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/ruin/unpowered)
 "ah" = (
@@ -44,8 +44,8 @@
 	},
 /obj/item/shard,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/ruin/unpowered)
 "ai" = (
@@ -105,8 +105,8 @@
 	in_use = 1
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/ruin/unpowered)
 "as" = (
@@ -140,8 +140,8 @@
 /area/ruin/unpowered)
 "ax" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/ruin/unpowered)
 "ay" = (
@@ -156,8 +156,8 @@
 /area/ruin/unpowered)
 "aA" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
 	},
 /area/ruin/unpowered)
 "aB" = (
@@ -185,8 +185,8 @@
 "aF" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
 	},
 /area/ruin/unpowered)
 "aG" = (
@@ -261,7 +261,6 @@
 /area/ruin/unpowered)
 "aT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/oil,
@@ -280,8 +279,8 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
 	},
 /area/ruin/unpowered)
 "aX" = (
@@ -502,8 +501,7 @@
 /area/ruin/unpowered)
 "bJ" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/mineral/plasma,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomZLevels/academy.dmm
+++ b/_maps/map_files/RandomZLevels/academy.dmm
@@ -43,13 +43,12 @@
 /area/awaymission/academy/headmaster)
 "aj" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
 	environ = 0;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -192,7 +191,6 @@
 /area/awaymission/academy/headmaster)
 "aD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -215,7 +213,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -476,8 +473,8 @@
 "bz" = (
 /mob/living/simple_animal/hostile/mimic/crate,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/academy/classrooms)
 "bA" = (
@@ -526,7 +523,6 @@
 /area/awaymission/academy/headmaster)
 "bL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -536,9 +532,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "bN" = (
@@ -552,9 +548,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "bP" = (
@@ -575,9 +571,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "bR" = (
@@ -606,8 +602,8 @@
 "bU" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -655,8 +651,8 @@
 "ce" = (
 /obj/machinery/autolathe,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/academy/classrooms)
@@ -667,9 +663,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "cg" = (
@@ -690,8 +686,8 @@
 "ci" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/structure/window/reinforced{
@@ -709,9 +705,9 @@
 /area/awaymission/academy/headmaster)
 "cl" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "cm" = (
@@ -727,9 +723,9 @@
 "cn" = (
 /obj/machinery/computer/area_atmos/area,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "co" = (
@@ -754,7 +750,6 @@
 /area/awaymission/academy/headmaster)
 "cr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -794,9 +789,7 @@
 	},
 /area/awaymission/academy/headmaster)
 "cz" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -806,8 +799,8 @@
 /area/awaymission/academy/headmaster)
 "cA" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/academy/classrooms)
 "cB" = (
@@ -816,8 +809,8 @@
 /area/awaymission/academy/classrooms)
 "cC" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/academy/classrooms)
 "cD" = (
@@ -907,8 +900,8 @@
 /area/awaymission/academy/classrooms)
 "cP" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/academy/classrooms)
 "cQ" = (
@@ -918,26 +911,19 @@
 /area/awaymission/academy/classrooms)
 "cR" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/awaymission/academy/classrooms)
-"cS" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/academy/headmaster)
 "cT" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "cU" = (
@@ -952,9 +938,9 @@
 /obj/structure/closet/crate,
 /obj/item/crowbar/red,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/headmaster)
 "cW" = (
@@ -1005,7 +991,6 @@
 /area/awaymission/academy/classrooms)
 "dd" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -1025,9 +1010,9 @@
 	},
 /obj/item/gun/projectile/shotgun/toy/tommygun,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "dh" = (
@@ -1091,14 +1076,13 @@
 "dq" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/classrooms)
 "dr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1112,8 +1096,8 @@
 /area/awaymission/academy/classrooms)
 "dt" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "du" = (
@@ -1125,15 +1109,15 @@
 /area/awaymission/academy/classrooms)
 "dw" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "dx" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/greengrid,
 /area/awaymission/academy/classrooms)
@@ -1273,8 +1257,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "dQ" = (
@@ -1410,13 +1394,11 @@
 /area/awaymission/academy/classrooms)
 "ej" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
-	environ = 3;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -1440,15 +1422,15 @@
 /area/awaymission/academy/classrooms)
 "em" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (SOUTHWEST)";
+	dir = 10;
 	icon_state = "green";
-	dir = 10
+	tag = "icon-green (SOUTHWEST)"
 	},
 /area/awaymission/academy/classrooms)
 "en" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green";
-	icon_state = "green"
+	icon_state = "green";
+	tag = "icon-green"
 	},
 /area/awaymission/academy/classrooms)
 "eo" = (
@@ -1460,8 +1442,8 @@
 "ep" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 6
+	dir = 6;
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "eq" = (
@@ -1495,8 +1477,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 10
+	dir = 10;
+	icon_state = "yellow"
 	},
 /area/awaymission/academy/classrooms)
 "ev" = (
@@ -1549,15 +1531,15 @@
 /area/awaymission/academy/headmaster)
 "eC" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "eD" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "eE" = (
@@ -1633,7 +1615,6 @@
 /area/awaymission/academy/classrooms)
 "eO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -1643,8 +1624,8 @@
 "eP" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "eQ" = (
@@ -1696,14 +1677,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "eY" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -1740,8 +1720,8 @@
 "fc" = (
 /obj/structure/mineral_door/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fd" = (
@@ -1803,8 +1783,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fk" = (
@@ -1815,8 +1795,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fl" = (
@@ -1850,16 +1830,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fp" = (
 /obj/structure/table,
 /obj/item/trash/semki,
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fq" = (
@@ -1867,8 +1847,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fr" = (
@@ -1881,8 +1861,8 @@
 /area/awaymission/academy/classrooms)
 "fs" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cautioncorner";
-	dir = 4
+	dir = 4;
+	icon_state = "cautioncorner"
 	},
 /area/awaymission/academy/classrooms)
 "ft" = (
@@ -1908,8 +1888,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fw" = (
@@ -1965,8 +1945,8 @@
 "fA" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "fB" = (
@@ -2039,8 +2019,8 @@
 /area/awaymission/academy/academyaft)
 "fI" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "fJ" = (
@@ -2066,19 +2046,19 @@
 /area/awaymission/academy/academyaft)
 "fN" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/academy/classrooms)
 "fO" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced{
 	dir = 5
@@ -2088,8 +2068,8 @@
 "fP" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/academy/classrooms)
 "fQ" = (
@@ -2099,8 +2079,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "fR" = (
@@ -2142,18 +2122,18 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "fX" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/academy/classrooms)
 "fY" = (
@@ -2170,8 +2150,8 @@
 /obj/structure/table,
 /obj/item/lazarus_injector,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "gb" = (
@@ -2191,8 +2171,8 @@
 /obj/structure/grille,
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced{
 	dir = 5
@@ -2208,20 +2188,20 @@
 /area/awaymission/academy/classrooms)
 "gg" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gh" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced{
 	dir = 5
@@ -2232,17 +2212,17 @@
 /obj/structure/table/reinforced,
 /obj/item/pen/red,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gj" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gk" = (
@@ -2273,8 +2253,8 @@
 /area/awaymission/academy/classrooms)
 "go" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "gp" = (
@@ -2286,15 +2266,13 @@
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gq" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaymission/academy/classrooms)
@@ -2304,20 +2282,12 @@
 /area/awaymission/academy/classrooms)
 "gs" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
-/area/awaymission/academy/classrooms)
-"gt" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
 /area/awaymission/academy/classrooms)
 "gu" = (
 /obj/structure/bookcase,
@@ -2326,7 +2296,6 @@
 /area/awaymission/academy/classrooms)
 "gv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -2335,19 +2304,16 @@
 /area/awaymission/academy/academyaft)
 "gw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gx" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/machinery/door/window{
 	dir = 8
 	},
@@ -2376,8 +2342,8 @@
 "gB" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable,
 /obj/structure/window/reinforced{
@@ -2388,8 +2354,8 @@
 "gC" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/structure/window/reinforced{
@@ -2404,9 +2370,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gE" = (
@@ -2417,9 +2383,9 @@
 	},
 /obj/item/gun/projectile/shotgun/toy/tommygun,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gF" = (
@@ -2433,9 +2399,9 @@
 "gG" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gH" = (
@@ -2463,15 +2429,13 @@
 "gL" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gM" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/item/ammo_casing,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -2521,9 +2485,9 @@
 	name = "Summoning Midterm Exam"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "gU" = (
@@ -2537,8 +2501,8 @@
 /obj/structure/grille,
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced{
 	dir = 5
@@ -2560,15 +2524,13 @@
 /area/awaymission/academy/academyaft)
 "gX" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "gY" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "gZ" = (
@@ -2630,9 +2592,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "hh" = (
@@ -2642,20 +2604,17 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/classrooms)
 "hi" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
-	environ = 3;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -2668,15 +2627,15 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/academy/classrooms)
 "hk" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/academy/academyaft)
 "hl" = (
@@ -2690,17 +2649,17 @@
 /area/awaymission/academy/academyaft)
 "hn" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (EAST)";
+	dir = 4;
 	icon_state = "green";
-	dir = 4
+	tag = "icon-green (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "ho" = (
 /obj/item/crowbar/red,
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (EAST)";
+	dir = 4;
 	icon_state = "green";
-	dir = 4
+	tag = "icon-green (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "hp" = (
@@ -2759,8 +2718,8 @@
 /obj/machinery/power/smes/magical,
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -2769,8 +2728,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -2814,8 +2773,8 @@
 "hD" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -2857,15 +2816,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/academy/classrooms)
-"hJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/academy/academyaft)
 "hK" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
@@ -2878,20 +2828,8 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
-"hM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
-	},
-/area/awaymission/academy/academyaft)
 "hN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -2973,7 +2911,6 @@
 /area/awaymission/academy/academyaft)
 "ia" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -2983,15 +2920,6 @@
 "ib" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel,
-/area/awaymission/academy/academyaft)
-"ic" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
 "id" = (
 /obj/item/stack/cable_coil/random,
@@ -3033,8 +2961,7 @@
 /area/awaymission/academy/academyaft)
 "ii" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "ij" = (
@@ -3042,15 +2969,13 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "ik" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "im" = (
@@ -3066,8 +2991,7 @@
 "io" = (
 /obj/structure/mineral_door/iron,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "ir" = (
@@ -3077,48 +3001,40 @@
 /area/awaymission/academy/academyaft)
 "is" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "it" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "iu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/academy/academyaft)
 "iv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/academy/academyaft)
 "iw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "ix" = (
@@ -3150,8 +3066,7 @@
 	name = "awaystart"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "iA" = (
@@ -3162,8 +3077,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "iB" = (
@@ -3184,8 +3098,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "iE" = (
@@ -3222,8 +3135,7 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "iL" = (
@@ -3257,8 +3169,8 @@
 /obj/structure/table,
 /obj/item/beach_ball/holoball,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/academy/academyaft)
 "iP" = (
@@ -3304,8 +3216,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/academy/academyaft)
 "iS" = (
@@ -3329,9 +3241,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (EAST)";
+	dir = 4;
 	icon_state = "green";
-	dir = 4
+	tag = "icon-green (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "iU" = (
@@ -3341,15 +3253,15 @@
 /obj/structure/table,
 /obj/item/soulstone,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-whitered (EAST)";
+	dir = 4;
 	icon_state = "whitered";
-	dir = 4
+	tag = "icon-whitered (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "iV" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l";
-	icon_state = "propulsion_l"
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l"
 	},
 /turf/space,
 /area/awaymission/academy/academyaft)
@@ -3359,16 +3271,16 @@
 /area/awaymission/academy/academyaft)
 "iX" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r";
-	icon_state = "propulsion_r"
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r"
 	},
 /turf/space,
 /area/awaymission/academy/academyaft)
 "iY" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced{
 	dir = 5
@@ -3438,9 +3350,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (EAST)";
+	dir = 4;
 	icon_state = "green";
-	dir = 4
+	tag = "icon-green (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "je" = (
@@ -3499,7 +3411,6 @@
 /area/awaymission/academy/academyaft)
 "jj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -3520,9 +3431,9 @@
 "jl" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-whitered (EAST)";
+	dir = 4;
 	icon_state = "whitered";
-	dir = 4
+	tag = "icon-whitered (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "jm" = (
@@ -3578,15 +3489,15 @@
 "js" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/awaymission/academy/academyaft)
 "jt" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 10
+	dir = 10;
+	icon_state = "yellow"
 	},
 /area/awaymission/academy/academyaft)
 "ju" = (
@@ -3604,9 +3515,9 @@
 "jw" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-white (EAST)";
+	dir = 4;
 	icon_state = "white";
-	dir = 4
+	tag = "icon-white (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "jx" = (
@@ -3614,9 +3525,9 @@
 /obj/structure/window/reinforced,
 /obj/item/batterer,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-whitered (EAST)";
+	dir = 4;
 	icon_state = "whitered";
-	dir = 4
+	tag = "icon-whitered (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "jy" = (
@@ -3674,12 +3585,10 @@
 "jG" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "jH" = (
@@ -3749,8 +3658,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced{
 	dir = 5
@@ -3784,8 +3693,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/awaymission/academy/academyaft)
 "jX" = (
@@ -3844,22 +3753,20 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-white (EAST)";
+	dir = 4;
 	icon_state = "white";
-	dir = 4
+	tag = "icon-white (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "ke" = (
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
-	environ = 3;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academygate)
@@ -3891,8 +3798,8 @@
 "ki" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/structure/window/reinforced{
@@ -3912,8 +3819,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/academy/academyaft)
 "kk" = (
@@ -3928,9 +3835,9 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-white (EAST)";
+	dir = 4;
 	icon_state = "white";
-	dir = 4
+	tag = "icon-white (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "kl" = (
@@ -3989,8 +3896,8 @@
 /obj/structure/grille,
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced{
 	dir = 5
@@ -4000,8 +3907,8 @@
 "kv" = (
 /mob/living/simple_animal/hostile/mimic/crate,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/academy/classrooms)
 "kw" = (
@@ -4025,9 +3932,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-whitered (EAST)";
+	dir = 4;
 	icon_state = "whitered";
-	dir = 4
+	tag = "icon-whitered (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "kA" = (
@@ -4068,8 +3975,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/academy/academyaft)
 "kH" = (
@@ -4089,7 +3996,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -4103,8 +4009,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "kM" = (
@@ -4121,8 +4027,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "kO" = (
@@ -4131,8 +4037,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "kP" = (
@@ -4142,8 +4048,8 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
 "kQ" = (
@@ -4166,9 +4072,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-white (EAST)";
+	dir = 4;
 	icon_state = "white";
-	dir = 4
+	tag = "icon-white (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "kT" = (
@@ -4191,8 +4097,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/academy/academyaft)
 "kW" = (
@@ -4212,9 +4118,9 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-white (EAST)";
+	dir = 4;
 	icon_state = "white";
-	dir = 4
+	tag = "icon-white (EAST)"
 	},
 /area/awaymission/academy/academyaft)
 "kZ" = (
@@ -4277,8 +4183,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academygate)
@@ -4299,8 +4204,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
@@ -4315,8 +4219,8 @@
 /area/awaymission/academy/academygate)
 "lj" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academygate)
@@ -4401,8 +4305,7 @@
 /area/awaymission/academy/academyaft)
 "lv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -4437,8 +4340,7 @@
 "lA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -11821,7 +11723,7 @@ bE
 fK
 dc
 dc
-gt
+db
 dc
 dc
 dc
@@ -12711,7 +12613,7 @@ br
 br
 br
 br
-cS
+bI
 br
 br
 aF
@@ -15337,7 +15239,7 @@ aa
 aa
 aa
 gZ
-hM
+hs
 lp
 hp
 hp
@@ -15467,7 +15369,7 @@ aa
 aa
 aa
 gZ
-hJ
+kh
 lo
 lq
 lr
@@ -15597,7 +15499,7 @@ aa
 aa
 aa
 gZ
-ic
+he
 hK
 hc
 ls

--- a/_maps/map_files/RandomZLevels/beach.dmm
+++ b/_maps/map_files/RandomZLevels/beach.dmm
@@ -109,8 +109,7 @@
 /area/awaymission/undersea)
 "aC" = (
 /obj/structure/mineral_door/wood{
-	tag = "icon-wood";
-	icon_state = "wood"
+	tag = "icon-wood"
 	},
 /turf/simulated/floor/beach/away/water/deep/wood_floor,
 /area/awaymission/undersea)
@@ -140,17 +139,15 @@
 /area/awaymission/undersea)
 "aI" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
+	dir = 4;
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/beach/away/water/deep/wood_floor,
 /area/awaymission/undersea)
 "aJ" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
-	icon_state = "wooden_chair_wings";
-	dir = 8
+	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/beach/away/water/deep/wood_floor,
 /area/awaymission/undersea)
@@ -165,15 +162,12 @@
 "aM" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/beach/away/water/deep/wood_floor,
 /area/awaymission/undersea)
 "aN" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -230,8 +224,7 @@
 /area/awaymission/undersea)
 "aY" = (
 /obj/structure/mineral_door/wood{
-	tag = "icon-wood";
-	icon_state = "wood"
+	tag = "icon-wood"
 	},
 /turf/simulated/floor/beach/away/water/deep/sand_floor,
 /area/awaymission/undersea)
@@ -252,10 +245,9 @@
 "bc" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTHWEST)";
+	dir = 9;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 9
+	tag = "icon-gravsnow_corner (NORTHWEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -265,10 +257,9 @@
 /area/awaymission/beach)
 "be" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTHEAST)";
+	dir = 5;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 5
+	tag = "icon-gravsnow_corner (NORTHEAST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -278,20 +269,18 @@
 /area/awaymission/beach)
 "bg" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "bh" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -306,28 +295,25 @@
 /area/awaymission/beach)
 "bk" = (
 /obj/effect/decal/snow/sand/surround{
-	tag = "icon-gravsnow_surround (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_surround";
-	dir = 1
+	tag = "icon-gravsnow_surround (NORTH)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "bl" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "bm" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTHWEST)";
+	dir = 9;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 9
+	tag = "icon-gravsnow_corner (NORTHWEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -339,10 +325,9 @@
 /area/awaymission/beach)
 "bo" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (SOUTHWEST)";
+	dir = 10;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 10
+	tag = "icon-gravsnow_corner (SOUTHWEST)"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/beach)
@@ -354,28 +339,25 @@
 /area/awaymission/beach)
 "bq" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (SOUTHEAST)";
+	dir = 6;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 6
+	tag = "icon-gravsnow_corner (SOUTHEAST)"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/beach)
 "br" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (SOUTHEAST)";
+	dir = 6;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 6
+	tag = "icon-gravsnow_corner (SOUTHEAST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "bs" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (SOUTHWEST)";
+	dir = 10;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 10
+	tag = "icon-gravsnow_corner (SOUTHWEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -386,19 +368,17 @@
 "bu" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTHWEST)";
+	dir = 9;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 9
+	tag = "icon-gravsnow_corner (NORTHWEST)"
 	},
 /turf/simulated/floor/beach/away/sand/dense,
 /area/awaymission/beach)
 "bv" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTHEAST)";
+	dir = 5;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 5
+	tag = "icon-gravsnow_corner (NORTHEAST)"
 	},
 /turf/simulated/floor/beach/away/sand/dense,
 /area/awaymission/beach)
@@ -409,19 +389,17 @@
 "bx" = (
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTHWEST)";
+	dir = 9;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 9
+	tag = "icon-gravsnow_corner (NORTHWEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "by" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -432,30 +410,27 @@
 "bA" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "bB" = (
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "bC" = (
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -479,29 +454,26 @@
 "bH" = (
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "bI" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /turf/simulated/floor/beach/away/sand/dense,
 /area/awaymission/beach)
 "bJ" = (
 /obj/effect/overlay/palmtree_l,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -517,10 +489,9 @@
 "bM" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -623,10 +594,9 @@
 /obj/effect/overlay/palmtree_r,
 /obj/effect/overlay/coconut,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -691,10 +661,9 @@
 "cs" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTHEAST)";
+	dir = 5;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 5
+	tag = "icon-gravsnow_corner (NORTHEAST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -733,10 +702,9 @@
 /area/awaymission/beach)
 "cB" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /obj/effect/overlay/palmtree_r,
 /turf/simulated/floor/beach/away/sand,
@@ -751,46 +719,41 @@
 "cG" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "cJ" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /obj/structure/closet/athletic_mixed,
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "cK" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /obj/effect/overlay/palmtree_l,
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "cL" = (
 /obj/structure/mineral_door/wood{
-	tag = "icon-wood";
-	icon_state = "wood"
+	tag = "icon-wood"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "cN" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/shoes/sandal,
@@ -807,8 +770,6 @@
 /area/awaymission/beach)
 "cS" = (
 /obj/structure/closet/gmcloset{
-	icon_closed = "black";
-	icon_state = "black";
 	name = "formal wardrobe"
 	},
 /turf/simulated/floor/wood,
@@ -905,10 +866,9 @@
 /area/awaymission/beach)
 "do" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/beach/away/sand,
@@ -944,17 +904,15 @@
 "dz" = (
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (SOUTHWEST)";
+	dir = 10;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 10
+	tag = "icon-gravsnow_corner (SOUTHWEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
 "dA" = (
 /obj/structure/mineral_door/wood{
-	tag = "icon-wood";
-	icon_state = "wood"
+	tag = "icon-wood"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/beach)
@@ -986,10 +944,9 @@
 /area/awaymission/beach)
 "dH" = (
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/beach/away/sand,
@@ -1037,10 +994,9 @@
 "dP" = (
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (SOUTHEAST)";
+	dir = 6;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 6
+	tag = "icon-gravsnow_corner (SOUTHEAST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)
@@ -1053,7 +1009,6 @@
 /area/awaymission/beach)
 "dR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -1063,8 +1018,7 @@
 /area/awaymission/beach)
 "dS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -1074,10 +1028,9 @@
 "dT" = (
 /obj/effect/overlay/palmtree_l,
 /obj/effect/decal/snow/sand/edge{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	name = "rough sand";
-	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/awaymission/beach)

--- a/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
+++ b/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
@@ -122,7 +122,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -198,9 +197,9 @@
 /area/awaymission/BMPship/Gate)
 "br" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
@@ -208,7 +207,6 @@
 	equipment = 0;
 	lighting = 0;
 	locked = 0;
-	operating = 1;
 	req_access = ""
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -287,7 +285,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -326,8 +323,8 @@
 /area/awaymission/BMPship/Fore)
 "bR" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/awaymission/BMPship/Fore)
 "bS" = (
@@ -386,7 +383,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated,
@@ -411,17 +407,17 @@
 "cg" = (
 /obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (NORTH)";
+	dir = 1;
 	icon_state = "carpetside";
-	dir = 1
+	tag = "icon-carpetside (NORTH)"
 	},
 /area/awaymission/BMPship/Fore)
 "ci" = (
 /obj/machinery/door/airlock/silver,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (NORTH)";
+	dir = 1;
 	icon_state = "carpetside";
-	dir = 1
+	tag = "icon-carpetside (NORTH)"
 	},
 /area/awaymission/BMPship/Fore)
 "cl" = (
@@ -432,8 +428,8 @@
 	calibrated = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Gate)
@@ -455,7 +451,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/gateway{
@@ -494,14 +489,14 @@
 /area/awaymission/BMPship/Gate)
 "cB" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet";
-	icon_state = "carpet"
+	icon_state = "carpet";
+	tag = "icon-carpet"
 	},
 /area/awaymission/BMPship/Fore)
 "cC" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
@@ -513,8 +508,8 @@
 	req_access = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet";
-	icon_state = "carpet"
+	icon_state = "carpet";
+	tag = "icon-carpet"
 	},
 /area/awaymission/BMPship/Fore)
 "cD" = (
@@ -532,9 +527,9 @@
 /area/awaymission/BMPship/Midship)
 "cF" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (WEST)";
+	dir = 8;
 	icon_state = "green";
-	dir = 8
+	tag = "icon-green (WEST)"
 	},
 /area/awaymission/BMPship/Midship)
 "cG" = (
@@ -555,9 +550,7 @@
 	},
 /area/awaymission/BMPship/Midship)
 "cI" = (
-/obj/structure/sink{
-	dir = 2
-	},
+/obj/structure/sink,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -572,9 +565,9 @@
 /area/awaymission/BMPship/Midship)
 "cK" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (EAST)";
+	dir = 4;
 	icon_state = "green";
-	dir = 4
+	tag = "icon-green (EAST)"
 	},
 /area/awaymission/BMPship/Midship)
 "cM" = (
@@ -586,8 +579,8 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "cO" = (
@@ -595,8 +588,8 @@
 /obj/item/kitchen/knife/butcher,
 /obj/item/reagent_containers/food/snacks/meat,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "cP" = (
@@ -608,16 +601,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "cQ" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "cR" = (
@@ -655,16 +648,16 @@
 /area/awaymission/BMPship/Midship)
 "cW" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-13 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-13";
-	dir = 4
+	tag = "icon-carpet15-13 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "cX" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-7 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-7";
-	dir = 4
+	tag = "icon-carpet15-7 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "cY" = (
@@ -672,13 +665,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-7 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-7";
-	dir = 4
+	tag = "icon-carpet15-7 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "cZ" = (
@@ -689,8 +681,8 @@
 /area/awaymission/BMPship/Midship)
 "db" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "dc" = (
@@ -701,8 +693,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "de" = (
@@ -722,9 +714,9 @@
 /area/awaymission/BMPship/Midship)
 "dh" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-14 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-14";
-	dir = 4
+	tag = "icon-carpet15-14 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "di" = (
@@ -770,9 +762,9 @@
 /area/awaymission/BMPship/Aft)
 "dp" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-11 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-11";
-	dir = 4
+	tag = "icon-carpet15-11 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "dq" = (
@@ -786,8 +778,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet";
-	icon_state = "carpet"
+	icon_state = "carpet";
+	tag = "icon-carpet"
 	},
 /area/awaymission/BMPship/Fore)
 "ds" = (
@@ -798,9 +790,9 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-11 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-11";
-	dir = 4
+	tag = "icon-carpet15-11 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "dt" = (
@@ -810,20 +802,20 @@
 "du" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "dv" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "dw" = (
@@ -832,8 +824,8 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "dx" = (
@@ -845,15 +837,15 @@
 "dy" = (
 /obj/machinery/door/window,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber";
-	icon_state = "barber"
+	icon_state = "barber";
+	tag = "icon-barber"
 	},
 /area/awaymission/BMPship/Midship)
 "dz" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -888,14 +880,13 @@
 /area/awaymission/BMPship/Aft)
 "dE" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
 	environ = 0;
-	equipment = 3;
 	locked = 0;
 	operating = 0;
 	req_access = ""
@@ -922,9 +913,9 @@
 	name = "Captain's log entry"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet6-0 (EAST)";
+	dir = 4;
 	icon_state = "carpet6-0";
-	dir = 4
+	tag = "icon-carpet6-0 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "dI" = (
@@ -932,17 +923,17 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet14-8 (EAST)";
+	dir = 4;
 	icon_state = "carpet14-8";
-	dir = 4
+	tag = "icon-carpet14-8 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "dJ" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet14-2 (EAST)";
+	dir = 4;
 	icon_state = "carpet14-2";
-	dir = 4
+	tag = "icon-carpet14-2 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "dK" = (
@@ -953,43 +944,43 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet";
-	icon_state = "carpet"
+	icon_state = "carpet";
+	tag = "icon-carpet"
 	},
 /area/awaymission/BMPship/Fore)
 "dL" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet10-0 (EAST)";
+	dir = 4;
 	icon_state = "carpet10-0";
-	dir = 4
+	tag = "icon-carpet10-0 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "dM" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (SOUTHWEST)";
+	dir = 10;
 	icon_state = "green";
-	dir = 10
+	tag = "icon-green (SOUTHWEST)"
 	},
 /area/awaymission/BMPship/Midship)
 "dN" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green";
-	icon_state = "green"
+	icon_state = "green";
+	tag = "icon-green"
 	},
 /area/awaymission/BMPship/Midship)
 "dO" = (
 /obj/machinery/seed_extractor,
 /obj/item/seeds/plump/walkingmushroom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-green";
-	icon_state = "green"
+	icon_state = "green";
+	tag = "icon-green"
 	},
 /area/awaymission/BMPship/Midship)
 "dP" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-green (SOUTHEAST)";
+	dir = 6;
 	icon_state = "green";
-	dir = 6
+	tag = "icon-green (SOUTHEAST)"
 	},
 /area/awaymission/BMPship/Midship)
 "dR" = (
@@ -1014,7 +1005,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -1054,7 +1044,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -1076,7 +1065,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -1086,7 +1074,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -1102,7 +1089,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -1126,9 +1112,8 @@
 /area/awaymission/BMPship/Aft)
 "eb" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (EAST)";
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1138,7 +1123,6 @@
 "ec" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -1149,38 +1133,37 @@
 /area/awaymission/BMPship/Aft)
 "ee" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-15 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-15";
-	dir = 4
+	tag = "icon-carpet15-15 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "ef" = (
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet5-0 (EAST)";
+	dir = 4;
 	icon_state = "carpet5-0";
-	dir = 4
+	tag = "icon-carpet5-0 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "eg" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet13-4 (EAST)";
+	dir = 4;
 	icon_state = "carpet13-4";
-	dir = 4
+	tag = "icon-carpet13-4 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "eh" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet13-1 (EAST)";
+	dir = 4;
 	icon_state = "carpet13-1";
-	dir = 4
+	tag = "icon-carpet13-1 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "ei" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -1190,30 +1173,18 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet (EAST)";
+	dir = 4;
 	icon_state = "carpet";
-	dir = 4
+	tag = "icon-carpet (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "ej" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet9-0 (EAST)";
+	dir = 4;
 	icon_state = "carpet9-0";
-	dir = 4
+	tag = "icon-carpet9-0 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
-"ek" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/awaymission/BMPship/Midship)
 "el" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1271,16 +1242,6 @@
 "er" = (
 /turf/simulated/wall/r_wall,
 /area/awaymission/BMPship/Midship)
-"es" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/BMPship/Aft)
 "et" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1289,22 +1250,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaymission/BMPship/Aft)
-"eu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/BMPship/Aft)
 "ev" = (
 /obj/item/shard,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (NORTHEAST)";
+	dir = 5;
 	icon_state = "carpetside";
-	dir = 5
+	tag = "icon-carpetside (NORTHEAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "ew" = (
@@ -1312,9 +1263,9 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (NORTHWEST)";
+	dir = 9;
 	icon_state = "carpetside";
-	dir = 9
+	tag = "icon-carpetside (NORTHWEST)"
 	},
 /area/awaymission/BMPship/Fore)
 "ex" = (
@@ -1331,8 +1282,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet";
-	icon_state = "carpet"
+	icon_state = "carpet";
+	tag = "icon-carpet"
 	},
 /area/awaymission/BMPship/Fore)
 "ey" = (
@@ -1352,13 +1303,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (EAST)";
+	dir = 4;
 	icon_state = "carpetside";
-	dir = 4
+	tag = "icon-carpetside (EAST)"
 	},
 /area/awaymission/BMPship/Midship)
 "eC" = (
@@ -1392,15 +1342,15 @@
 "eE" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Midship)
 "eF" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
@@ -1484,7 +1434,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -1493,8 +1442,8 @@
 /area/awaymission/BMPship/Aft)
 "eP" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
 	dir = 8
@@ -1535,13 +1484,13 @@
 	outputting = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Aft)
@@ -1563,17 +1512,17 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet11-12 (EAST)";
+	dir = 4;
 	icon_state = "carpet11-12";
-	dir = 4
+	tag = "icon-carpet11-12 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "eW" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet7-3 (EAST)";
+	dir = 4;
 	icon_state = "carpet7-3";
-	dir = 4
+	tag = "icon-carpet7-3 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "eX" = (
@@ -1581,9 +1530,9 @@
 	icon_state = "medium"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-14 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-14";
-	dir = 4
+	tag = "icon-carpet15-14 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "eZ" = (
@@ -1594,9 +1543,9 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-15 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-15";
-	dir = 4
+	tag = "icon-carpet15-15 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fa" = (
@@ -1701,7 +1650,6 @@
 "fq" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right"
 	},
 /turf/simulated/floor/plating,
@@ -1711,13 +1659,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-13 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-13";
-	dir = 4
+	tag = "icon-carpet15-13 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fs" = (
@@ -1734,9 +1681,9 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-7 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-7";
-	dir = 4
+	tag = "icon-carpet15-7 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fu" = (
@@ -1747,9 +1694,9 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-15 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-15";
-	dir = 4
+	tag = "icon-carpet15-15 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fv" = (
@@ -1757,13 +1704,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-7 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-7";
-	dir = 4
+	tag = "icon-carpet15-7 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fw" = (
@@ -1788,7 +1734,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -1850,16 +1795,16 @@
 /area/awaymission/BMPship/Aft)
 "fE" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (SOUTHEAST)";
+	dir = 6;
 	icon_state = "carpetside";
-	dir = 6
+	tag = "icon-carpetside (SOUTHEAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fF" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (SOUTHWEST)";
+	dir = 10;
 	icon_state = "carpetside";
-	dir = 10
+	tag = "icon-carpetside (SOUTHWEST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fG" = (
@@ -1873,27 +1818,25 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-11 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-11";
-	dir = 4
+	tag = "icon-carpet15-11 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fJ" = (
 /obj/machinery/door/airlock/silver,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside (EAST)";
+	dir = 4;
 	icon_state = "carpetside";
-	dir = 4
+	tag = "icon-carpetside (EAST)"
 	},
 /area/awaymission/BMPship/Midship)
 "fK" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right"
 	},
 /turf/simulated/floor/plating,
@@ -1927,7 +1870,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -1968,7 +1910,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -2000,20 +1941,6 @@
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Aft)
-"fV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-15 (EAST)";
-	icon_state = "carpet15-15";
-	dir = 4
-	},
-/area/awaymission/BMPship/Fore)
 "fW" = (
 /obj/structure/closet,
 /obj/item/clothing/head/bio_hood,
@@ -2028,22 +1955,21 @@
 /area/awaymission/BMPship/Aft)
 "fY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/closet,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet (EAST)";
+	dir = 4;
 	icon_state = "carpet";
-	dir = 4
+	tag = "icon-carpet (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "fZ" = (
 /obj/structure/closet,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpet15-15 (EAST)";
+	dir = 4;
 	icon_state = "carpet15-15";
-	dir = 4
+	tag = "icon-carpet15-15 (EAST)"
 	},
 /area/awaymission/BMPship/Fore)
 "ga" = (
@@ -2085,8 +2011,8 @@
 "gh" = (
 /obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside";
-	icon_state = "carpetside"
+	icon_state = "carpetside";
+	tag = "icon-carpetside"
 	},
 /area/awaymission/BMPship/Fore)
 "gi" = (
@@ -2094,13 +2020,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/plasteel{
-	tag = "icon-carpetside";
-	icon_state = "carpetside"
+	icon_state = "carpetside";
+	tag = "icon-carpetside"
 	},
 /area/awaymission/BMPship/Fore)
 "gk" = (
@@ -2184,7 +2109,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/burnturf,
@@ -2221,7 +2145,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -2278,18 +2201,6 @@
 	icon_state = "bar"
 	},
 /area/awaymission/BMPship/Midship)
-"gI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/awaymission/BMPship/Aft)
 "gJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -2336,7 +2247,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -2432,7 +2342,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -2533,8 +2442,8 @@
 /area/awaymission)
 "hG" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/computer/monitor/secret,
 /obj/effect/decal/warning_stripes/west,
@@ -2602,7 +2511,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -2717,8 +2625,8 @@
 /area/awaymission)
 "ij" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission)
@@ -2728,7 +2636,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -2738,21 +2645,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission)
-"im" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/BMPship/Aft)
 "in" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2785,8 +2681,7 @@
 "iu" = (
 /obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship/Aft)
 "iv" = (
@@ -2797,8 +2692,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship/Aft)
 "iw" = (
@@ -2806,8 +2700,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship/Aft)
 "ix" = (
@@ -2824,12 +2717,9 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/BMPship/Aft)
 "iB" = (
-/obj/structure/sink{
-	dir = 2
-	},
+/obj/structure/sink,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship/Aft)
 "iD" = (
@@ -2983,7 +2873,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -2993,7 +2882,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/item/hand_labeler,
@@ -3004,7 +2892,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/item/storage/box,
@@ -9760,7 +9647,7 @@ cX
 dp
 ft
 fI
-fV
+eZ
 gi
 gC
 gA
@@ -10406,7 +10293,7 @@ cM
 cM
 cM
 em
-ek
+dS
 cM
 cM
 cM
@@ -10665,7 +10552,7 @@ cF
 cF
 cF
 dM
-ek
+dS
 er
 er
 er
@@ -10795,7 +10682,7 @@ cI
 dc
 dc
 dN
-ek
+dS
 er
 fd
 fd
@@ -10925,7 +10812,7 @@ cH
 dc
 dt
 dN
-ek
+dS
 er
 fe
 fd
@@ -11055,7 +10942,7 @@ cJ
 dc
 dc
 dO
-ek
+dS
 er
 fd
 fg
@@ -11185,7 +11072,7 @@ cI
 dc
 dc
 dN
-ek
+dS
 er
 ff
 ff
@@ -11315,7 +11202,7 @@ cK
 cK
 cK
 dP
-ek
+dS
 eE
 fg
 fg
@@ -11578,7 +11465,7 @@ cM
 cM
 cM
 fa
-ek
+dS
 cM
 cM
 gm
@@ -11838,7 +11725,7 @@ cM
 cM
 cM
 cM
-ek
+dS
 cM
 cM
 cM
@@ -12103,7 +11990,7 @@ cM
 cM
 hV
 cM
-ek
+dS
 cM
 cl
 hH
@@ -12233,7 +12120,7 @@ cM
 eq
 gl
 gH
-ek
+dS
 cM
 cl
 gY
@@ -12363,7 +12250,7 @@ fP
 er
 gp
 er
-ek
+dS
 cM
 cl
 ac
@@ -12493,7 +12380,7 @@ cM
 er
 go
 er
-ek
+dS
 hd
 cl
 hJ
@@ -12623,7 +12510,7 @@ cM
 er
 go
 er
-ek
+dS
 cM
 cl
 hH
@@ -12753,7 +12640,7 @@ cM
 er
 go
 er
-ek
+dS
 cM
 cl
 ac
@@ -13668,7 +13555,7 @@ ai
 dq
 hP
 hu
-im
+hQ
 dq
 iA
 ai
@@ -13798,7 +13685,7 @@ ai
 dq
 dq
 dq
-im
+hQ
 dq
 iA
 ai
@@ -13922,13 +13809,13 @@ fp
 fp
 eR
 gk
-gI
+fR
 dj
 hg
 dq
 bd
 dq
-im
+hQ
 it
 dq
 ai
@@ -14052,13 +13939,13 @@ bd
 fz
 fD
 gf
-gI
+fR
 dj
 ai
 dq
 dq
 ie
-im
+hQ
 is
 bd
 ai
@@ -14182,13 +14069,13 @@ bd
 bd
 bd
 gf
-gI
+fR
 fG
 ai
 ht
 dq
 dq
-im
+hQ
 dq
 dq
 ai
@@ -14955,17 +14842,17 @@ jB
 de
 de
 dX
-es
+de
 eO
 eO
-es
-es
-es
+de
+de
+de
 eO
-es
-eu
+de
+bO
 hf
-es
+de
 hS
 dq
 ai
@@ -15215,7 +15102,7 @@ am
 ai
 do
 dZ
-eu
+bO
 eT
 fj
 fj
@@ -15477,7 +15364,7 @@ hw
 ea
 bO
 eU
-eu
+bO
 fj
 fT
 bd

--- a/_maps/map_files/RandomZLevels/centcomAway.dmm
+++ b/_maps/map_files/RandomZLevels/centcomAway.dmm
@@ -46,21 +46,18 @@
 	req_access_txt = "101"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/maint)
 "ai" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "aj" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "ak" = (
@@ -69,26 +66,26 @@
 "al" = (
 /obj/structure/closet/chefcloset,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "am" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "an" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "ao" = (
@@ -96,18 +93,18 @@
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "ap" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "aq" = (
@@ -117,9 +114,9 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "ar" = (
@@ -127,9 +124,9 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "as" = (
@@ -140,9 +137,9 @@
 	},
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "at" = (
@@ -172,12 +169,10 @@
 /area/awaymission/centcomAway/cafe)
 "aw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "ax" = (
@@ -187,9 +182,9 @@
 /area/awaymission/centcomAway/cafe)
 "ay" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "az" = (
@@ -218,9 +213,9 @@
 "aC" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "aD" = (
@@ -252,12 +247,10 @@
 /area/awaymission/centcomAway/cafe)
 "aJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "aK" = (
@@ -277,8 +270,8 @@
 "aL" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
-	icon_state = "redyellowfull"
+	icon_state = "redyellowfull";
+	tag = "icon-redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "aM" = (
@@ -286,8 +279,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "aN" = (
@@ -304,9 +296,9 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "aP" = (
@@ -315,8 +307,8 @@
 /area/awaymission/centcomAway/maint)
 "aQ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/cafe)
 "aR" = (
@@ -325,8 +317,8 @@
 /area/awaymission/centcomAway/cafe)
 "aS" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/cafe)
 "aT" = (
@@ -365,7 +357,6 @@
 "aX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -376,7 +367,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -384,14 +374,13 @@
 "aZ" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "ba" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -420,45 +409,44 @@
 "be" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bf" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bg" = (
 /obj/structure/sink,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bh" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bi" = (
 /obj/structure/table,
 /obj/machinery/processor{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bj" = (
@@ -467,8 +455,8 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "bk" = (
@@ -486,50 +474,47 @@
 /area/space/nearstation)
 "bn" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "bo" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "bp" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "bq" = (
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "br" = (
 /obj/machinery/chem_dispenser,
 /obj/item/storage/box/beakers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bs" = (
 /obj/machinery/chem_master,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bt" = (
@@ -544,9 +529,9 @@
 /area/awaymission/centcomAway/hangar)
 "bu" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHWEST)";
+	dir = 9;
 	icon_state = "vault";
-	dir = 9
+	tag = "icon-vault (NORTHWEST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "bv" = (
@@ -557,8 +542,8 @@
 /area/awaymission/centcomAway/cafe)
 "bw" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/hangar)
@@ -567,8 +552,8 @@
 /area/awaymission/centcomAway/hangar)
 "by" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/hangar)
@@ -588,7 +573,6 @@
 /area/awaymission/centcomAway/cafe)
 "bC" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -596,15 +580,14 @@
 "bE" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "bF" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "bG" = (
@@ -612,12 +595,10 @@
 	name = "CondiMaster Neo"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "bH" = (
@@ -628,8 +609,7 @@
 /area/awaymission/centcomAway/hangar)
 "bI" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "bJ" = (
@@ -642,7 +622,6 @@
 "bK" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -655,31 +634,29 @@
 "bS" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "bT" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bV" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "bW" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "bX" = (
@@ -692,26 +669,24 @@
 "bZ" = (
 /obj/machinery/gibber,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "ca" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 6
+	dir = 6;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/cafe)
 "cb" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/centcomAway/cafe)
 "cc" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "centcomawaysolar";
@@ -733,8 +708,7 @@
 "cg" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = -2;
@@ -795,16 +769,16 @@
 /obj/item/paper_bin,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
-	icon_state = "redyellowfull"
+	icon_state = "redyellowfull";
+	tag = "icon-redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "cp" = (
 /obj/item/clipboard,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
-	icon_state = "redyellowfull"
+	icon_state = "redyellowfull";
+	tag = "icon-redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "cq" = (
@@ -814,9 +788,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/southright,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
+	dir = 1;
 	icon_state = "greenfull";
-	dir = 1
+	tag = "icon-greenfull (NORTH)"
 	},
 /area/awaymission/centcomAway/cafe)
 "cs" = (
@@ -826,8 +800,8 @@
 /area/awaymission/centcomAway/cafe)
 "ct" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/cafe)
 "cu" = (
@@ -841,7 +815,6 @@
 "cv" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
@@ -873,7 +846,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -949,7 +921,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -959,7 +930,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -969,7 +939,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -992,7 +961,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -1004,7 +972,6 @@
 /area/awaymission/centcomAway/hangar)
 "cQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -1017,7 +984,6 @@
 /area/awaymission/centcomAway/hangar)
 "cT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -1029,8 +995,8 @@
 /obj/item/pen,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
-	icon_state = "redyellowfull"
+	icon_state = "redyellowfull";
+	tag = "icon-redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "cW" = (
@@ -1064,8 +1030,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/cafe)
 "da" = (
@@ -1087,8 +1053,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -1119,12 +1084,11 @@
 /area/awaymission/centcomAway/hangar)
 "dj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "dk" = (
@@ -1137,8 +1101,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -1151,7 +1114,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
@@ -1162,15 +1124,11 @@
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaymission/centcomAway/hangar)
 "dp" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
-	dir = 8
-	},
+/obj/machinery/sleeper,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaymission/centcomAway/hangar)
 "dr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -1188,8 +1146,7 @@
 "dt" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/maint)
 "du" = (
@@ -1224,19 +1181,18 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/cafe)
 "dz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHWEST)";
+	dir = 9;
 	icon_state = "vault";
-	dir = 9
+	tag = "icon-vault (NORTHWEST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "dA" = (
@@ -1249,15 +1205,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "dD" = (
@@ -1274,36 +1230,36 @@
 /area/awaymission/centcomAway/hangar)
 "dG" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "dH" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dI" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dK" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dL" = (
@@ -1323,32 +1279,29 @@
 "dN" = (
 /obj/machinery/gibber,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "dO" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/cafe)
 "dP" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/cafe)
 "dQ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1361,8 +1314,7 @@
 "dR" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "dS" = (
@@ -1372,9 +1324,7 @@
 /area/awaymission/centcomAway/hangar)
 "dT" = (
 /obj/machinery/door/window/northright{
-	base_state = "right";
 	dir = 4;
-	icon_state = "right";
 	name = "Security Desk";
 	req_access_txt = "103"
 	},
@@ -1391,7 +1341,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -1450,20 +1399,18 @@
 	name = "CondiMaster Neo"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor";
-	dir = 2
+	icon_state = "freezerfloor"
 	},
 /area/awaymission/centcomAway/cafe)
 "ed" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/cafe)
 "ee" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -1480,7 +1427,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -1494,33 +1440,32 @@
 "ej" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "ek" = (
 /obj/machinery/chem_dispenser,
 /obj/item/storage/box/beakers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "el" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/cafe)
 "em" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "en" = (
@@ -1538,25 +1483,24 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
-	icon_state = "redyellowfull"
+	icon_state = "redyellowfull";
+	tag = "icon-redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "eq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "er" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "es" = (
@@ -1578,19 +1522,18 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "eu" = (
 /obj/structure/table,
 /obj/machinery/processor{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "ev" = (
@@ -1604,14 +1547,12 @@
 "ew" = (
 /obj/structure/bed,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/centcomAway/hangar)
 "ex" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -1623,8 +1564,8 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "ez" = (
@@ -1655,16 +1596,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
 "eD" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Rest Room";
-	req_access_txt = "0"
+	name = "Rest Room"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/centcomAway/hangar)
@@ -1714,9 +1653,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/hangar)
 "eO" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "eR" = (
 /obj/machinery/power/apc/noalarm{
@@ -1729,26 +1666,25 @@
 	start_charge = 100
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "eS" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "eT" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/cafe)
 "eU" = (
@@ -1758,8 +1694,8 @@
 /area/awaymission/centcomAway/general)
 "eV" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/cafe)
 "eW" = (
@@ -1771,7 +1707,6 @@
 "eX" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -1808,17 +1743,17 @@
 "fe" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid11";
+	icon_state = "asteroid11";
 	name = "plating";
-	icon_state = "asteroid11"
+	tag = "icon-asteroid11"
 	},
 /area/awaymission/centcomAway/cafe)
 "ff" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid2";
+	icon_state = "asteroid2";
 	name = "plating";
-	icon_state = "asteroid2"
+	tag = "icon-asteroid2"
 	},
 /area/awaymission/centcomAway/cafe)
 "fg" = (
@@ -1846,9 +1781,9 @@
 "fi" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid";
+	icon_state = "asteroid";
 	name = "plating";
-	icon_state = "asteroid"
+	tag = "icon-asteroid"
 	},
 /area/awaymission/centcomAway/cafe)
 "fj" = (
@@ -1857,9 +1792,9 @@
 "fk" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid3";
+	icon_state = "asteroid3";
 	name = "plating";
-	icon_state = "asteroid3"
+	tag = "icon-asteroid3"
 	},
 /area/awaymission/centcomAway/cafe)
 "fl" = (
@@ -1873,24 +1808,23 @@
 "fn" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid10";
+	icon_state = "asteroid10";
 	name = "plating";
-	icon_state = "asteroid10"
+	tag = "icon-asteroid10"
 	},
 /area/awaymission/centcomAway/cafe)
 "fo" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid9";
+	icon_state = "asteroid9";
 	name = "plating";
-	icon_state = "asteroid9"
+	tag = "icon-asteroid9"
 	},
 /area/awaymission/centcomAway/cafe)
 "fp" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "fq" = (
@@ -1898,19 +1832,16 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar";
-	dir = 2
+	icon_state = "bar"
 	},
 /area/awaymission/centcomAway/cafe)
 "fr" = (
 /obj/structure/table,
 /obj/item/radio/off,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -1918,15 +1849,15 @@
 "fs" = (
 /obj/structure/closet/chefcloset,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "ft" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "fu" = (
@@ -1935,8 +1866,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "fv" = (
@@ -1944,16 +1875,16 @@
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "fw" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "fx" = (
@@ -1969,8 +1900,8 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "fD" = (
@@ -1981,8 +1912,8 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "fF" = (
@@ -2038,8 +1969,8 @@
 	},
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "fN" = (
@@ -2049,9 +1980,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "fQ" = (
 /turf/simulated/floor/carpet,
@@ -2102,37 +2031,34 @@
 /area/awaymission/centcomAway/courtroom)
 "fY" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "fZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "ga" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "gc" = (
@@ -2146,9 +2072,7 @@
 	dir = 1;
 	in_use = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ge" = (
 /turf/simulated/floor/plasteel{
@@ -2173,9 +2097,7 @@
 /area/awaymission/centcomAway/general)
 "gh" = (
 /obj/machinery/door/window/eastright,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "gi" = (
 /obj/machinery/door/window/northleft,
@@ -2257,13 +2179,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "gv" = (
@@ -2317,10 +2238,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/general)
 "gA" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
-	dir = 8
-	},
+/obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -2397,9 +2315,7 @@
 /area/awaymission/centcomAway/general)
 "gL" = (
 /obj/machinery/pdapainter,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "gM" = (
 /obj/machinery/clonepod,
@@ -2417,9 +2333,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "gO" = (
 /obj/machinery/dna_scannernew,
@@ -2444,15 +2358,11 @@
 /area/awaymission/centcomAway/maint)
 "gQ" = (
 /obj/structure/filingcabinet,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "gR" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "gS" = (
 /obj/machinery/light,
@@ -2460,7 +2370,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -2504,7 +2413,6 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -2535,7 +2443,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -2556,9 +2463,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hi" = (
 /obj/structure/cable{
@@ -2567,16 +2472,14 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hj" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "hk" = (
@@ -2594,44 +2497,35 @@
 /area/awaymission/centcomAway/general)
 "hl" = (
 /obj/machinery/computer/robotics,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hm" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hn" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ho" = (
 /obj/machinery/computer/med_data,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hp" = (
 /obj/machinery/door/airlock/centcom,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "hq" = (
@@ -2660,8 +2554,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/awaymission/centcomAway/courtroom)
@@ -2694,21 +2587,15 @@
 /area/awaymission/centcomAway/general)
 "hz" = (
 /obj/machinery/computer/card,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hA" = (
 /obj/structure/chair/office/dark,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hB" = (
 /obj/machinery/computer/crew,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hC" = (
 /obj/machinery/vending/cigarette,
@@ -2767,18 +2654,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hN" = (
 /obj/machinery/computer/secure_data,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hO" = (
 /obj/structure/cable{
@@ -2792,16 +2674,13 @@
 /area/awaymission/centcomAway/general)
 "hP" = (
 /obj/machinery/computer/security,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hQ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2810,16 +2689,14 @@
 	tag = "90Curve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 10
+	dir = 10;
+	icon_state = "yellow"
 	},
 /area/awaymission/centcomAway/general)
 "hR" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hS" = (
 /obj/structure/grille,
@@ -2871,22 +2748,21 @@
 /area/awaymission/centcomAway/courtroom)
 "hY" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (NORTH)";
+	dir = 1;
 	icon_state = "blackcorner";
-	dir = 1
+	tag = "icon-blackcorner (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "hZ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (EAST)";
+	dir = 4;
 	icon_state = "blackcorner";
-	dir = 4
+	tag = "icon-blackcorner (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "ia" = (
@@ -2965,12 +2841,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "il" = (
 /obj/machinery/power/terminal,
@@ -2978,9 +2851,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "im" = (
 /obj/machinery/door/airlock/centcom,
@@ -3009,9 +2880,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ip" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -3027,12 +2896,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ir" = (
 /obj/machinery/power/apc/noalarm{
@@ -3045,19 +2911,16 @@
 	start_charge = 100
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "is" = (
 /obj/structure/closet,
@@ -3082,9 +2945,7 @@
 	dir = 1
 	},
 /obj/item/storage/box/monkeycubes,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "iw" = (
 /obj/machinery/computer/scan_consolenew,
@@ -3108,7 +2969,6 @@
 /area/awaymission/centcomAway/courtroom)
 "iz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -3133,14 +2993,12 @@
 /area/awaymission/centcomAway/courtroom)
 "iD" = (
 /obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "iE" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "yellow";
-	dir = 10
+	dir = 10;
+	icon_state = "yellow"
 	},
 /area/awaymission/centcomAway/general)
 "iF" = (
@@ -3191,16 +3049,13 @@
 	charge = 5e+006;
 	input_level = 200000;
 	inputting = 0;
-	output_level = 100000;
-	outputting = 1
+	output_level = 100000
 	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "iM" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
@@ -3232,7 +3087,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -3269,9 +3123,7 @@
 	icon_state = "1-4";
 	tag = "90Curve"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "iV" = (
 /obj/machinery/light{
@@ -3282,7 +3134,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -3302,7 +3153,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -3315,13 +3165,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-purplecorner (EAST)";
+	dir = 4;
 	icon_state = "purplecorner";
-	dir = 4
+	tag = "icon-purplecorner (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "ja" = (
@@ -3354,12 +3203,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "jd" = (
 /obj/structure/sign/lifestar,
@@ -3374,13 +3220,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-purple (NORTH)";
+	dir = 1;
 	icon_state = "purple";
-	dir = 1
+	tag = "icon-purple (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "jf" = (
@@ -3388,18 +3233,16 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-purple (NORTH)";
+	dir = 1;
 	icon_state = "purple";
-	dir = 1
+	tag = "icon-purple (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "jg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -3422,7 +3265,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -3449,39 +3291,31 @@
 	start_charge = 100
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
-"jm" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "greencorner";
-	dir = 8
-	},
-/area/awaymission/centcomAway/general)
 "jn" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/centcomAway/courtroom)
 "jo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "jp" = (
@@ -3489,8 +3323,8 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "jq" = (
@@ -3501,8 +3335,8 @@
 	tag = "90Curve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "jr" = (
@@ -3510,7 +3344,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/wall/r_wall,
@@ -3523,7 +3356,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -3532,37 +3364,31 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ju" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "jv" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "jw" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "jx" = (
 /obj/structure/table/reinforced,
@@ -3575,7 +3401,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -3593,9 +3418,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "jB" = (
 /obj/structure/cable{
@@ -3611,41 +3434,33 @@
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "jC" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "greencorner";
-	dir = 4
+	dir = 4;
+	icon_state = "greencorner"
 	},
 /area/awaymission/centcomAway/general)
 "jD" = (
 /obj/machinery/photocopier,
 /obj/item/paper/ccaMemo,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "jE" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "jF" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "jG" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "greencorner";
-	dir = 1
+	dir = 1;
+	icon_state = "greencorner"
 	},
 /area/awaymission/centcomAway/general)
 "jH" = (
@@ -3699,7 +3514,6 @@
 /area/awaymission/centcomAway/courtroom)
 "jO" = (
 /obj/machinery/crema_switch{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -3730,13 +3544,12 @@
 /area/awaymission/centcomAway/general)
 "jS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (WEST)";
+	dir = 8;
 	icon_state = "blackcorner";
-	dir = 8
+	tag = "icon-blackcorner (WEST)"
 	},
 /area/awaymission/centcomAway/general)
 "jT" = (
@@ -3756,18 +3569,16 @@
 /area/awaymission/centcomAway/cafe)
 "jV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner";
-	icon_state = "blackcorner"
+	icon_state = "blackcorner";
+	tag = "icon-blackcorner"
 	},
 /area/awaymission/centcomAway/general)
 "jW" = (
@@ -3778,7 +3589,6 @@
 /area/awaymission/centcomAway/general)
 "jX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -3786,7 +3596,6 @@
 "jY" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -3833,13 +3642,10 @@
 "kf" = (
 /obj/machinery/door/window/northright,
 /obj/machinery/door/window/southleft,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -3849,23 +3655,17 @@
 "kh" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ki" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/PDAs,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kj" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kk" = (
 /obj/machinery/door/airlock/centcom{
@@ -3879,9 +3679,7 @@
 /area/awaymission/centcomAway/courtroom)
 "kl" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kn" = (
 /obj/structure/table,
@@ -3893,7 +3691,6 @@
 /area/awaymission/centcomAway/hangar)
 "ko" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -3959,9 +3756,7 @@
 /area/awaymission/centcomAway/hangar)
 "ku" = (
 /obj/structure/chair,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kv" = (
 /obj/structure/table/reinforced,
@@ -3972,8 +3767,8 @@
 /area/awaymission/centcomAway/general)
 "kw" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 1
+	dir = 1;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "kx" = (
@@ -3984,13 +3779,10 @@
 /area/awaymission/centcomAway/general)
 "ky" = (
 /obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/hangar)
 "kz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -4001,13 +3793,10 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kB" = (
 /obj/structure/rack,
@@ -4044,23 +3833,13 @@
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
-/area/awaymission/centcomAway/general)
-"kG" = (
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "greencorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kH" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "kI" = (
 /obj/machinery/gateway{
@@ -4107,12 +3886,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/hangar)
-"kP" = (
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "green"
-	},
-/area/awaymission/centcomAway/general)
 "kQ" = (
 /obj/machinery/gateway{
 	dir = 10
@@ -4134,7 +3907,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -4186,16 +3958,16 @@
 /obj/item/flash,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "kY" = (
 /obj/structure/table,
 /obj/item/mmi,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "kZ" = (
@@ -4206,7 +3978,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
@@ -4216,12 +3987,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner";
-	icon_state = "blackcorner"
+	icon_state = "blackcorner";
+	tag = "icon-blackcorner"
 	},
 /area/awaymission/centcomAway/general)
 "lb" = (
@@ -4229,13 +3999,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (WEST)";
+	dir = 8;
 	icon_state = "blackcorner";
-	dir = 8
+	tag = "icon-blackcorner (WEST)"
 	},
 /area/awaymission/centcomAway/general)
 "lc" = (
@@ -4252,15 +4021,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "le" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "lf" = (
 /obj/structure/table/wood,
@@ -4281,17 +4046,16 @@
 "lh" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "li" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/awaymission/centcomAway/general)
@@ -4309,17 +4073,13 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ll" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "lm" = (
 /mob/living/simple_animal/hostile/russian/ranged{
@@ -4330,8 +4090,8 @@
 "ln" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/hangar)
@@ -4341,17 +4101,17 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (WEST)";
+	dir = 8;
 	icon_state = "vault";
-	dir = 8
+	tag = "icon-vault (WEST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "lp" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "lq" = (
@@ -4432,9 +4192,9 @@
 /area/awaymission/centcomAway/general)
 "lA" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (WEST)";
+	dir = 8;
 	icon_state = "vault";
-	dir = 8
+	tag = "icon-vault (WEST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "lB" = (
@@ -4456,24 +4216,22 @@
 	name = "XCC Main Access Shutters"
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "lF" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "lG" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "lH" = (
@@ -4500,8 +4258,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/general)
@@ -4520,17 +4277,17 @@
 /area/awaymission/centcomAway/hangar)
 "lL" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "lM" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand3 (WEST)";
-	icon_state = "ironsand3";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "ironsand3";
+	tag = "icon-ironsand3 (WEST)"
 	},
 /area/awaymission/centcomAway/general)
 "lN" = (
@@ -4538,9 +4295,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "lO" = (
@@ -4548,9 +4305,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "lP" = (
@@ -4567,8 +4324,8 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 9
+	dir = 9;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "lR" = (
@@ -4591,20 +4348,19 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 5
+	dir = 5;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "lT" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "greencorner";
-	dir = 4
+	dir = 4;
+	icon_state = "greencorner"
 	},
 /area/awaymission/centcomAway/general)
 "lU" = (
@@ -4613,33 +4369,33 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "lV" = (
 /obj/structure/closet/wardrobe/red,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "lW" = (
 /obj/structure/mecha_wreckage/seraph,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "lX" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "lY" = (
@@ -4647,45 +4403,45 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "lZ" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand11 (WEST)";
-	icon_state = "ironsand11";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "ironsand11";
+	tag = "icon-ironsand11 (WEST)"
 	},
 /area/awaymission/centcomAway/general)
 "ma" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 9
+	dir = 9;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "mb" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 5
+	dir = 5;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "mc" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "md" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand9 (WEST)";
-	icon_state = "ironsand9";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "ironsand9";
+	tag = "icon-ironsand9 (WEST)"
 	},
 /area/awaymission/centcomAway/general)
 "me" = (
@@ -4765,9 +4521,9 @@
 /area/awaymission/centcomAway/general)
 "mm" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "mn" = (
@@ -4777,35 +4533,33 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/hangar)
 "mo" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand4 (WEST)";
-	icon_state = "ironsand4";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "ironsand4";
+	tag = "icon-ironsand4 (WEST)"
 	},
 /area/awaymission/centcomAway/general)
 "mp" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 10
+	dir = 10;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "mq" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 6
+	dir = 6;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "mr" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "ms" = (
 /obj/structure/table/reinforced,
@@ -4817,9 +4571,9 @@
 "mt" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/hangar)
 "mu" = (
@@ -4827,9 +4581,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "mv" = (
@@ -4842,11 +4596,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/awaymission/centcomAway/general)
@@ -4886,23 +4638,21 @@
 /obj/item/stamp/granted,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "mE" = (
 /obj/machinery/igniter/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "mF" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (WEST)";
+	dir = 8;
 	icon_state = "vault";
-	dir = 8
+	tag = "icon-vault (WEST)"
 	},
 /area/awaymission/centcomAway/hangar)
 "mG" = (
@@ -4925,8 +4675,8 @@
 /obj/structure/table,
 /obj/item/firstaid_arm_assembly,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "mK" = (
@@ -4946,16 +4696,16 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "mM" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "mN" = (
@@ -4970,8 +4720,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/general)
@@ -4986,9 +4735,9 @@
 "mP" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid10";
+	icon_state = "asteroid10";
 	name = "plating";
-	icon_state = "asteroid10"
+	tag = "icon-asteroid10"
 	},
 /area/awaymission/centcomAway/general)
 "mQ" = (
@@ -5002,9 +4751,9 @@
 "mR" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid4";
+	icon_state = "asteroid4";
 	name = "plating";
-	icon_state = "asteroid4"
+	tag = "icon-asteroid4"
 	},
 /area/awaymission/centcomAway/general)
 "mS" = (
@@ -5012,8 +4761,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "mT" = (
@@ -5021,8 +4770,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "mU" = (
@@ -5044,17 +4793,17 @@
 "mW" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid";
+	icon_state = "asteroid";
 	name = "plating";
-	icon_state = "asteroid"
+	tag = "icon-asteroid"
 	},
 /area/awaymission/centcomAway/general)
 "mX" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid9";
+	icon_state = "asteroid9";
 	name = "plating";
-	icon_state = "asteroid9"
+	tag = "icon-asteroid9"
 	},
 /area/awaymission/centcomAway/general)
 "mY" = (
@@ -5068,17 +4817,17 @@
 "mZ" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid11";
+	icon_state = "asteroid11";
 	name = "plating";
-	icon_state = "asteroid11"
+	tag = "icon-asteroid11"
 	},
 /area/awaymission/centcomAway/general)
 "na" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid8";
+	icon_state = "asteroid8";
 	name = "plating";
-	icon_state = "asteroid8"
+	tag = "icon-asteroid8"
 	},
 /area/awaymission/centcomAway/general)
 "nb" = (
@@ -5097,42 +4846,35 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "nd" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "ne" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "nf" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/ccaInfo,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ng" = (
 /obj/machinery/door/poddoor{
@@ -5148,7 +4890,6 @@
 /area/awaymission/centcomAway/hangar)
 "ni" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -5167,7 +4908,6 @@
 "nk" = (
 /obj/structure/flora/ausbushes,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -5179,52 +4919,44 @@
 "nl" = (
 /obj/structure/flora/ausbushes,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid";
+	icon_state = "asteroid";
 	name = "plating";
-	icon_state = "asteroid"
+	tag = "icon-asteroid"
 	},
 /area/awaymission/centcomAway/general)
 "nm" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid5";
+	icon_state = "asteroid5";
 	name = "plating";
-	icon_state = "asteroid5"
+	tag = "icon-asteroid5"
 	},
 /area/awaymission/centcomAway/general)
 "nn" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "no" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "np" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "nq" = (
@@ -5232,12 +4964,11 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "nr" = (
@@ -5262,8 +4993,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
@@ -5273,9 +5003,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper/pamphlet/ccaInfo,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "nv" = (
@@ -5291,9 +5021,9 @@
 "nw" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "nx" = (
@@ -5303,40 +5033,35 @@
 	dir = 1;
 	in_use = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ny" = (
 /obj/structure/chair/comfy/teal,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "nz" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 8
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/awaymission/centcomAway/general)
 "nA" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/awaymission/centcomAway/general)
 "nB" = (
 /obj/machinery/computer/card,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "nC" = (
@@ -5346,13 +5071,12 @@
 "nD" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/general)
 "nE" = (
@@ -5363,12 +5087,9 @@
 /area/awaymission/centcomAway/hangar)
 "nF" = (
 /obj/machinery/door/window/northright{
-	icon_state = "right";
 	dir = 2
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "nG" = (
 /obj/structure/table/reinforced,
@@ -5382,9 +5103,9 @@
 /area/awaymission/centcomAway/general)
 "nH" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "nI" = (
@@ -5395,21 +5116,19 @@
 /area/awaymission/centcomAway/general)
 "nJ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/general)
 "nK" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 2
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/general)
 "nL" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 2
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/general)
 "nM" = (
@@ -5421,9 +5140,9 @@
 "nN" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "nO" = (
@@ -5431,16 +5150,16 @@
 /obj/item/storage/box/handcuffs,
 /obj/item/stamp/granted,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "nP" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/general)
 "nQ" = (
@@ -5448,12 +5167,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 6
+	dir = 6;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/general)
 "nR" = (
@@ -5464,9 +5182,9 @@
 "nS" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/general)
 "nT" = (
@@ -5474,15 +5192,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/general)
 "nU" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/centcomAway/thunderdome)
@@ -5494,23 +5211,20 @@
 /area/awaymission/centcomAway/courtroom)
 "nW" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/centcomAway/thunderdome)
 "nX" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/centcomAway/thunderdome)
 "nY" = (
 /obj/structure/computerframe,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "nZ" = (
 /obj/machinery/light,
@@ -5522,16 +5236,13 @@
 /mob/living/simple_animal/hostile/russian/ranged{
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ob" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/general)
@@ -5551,9 +5262,7 @@
 /area/awaymission/centcomAway/hangar)
 "oe" = (
 /obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "of" = (
 /obj/item/clipboard,
@@ -5561,9 +5270,9 @@
 /obj/item/taperecorder,
 /obj/item/stamp/granted,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/general)
 "og" = (
@@ -5576,9 +5285,9 @@
 /obj/structure/table,
 /obj/item/paicard,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oi" = (
@@ -5586,40 +5295,39 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/thunderdome)
 "oj" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "ok" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "ol" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "om" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "on" = (
@@ -5634,9 +5342,9 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oo" = (
@@ -5645,9 +5353,9 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "op" = (
@@ -5680,50 +5388,50 @@
 "ot" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "ou" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "ov" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
-	icon_state = "barber";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "barber";
+	tag = "icon-barber (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "ow" = (
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "ox" = (
 /obj/machinery/door/window/southright,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oy" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oz" = (
@@ -5732,35 +5440,35 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
-	icon_state = "barber";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "barber";
+	tag = "icon-barber (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oA" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
-	icon_state = "barber";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "barber";
+	tag = "icon-barber (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oB" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/popcorn,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
-	icon_state = "barber";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "barber";
+	tag = "icon-barber (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oC" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
+	dir = 8;
 	icon_state = "redbluefull";
-	dir = 8
+	tag = "icon-redbluefull (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oD" = (
@@ -5769,9 +5477,9 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
+	dir = 8;
 	icon_state = "redbluefull";
-	dir = 8
+	tag = "icon-redbluefull (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oE" = (
@@ -5781,17 +5489,17 @@
 "oF" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
+	dir = 8;
 	icon_state = "redbluefull";
-	dir = 8
+	tag = "icon-redbluefull (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oG" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
+	dir = 8;
 	icon_state = "redbluefull";
-	dir = 8
+	tag = "icon-redbluefull (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oH" = (
@@ -5801,9 +5509,9 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
+	dir = 8;
 	icon_state = "redbluefull";
-	dir = 8
+	tag = "icon-redbluefull (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oI" = (
@@ -5815,9 +5523,9 @@
 "oJ" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
+	dir = 8;
 	icon_state = "redbluefull";
-	dir = 8
+	tag = "icon-redbluefull (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oK" = (
@@ -5825,18 +5533,18 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oL" = (
 /obj/structure/table,
 /obj/item/lipstick,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oM" = (
@@ -5845,19 +5553,19 @@
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/drinks/ice,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
-	icon_state = "barber";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "barber";
+	tag = "icon-barber (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oN" = (
 /obj/machinery/icemachine,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
-	icon_state = "barber";
 	dir = 8;
-	heat_capacity = 1
+	heat_capacity = 1;
+	icon_state = "barber";
+	tag = "icon-barber (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oO" = (
@@ -5865,17 +5573,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oP" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
+	dir = 8;
 	icon_state = "redbluefull";
-	dir = 8
+	tag = "icon-redbluefull (WEST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oQ" = (
@@ -5905,19 +5613,18 @@
 /area/awaymission/centcomAway/thunderdome)
 "oT" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oV" = (
@@ -5931,27 +5638,27 @@
 /area/awaymission/centcomAway/hangar)
 "oW" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oX" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oY" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "oZ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pa" = (
@@ -5993,7 +5700,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "pg" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -6027,9 +5733,9 @@
 /obj/structure/table,
 /obj/item/camera,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pk" = (
@@ -6053,18 +5759,16 @@
 /area/awaymission/centcomAway/thunderdome)
 "pm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pn" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -6073,7 +5777,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "po" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -6082,7 +5785,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "pp" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/awaymission/centcomAway/thunderdome)
@@ -6098,9 +5800,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -6108,38 +5808,32 @@
 /area/awaymission/centcomAway/thunderdome)
 "ps" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "pu" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-plaque";
-	icon_state = "plaque"
+	icon_state = "plaque";
+	tag = "icon-plaque"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "pw" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "px" = (
@@ -6150,8 +5844,8 @@
 /area/awaymission/centcomAway/thunderdome)
 "py" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pz" = (
@@ -6162,7 +5856,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "pA" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/awaymission/centcomAway/thunderdome)
@@ -6180,16 +5873,16 @@
 /area/awaymission/centcomAway/thunderdome)
 "pD" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
+	dir = 4;
 	icon_state = "vault";
-	dir = 4
+	tag = "icon-vault (EAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pE" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
+	dir = 1;
 	icon_state = "vault";
-	dir = 1
+	tag = "icon-vault (NORTH)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pF" = (
@@ -6208,26 +5901,23 @@
 	name = "XCC Checkpoint 1 Shutters"
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "pH" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pI" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pJ" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/centcomAway/thunderdome)
@@ -6240,8 +5930,8 @@
 "pL" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 6
+	dir = 6;
+	icon_state = "green"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pM" = (
@@ -6252,9 +5942,9 @@
 /area/awaymission/centcomAway/thunderdome)
 "pN" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pO" = (
@@ -6262,18 +5952,18 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pP" = (
 /obj/structure/table/wood,
 /obj/item/radio/off,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pQ" = (
@@ -6281,9 +5971,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pR" = (
@@ -6293,9 +5983,9 @@
 	req_access_txt = "102"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pS" = (
@@ -6303,9 +5993,9 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pT" = (
@@ -6319,18 +6009,18 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pV" = (
 /obj/structure/table,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pW" = (
@@ -6339,33 +6029,33 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pX" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pY" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pZ" = (
 /obj/machinery/computer/area_atmos,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "qa" = (
@@ -6378,26 +6068,26 @@
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "qc" = (
 /obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "qd" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "qe" = (
@@ -6405,18 +6095,18 @@
 /obj/item/reagent_containers/food/snacks/popcorn,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "qf" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
+	dir = 5;
 	icon_state = "redyellowfull";
-	dir = 5
+	tag = "icon-redyellowfull (NORTHEAST)"
 	},
 /area/awaymission/centcomAway/thunderdome)
 "qg" = (
@@ -6425,9 +6115,7 @@
 	name = "XCC Thunderdome Melee!"
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "qh" = (
 /obj/machinery/door_control{
@@ -6435,9 +6123,7 @@
 	name = "XCC Thunderdome Guns!"
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "qi" = (
 /obj/machinery/door_control{
@@ -6445,9 +6131,7 @@
 	name = "XCC Thunderdome Go!"
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/thunderdome)
 "qj" = (
 /obj/structure/rack,
@@ -6462,9 +6146,7 @@
 	name = "XCC Checkpoint 2 Shutters"
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "ql" = (
 /obj/machinery/door_control{
@@ -6479,9 +6161,7 @@
 /area/awaymission/centcomAway/hangar)
 "qm" = (
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "qn" = (
 /obj/machinery/door/poddoor{
@@ -6530,9 +6210,7 @@
 /obj/machinery/tcomms/relay/ruskie{
 	network_id = "XCC-P5831-RELAY"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floor"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 
 (1,1,1) = {"
@@ -15178,7 +14856,7 @@ eO
 kh
 fH
 kw
-kG
+gn
 eF
 eF
 eF
@@ -15308,7 +14986,7 @@ hA
 hN
 fH
 kw
-kP
+go
 eF
 lE
 fg
@@ -16079,11 +15757,11 @@ eU
 eU
 fJ
 jf
-jm
+mv
 jv
 jG
 eO
-jm
+mv
 jv
 jv
 jv

--- a/_maps/map_files/RandomZLevels/evil_santa.dmm
+++ b/_maps/map_files/RandomZLevels/evil_santa.dmm
@@ -100,8 +100,7 @@
 /area/awaymission/challenge/main)
 "aq" = (
 /obj/structure/mineral_door/wood{
-	tag = "icon-wood";
-	icon_state = "wood"
+	tag = "icon-wood"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
@@ -250,9 +249,8 @@
 "aN" = (
 /obj/structure/inflatable/door,
 /obj/effect/decal/snow/clean/edge{
-	tag = "icon-snow_corner (NORTH)";
-	icon_state = "snow_corner";
-	dir = 1
+	dir = 1;
+	tag = "icon-snow_corner (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_plating = "asteroid";
@@ -296,8 +294,7 @@
 /area/awaymission/challenge/main)
 "aY" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/challenge/main)
 "aZ" = (
@@ -341,8 +338,7 @@
 "bf" = (
 /mob/living/simple_animal/hostile/winter/santa/stage_1,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/challenge/main)
 "bj" = (
@@ -386,8 +382,7 @@
 /area/awaymission/challenge/main)
 "bq" = (
 /obj/structure/mineral_door/wood{
-	tag = "icon-wood";
-	icon_state = "wood"
+	tag = "icon-wood"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/wood,
@@ -421,7 +416,6 @@
 /area/awaymission/challenge/main)
 "bx" = (
 /obj/machinery/porta_turret/syndicate/interior{
-	density = 0;
 	desc = "Winterized interior defense turret chambered for .45 rounds and mounted on a wall. Designed to down intruders without damaging the hull.";
 	faction = "winter";
 	name = "wall mounted machine gun turret (.45)";
@@ -471,8 +465,7 @@
 /obj/structure/fans/tiny,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/challenge/main)
 "bF" = (
@@ -505,8 +498,7 @@
 	id = "challenge";
 	name = "Gateway Lockdown";
 	pixel_x = -4;
-	pixel_y = 26;
-	req_access_txt = "0"
+	pixel_y = 26
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
@@ -587,8 +579,8 @@
 "bX" = (
 /obj/machinery/power/smes/magical,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/challenge/main)
@@ -606,8 +598,7 @@
 /obj/machinery/power/apc/noalarm{
 	dir = 4;
 	name = "Worn-out APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/challenge/main)
@@ -624,8 +615,7 @@
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/challenge/start)
@@ -656,12 +646,11 @@
 /area/awaymission/challenge/main)
 "ch" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/challenge/main)
@@ -679,8 +668,7 @@
 /obj/machinery/power/apc/noalarm{
 	dir = 4;
 	name = "Worn-out APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/challenge/start)
@@ -690,8 +678,7 @@
 /area/awaymission/challenge/start)
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/challenge/start)
@@ -787,8 +774,7 @@
 	id = "challenge";
 	name = "Gateway Lockdown";
 	pixel_x = -4;
-	pixel_y = 26;
-	req_access_txt = "0"
+	pixel_y = 26
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomZLevels/example.dmm
+++ b/_maps/map_files/RandomZLevels/example.dmm
@@ -19,9 +19,9 @@
 	charge = 5e+006
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -30,23 +30,21 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
 "ag" = (
 /obj/machinery/power/apc/noalarm{
 	dir = 1;
-	name = "area power controller";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -100,7 +98,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -122,9 +119,9 @@
 /area/awaymission/example)
 "ao" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/gateway/centeraway,
 /turf/simulated/floor/plasteel,
@@ -173,7 +170,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -190,8 +186,8 @@
 /area/awaymission/example)
 "ax" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/example)
@@ -201,7 +197,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -211,7 +206,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -228,7 +222,6 @@
 /area/awaymission/example)
 "aB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/table,
@@ -237,8 +230,7 @@
 /area/awaymission/example)
 "aC" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -309,15 +301,14 @@
 /area/awaymission/example)
 "aQ" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-yellowfull (WEST)";
+	dir = 8;
 	icon_state = "yellowfull";
-	dir = 8
+	tag = "icon-yellowfull (WEST)"
 	},
 /area/awaymission/example)
 "aR" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/example)
 "aS" = (
@@ -462,7 +453,6 @@
 /area/awaymission/example)
 "bj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -501,9 +491,9 @@
 /area/awaymission/example)
 "bo" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_stairs (WEST)";
+	dir = 8;
 	icon_state = "stage_stairs";
-	dir = 8
+	tag = "icon-stage_stairs (WEST)"
 	},
 /area/awaymission/example)
 "bp" = (
@@ -612,7 +602,6 @@
 /area/awaymission/example)
 "bC" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -636,8 +625,7 @@
 /area/awaymission/example)
 "bF" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -671,9 +659,8 @@
 /area/awaymission/example)
 "bJ" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
-	icon_state = "wooden_chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -681,9 +668,8 @@
 /area/awaymission/example)
 "bK" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
-	icon_state = "wooden_chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -707,9 +693,8 @@
 /area/awaymission/example)
 "bN" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
-	icon_state = "wooden_chair";
-	dir = 1
+	dir = 1;
+	tag = "icon-wooden_chair (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -810,7 +795,6 @@
 /obj/item/screwdriver,
 /obj/item/hand_labeler,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -886,9 +870,8 @@
 	name = "awaystart"
 	},
 /obj/machinery/light_construct/small{
-	tag = "icon-bulb-construct-stage1 (WEST)";
-	icon_state = "bulb-construct-stage1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb-construct-stage1 (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -4,7 +4,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -16,7 +15,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -29,7 +27,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -44,7 +41,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -61,7 +57,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -76,7 +71,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -95,7 +89,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -107,7 +100,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -122,7 +114,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -135,7 +126,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -154,7 +144,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -169,7 +158,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -181,7 +169,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -196,7 +183,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -210,7 +196,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -233,7 +218,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -247,7 +231,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -263,7 +246,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -273,7 +255,6 @@
 "as" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "at" = (
@@ -287,7 +268,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -302,7 +282,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -318,7 +297,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -333,7 +311,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -347,7 +324,6 @@
 	tag = "icon-darkred (NORTHWEST)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ay" = (
@@ -355,7 +331,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "az" = (
@@ -365,7 +340,6 @@
 	tag = "icon-darkredcorners (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aA" = (
@@ -376,7 +350,6 @@
 	tag = "icon-darkred (NORTHEAST)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aB" = (
@@ -386,7 +359,6 @@
 	tag = "icon-darkredcorners (EAST)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aC" = (
@@ -395,7 +367,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -423,7 +394,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -438,7 +408,6 @@
 	tag = "icon-darkredcorners (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aF" = (
@@ -450,7 +419,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aG" = (
@@ -462,7 +430,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aH" = (
@@ -474,7 +441,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aI" = (
@@ -493,7 +459,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -511,7 +476,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -531,7 +495,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -546,7 +509,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -561,7 +523,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aN" = (
@@ -572,7 +533,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aO" = (
@@ -584,19 +544,16 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aQ" = (
@@ -608,7 +565,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aR" = (
@@ -620,7 +576,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -638,7 +593,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -648,7 +602,6 @@
 "aT" = (
 /turf/simulated/wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aU" = (
@@ -658,21 +611,19 @@
 	tag = "icon-darkredcorners (WEST)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aV" = (
 /obj/machinery/gateway,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aW" = (
@@ -684,17 +635,14 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aX" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aY" = (
@@ -707,7 +655,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "aZ" = (
@@ -715,7 +662,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -732,7 +678,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -747,7 +692,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -760,7 +704,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bd" = (
@@ -772,7 +715,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "be" = (
@@ -783,7 +725,6 @@
 	tag = "icon-darkred (SOUTHWEST)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bf" = (
@@ -791,14 +732,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bg" = (
@@ -808,18 +747,15 @@
 	tag = "icon-darkred (SOUTHEAST)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bi" = (
@@ -838,7 +774,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -851,7 +786,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -869,7 +803,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -880,7 +813,6 @@
 /turf/simulated/mineral/random/high_chance,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -893,7 +825,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bn" = (
@@ -908,7 +839,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bo" = (
@@ -924,13 +854,10 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bp" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
-	locked = 1;
 	pixel_y = 23;
 	req_access = "150"
 	},
@@ -938,7 +865,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bq" = (
@@ -956,7 +882,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "br" = (
@@ -976,7 +901,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bs" = (
@@ -989,13 +913,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bt" = (
@@ -1008,7 +930,6 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bu" = (
@@ -1023,19 +944,16 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bv" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bw" = (
@@ -1050,7 +968,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bx" = (
@@ -1058,14 +975,12 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "by" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/trash/plate,
 /obj/item/cigbutt,
@@ -1073,7 +988,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bz" = (
@@ -1083,7 +997,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bA" = (
@@ -1093,7 +1006,6 @@
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bB" = (
@@ -1101,45 +1013,36 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
-	locked = 1;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bE" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bF" = (
@@ -1150,7 +1053,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bG" = (
@@ -1159,7 +1061,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bH" = (
@@ -1170,7 +1071,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bI" = (
@@ -1180,7 +1080,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bJ" = (
@@ -1189,7 +1088,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bK" = (
@@ -1197,7 +1095,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bL" = (
@@ -1206,7 +1103,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bM" = (
@@ -1215,7 +1111,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bN" = (
@@ -1227,7 +1122,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bO" = (
@@ -1236,7 +1130,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bP" = (
@@ -1244,7 +1137,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bQ" = (
@@ -1252,7 +1144,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -1263,7 +1154,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bR" = (
@@ -1283,12 +1173,10 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bS" = (
 /obj/machinery/power/smes{
-	charge = 0;
 	input_level = 10000;
 	inputting = 0;
 	output_level = 15000;
@@ -1300,40 +1188,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bT" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/computer/monitor/secret,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bU" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
-	locked = 1;
 	pixel_y = 23;
 	req_access = "150"
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bV" = (
@@ -1341,7 +1223,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bW" = (
@@ -1350,7 +1231,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -1371,18 +1251,15 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bY" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "awaysyndie"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "bZ" = (
@@ -1402,7 +1279,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ca" = (
@@ -1411,7 +1287,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cb" = (
@@ -1425,12 +1300,10 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cc" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = "150"
@@ -1440,7 +1313,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cd" = (
@@ -1451,7 +1323,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ce" = (
@@ -1464,7 +1335,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cf" = (
@@ -1472,7 +1342,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1481,7 +1350,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cg" = (
@@ -1498,12 +1366,10 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ch" = (
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
@@ -1511,7 +1377,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ci" = (
@@ -1519,7 +1384,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/table,
@@ -1535,22 +1399,19 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cj" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ck" = (
@@ -1558,7 +1419,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cl" = (
@@ -1566,7 +1426,6 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cm" = (
@@ -1579,7 +1438,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cn" = (
@@ -1587,7 +1445,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "co" = (
@@ -1595,7 +1452,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cp" = (
@@ -1604,7 +1460,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cq" = (
@@ -1620,13 +1475,11 @@
 	icon_state = "small"
 	},
 /turf/simulated/floor/plasteel{
-	carbon_dioxide = 0;
 	nitrogen = 0;
 	oxygen = 0;
 	temperature = 2.7
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cr" = (
@@ -1636,7 +1489,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cs" = (
@@ -1646,7 +1498,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ct" = (
@@ -1660,14 +1511,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cu" = (
@@ -1675,7 +1524,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless{
@@ -1684,7 +1532,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cv" = (
@@ -1692,7 +1539,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1700,7 +1546,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cw" = (
@@ -1712,7 +1557,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cx" = (
@@ -1720,7 +1564,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/engineering{
@@ -1729,7 +1572,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cy" = (
@@ -1737,7 +1579,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -1755,7 +1596,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cz" = (
@@ -1767,7 +1607,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cA" = (
@@ -1776,7 +1615,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cB" = (
@@ -1789,18 +1627,15 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cC" = (
 /obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cD" = (
@@ -1809,7 +1644,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cE" = (
@@ -1819,7 +1653,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cF" = (
@@ -1834,7 +1667,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cG" = (
@@ -1845,18 +1677,15 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
-	dir = 2;
 	icon_state = "red";
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cI" = (
@@ -1866,38 +1695,30 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cJ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
-	locked = 1;
 	name = "Worn-out APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = "150";
 	start_charge = 0
 	},
 /turf/simulated/floor/plasteel/airless{
-	dir = 2;
 	icon_state = "red";
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cK" = (
 /turf/simulated/floor/plasteel/airless{
-	dir = 2;
 	icon_state = "red";
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cL" = (
@@ -1910,7 +1731,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cM" = (
@@ -1919,7 +1739,6 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cN" = (
@@ -1931,7 +1750,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cO" = (
@@ -1944,7 +1762,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cP" = (
@@ -1952,7 +1769,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cQ" = (
@@ -1966,7 +1782,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cR" = (
@@ -1976,16 +1791,12 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cS" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
-	locked = 1;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /obj/machinery/light{
@@ -2000,7 +1811,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cT" = (
@@ -2021,7 +1831,6 @@
 	tag = "icon-warningcorner (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cU" = (
@@ -2031,7 +1840,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cV" = (
@@ -2042,7 +1850,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cW" = (
@@ -2052,7 +1859,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cX" = (
@@ -2069,7 +1875,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cY" = (
@@ -2082,7 +1887,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "cZ" = (
@@ -2090,9 +1894,7 @@
 	id = "awaydorm4";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/bed,
@@ -2104,7 +1906,6 @@
 	tag = "icon-warningcorner (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "da" = (
@@ -2116,7 +1917,6 @@
 	tag = "icon-warningcorner (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "db" = (
@@ -2124,22 +1924,18 @@
 	id = "awaydorm5";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dc" = (
 /turf/simulated/floor/wood,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dd" = (
@@ -2150,7 +1946,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -2166,7 +1961,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "df" = (
@@ -2175,7 +1969,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dg" = (
@@ -2188,17 +1981,13 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dh" = (
 /obj/structure/chair/wood,
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
-	locked = 1;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2209,7 +1998,6 @@
 	tag = "icon-warningcorner (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "di" = (
@@ -2223,21 +2011,16 @@
 	tag = "icon-warningcorner (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dj" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
-	locked = 1;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /turf/simulated/floor/wood,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dk" = (
@@ -2246,7 +2029,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dl" = (
@@ -2260,7 +2042,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dm" = (
@@ -2275,7 +2056,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dn" = (
@@ -2285,7 +2065,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "do" = (
@@ -2294,7 +2073,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dp" = (
@@ -2303,8 +2081,8 @@
 	name = "S.U.P.E.R.P.A.C.M.A.N.-type portable generator"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
@@ -2326,7 +2104,6 @@
 	tag = "icon-warningcorner (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dr" = (
@@ -2338,7 +2115,6 @@
 	icon_off = "cabinetdetective_broken";
 	icon_opened = "cabinetdetective_open";
 	icon_state = "cabinetdetective_locked";
-	locked = 1;
 	name = "personal closet";
 	req_access_txt = "150"
 	},
@@ -2352,7 +2128,6 @@
 	tag = "icon-warningcorner (NORTH)"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ds" = (
@@ -2371,7 +2146,6 @@
 /obj/item/stack/spacecash/c50,
 /turf/simulated/floor/wood,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dt" = (
@@ -2380,7 +2154,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "du" = (
@@ -2389,7 +2162,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dv" = (
@@ -2402,7 +2174,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2415,7 +2186,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dx" = (
@@ -2424,7 +2194,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dy" = (
@@ -2442,7 +2211,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dz" = (
@@ -2454,7 +2222,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2466,7 +2233,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2478,7 +2244,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/damageturf,
@@ -2495,14 +2260,12 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dD" = (
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
 	name = "\improper HOSTILE ATMOSPHERE AHEAD";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2511,7 +2274,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dE" = (
@@ -2526,7 +2288,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2543,7 +2304,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2563,7 +2323,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2578,7 +2337,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dI" = (
@@ -2587,7 +2345,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2600,7 +2357,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2616,7 +2372,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2633,7 +2388,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "dM" = (
@@ -2645,7 +2399,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2676,7 +2429,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -2697,7 +2449,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -2710,7 +2461,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2724,7 +2474,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2740,7 +2489,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2760,7 +2508,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "The Hive";
 	power_environ = 0;
 	power_equip = 0;
@@ -2773,7 +2520,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2787,7 +2533,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2802,7 +2547,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2818,7 +2562,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2833,7 +2576,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -2844,19 +2586,16 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "dZ" = (
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ea" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eb" = (
@@ -2867,14 +2606,12 @@
 	name = "plating"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "ec" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ed" = (
@@ -2883,14 +2620,12 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ee" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ef" = (
@@ -2899,7 +2634,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eg" = (
@@ -2911,7 +2645,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eh" = (
@@ -2922,7 +2655,6 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ei" = (
@@ -2942,7 +2674,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ej" = (
@@ -2950,7 +2681,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/alien/weeds{
@@ -2961,7 +2691,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ek" = (
@@ -2974,12 +2703,11 @@
 	req_access = null
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "el" = (
@@ -2996,7 +2724,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "em" = (
@@ -3012,14 +2739,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "en" = (
 /obj/structure/alien/weeds,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eo" = (
@@ -3041,7 +2766,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ep" = (
@@ -3049,7 +2773,6 @@
 	desc = "A wall-mounted ignition device. This one has been applied with an acid-proof coating.";
 	id = "awayxenobio";
 	name = "Acid-Proof mounted igniter";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/alien/weeds{
@@ -3058,7 +2781,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eq" = (
@@ -3066,7 +2788,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "er" = (
@@ -3079,7 +2800,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "es" = (
@@ -3096,7 +2816,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "et" = (
@@ -3105,13 +2824,11 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eu" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ev" = (
@@ -3124,7 +2841,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ew" = (
@@ -3137,7 +2853,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ex" = (
@@ -3145,19 +2860,16 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ey" = (
@@ -3174,13 +2886,12 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ez" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
@@ -3192,7 +2903,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eA" = (
@@ -3203,7 +2913,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eB" = (
@@ -3220,14 +2929,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eC" = (
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eD" = (
@@ -3236,7 +2943,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eE" = (
@@ -3246,7 +2952,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eF" = (
@@ -3256,7 +2961,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eG" = (
@@ -3264,7 +2968,6 @@
 /obj/structure/bed/nest,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eH" = (
@@ -3279,7 +2982,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eI" = (
@@ -3291,28 +2993,23 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eJ" = (
 /turf/simulated/wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eK" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eL" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eM" = (
@@ -3325,7 +3022,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eN" = (
@@ -3345,7 +3041,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eO" = (
@@ -3353,7 +3048,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -3364,7 +3058,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eP" = (
@@ -3389,7 +3082,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eQ" = (
@@ -3403,7 +3095,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eR" = (
@@ -3415,7 +3106,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eS" = (
@@ -3424,7 +3114,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eT" = (
@@ -3443,11 +3132,9 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eX" = (
@@ -3458,11 +3145,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "eY" = (
@@ -3471,8 +3156,8 @@
 	name = "P.A.C.M.A.N.-type portable generator"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a7)
@@ -3491,7 +3176,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/landmark/damageturf,
@@ -3499,8 +3183,8 @@
 /area/awaycontent/a7)
 "fb" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/smes{
 	charge = 1.5e+006;
@@ -3516,11 +3200,10 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -3532,7 +3215,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/tracks{
@@ -3545,7 +3227,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fe" = (
@@ -3566,7 +3247,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/item/newspaper,
@@ -3581,7 +3261,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fi" = (
@@ -3598,12 +3277,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fj" = (
 /obj/machinery/firealarm/no_alarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/table,
@@ -3615,7 +3292,6 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fk" = (
@@ -3624,7 +3300,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fl" = (
@@ -3632,7 +3307,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fm" = (
@@ -3640,7 +3314,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -3648,7 +3321,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fn" = (
@@ -3662,14 +3334,13 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fo" = (
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
@@ -3680,7 +3351,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fp" = (
@@ -3694,7 +3364,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fq" = (
@@ -3709,7 +3378,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fr" = (
@@ -3717,7 +3385,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -3735,12 +3402,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	desc = "Your instincts say you shouldn't be following these.";
@@ -3764,11 +3429,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fv" = (
@@ -3784,7 +3447,6 @@
 	status = 2
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -3794,7 +3456,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fw" = (
@@ -3813,7 +3474,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fx" = (
@@ -3836,7 +3496,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3848,13 +3507,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fA" = (
@@ -3862,12 +3519,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fB" = (
@@ -3875,14 +3530,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fC" = (
@@ -3890,7 +3543,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/alien/weeds/node,
@@ -3898,7 +3550,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fD" = (
@@ -3915,7 +3566,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fE" = (
@@ -3936,7 +3586,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fF" = (
@@ -3961,12 +3610,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fG" = (
@@ -3980,7 +3627,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fH" = (
@@ -3997,7 +3643,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fI" = (
@@ -4012,7 +3657,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fJ" = (
@@ -4025,7 +3669,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fK" = (
@@ -4039,7 +3682,6 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fL" = (
@@ -4059,7 +3701,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fM" = (
@@ -4086,7 +3727,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -4099,7 +3739,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -4114,7 +3753,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fR" = (
@@ -4122,7 +3760,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -4134,11 +3771,9 @@
 /obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fS" = (
@@ -4157,7 +3792,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fU" = (
@@ -4173,7 +3807,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fV" = (
@@ -4189,7 +3822,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fX" = (
@@ -4197,7 +3829,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "fY" = (
@@ -4215,7 +3846,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -4225,19 +3855,17 @@
 /area/awaycontent/a7)
 "gb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gc" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
@@ -4252,7 +3880,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gd" = (
@@ -4268,7 +3895,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ge" = (
@@ -4284,7 +3910,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gf" = (
@@ -4299,7 +3924,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gg" = (
@@ -4316,7 +3940,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gh" = (
@@ -4324,7 +3947,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -4339,15 +3961,11 @@
 /turf/simulated/floor/plating,
 /area/awaycontent/a7)
 "gi" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -4360,7 +3978,6 @@
 	icon_off = "secoff";
 	icon_opened = "secopen";
 	icon_state = "sec1";
-	locked = 1;
 	name = "security officer's locker";
 	req_access_txt = "271"
 	},
@@ -4373,7 +3990,6 @@
 	pixel_y = -2
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -4383,20 +3999,17 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gk" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gl" = (
@@ -4405,7 +4018,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gm" = (
@@ -4420,17 +4032,14 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "go" = (
@@ -4441,7 +4050,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/alien/weeds{
@@ -4449,31 +4057,25 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gq" = (
@@ -4487,7 +4089,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gr" = (
@@ -4507,7 +4108,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gs" = (
@@ -4517,13 +4117,11 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gt" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -4531,7 +4129,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gu" = (
@@ -4540,13 +4137,12 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gv" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -4563,7 +4159,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gw" = (
@@ -4576,7 +4171,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gx" = (
@@ -4591,23 +4185,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gz" = (
 /turf/simulated/mineral/random/labormineral,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "Syndicate Outpost"
 	})
 "gA" = (
@@ -4621,30 +4211,25 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gD" = (
@@ -4660,7 +4245,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gE" = (
@@ -4668,15 +4252,13 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gF" = (
@@ -4694,7 +4276,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gG" = (
@@ -4703,7 +4284,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gH" = (
@@ -4713,7 +4293,6 @@
 /obj/item/shard,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gI" = (
@@ -4725,7 +4304,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gJ" = (
@@ -4743,7 +4321,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gK" = (
@@ -4781,7 +4358,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gL" = (
@@ -4804,7 +4380,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gN" = (
@@ -4817,7 +4392,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gO" = (
@@ -4828,14 +4402,13 @@
 	name = "Acid-Proof containment chamber blast door"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gP" = (
@@ -4846,7 +4419,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/power/apc/noalarm{
@@ -4866,7 +4438,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/item/stack/rods,
@@ -4883,14 +4454,12 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gS" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gT" = (
@@ -4899,7 +4468,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gU" = (
@@ -4911,7 +4479,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gV" = (
@@ -4924,7 +4491,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gW" = (
@@ -4939,7 +4505,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gX" = (
@@ -4965,7 +4530,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gY" = (
@@ -4976,7 +4540,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "gZ" = (
@@ -4987,7 +4550,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ha" = (
@@ -5000,7 +4562,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hb" = (
@@ -5019,13 +4580,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hc" = (
 /obj/machinery/light{
 	active_power_usage = 0;
-	dir = 2;
 	icon_state = "tube-broken";
 	status = 2
 	},
@@ -5039,7 +4598,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hd" = (
@@ -5047,7 +4605,6 @@
 	desc = "A wall-mounted ignition device. This one has been applied with an acid-proof coating.";
 	id = "awayxenobio";
 	name = "Acid-Proof mounted igniter";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/structure/alien/weeds{
@@ -5056,7 +4613,6 @@
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "he" = (
@@ -5067,7 +4623,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hf" = (
@@ -5075,7 +4630,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/firealarm/no_alarm{
@@ -5085,11 +4639,9 @@
 /obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hg" = (
@@ -5109,15 +4661,13 @@
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hj" = (
@@ -5132,7 +4682,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hk" = (
@@ -5142,7 +4691,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hl" = (
@@ -5150,7 +4698,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/oil{
@@ -5180,25 +4727,19 @@
 	status = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hp" = (
 /obj/structure/table,
-/obj/item/storage/box/gloves{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hq" = (
@@ -5214,11 +4755,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hr" = (
@@ -5231,7 +4770,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hs" = (
@@ -5242,16 +4780,14 @@
 	pixel_y = 2
 	},
 /obj/machinery/firealarm/no_alarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ht" = (
@@ -5263,7 +4799,6 @@
 	status = 2
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -5273,12 +4808,11 @@
 	name = "Personal Log &mdash; Gerald Rosswell"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hu" = (
@@ -5293,7 +4827,6 @@
 	id = "Awaybiohazard";
 	name = "Biohazard Shutter Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "271"
 	},
 /obj/machinery/light/small{
@@ -5308,16 +4841,13 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hw" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hx" = (
@@ -5329,7 +4859,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hy" = (
@@ -5341,7 +4870,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hz" = (
@@ -5365,7 +4893,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hA" = (
@@ -5377,15 +4904,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hB" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/firstaid/fire,
 /obj/machinery/firealarm/no_alarm{
 	dir = 4;
 	pixel_x = 28
@@ -5395,28 +4918,25 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hC" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hE" = (
@@ -5428,19 +4948,15 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hF" = (
@@ -5450,7 +4966,6 @@
 	},
 /obj/machinery/light/small{
 	active_power_usage = 0;
-	dir = 2;
 	icon_state = "bulb-broken";
 	status = 2
 	},
@@ -5468,7 +4983,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hG" = (
@@ -5477,7 +4991,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hH" = (
@@ -5492,17 +5005,12 @@
 /area/awaycontent/a7)
 "hI" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/firstaid/regular,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
@@ -5510,19 +5018,16 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hJ" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hK" = (
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hL" = (
@@ -5530,7 +5035,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5549,12 +5053,11 @@
 "hN" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hO" = (
@@ -5570,7 +5073,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hP" = (
@@ -5580,7 +5082,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hQ" = (
@@ -5595,7 +5096,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hR" = (
@@ -5606,7 +5106,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hS" = (
@@ -5617,15 +5116,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hT" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/urinal{
 	pixel_y = 29
@@ -5638,7 +5134,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hU" = (
@@ -5650,7 +5145,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hV" = (
@@ -5661,14 +5155,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hW" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "hX" = (
@@ -5686,7 +5178,6 @@
 /obj/item/clothing/suit/storage/labcoat,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hY" = (
@@ -5703,12 +5194,11 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "hZ" = (
@@ -5718,12 +5208,11 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ia" = (
@@ -5737,12 +5226,11 @@
 	network = list("MO19X","MO19R")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ib" = (
@@ -5751,12 +5239,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ic" = (
@@ -5772,7 +5259,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "id" = (
@@ -5784,11 +5270,9 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ie" = (
@@ -5802,7 +5286,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "if" = (
@@ -5811,7 +5294,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ig" = (
@@ -5822,7 +5304,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ih" = (
@@ -5830,7 +5311,6 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -5838,14 +5318,12 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ii" = (
 /obj/structure/closet/l3closet/general,
 /obj/machinery/light/small{
 	active_power_usage = 0;
-	dir = 2;
 	icon_state = "bulb-broken";
 	status = 2
 	},
@@ -5854,7 +5332,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ij" = (
@@ -5864,16 +5341,13 @@
 	icon_state = "whitecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ik" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -5883,27 +5357,23 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "il" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
+	broken = 1;
 	desc = "Oh no, seven years of bad luck!";
 	icon_state = "mirror_broke";
-	pixel_x = 28;
-	broken = 1
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "im" = (
@@ -5911,7 +5381,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "in" = (
@@ -5923,7 +5392,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "io" = (
@@ -5934,7 +5402,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ip" = (
@@ -5947,7 +5414,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iq" = (
@@ -5959,7 +5425,6 @@
 	icon_off = "secureresoff";
 	icon_opened = "secureresopen";
 	icon_state = "secureres1";
-	locked = 1;
 	name = "scientist's locker";
 	req_access_txt = "271"
 	},
@@ -5969,7 +5434,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ir" = (
@@ -5978,12 +5442,11 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "is" = (
@@ -5991,7 +5454,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "it" = (
@@ -6001,7 +5463,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iu" = (
@@ -6012,7 +5473,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iv" = (
@@ -6021,13 +5481,11 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iw" = (
 /obj/item/storage/secure/safe{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/pen,
@@ -6040,7 +5498,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ix" = (
@@ -6054,7 +5511,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iy" = (
@@ -6065,7 +5521,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iz" = (
@@ -6076,7 +5531,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iA" = (
@@ -6085,7 +5539,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iB" = (
@@ -6097,7 +5550,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iC" = (
@@ -6107,7 +5559,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iD" = (
@@ -6117,7 +5568,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iE" = (
@@ -6127,7 +5577,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iF" = (
@@ -6138,7 +5587,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iG" = (
@@ -6146,11 +5594,9 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iH" = (
@@ -6164,17 +5610,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iI" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light/small{
 	active_power_usage = 0;
-	dir = 2;
 	icon_state = "bulb-broken";
 	status = 2
 	},
@@ -6184,26 +5627,23 @@
 	network = list("MO19","MO19R")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iJ" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iK" = (
@@ -6211,12 +5651,11 @@
 /obj/item/radio/off,
 /obj/item/laser_pointer,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iL" = (
@@ -6224,7 +5663,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/burnturf,
@@ -6236,7 +5674,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower";
 	tag = "icon-shower (EAST)"
 	},
@@ -6245,7 +5682,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iN" = (
@@ -6255,7 +5691,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iO" = (
@@ -6269,7 +5704,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iP" = (
@@ -6279,19 +5713,16 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "iQ" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iR" = (
@@ -6303,7 +5734,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iS" = (
@@ -6314,7 +5744,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iT" = (
@@ -6328,30 +5757,22 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iU" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/computer/security/telescreen/entertainment,
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iV" = (
-/obj/machinery/vending/boozeomat{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iW" = (
@@ -6362,7 +5783,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iX" = (
@@ -6374,29 +5794,26 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iY" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "iZ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ja" = (
@@ -6407,7 +5824,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jb" = (
@@ -6417,7 +5833,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -6435,13 +5850,11 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jd" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -6451,7 +5864,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "je" = (
@@ -6461,19 +5873,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jf" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jg" = (
@@ -6482,7 +5891,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jh" = (
@@ -6491,7 +5899,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ji" = (
@@ -6500,7 +5907,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jj" = (
@@ -6514,7 +5920,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jk" = (
@@ -6523,7 +5928,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jl" = (
@@ -6531,14 +5935,12 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jm" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jn" = (
@@ -6549,18 +5951,16 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jo" = (
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jp" = (
@@ -6571,12 +5971,11 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jq" = (
@@ -6586,8 +5985,7 @@
 	pixel_x = 3
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -6596,7 +5994,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jr" = (
@@ -6607,19 +6004,17 @@
 	icon_off = "rdsecureoff";
 	icon_opened = "rdsecureopen";
 	icon_state = "rdsecure1";
-	locked = 1;
 	name = "research director's locker";
 	req_access_txt = "271"
 	},
 /obj/item/storage/backpack/satchel_tox,
 /obj/item/clothing/gloves/color/latex,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "js" = (
@@ -6629,7 +6024,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jt" = (
@@ -6638,12 +6032,11 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ju" = (
@@ -6651,16 +6044,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jv" = (
@@ -6668,14 +6058,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jw" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jx" = (
@@ -6684,12 +6072,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jy" = (
 /obj/structure/sign/science{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6699,7 +6085,6 @@
 	tag = "icon-purple (NORTHWEST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jz" = (
@@ -6709,20 +6094,17 @@
 	tag = "icon-purple (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jB" = (
@@ -6736,7 +6118,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -6752,7 +6133,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -6768,7 +6148,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -6785,14 +6164,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jG" = (
@@ -6801,13 +6178,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jH" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jI" = (
@@ -6815,7 +6190,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jJ" = (
@@ -6824,11 +6198,9 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jK" = (
@@ -6842,19 +6214,16 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jL" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jM" = (
@@ -6867,7 +6236,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jN" = (
@@ -6876,7 +6244,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jO" = (
@@ -6884,7 +6251,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jP" = (
@@ -6893,7 +6259,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jQ" = (
@@ -6903,12 +6268,11 @@
 	},
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jR" = (
@@ -6918,23 +6282,21 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jS" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jT" = (
@@ -6947,30 +6309,25 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jU" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/landmark/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jV" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jW" = (
@@ -6978,24 +6335,21 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "jX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jY" = (
@@ -7007,16 +6361,14 @@
 	locked = 1;
 	name = "Research Director's Office";
 	opacity = 0;
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "jZ" = (
@@ -7026,7 +6378,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "ka" = (
@@ -7038,7 +6389,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "kb" = (
@@ -7062,7 +6412,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ke" = (
@@ -7071,22 +6420,19 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kf" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "kg" = (
@@ -7096,7 +6442,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kh" = (
@@ -7104,7 +6449,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -7113,22 +6457,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ki" = (
 /obj/machinery/door/airlock/research{
 	id_tag = "";
 	name = "Research Division";
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "kj" = (
@@ -7139,24 +6480,21 @@
 /obj/machinery/door_control{
 	id = "Awaybiohazard";
 	name = "Biohazard Shutter Control";
-	pixel_x = 0;
 	pixel_y = 8;
 	req_access_txt = "271"
 	},
 /obj/machinery/door_control{
 	id = "AwayRD";
 	name = "Privacy Shutter Control";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "MO19 Research"
 	})
 "kk" = (
@@ -7164,7 +6502,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7175,13 +6512,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "km" = (
@@ -7189,11 +6524,9 @@
 /obj/item/trash/candy,
 /obj/item/trash/can,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kn" = (
@@ -7201,7 +6534,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/oil{
@@ -7216,18 +6548,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kq" = (
@@ -7235,12 +6565,11 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kr" = (
@@ -7251,46 +6580,40 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ks" = (
 /obj/effect/decal/cleanable/plant_smudge,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/processor,
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ku" = (
@@ -7298,7 +6621,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -7309,32 +6631,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kw" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kx" = (
 /obj/machinery/light/small,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/camera{
@@ -7343,11 +6659,9 @@
 	network = list("MO19")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ky" = (
@@ -7356,7 +6670,6 @@
 	icon_state = "whitecorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kz" = (
@@ -7364,11 +6677,9 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kA" = (
@@ -7376,17 +6687,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kB" = (
@@ -7398,7 +6706,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kC" = (
@@ -7410,27 +6717,24 @@
 	tag = "icon-purple (NORTH)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kD" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
 	dir = 1;
 	locked = 0;
 	name = "Habitat APC";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access = null;
 	start_charge = 100
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kE" = (
@@ -7438,7 +6742,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kF" = (
@@ -7446,18 +6749,15 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kG" = (
@@ -7465,18 +6765,15 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kH" = (
@@ -7484,19 +6781,16 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kI" = (
@@ -7504,18 +6798,15 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kJ" = (
@@ -7526,7 +6817,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kK" = (
@@ -7537,7 +6827,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kL" = (
@@ -7549,7 +6838,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kM" = (
@@ -7563,7 +6851,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kN" = (
@@ -7571,12 +6858,11 @@
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/badrecipe,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kO" = (
@@ -7585,7 +6871,6 @@
 	icon_state = "arrival"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kP" = (
@@ -7596,17 +6881,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kQ" = (
@@ -7614,18 +6896,15 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kR" = (
@@ -7633,7 +6912,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor{
@@ -7643,13 +6921,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kS" = (
@@ -7659,11 +6935,9 @@
 	opacity = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kT" = (
@@ -7676,7 +6950,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kU" = (
@@ -7685,17 +6958,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kV" = (
@@ -7704,13 +6974,10 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kW" = (
@@ -7718,27 +6985,20 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kX" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kY" = (
@@ -7748,7 +7008,6 @@
 	icon_state = "blue"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "kZ" = (
@@ -7758,7 +7017,6 @@
 	icon_state = "blue"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "la" = (
@@ -7773,7 +7031,6 @@
 	icon_state = "blue"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lb" = (
@@ -7783,13 +7040,11 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lc" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen";
@@ -7797,18 +7052,16 @@
 	network = list("MO19")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ld" = (
 /turf/simulated/wall/mineral/titanium,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lg" = (
@@ -7818,18 +7071,15 @@
 	icon_state = "arrival"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "li" = (
@@ -7837,16 +7087,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lj" = (
@@ -7855,7 +7102,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lk" = (
@@ -7867,7 +7113,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -7885,7 +7130,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lm" = (
@@ -7896,20 +7140,17 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ln" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lo" = (
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lp" = (
@@ -7919,7 +7160,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lq" = (
@@ -7929,15 +7169,12 @@
 /obj/structure/chair/wood,
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lr" = (
@@ -7948,17 +7185,14 @@
 /obj/item/storage/box,
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ls" = (
@@ -7969,7 +7203,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lt" = (
@@ -7987,25 +7220,21 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lu" = (
 /obj/machinery/door_control{
 	id = "awaykitchen";
 	name = "Kitchen Shutters Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lv" = (
@@ -8013,7 +7242,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lw" = (
@@ -8027,7 +7255,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lx" = (
@@ -8036,7 +7263,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ly" = (
@@ -8051,7 +7277,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lE" = (
@@ -8062,7 +7287,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lF" = (
@@ -8073,7 +7297,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lG" = (
@@ -8081,19 +7304,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lH" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lI" = (
@@ -8101,7 +7321,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lJ" = (
@@ -8109,12 +7328,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -8122,21 +7339,18 @@
 	tag = "icon-purplecorner (NORTH)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lK" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (EAST)";
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lL" = (
@@ -8146,7 +7360,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lM" = (
@@ -8154,32 +7367,27 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lN" = (
 /obj/structure/table/wood,
 /obj/item/lighter/zippo,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lO" = (
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lQ" = (
@@ -8188,7 +7396,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lR" = (
@@ -8199,25 +7406,21 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "purplecorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lS" = (
@@ -8225,7 +7428,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lT" = (
@@ -8234,7 +7436,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lU" = (
@@ -8245,7 +7446,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lV" = (
@@ -8261,7 +7461,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lX" = (
@@ -8269,7 +7468,6 @@
 /obj/item/storage/lockbox,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "lY" = (
@@ -8277,17 +7475,14 @@
 /obj/item/radio/off,
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ma" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mb" = (
@@ -8299,13 +7494,11 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mc" = (
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "md" = (
@@ -8314,12 +7507,10 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "me" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light/small{
@@ -8327,14 +7518,12 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mf" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mg" = (
@@ -8345,7 +7534,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mh" = (
@@ -8353,7 +7541,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mi" = (
@@ -8362,7 +7549,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mj" = (
@@ -8371,7 +7557,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mk" = (
@@ -8382,7 +7567,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ml" = (
@@ -8391,7 +7575,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mm" = (
@@ -8401,7 +7584,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mn" = (
@@ -8409,20 +7591,17 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "purplecorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mo" = (
@@ -8430,13 +7609,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mp" = (
@@ -8449,16 +7626,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mq" = (
@@ -8466,7 +7640,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mr" = (
@@ -8478,13 +7651,11 @@
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ms" = (
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mt" = (
@@ -8493,7 +7664,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mu" = (
@@ -8505,7 +7675,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mv" = (
@@ -8517,7 +7686,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mw" = (
@@ -8531,20 +7699,17 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mx" = (
 /obj/structure/grille,
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
-	name = "\improper HOSTILE ATMOSPHERE AHEAD";
-	pixel_x = 0
+	name = "\improper HOSTILE ATMOSPHERE AHEAD"
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "my" = (
@@ -8557,7 +7722,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mz" = (
@@ -8565,7 +7729,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mA" = (
@@ -8575,17 +7738,13 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mB" = (
@@ -8594,7 +7753,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mC" = (
@@ -8603,7 +7761,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mD" = (
@@ -8615,7 +7772,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mE" = (
@@ -8627,7 +7783,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mF" = (
@@ -8641,14 +7796,12 @@
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mG" = (
@@ -8657,14 +7810,12 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mH" = (
 /obj/machinery/computer/shuttle,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mI" = (
@@ -8673,7 +7824,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mJ" = (
@@ -8682,7 +7832,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mK" = (
@@ -8697,7 +7846,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mL" = (
@@ -8706,7 +7854,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mM" = (
@@ -8714,7 +7861,6 @@
 /obj/structure/window/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mN" = (
@@ -8722,14 +7868,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mO" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mP" = (
@@ -8738,7 +7882,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mQ" = (
@@ -8748,7 +7891,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mR" = (
@@ -8760,7 +7902,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mS" = (
@@ -8771,7 +7912,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mT" = (
@@ -8784,7 +7924,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mU" = (
@@ -8801,7 +7940,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mV" = (
@@ -8810,15 +7948,12 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mW" = (
@@ -8827,7 +7962,6 @@
 /obj/item/pen,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mX" = (
@@ -8837,7 +7971,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "mZ" = (
@@ -8847,7 +7980,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "na" = (
@@ -8856,14 +7988,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nb" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nc" = (
@@ -8874,7 +8004,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nd" = (
@@ -8892,14 +8021,12 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ng" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nh" = (
@@ -8909,18 +8036,15 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ni" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nj" = (
@@ -8939,7 +8063,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nk" = (
@@ -8955,7 +8078,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nl" = (
@@ -8964,14 +8086,12 @@
 /obj/structure/window/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nm" = (
 /obj/item/cigbutt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nn" = (
@@ -8979,19 +8099,16 @@
 /obj/item/trash/candy,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "np" = (
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
 	name = "\improper HOSTILE ATMOSPHERE AHEAD";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nq" = (
@@ -8999,7 +8116,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nr" = (
@@ -9009,7 +8125,6 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ns" = (
@@ -9022,14 +8137,12 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nt" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nu" = (
@@ -9037,14 +8150,12 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nv" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nx" = (
@@ -9057,7 +8168,6 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ny" = (
@@ -9077,7 +8187,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nz" = (
@@ -9087,7 +8196,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nA" = (
@@ -9095,16 +8203,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nB" = (
@@ -9113,14 +8218,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nC" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nD" = (
@@ -9139,7 +8242,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9149,10 +8251,8 @@
 "nE" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel/airless{
@@ -9160,7 +8260,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nF" = (
@@ -9168,7 +8267,6 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nG" = (
@@ -9177,7 +8275,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nH" = (
@@ -9185,7 +8282,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nI" = (
@@ -9196,8 +8292,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/effect/decal/remains/human{
@@ -9206,7 +8300,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nJ" = (
@@ -9217,7 +8310,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nK" = (
@@ -9226,7 +8318,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nL" = (
@@ -9237,24 +8328,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nM" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nO" = (
@@ -9268,7 +8355,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nP" = (
@@ -9278,7 +8364,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nQ" = (
@@ -9290,7 +8375,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nR" = (
@@ -9298,7 +8382,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nS" = (
@@ -9306,7 +8389,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nT" = (
@@ -9316,7 +8398,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nU" = (
@@ -9328,22 +8409,18 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nV" = (
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nW" = (
@@ -9352,7 +8429,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nX" = (
@@ -9362,8 +8438,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard{
 	dir = 8;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/paper{
 	info = "<p><p align=center><h2>Welcome to Moon Outpost 19! Property of Nanotrasen Inc.</h2></p><hr><h3>Staff Roster:</h3><ul><li>Dr. Gerald Rosswell: Research Director & Acting Captain</li><li>Dr. Sakuma Sano: Xenobiologist</li><li>Dr. Mark Douglas: Xenobiologist</li><li>Kenneth Cunningham: Security Officer</li><li>Ivan Volodin: Engineer</li><li>Mathias Kuester: Bartender</li><li>Sven Edling: Chef</li><li>Steve: Assistant</li></ul><br>Please enjoy your stay, and report any abnormalities to an officer.";
@@ -9378,7 +8453,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nY" = (
@@ -9388,7 +8462,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "nZ" = (
@@ -9401,13 +8474,11 @@
 	name = "plating"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oa" = (
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ob" = (
@@ -9416,7 +8487,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oc" = (
@@ -9429,7 +8499,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "od" = (
@@ -9442,7 +8511,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9457,7 +8525,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9470,7 +8537,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9488,7 +8554,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oh" = (
@@ -9497,7 +8562,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9508,7 +8572,6 @@
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/plating/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oj" = (
@@ -9524,7 +8587,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9533,18 +8595,15 @@
 	})
 "ok" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ol" = (
 /turf/simulated/mineral,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "om" = (
@@ -9555,7 +8614,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9570,7 +8628,6 @@
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
 	name = "Khonsu 19";
 	power_environ = 0;
 	power_equip = 0;
@@ -9580,25 +8637,21 @@
 "oo" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oq" = (
@@ -9607,23 +8660,19 @@
 	name = "Diner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "or" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "os" = (
@@ -9633,12 +8682,11 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ot" = (
@@ -9653,12 +8701,10 @@
 	name = "Serving Hatch"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ou" = (
@@ -9666,14 +8712,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ov" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ow" = (
@@ -9681,25 +8725,21 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "ox" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oz" = (
@@ -9714,7 +8754,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oA" = (
@@ -9733,7 +8772,6 @@
 /obj/item/clothing/under/suit_jacket/navy,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oB" = (
@@ -9744,7 +8782,6 @@
 	icon_state = "blue"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oC" = (
@@ -9753,7 +8790,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oD" = (
@@ -9767,7 +8803,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oE" = (
@@ -9779,7 +8814,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oF" = (
@@ -9793,7 +8827,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oG" = (
@@ -9804,7 +8837,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oH" = (
@@ -9817,7 +8849,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oI" = (
@@ -9832,24 +8863,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oJ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oK" = (
@@ -9873,7 +8898,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oL" = (
@@ -9892,7 +8916,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oM" = (
@@ -9916,7 +8939,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oO" = (
@@ -9927,7 +8949,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oP" = (
@@ -9936,7 +8957,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oQ" = (
@@ -9945,14 +8965,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
@@ -9960,14 +8978,12 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oT" = (
 /obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oU" = (
@@ -9988,7 +9004,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oW" = (
@@ -10000,7 +9015,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oX" = (
@@ -10009,7 +9023,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oY" = (
@@ -10026,7 +9039,6 @@
 	name = "floor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "oZ" = (
@@ -10045,7 +9057,6 @@
 /obj/item/clothing/under/assistantformal,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "pa" = (
@@ -10054,17 +9065,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "pe" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "pg" = (
@@ -10083,14 +9091,12 @@
 /obj/item/clothing/under/suit_jacket/burgundy,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 "xB" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "MO19 Arrivals"
 	})
 

--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -10,33 +10,31 @@
 /area/awaymission/spacebattle/syndicate2)
 "ad" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /turf/space,
 /area/awaymission/spacebattle/syndicate2)
 "ae" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	tag = "icon-propulsion (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate2)
 "af" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /turf/space,
 /area/awaymission/spacebattle/syndicate2)
 "ai" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -99,25 +97,24 @@
 /area/awaymission/spacebattle/syndicate3)
 "aw" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate3)
 "ax" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	tag = "icon-propulsion (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate3)
 "ay" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate3)
@@ -128,9 +125,8 @@
 /area/awaymission/spacebattle/syndicate2)
 "aC" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -171,25 +167,24 @@
 /area/awaymission/spacebattle/syndicate1)
 "aP" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate1)
 "aQ" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	tag = "icon-propulsion (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate1)
 "aR" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate1)
@@ -199,9 +194,8 @@
 /area/awaymission/spacebattle/syndicate3)
 "aW" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -209,9 +203,8 @@
 "aX" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -221,9 +214,8 @@
 "aY" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -296,8 +288,7 @@
 /obj/machinery/door/poddoor{
 	icon_state = "pdoor1";
 	id_tag = "spacebattlepod3";
-	name = "Front Hull Door";
-	opacity = 1
+	name = "Front Hull Door"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/syndicate2)
@@ -354,9 +345,9 @@
 /area/awaymission/spacebattle/cruiser)
 "bF" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
@@ -366,18 +357,17 @@
 /area/awaymission/spacebattle/cruiser)
 "bH" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
 "bK" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -390,9 +380,8 @@
 "bM" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -416,17 +405,16 @@
 /area/awaymission/spacebattle/cruiser)
 "bU" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l (EAST)";
+	dir = 4;
 	icon_state = "burst_l";
-	dir = 4
+	tag = "icon-burst_l (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
 "bV" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -453,9 +441,8 @@
 /area/awaymission/spacebattle/cruiser)
 "cc" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (EAST)";
-	icon_state = "propulsion";
-	dir = 4
+	dir = 4;
+	tag = "icon-propulsion (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
@@ -469,7 +456,6 @@
 	icon_state = "open";
 	id_tag = "spacebattlepod";
 	name = "Front Hull Door";
-	opacity = 1;
 	tag = "icon-pdoor0"
 	},
 /turf/simulated/floor/plating,
@@ -556,54 +542,47 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/sausage,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cA" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cB" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cC" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cD" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cE" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cG" = (
@@ -634,8 +613,7 @@
 /area/awaymission/spacebattle/cruiser)
 "cM" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cN" = (
@@ -652,31 +630,27 @@
 "cQ" = (
 /obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cR" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/fries,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cS" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/soup/stew,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cT" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cU" = (
@@ -714,9 +688,9 @@
 /area/awaymission/spacebattle/cruiser)
 "dc" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (EAST)";
+	dir = 4;
 	icon_state = "propulsion_r";
-	dir = 4
+	tag = "icon-propulsion_r (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
@@ -772,7 +746,6 @@
 	icon_state = "open";
 	id_tag = "spacebattlepod2";
 	name = "Front Hull Door";
-	opacity = 1;
 	tag = "icon-pdoor0"
 	},
 /turf/simulated/floor/plating,
@@ -800,14 +773,14 @@
 "dw" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "dx" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "dy" = (
@@ -815,15 +788,15 @@
 	name = "awaystart"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "dz" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "dB" = (
@@ -902,15 +875,15 @@
 "dS" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "dT" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "dV" = (
@@ -969,8 +942,8 @@
 "eg" = (
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "ej" = (
@@ -1029,8 +1002,8 @@
 /area/awaymission/spacebattle/cruiser)
 "ev" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "ew" = (
@@ -1046,8 +1019,8 @@
 /area/awaymission/spacebattle/cruiser)
 "ey" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "eA" = (
@@ -1067,8 +1040,8 @@
 "eC" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/awaymission/spacebattle/cruiser)
 "eE" = (
@@ -1091,8 +1064,8 @@
 /area/awaymission/spacebattle/syndicate4)
 "eK" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/awaymission/spacebattle/cruiser)
 "eL" = (
@@ -1108,8 +1081,8 @@
 "eN" = (
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/awaymission/spacebattle/cruiser)
 "eP" = (
@@ -1162,8 +1135,8 @@
 "eX" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/awaymission/spacebattle/cruiser)
 "eY" = (
@@ -1180,8 +1153,8 @@
 /area/awaymission/spacebattle/cruiser)
 "fa" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "fb" = (
@@ -1191,8 +1164,8 @@
 /area/awaymission/spacebattle/cruiser)
 "fc" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/awaymission/spacebattle/cruiser)
 "fd" = (
@@ -1214,8 +1187,8 @@
 "fg" = (
 /mob/living/simple_animal/hostile/syndicate/ranged,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/awaymission/spacebattle/cruiser)
 "fh" = (
@@ -1306,8 +1279,8 @@
 "ft" = (
 /obj/machinery/computer/shuttle,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/awaymission/spacebattle/cruiser)
 "fu" = (
@@ -1385,8 +1358,8 @@
 "fN" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/awaymission/spacebattle/cruiser)
 "ga" = (
@@ -1420,19 +1393,16 @@
 /area/awaymission/spacebattle/cruiser)
 "gq" = (
 /obj/machinery/door_control{
-	dir = 2;
 	id = "spacebattlestorage";
 	name = "Secure Storage";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "gr" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gs" = (
@@ -1440,32 +1410,28 @@
 /obj/item/scalpel,
 /obj/item/circular_saw,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gt" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gu" = (
 /obj/structure/table/reinforced,
 /obj/item/hemostat,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gv" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gw" = (
@@ -1507,15 +1473,15 @@
 "gI" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gJ" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gK" = (
@@ -1577,8 +1543,8 @@
 "gT" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gU" = (
@@ -1629,9 +1595,8 @@
 /area/awaymission/spacebattle/syndicate7)
 "hg" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (EAST)";
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1743,9 +1708,8 @@
 /area/awaymission/spacebattle/syndicate7)
 "hO" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /obj/item/bikehorn/rubberducky,
 /turf/simulated/floor/plasteel{
@@ -1759,9 +1723,8 @@
 /area/awaymission/spacebattle/cruiser)
 "hQ" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -1801,9 +1764,8 @@
 /area/awaymission/spacebattle/cruiser)
 "hY" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -1811,9 +1773,8 @@
 /area/awaymission/spacebattle/cruiser)
 "hZ" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	tag = "icon-shower (WEST)"
 	},
 /obj/item/soap,
 /turf/simulated/floor/plasteel{
@@ -1862,9 +1823,7 @@
 "ih" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -1873,14 +1832,14 @@
 "ii" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "ik" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "il" = (
@@ -2023,8 +1982,8 @@
 /area/awaymission/spacebattle/secret)
 "je" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-alienvault";
-	icon_state = "alienvault"
+	icon_state = "alienvault";
+	tag = "icon-alienvault"
 	},
 /area/awaymission/spacebattle/secret)
 "jf" = (
@@ -2041,17 +2000,17 @@
 /area/space/nearstation)
 "Jj" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate2)
 "Jw" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate2)

--- a/_maps/map_files/RandomZLevels/stationCollision.dmm
+++ b/_maps/map_files/RandomZLevels/stationCollision.dmm
@@ -94,7 +94,6 @@
 /obj/structure/window/reinforced/tinted,
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/table,
@@ -131,7 +130,6 @@
 /obj/structure/window/reinforced/tinted,
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -190,9 +188,8 @@
 /area/awaymission/northblock)
 "aP" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/syndishuttle)
@@ -277,16 +274,15 @@
 /area/awaymission/northblock)
 "bj" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (WEST)";
+	dir = 8;
 	icon_state = "bluecorner";
-	dir = 8
+	tag = "icon-bluecorner (WEST)"
 	},
 /area/awaymission/northblock)
 "bk" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
-	dir = 2
+	tag = "icon-bluecorner"
 	},
 /area/awaymission/northblock)
 "bl" = (
@@ -297,9 +293,9 @@
 /area/awaymission/northblock)
 "bm" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (WEST)";
+	dir = 8;
 	icon_state = "blue";
-	dir = 8
+	tag = "icon-blue (WEST)"
 	},
 /area/awaymission/northblock)
 "bn" = (
@@ -314,9 +310,8 @@
 /area/awaymission/syndishuttle)
 "bq" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/syndishuttle)
@@ -334,9 +329,9 @@
 /area/awaymission/syndishuttle)
 "bu" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (SOUTHEAST)";
+	dir = 6;
 	icon_state = "blue";
-	dir = 6
+	tag = "icon-blue (SOUTHEAST)"
 	},
 /area/awaymission/northblock)
 "bv" = (
@@ -358,23 +353,22 @@
 "bz" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
-	dir = 2
+	tag = "icon-bluecorner"
 	},
 /area/awaymission/northblock)
 "bA" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (SOUTHWEST)";
+	dir = 10;
 	icon_state = "blue";
-	dir = 10
+	tag = "icon-blue (SOUTHWEST)"
 	},
 /area/awaymission/northblock)
 "bB" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTHWEST)";
+	dir = 9;
 	icon_state = "blue";
-	dir = 9
+	tag = "icon-blue (NORTHWEST)"
 	},
 /area/awaymission/northblock)
 "bC" = (
@@ -387,9 +381,9 @@
 /area/awaymission/northblock)
 "bD" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
+	dir = 1;
 	icon_state = "blue";
-	dir = 1
+	tag = "icon-blue (NORTH)"
 	},
 /area/awaymission/northblock)
 "bF" = (
@@ -498,17 +492,16 @@
 /area/awaymission/research)
 "bV" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/syndishuttle)
 "bX" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTHEAST)";
+	dir = 5;
 	icon_state = "blue";
-	dir = 5
+	tag = "icon-blue (NORTHEAST)"
 	},
 /area/awaymission/northblock)
 "bY" = (
@@ -598,7 +591,6 @@
 /obj/item/clothing/head/helmet/space/syndicate,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -708,9 +700,8 @@
 /area/awaymission/research)
 "cz" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -750,7 +741,6 @@
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 1;
-	icon_state = "emitter";
 	state = 2
 	},
 /turf/simulated/floor/plasteel{
@@ -784,9 +774,8 @@
 /area/awaymission/research)
 "cK" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -800,7 +789,6 @@
 "cL" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/clipboard{
@@ -837,7 +825,6 @@
 /area/awaymission/research)
 "cP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -926,9 +913,8 @@
 /area/awaymission/northblock)
 "db" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /obj/structure/window/reinforced/tinted,
 /turf/simulated/floor/plasteel,
@@ -951,7 +937,6 @@
 /area/awaymission/research)
 "de" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -985,8 +970,8 @@
 	pixel_x = -28
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -1005,7 +990,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -1067,7 +1051,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -1093,7 +1076,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -1124,9 +1106,9 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (EAST)";
+	dir = 4;
 	icon_state = "blue";
-	dir = 4
+	tag = "icon-blue (EAST)"
 	},
 /area/awaymission/northblock)
 "dx" = (
@@ -1143,7 +1125,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -1153,13 +1134,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (EAST)";
+	dir = 4;
 	icon_state = "blue";
-	dir = 4
+	tag = "icon-blue (EAST)"
 	},
 /area/awaymission/northblock)
 "dA" = (
@@ -1167,7 +1147,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -1176,7 +1155,6 @@
 "dB" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	pixel_y = -10;
 	tag = "icon-shower (EAST)"
 	},
@@ -1243,7 +1221,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -1279,9 +1256,9 @@
 "dM" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (EAST)";
+	dir = 4;
 	icon_state = "bluecorner";
-	dir = 4
+	tag = "icon-bluecorner (EAST)"
 	},
 /area/awaymission/northblock)
 "dN" = (
@@ -1300,24 +1277,24 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTHWEST)";
+	dir = 9;
 	icon_state = "blue";
-	dir = 9
+	tag = "icon-blue (NORTHWEST)"
 	},
 /area/awaymission/northblock)
 "dP" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
+	dir = 1;
 	icon_state = "blue";
-	dir = 1
+	tag = "icon-blue (NORTH)"
 	},
 /area/awaymission/northblock)
 "dQ" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (EAST)";
+	dir = 4;
 	icon_state = "bluecorner";
-	dir = 4
+	tag = "icon-bluecorner (EAST)"
 	},
 /area/awaymission/northblock)
 "dR" = (
@@ -1412,25 +1389,25 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
+	dir = 1;
 	icon_state = "blue";
-	dir = 1
+	tag = "icon-blue (NORTH)"
 	},
 /area/awaymission/northblock)
 "ee" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (EAST)";
+	dir = 4;
 	icon_state = "bluecorner";
-	dir = 4
+	tag = "icon-bluecorner (EAST)"
 	},
 /area/awaymission/northblock)
 "ef" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
+	dir = 1;
 	icon_state = "blue";
-	dir = 1
+	tag = "icon-blue (NORTH)"
 	},
 /area/awaymission/northblock)
 "eg" = (
@@ -1518,7 +1495,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -1528,7 +1504,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/damageturf,
@@ -1548,7 +1523,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/burnturf,
@@ -1576,7 +1550,6 @@
 /area/awaymission/syndishuttle)
 "ey" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/landmark/damageturf,
@@ -1635,9 +1608,8 @@
 /area/awaymission/research)
 "eH" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1761,7 +1733,6 @@
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 1;
-	icon_state = "emitter";
 	state = 2
 	},
 /turf/simulated/floor/plasteel{
@@ -1795,7 +1766,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -1949,7 +1919,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/damageturf,
@@ -2020,7 +1989,6 @@
 "fA" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/c10mm,
@@ -2039,7 +2007,6 @@
 "fC" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/c10mm,
@@ -2056,7 +2023,6 @@
 "fD" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/c10mm,
@@ -2068,7 +2034,6 @@
 /area/awaymission/midblock)
 "fE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -2102,8 +2067,8 @@
 "fH" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "fI" = (
@@ -2202,7 +2167,6 @@
 "gf" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/c10mm,
@@ -2232,12 +2196,10 @@
 /obj/structure/closet/wardrobe/pjs,
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -2353,7 +2315,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -2394,7 +2355,6 @@
 "gM" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/effect/landmark/sc_bible_spawner,
@@ -2442,15 +2402,15 @@
 "gV" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "gW" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "gX" = (
@@ -2458,8 +2418,8 @@
 /obj/item/melee/baton,
 /obj/item/clothing/head/warden,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "gY" = (
@@ -2471,22 +2431,22 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "gZ" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "ha" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "hb" = (
@@ -2504,12 +2464,10 @@
 "hd" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -2573,8 +2531,7 @@
 /area/awaymission/midblock)
 "hk" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -2611,8 +2568,8 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "hu" = (
@@ -2627,8 +2584,8 @@
 	name = "Windoor"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "hy" = (
@@ -2645,8 +2602,7 @@
 /area/awaymission/midblock)
 "hz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2688,8 +2644,8 @@
 /area/awaymission/midblock)
 "hF" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "hG" = (
@@ -2710,8 +2666,8 @@
 /area/awaymission/arrivalblock)
 "hJ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "hK" = (
@@ -2777,12 +2733,12 @@
 	pixel_x = -28
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "hY" = (
@@ -2790,7 +2746,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -2803,7 +2758,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -2814,24 +2768,21 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "ib" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Glass Airlock";
-	req_access_txt = "0"
+	name = "Glass Airlock"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -2841,7 +2792,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -2849,8 +2799,8 @@
 "id" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "ie" = (
@@ -2907,15 +2857,14 @@
 /area/awaymission/arrivalblock)
 "im" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/arrivalblock)
 "in" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "io" = (
@@ -2925,8 +2874,8 @@
 /area/awaymission/arrivalblock)
 "ip" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "iq" = (
@@ -3034,19 +2983,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "iO" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "iP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -3054,15 +3002,13 @@
 /area/awaymission/gateroom)
 "iQ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/awaymission/gateroom)
 "iR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -3098,8 +3044,7 @@
 /area/awaymission/southblock)
 "iX" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
@@ -3109,8 +3054,8 @@
 "ja" = (
 /obj/structure/closet/wardrobe/orange,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/awaymission/arrivalblock)
 "jb" = (
@@ -3128,8 +3073,8 @@
 /area/awaymission/arrivalblock)
 "jd" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r";
-	icon_state = "propulsion_r"
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r"
 	},
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -3143,16 +3088,16 @@
 /area/awaymission/arrivalblock)
 "jg" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l";
-	icon_state = "propulsion_l"
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l"
 	},
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l";
-	icon_state = "burst_l"
+	icon_state = "burst_l";
+	tag = "icon-burst_l"
 	},
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l";
-	icon_state = "propulsion_l"
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l"
 	},
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -3171,7 +3116,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -3184,7 +3128,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel/airless,
@@ -3194,7 +3137,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3256,8 +3198,7 @@
 "jr" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Glass Airlock";
-	req_access_txt = "0"
+	name = "Glass Airlock"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
@@ -3294,7 +3235,6 @@
 "jA" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /turf/simulated/floor/plasteel,
@@ -3339,16 +3279,16 @@
 /area/awaymission/southblock)
 "jH" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "jI" = (
 /obj/structure/table,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "jJ" = (
@@ -3466,22 +3406,19 @@
 "kc" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "kd" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "ke" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "kf" = (
@@ -3491,8 +3428,7 @@
 /area/awaymission/southblock)
 "kg" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3510,9 +3446,9 @@
 /area/awaymission/gateroom)
 "ki" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/gateway/centeraway{
 	calibrated = 0
@@ -3616,18 +3552,18 @@
 /area/awaymission/gateroom)
 "kA" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/awaymission/arrivalblock)
 "kB" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -3656,7 +3592,6 @@
 /obj/item/clothing/under/syndicate,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/paper/sc_safehint_paper_hydro,
@@ -3671,8 +3606,8 @@
 "kI" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	dir = 1;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "kJ" = (
@@ -3690,7 +3625,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -3707,7 +3641,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -3718,7 +3651,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/northeast,
@@ -3742,9 +3674,9 @@
 /area/awaymission/arrivalblock)
 "kR" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitehall (WEST)";
+	dir = 8;
 	icon_state = "whitehall";
-	dir = 8
+	tag = "icon-whitehall (WEST)"
 	},
 /area/awaymission/southblock)
 "kS" = (
@@ -3752,14 +3684,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "kT" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "kU" = (
@@ -3791,7 +3723,6 @@
 "kY" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted{
@@ -3813,8 +3744,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "ld" = (
@@ -3838,19 +3769,17 @@
 /area/awaymission/arrivalblock)
 "lh" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitehall (WEST)";
+	dir = 8;
 	icon_state = "whitehall";
-	dir = 8
+	tag = "icon-whitehall (WEST)"
 	},
 /area/awaymission/southblock)
 "li" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -3860,8 +3789,8 @@
 /obj/structure/window/reinforced/tinted,
 /obj/item/bedsheet/medical,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "lt" = (
@@ -3909,8 +3838,8 @@
 /obj/item/bedsheet/medical,
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "lA" = (
@@ -3990,13 +3919,12 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "lL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -4015,7 +3943,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -4025,7 +3952,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/engineering,
@@ -4036,7 +3962,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -4046,7 +3971,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -4102,12 +4026,10 @@
 "lY" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "lZ" = (
@@ -4115,8 +4037,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "md" = (
@@ -4133,8 +4054,7 @@
 /obj/machinery/power/apc/noalarm{
 	dir = 4;
 	name = "Gateroom APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable{
 	d2 = 8;

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -18,18 +18,15 @@
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "af" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -122,7 +119,6 @@
 /area/awaymission/UO71/plaza)
 "au" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaymission/UO71/plaza)
@@ -140,7 +136,6 @@
 /area/awaymission/UO71/plaza)
 "ax" = (
 /obj/structure/chair/comfy/beige{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -191,8 +186,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/item/gun/energy/laser/retro,
 /obj/item/paper/terrorspiders8,
@@ -227,7 +221,6 @@
 /area/awaymission/UO71/plaza)
 "aH" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair";
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
@@ -239,10 +232,8 @@
 "aJ" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel,
@@ -253,9 +244,7 @@
 	},
 /area/awaymission/UO71/plaza)
 "aL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -273,7 +262,6 @@
 "aN" = (
 /obj/machinery/door/airlock{
 	id_tag = "awaydormE1";
-	locked = 0;
 	name = "Executive Dorm 1";
 	req_access_txt = "271"
 	},
@@ -310,16 +298,14 @@
 /area/awaymission/UO71/plaza)
 "aS" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "aT" = (
 /obj/structure/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -372,10 +358,7 @@
 	},
 /area/awaymission/UO71/plaza)
 "ba" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bb" = (
@@ -387,7 +370,6 @@
 /obj/machinery/light/small,
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -398,8 +380,7 @@
 /area/awaymission/UO71/plaza)
 "bd" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -433,8 +414,7 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/item/gun/energy/laser/awaymission_aeg,
 /turf/simulated/floor/carpet,
@@ -481,8 +461,7 @@
 /area/awaymission/UO71/plaza)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -500,8 +479,7 @@
 /area/awaymission/UO71/plaza)
 "bn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -576,7 +554,6 @@
 "bB" = (
 /obj/machinery/door/airlock{
 	id_tag = "awaydormE2";
-	locked = 0;
 	name = "Executive Dorm 2";
 	req_access_txt = "271"
 	},
@@ -653,10 +630,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -718,8 +692,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/damageturf,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
@@ -764,7 +737,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -774,8 +746,7 @@
 "ch" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -800,8 +771,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -810,13 +780,11 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair";
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -864,16 +832,13 @@
 /area/awaymission/UO71/plaza)
 "cs" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair";
 	dir = 1
 	},
 /obj/machinery/door_control{
 	id = "awaydorm2";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -907,9 +872,7 @@
 	id = "awaydorm1";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -949,8 +912,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
@@ -981,7 +943,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm1";
-	locked = 0;
 	name = "Dorm 1";
 	req_access_txt = "271"
 	},
@@ -1049,22 +1010,17 @@
 /area/awaymission/UO71/science)
 "cW" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "cX" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/awaymission/UO71/plaza)
@@ -1081,7 +1037,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -1126,8 +1081,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1189,7 +1143,6 @@
 /area/awaymission/UO71/plaza)
 "dm" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -1253,8 +1206,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light/small{
@@ -1298,7 +1249,6 @@
 "dv" = (
 /obj/structure/chair,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -1314,7 +1264,6 @@
 	icon_off = "secoff";
 	icon_opened = "secopen";
 	icon_state = "sec1";
-	locked = 1;
 	name = "security officer's locker";
 	req_access_txt = "271"
 	},
@@ -1347,21 +1296,16 @@
 "dA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaymission/UO71/plaza)
 "dB" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1449,8 +1393,7 @@
 "dL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Checkpoint Maintenance";
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
@@ -1493,9 +1436,7 @@
 "dV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
@@ -1516,10 +1457,8 @@
 "dZ" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1569,7 +1508,6 @@
 /area/awaymission/UO71/plaza)
 "ed" = (
 /obj/structure/chair/office{
-	icon_state = "chair";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -1587,7 +1525,6 @@
 /area/awaymission/UO71/plaza)
 "eg" = (
 /obj/structure/chair/office{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -1618,8 +1555,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1632,9 +1568,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Security Checkpoint";
 	req_access_txt = "271"
 	},
@@ -1651,7 +1585,6 @@
 /area/awaymission/UO71/plaza)
 "em" = (
 /obj/structure/chair/office{
-	icon_state = "chair";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1695,7 +1628,6 @@
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/watertank,
@@ -1762,7 +1694,6 @@
 /area/awaymission/UO71/plaza)
 "ez" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/awaymission/UO71/plaza)
@@ -1775,14 +1706,12 @@
 /area/awaymission/UO71/plaza)
 "eB" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
 "eC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
@@ -1794,20 +1723,17 @@
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "Hydroponics APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 5
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
@@ -1815,12 +1741,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
@@ -1828,15 +1752,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
@@ -1845,11 +1766,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
@@ -1857,11 +1776,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
@@ -1883,18 +1800,14 @@
 	},
 /area/awaymission/UO71/plaza)
 "eK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/awaymission/UO71/plaza)
 "eL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -1903,10 +1816,8 @@
 "eM" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -1947,8 +1858,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1989,8 +1899,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2006,9 +1915,7 @@
 "eV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
@@ -2034,9 +1941,7 @@
 	id = "awaydorm3";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2125,7 +2030,6 @@
 /obj/machinery/light/small,
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -2139,15 +2043,12 @@
 "fm" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
 "fn" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2156,7 +2057,6 @@
 /area/awaymission/UO71/plaza)
 "fo" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2165,7 +2065,6 @@
 "fp" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -2189,7 +2088,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -2219,8 +2117,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2262,16 +2159,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
@@ -2280,8 +2175,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
@@ -2447,8 +2341,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2476,7 +2369,6 @@
 "gf" = (
 /obj/machinery/camera{
 	c_tag = "Research Lab";
-	dir = 2;
 	network = list("UO71")
 	},
 /turf/simulated/floor/vault,
@@ -2494,12 +2386,8 @@
 /area/awaymission/UO71/gateway)
 "gi" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/UO71/science)
@@ -2514,7 +2402,6 @@
 	amount = 23
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/UO71/science)
@@ -2594,8 +2481,6 @@
 /area/awaymission/UO71/science)
 "gw" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/item/robot_parts/l_arm,
@@ -2612,14 +2497,12 @@
 /area/awaymission/UO71/prince)
 "gy" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /obj/machinery/camera{
 	c_tag = "Research Lab";
-	dir = 2;
 	network = list("UO71")
 	},
 /turf/simulated/floor/plasteel{
@@ -2659,10 +2542,8 @@
 "gC" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -2707,7 +2588,6 @@
 "gH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -2736,9 +2616,7 @@
 	},
 /area/awaymission/UO71/centralhall)
 "gL" = (
-/obj/machinery/vending/boozeomat{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -2756,8 +2634,7 @@
 /area/awaymission/UO71/centralhall)
 "gN" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -2776,10 +2653,8 @@
 "gP" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/camera{
@@ -2824,11 +2699,8 @@
 	},
 /area/awaymission/UO71/gateway)
 "gT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -2837,7 +2709,6 @@
 /area/awaymission/UO71/gateway)
 "gV" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2894,9 +2765,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
 "hc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -2904,10 +2773,8 @@
 "hd" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/camera{
@@ -2944,7 +2811,6 @@
 /area/awaymission/UO71/centralhall)
 "hh" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -2998,8 +2864,7 @@
 "hn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -3062,8 +2927,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3094,8 +2958,8 @@
 "hw" = (
 /obj/machinery/gateway,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3105,15 +2969,12 @@
 "hx" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -3122,7 +2983,6 @@
 /area/awaymission/UO71/gateway)
 "hy" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -3161,10 +3021,8 @@
 "hE" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -3217,7 +3075,6 @@
 /area/awaymission/UO71/centralhall)
 "hL" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3310,8 +3167,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window{
 	dir = 2;
@@ -3328,7 +3184,6 @@
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3370,14 +3225,12 @@
 /area/awaymission/UO71/science)
 "ih" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway Ready Room";
-	dir = 2;
 	network = list("UO71")
 	},
 /obj/structure/table,
@@ -3442,9 +3295,7 @@
 	},
 /area/awaymission/UO71/centralhall)
 "ip" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -3490,8 +3341,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3528,8 +3378,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
@@ -3554,24 +3403,15 @@
 	icon_state = "white"
 	},
 /area/awaymission/UO71/science)
-"iA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/gateway)
 "iB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/mineral/random/labormineral,
 /area/awaymission/UO71/outside)
 "iE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -3583,7 +3423,6 @@
 	dir = 4
 	},
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -3631,8 +3470,7 @@
 "iS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -3642,10 +3480,8 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
@@ -3654,8 +3490,7 @@
 /area/awaymission/UO71/centralhall)
 "iU" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -3680,7 +3515,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -3708,8 +3542,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -3797,10 +3631,8 @@
 "jj" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
 	icon_state = "weld";
 	on = 1;
-	pressure_checks = 1;
 	welded = 1
 	},
 /obj/machinery/light/small{
@@ -3819,10 +3651,7 @@
 "jo" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -3872,8 +3701,7 @@
 "jv" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -3914,8 +3742,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3972,10 +3799,8 @@
 "jJ" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3998,8 +3823,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/research{
 	name = "Research Lab";
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -4022,8 +3846,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4033,7 +3856,6 @@
 /area/awaymission/UO71/science)
 "jR" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -4057,15 +3879,14 @@
 /area/awaymission/UO71/centralhall)
 "jU" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
 	dir = 1;
 	locked = 0;
 	name = "UO71 Bar APC";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access = null;
 	start_charge = 100
@@ -4083,12 +3904,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4105,8 +3925,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -4123,8 +3942,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4141,8 +3959,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4150,10 +3967,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4183,8 +3997,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4229,8 +4042,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
 	name = "Gateway";
@@ -4275,8 +4087,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/terrorspiders5,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	dir = 9
+	dir = 9;
+	icon_state = "whitepurple"
 	},
 /area/awaymission/UO71/science)
 "kp" = (
@@ -4285,8 +4097,8 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	dir = 5
+	dir = 5;
+	icon_state = "whitepurple"
 	},
 /area/awaymission/UO71/science)
 "kq" = (
@@ -4308,11 +4120,8 @@
 /area/awaymission/UO71/science)
 "ks" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -4346,7 +4155,6 @@
 /area/awaymission/UO71/centralhall)
 "kv" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -4379,8 +4187,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4409,8 +4216,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4441,7 +4247,6 @@
 /area/awaymission/UO71/gateway)
 "kF" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4467,9 +4272,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kJ" = (
@@ -4477,9 +4282,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kK" = (
@@ -4491,9 +4296,9 @@
 	},
 /mob/living/simple_animal/hostile/poison/terror_spider/gray,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kL" = (
@@ -4501,15 +4306,14 @@
 	dir = 4
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kM" = (
@@ -4520,9 +4324,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kN" = (
@@ -4531,9 +4335,9 @@
 	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kO" = (
@@ -4545,9 +4349,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kQ" = (
@@ -4560,16 +4364,14 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kR" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -4611,18 +4413,16 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kX" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -4634,9 +4434,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "kZ" = (
@@ -4645,24 +4445,24 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "la" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "lb" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "lc" = (
@@ -4734,8 +4534,7 @@
 /obj/structure/table,
 /obj/item/newspaper,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -4762,7 +4561,6 @@
 "ln" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4794,7 +4592,6 @@
 	dir = 5
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -4810,7 +4607,6 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -4839,8 +4635,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4883,8 +4678,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
@@ -4906,8 +4700,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -4918,8 +4711,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -4928,8 +4720,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -4940,8 +4731,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -4955,8 +4745,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4973,8 +4762,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4987,14 +4775,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5002,12 +4788,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5015,12 +4799,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5032,7 +4814,6 @@
 	network = list("UO71")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5040,15 +4821,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5056,8 +4834,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5066,7 +4843,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5075,8 +4851,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5086,7 +4861,6 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5094,8 +4868,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5105,7 +4878,6 @@
 	wander = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5113,8 +4885,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -5132,7 +4903,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5143,10 +4913,8 @@
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "UO71 Research Division APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -5158,7 +4926,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5166,21 +4933,17 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5205,7 +4968,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5214,7 +4976,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5224,14 +4985,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "lW" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -5243,13 +5002,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "lX" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5258,7 +5015,6 @@
 	pixel_y = -12
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -5272,9 +5028,7 @@
 	},
 /area/awaymission/UO71/science)
 "ma" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
 "mb" = (
@@ -5294,7 +5048,6 @@
 /area/awaymission/UO71/centralhall)
 "md" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5305,8 +5058,7 @@
 "me" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -5323,7 +5075,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -5335,8 +5086,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5368,8 +5118,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5388,8 +5137,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5411,8 +5159,7 @@
 "mq" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Lab";
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -5423,8 +5170,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5471,7 +5217,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 2;
 	network = list("UO71")
 	},
 /turf/simulated/floor/plating,
@@ -5505,7 +5250,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -5515,8 +5259,7 @@
 "mE" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/paper/terrorspiders4,
 /obj/item/reagent_containers/food/pill/charcoal{
@@ -5548,7 +5291,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -5562,8 +5304,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5612,8 +5353,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5630,7 +5370,6 @@
 /area/awaymission/UO71/gateway)
 "mN" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/rack{
@@ -5651,7 +5390,6 @@
 /obj/item/clothing/shoes/magboots,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
@@ -5660,10 +5398,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "UO71 Gateway APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -5716,8 +5452,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5736,7 +5471,6 @@
 	icon_off = "rdsecureoff";
 	icon_opened = "rdsecureopen";
 	icon_state = "rdsecure1";
-	locked = 1;
 	name = "research director's locker";
 	req_access_txt = "271"
 	},
@@ -5785,9 +5519,7 @@
 /area/awaymission/UO71/science)
 "nc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -5808,9 +5540,7 @@
 /obj/item/book/manual/security_space_law,
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -5845,20 +5575,15 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
 "ni" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/door_control{
 	id = "awaydorm5";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair";
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
@@ -5886,9 +5611,7 @@
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/centralhall)
 "nl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
@@ -5898,9 +5621,7 @@
 	id = "awaydorm7";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -5936,7 +5657,6 @@
 /area/awaymission/UO71/eng)
 "ns" = (
 /obj/structure/chair/comfy/black{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -5946,7 +5666,6 @@
 /area/awaymission/UO71/centralhall)
 "nt" = (
 /obj/structure/chair/comfy/black{
-	icon_state = "comfychair";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5983,8 +5702,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6008,9 +5726,7 @@
 "nA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -6038,9 +5754,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
 "nD" = (
@@ -6102,8 +5818,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6120,8 +5835,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6133,8 +5847,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6142,10 +5855,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -6175,8 +5885,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6262,8 +5971,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6323,8 +6031,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -6339,8 +6046,7 @@
 "od" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Lab";
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -6368,8 +6074,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6379,10 +6084,8 @@
 "oh" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -6425,8 +6128,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -6440,8 +6142,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6458,8 +6159,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6480,7 +6180,6 @@
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring the research division and the labs within.";
-	dir = 2;
 	name = "research monitor";
 	network = list("UO71")
 	},
@@ -6527,10 +6226,8 @@
 "or" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/item/radio/off,
@@ -6560,8 +6257,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -6575,10 +6271,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
@@ -6590,8 +6284,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6608,8 +6301,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6627,8 +6319,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6636,7 +6327,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/camera{
 	c_tag = "Dormitories";
-	dir = 2;
 	network = list("UO71")
 	},
 /turf/simulated/floor/plasteel{
@@ -6649,8 +6339,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6670,8 +6359,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -6693,8 +6381,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6709,8 +6396,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6725,11 +6411,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -6751,8 +6435,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6770,8 +6453,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6788,8 +6470,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6809,8 +6490,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6836,8 +6516,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6854,8 +6533,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -6892,12 +6570,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-y"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -6907,8 +6584,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6923,8 +6599,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -6934,8 +6609,7 @@
 	charge = 5e+006;
 	input_level = 30000;
 	inputting = 0;
-	output_level = 25000;
-	outputting = 1
+	output_level = 25000
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -6945,8 +6619,7 @@
 	charge = 5e+006;
 	input_level = 10000;
 	inputting = 0;
-	output_level = 25000;
-	outputting = 1
+	output_level = 25000
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -7034,7 +6707,6 @@
 	icon_off = "secoff";
 	icon_opened = "secopen";
 	icon_state = "sec1";
-	locked = 1;
 	name = "security officer's locker";
 	req_access_txt = "271"
 	},
@@ -7065,8 +6737,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7084,7 +6755,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaymission/UO71/centralhall)
@@ -7114,7 +6784,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -7125,7 +6794,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaymission/UO71/centralhall)
@@ -7138,7 +6806,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -7157,7 +6824,6 @@
 "pn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaymission/UO71/centralhall)
@@ -7200,15 +6866,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -7246,8 +6909,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -7257,7 +6919,6 @@
 /area/awaymission/UO71/eng)
 "px" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman/super{
@@ -7270,14 +6931,13 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
 "py" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman{
@@ -7285,8 +6945,8 @@
 	name = "P.A.C.M.A.N.-type portable generator"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -7294,8 +6954,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -7304,7 +6963,6 @@
 /area/awaymission/UO71/eng)
 "pA" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman{
@@ -7350,7 +7008,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -7389,9 +7046,7 @@
 	},
 /area/awaymission/UO71/centralhall)
 "pJ" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -7430,8 +7085,7 @@
 /area/awaymission/UO71/centralhall)
 "pN" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -7439,15 +7093,11 @@
 /area/awaymission/UO71/centralhall)
 "pO" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "pP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	external_pressure_bound = 0;
 	frequency = 1443;
 	icon_state = "in";
@@ -7461,7 +7111,6 @@
 /area/awaymission/UO71/eng)
 "pQ" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 2;
 	frequency = 1443;
 	id = "UO71_air_in"
 	},
@@ -7508,8 +7157,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -7528,8 +7176,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -7559,8 +7206,7 @@
 "qf" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Medical Storage";
-	req_access_txt = "0"
+	name = "Medical Storage"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -7570,8 +7216,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7594,8 +7239,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7628,17 +7272,13 @@
 "ql" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/door_control{
 	id = "awaydorm4";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -7652,17 +7292,13 @@
 "qn" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/door_control{
 	id = "awaydorm6";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -7694,7 +7330,6 @@
 /area/awaymission/UO71/centralhall)
 "qr" = (
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO71_mair_out_meter";
 	layer = 3.3;
 	name = "Mixed Air Tank Out"
@@ -7705,7 +7340,6 @@
 "qs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO71_mair_in_meter";
 	layer = 3.3;
 	name = "Mixed Air Tank In"
@@ -7755,9 +7389,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7768,8 +7400,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7793,13 +7424,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "SMES Room";
-	req_access_txt = "271";
-	req_one_access_txt = "0"
+	req_access_txt = "271"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -7816,9 +7445,7 @@
 	},
 /area/awaymission/UO71/science)
 "qC" = (
-/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7854,7 +7481,6 @@
 "qH" = (
 /obj/structure/table,
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -7862,7 +7488,6 @@
 /obj/item/hand_labeler,
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/awaymission/UO71/medical)
@@ -7899,10 +7524,8 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
@@ -7910,10 +7533,8 @@
 "qN" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
@@ -7931,10 +7552,8 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
@@ -7944,9 +7563,7 @@
 "qQ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7972,8 +7589,8 @@
 /area/awaymission/UO71/eng)
 "qU" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/computer/monitor/secret{
 	name = "primary power monitoring console"
@@ -7998,8 +7615,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -8035,7 +7651,6 @@
 	icon_off = "secureengoff";
 	icon_opened = "secureengopen";
 	icon_state = "secureeng1";
-	locked = 1;
 	name = "engineer's locker";
 	req_access_txt = "271"
 	},
@@ -8072,8 +7687,7 @@
 	},
 /obj/machinery/alarm/monitor/server{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/r_n_d/server/core{
 	id_with_download_string = "3";
@@ -8103,7 +7717,6 @@
 "rc" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics";
-	dir = 2;
 	network = list("UO71")
 	},
 /obj/structure/table,
@@ -8112,8 +7725,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/item/multitool,
@@ -8142,8 +7753,6 @@
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access = null;
 	target_pressure = 4500
 	},
@@ -8164,8 +7773,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8228,7 +7836,6 @@
 /area/awaymission/UO71/medical)
 "rq" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/landmark/damageturf,
@@ -8240,7 +7847,6 @@
 "rt" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/pen,
@@ -8255,8 +7861,7 @@
 "rv" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/centralhall)
@@ -8286,9 +7891,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -8301,7 +7904,6 @@
 "rA" = (
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -8316,8 +7918,7 @@
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -8326,7 +7927,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -8338,9 +7938,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "rE" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
@@ -8357,8 +7955,6 @@
 /area/awaymission/UO71/eng)
 "rH" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/dispenser{
@@ -8377,7 +7973,6 @@
 /obj/item/storage/box,
 /obj/item/storage/box,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -8391,20 +7986,16 @@
 	},
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -8417,16 +8008,14 @@
 /area/awaymission/UO71/eng)
 "rK" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
 	dir = 8;
-	locked = 1;
 	name = "UO71 Engineering APC";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access = null;
 	start_charge = 100
 	},
@@ -8448,8 +8037,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8458,23 +8046,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/eng)
-"rN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "rO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -8549,7 +8128,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -8624,8 +8202,7 @@
 "sh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -8695,8 +8272,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8719,8 +8295,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -8732,8 +8307,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8751,8 +8325,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8770,11 +8343,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -8794,8 +8365,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8812,8 +8382,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8821,9 +8390,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -8834,8 +8401,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8844,8 +8410,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Reception";
-	req_access_txt = "0"
+	name = "Engineering Reception"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -8854,8 +8419,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8872,8 +8436,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8885,8 +8448,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8998,11 +8560,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO71_dloop_atm_meter";
 	name = "Distribution Loop"
 	},
@@ -9019,8 +8579,7 @@
 "sJ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Mix to Distro";
-	on = 0
+	name = "Mix to Distro"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -9106,10 +8665,8 @@
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
 	dir = 8;
-	locked = 1;
 	name = "UO71 Medical APC";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access = null;
 	start_charge = 100
 	},
@@ -9158,7 +8715,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -9208,8 +8764,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -9229,9 +8784,7 @@
 "tc" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9248,7 +8801,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -9277,8 +8829,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Reception";
-	req_access_txt = "0"
+	name = "Engineering Reception"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -9312,8 +8863,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -9331,9 +8881,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -9373,9 +8921,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "tp" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 2
-	},
+/obj/machinery/atmospherics/binary/valve,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
@@ -9390,8 +8936,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 1
@@ -9400,7 +8945,6 @@
 /area/awaymission/UO71/eng)
 "ts" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
 	name = "Mix to Filter";
 	on = 1
 	},
@@ -9435,8 +8979,7 @@
 	layer = 3.3
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/eng)
@@ -9502,7 +9045,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -9516,8 +9058,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -9563,8 +9104,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -9583,9 +9123,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
 "tS" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/portables_connector,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -9597,9 +9135,7 @@
 	},
 /area/awaymission/UO71/eng)
 "tT" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -9619,8 +9155,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9686,8 +9221,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4;
@@ -9704,7 +9238,6 @@
 /area/awaymission/UO71/eng)
 "ud" = (
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO71_wloop_atm_meter";
 	name = "Waste Loop"
 	},
@@ -9732,8 +9265,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -9765,15 +9297,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9785,8 +9315,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "UO71_Engineering";
@@ -9802,8 +9331,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9812,8 +9340,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
@@ -9821,8 +9348,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9845,14 +9371,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -9872,8 +9396,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9941,10 +9464,8 @@
 "uy" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
 	icon_state = "weld";
 	on = 1;
-	pressure_checks = 1;
 	welded = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -9957,8 +9478,7 @@
 /area/awaymission/UO71/bridge)
 "uA" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/bikehorn/rubberducky,
 /turf/simulated/floor/plasteel{
@@ -9977,8 +9497,7 @@
 /area/awaymission/UO71/eng)
 "uD" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -9988,8 +9507,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -10010,8 +9528,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10047,7 +9564,6 @@
 	icon_off = "secoff";
 	icon_opened = "secopen";
 	icon_state = "sec1";
-	locked = 1;
 	name = "security officer's locker";
 	req_access_txt = "271"
 	},
@@ -10084,8 +9600,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -10178,8 +9693,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10198,8 +9712,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -10236,10 +9749,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "vb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "vc" = (
@@ -10287,8 +9797,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -10309,8 +9818,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -10327,18 +9835,14 @@
 /turf/simulated/wall/rust,
 /area/awaymission/UO71/mining)
 "vm" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 2
-	},
+/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "vn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/vending/engivend{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/engivend,
 /obj/machinery/camera{
 	c_tag = "Engineering Foyer";
 	dir = 1;
@@ -10358,7 +9862,6 @@
 "vp" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/UO71/medical)
@@ -10367,14 +9870,12 @@
 /obj/item/defibrillator,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/awaymission/UO71/medical)
 "vr" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/UO71/medical)
@@ -10384,7 +9885,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/UO71/medical)
@@ -10429,8 +9929,7 @@
 /area/awaymission/UO71/centralhall)
 "vz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -10460,8 +9959,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10545,9 +10043,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10555,10 +10051,8 @@
 "vL" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -10574,8 +10068,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10585,8 +10078,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10601,7 +10093,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/miner{
@@ -10661,7 +10152,6 @@
 	desc = "A remote control-switch for heavy lockdown doors.";
 	id = "UO71_Containment";
 	name = "Science Containment Doors";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "271";
 	wires = 1
@@ -10674,7 +10164,6 @@
 	desc = "A remote control-switch for heavy lockdown doors.";
 	id = "UO71_Queen";
 	name = "Terror Queen Containment Doors";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "271";
 	wires = 1
@@ -10687,7 +10176,6 @@
 	desc = "A remote control-switch for heavy lockdown doors.";
 	id = "UO71_Armory";
 	name = "Armory Doors";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "271";
 	wires = 1
@@ -10704,7 +10192,6 @@
 /area/awaymission/UO71/centralhall)
 "wa" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "UO71_mining"
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -10728,8 +10215,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -10756,8 +10242,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10795,8 +10280,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -10817,8 +10301,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10862,8 +10345,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -10871,8 +10353,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -10884,17 +10365,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10902,8 +10380,7 @@
 "wt" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -10958,8 +10435,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/mining/glass{
@@ -10979,7 +10455,6 @@
 /area/awaymission/UO71/mining)
 "wD" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "UO71_mining"
 	},
 /obj/structure/sign/nosmoking_2{
@@ -11011,8 +10486,7 @@
 /area/awaymission/UO71/mining)
 "wH" = (
 /obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
@@ -11021,8 +10495,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11085,7 +10558,6 @@
 /area/awaymission/UO71/mining)
 "wN" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "UO71_mining"
 	},
 /obj/machinery/light/small{
@@ -11100,7 +10572,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -11129,10 +10600,7 @@
 /area/awaymission/UO71/medical)
 "wS" = (
 /obj/structure/bed,
-/obj/item/storage/box/gloves{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitecorner"
@@ -11145,9 +10613,7 @@
 	},
 /area/awaymission/UO71/medical)
 "wU" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/bridge)
 "wV" = (
@@ -11163,7 +10629,6 @@
 "wX" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
@@ -11230,8 +10695,8 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -11244,8 +10709,8 @@
 /obj/structure/window/full/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -11253,8 +10718,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -11268,7 +10732,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11312,9 +10775,7 @@
 	id = "awaydorm8";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -11335,8 +10796,8 @@
 "xo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -11359,7 +10820,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11368,7 +10828,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11381,7 +10840,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11389,8 +10847,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -11398,7 +10855,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11438,8 +10894,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -11447,13 +10902,11 @@
 "xz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
 "xA" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11461,7 +10914,6 @@
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11477,21 +10929,17 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
 "xE" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/light/small,
 /obj/structure/mirror{
@@ -11523,9 +10971,7 @@
 	id = "awaydorm9";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -11534,8 +10980,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11563,7 +11008,6 @@
 	},
 /obj/item/stamp/ce,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11579,7 +11023,6 @@
 	amount = 50
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11587,7 +11030,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11595,23 +11037,19 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11643,10 +11081,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "UO71 Mining APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 1
@@ -11669,7 +11105,6 @@
 /obj/item/storage/backpack/satchel_eng,
 /obj/item/clothing/gloves/fingerless,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/awaymission/UO71/mining)
@@ -11692,11 +11127,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/awaymission/UO71/mining)
@@ -11706,7 +11139,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/awaymission/UO71/mining)
@@ -11719,7 +11151,6 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11730,7 +11161,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11740,23 +11170,19 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
 "xX" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
 "xY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/newscaster{
 	pixel_y = -28
@@ -11768,7 +11194,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11783,8 +11208,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -11800,7 +11224,6 @@
 "yb" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11810,7 +11233,6 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11834,7 +11256,6 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaymission/UO71/eng)
@@ -11849,8 +11270,7 @@
 "yf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -11869,8 +11289,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -11907,8 +11326,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -11941,10 +11359,8 @@
 "yr" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11967,8 +11383,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12046,8 +11461,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12062,14 +11476,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
 "yF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12102,7 +11514,6 @@
 /area/awaymission/UO71/mining)
 "yI" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -12135,8 +11546,8 @@
 "yM" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12258,8 +11669,7 @@
 /area/awaymission/UO71/queen)
 "zk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -12316,8 +11726,7 @@
 /area/awaymission/UO71/loot)
 "zu" = (
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/loot)
@@ -12417,7 +11826,6 @@
 "zX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair";
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -12428,7 +11836,6 @@
 /area/awaymission/UO71/queen)
 "zZ" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair";
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -12448,7 +11855,6 @@
 /area/awaymission/UO71/queen)
 "Ac" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair";
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -12560,10 +11966,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "Iq" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -12656,9 +12059,7 @@
 /obj/item/bedsheet,
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -12704,7 +12105,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO71/science)
@@ -16378,7 +15778,7 @@ fM
 gX
 hA
 fL
-iA
+ix
 fM
 fM
 fL
@@ -27792,7 +27192,7 @@ pz
 pZ
 qy
 qX
-rN
+tu
 sI
 ts
 uc
@@ -27942,7 +27342,7 @@ np
 nT
 np
 rc
-rN
+tu
 sO
 tv
 ue

--- a/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
@@ -3,7 +3,6 @@
 /turf/simulated/wall/indestructible/rock,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -14,7 +13,6 @@
 /turf/simulated/mineral/random/labormineral,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -24,13 +22,11 @@
 "ad" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ae" = (
 /turf/simulated/wall/mineral/titanium,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ai" = (
@@ -40,7 +36,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aj" = (
@@ -52,7 +47,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ak" = (
@@ -61,7 +55,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "al" = (
@@ -70,35 +63,30 @@
 	id = "UO45_useless";
 	name = "B1";
 	pixel_x = 6;
-	pixel_y = -24;
-	req_access_txt = "0"
+	pixel_y = -24
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the elevator doors.";
 	id = "UO45_Elevator";
 	name = "Elevator Doors";
 	pixel_x = -6;
-	pixel_y = -24;
-	req_access_txt = "0"
+	pixel_y = -24
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch to send the elevator to the ground floor.";
 	id = "UO45_useless";
 	name = "G1";
 	pixel_x = 6;
-	pixel_y = -34;
-	req_access_txt = "0"
+	pixel_y = -34
 	},
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "am" = (
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "an" = (
@@ -109,7 +97,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ao" = (
@@ -120,7 +107,6 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ap" = (
@@ -128,7 +114,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aq" = (
@@ -141,7 +126,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ar" = (
@@ -152,7 +136,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "as" = (
@@ -163,31 +146,27 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "at" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "au" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-darkblue (SOUTHEAST)";
+	dir = 6;
 	icon_state = "darkblue";
-	dir = 6
+	tag = "icon-darkblue (SOUTHEAST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ax" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ay" = (
@@ -195,19 +174,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aB" = (
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aC" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aD" = (
@@ -217,7 +193,6 @@
 	tag = "icon-floorgrime (WEST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aE" = (
@@ -227,7 +202,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aF" = (
@@ -236,20 +210,17 @@
 	id = "UO45_useless";
 	name = "Call Elevator";
 	pixel_x = -6;
-	pixel_y = 24;
-	req_access_txt = "0"
+	pixel_y = 24
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the elevator doors.";
 	id = "UO45_Elevator";
 	name = "Elevator Doors";
 	pixel_x = 6;
-	pixel_y = 24;
-	req_access_txt = "0"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aG" = (
@@ -259,13 +230,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aH" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aI" = (
@@ -274,7 +243,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aJ" = (
@@ -283,18 +251,14 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aK" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aL" = (
@@ -307,14 +271,12 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aN" = (
@@ -323,7 +285,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aO" = (
@@ -333,7 +294,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aP" = (
@@ -341,17 +301,14 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aQ" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aR" = (
@@ -361,18 +318,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aT" = (
@@ -381,14 +335,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aU" = (
 /obj/structure/chair/comfy/beige{
-	tag = "icon-comfychair (EAST)";
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	tag = "icon-comfychair (EAST)"
 	},
 /obj/effect/landmark{
 	name = "awaystart"
@@ -397,7 +349,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aV" = (
@@ -409,7 +360,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aW" = (
@@ -419,7 +369,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aX" = (
@@ -429,7 +378,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aY" = (
@@ -438,7 +386,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "aZ" = (
@@ -450,7 +397,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ba" = (
@@ -468,7 +414,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bb" = (
@@ -478,7 +423,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bc" = (
@@ -487,7 +431,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bd" = (
@@ -498,16 +441,13 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "be" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/effect/landmark{
@@ -515,7 +455,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bf" = (
@@ -526,13 +465,10 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/landmark{
 	name = "awaystart"
 	},
@@ -541,7 +477,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bh" = (
@@ -549,7 +484,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bi" = (
@@ -561,7 +495,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bj" = (
@@ -572,7 +505,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bk" = (
@@ -584,30 +516,25 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bm" = (
 /obj/structure/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bn" = (
@@ -617,7 +544,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bo" = (
@@ -633,7 +559,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bp" = (
@@ -646,7 +571,6 @@
 	icon_state = "grimy"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bq" = (
@@ -656,13 +580,11 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "br" = (
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bs" = (
@@ -671,17 +593,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bt" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bu" = (
@@ -689,14 +606,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bv" = (
 /obj/machinery/light/small,
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -705,19 +620,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bw" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bx" = (
@@ -732,7 +644,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "by" = (
@@ -742,7 +653,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bz" = (
@@ -753,7 +663,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bA" = (
@@ -764,7 +673,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bB" = (
@@ -773,7 +681,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bC" = (
@@ -785,20 +692,17 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bE" = (
@@ -810,20 +714,17 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bG" = (
@@ -835,7 +736,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bH" = (
@@ -847,17 +747,14 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bJ" = (
@@ -871,7 +768,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bK" = (
@@ -886,7 +782,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bL" = (
@@ -895,21 +790,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bO" = (
@@ -919,7 +811,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bP" = (
@@ -928,7 +819,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bQ" = (
@@ -937,7 +827,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bR" = (
@@ -946,7 +835,6 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bS" = (
@@ -957,7 +845,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bT" = (
@@ -967,14 +854,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bV" = (
@@ -985,17 +870,14 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "bX" = (
@@ -1009,7 +891,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -1023,7 +904,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -1034,14 +914,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ca" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cb" = (
@@ -1051,7 +929,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cc" = (
@@ -1060,7 +937,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cd" = (
@@ -1069,7 +945,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ce" = (
@@ -1079,7 +954,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cf" = (
@@ -1091,20 +965,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ch" = (
@@ -1114,14 +983,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ci" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cj" = (
@@ -1130,7 +997,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ck" = (
@@ -1141,7 +1007,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cl" = (
@@ -1152,7 +1017,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cm" = (
@@ -1163,7 +1027,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cn" = (
@@ -1171,7 +1034,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "co" = (
@@ -1181,21 +1043,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cr" = (
@@ -1203,14 +1062,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ct" = (
@@ -1219,21 +1076,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cv" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cw" = (
@@ -1241,7 +1095,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cx" = (
@@ -1249,7 +1102,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -1259,7 +1111,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cy" = (
@@ -1270,12 +1121,10 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cz" = (
@@ -1295,7 +1144,6 @@
 /obj/item/clothing/under/pj/blue,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cA" = (
@@ -1319,19 +1167,16 @@
 /obj/item/clothing/under/suit_jacket/female,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cC" = (
@@ -1339,7 +1184,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -1348,13 +1192,11 @@
 	dir = 10
 	},
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
-	icon_state = "wooden_chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cD" = (
@@ -1363,7 +1205,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cE" = (
@@ -1371,7 +1212,6 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cF" = (
@@ -1381,14 +1221,12 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cG" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cH" = (
@@ -1398,40 +1236,32 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cJ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
-	icon_state = "wooden_chair";
-	dir = 1
+	dir = 1;
+	tag = "icon-wooden_chair (NORTH)"
 	},
 /obj/machinery/door_control{
 	id = "awaydorm2";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cK" = (
@@ -1442,21 +1272,17 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cL" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cM" = (
@@ -1467,14 +1293,11 @@
 	id = "awaydorm1";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cN" = (
@@ -1483,7 +1306,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cO" = (
@@ -1493,7 +1315,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cP" = (
@@ -1505,7 +1326,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cQ" = (
@@ -1516,7 +1336,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cR" = (
@@ -1526,7 +1345,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cS" = (
@@ -1535,13 +1353,11 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/basic{
-	tag = "icon-window (WEST)";
-	icon_state = "window";
-	dir = 8
+	dir = 8;
+	tag = "icon-window (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cT" = (
@@ -1551,7 +1367,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cU" = (
@@ -1560,13 +1375,11 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/window/basic{
-	tag = "icon-window (EAST)";
-	icon_state = "window";
-	dir = 4
+	dir = 4;
+	tag = "icon-window (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cV" = (
@@ -1576,31 +1389,26 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cX" = (
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cY" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "cZ" = (
@@ -1608,7 +1416,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "da" = (
@@ -1619,7 +1426,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "db" = (
@@ -1629,7 +1435,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dc" = (
@@ -1640,7 +1445,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dd" = (
@@ -1651,7 +1455,6 @@
 /obj/item/poster/random_contraband,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "de" = (
@@ -1660,16 +1463,13 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "df" = (
@@ -1678,7 +1478,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dg" = (
@@ -1687,7 +1486,6 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dh" = (
@@ -1698,7 +1496,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "di" = (
@@ -1707,7 +1504,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dj" = (
@@ -1716,7 +1512,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dk" = (
@@ -1726,7 +1521,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dl" = (
@@ -1735,7 +1529,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dm" = (
@@ -1743,7 +1536,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "dn" = (
@@ -1752,39 +1544,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "do" = (
 /obj/machinery/firealarm/no_alarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dp" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner";
 	tag = "icon-greencorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dr" = (
@@ -1794,7 +1577,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ds" = (
@@ -1803,7 +1585,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -1811,7 +1592,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dt" = (
@@ -1823,7 +1603,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "du" = (
@@ -1833,7 +1612,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dv" = (
@@ -1844,14 +1622,12 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dx" = (
@@ -1861,7 +1637,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dy" = (
@@ -1880,7 +1655,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dz" = (
@@ -1889,7 +1663,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dA" = (
@@ -1898,7 +1671,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dB" = (
@@ -1907,7 +1679,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dC" = (
@@ -1916,7 +1687,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dD" = (
@@ -1932,7 +1702,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dE" = (
@@ -1947,7 +1716,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dF" = (
@@ -1960,12 +1728,10 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dG" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -1981,7 +1747,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dH" = (
@@ -1995,7 +1760,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dI" = (
@@ -2007,7 +1771,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dJ" = (
@@ -2021,7 +1784,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dK" = (
@@ -2038,7 +1800,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dL" = (
@@ -2049,8 +1810,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/no_alarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -2058,7 +1817,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dM" = (
@@ -2081,7 +1839,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dN" = (
@@ -2090,7 +1847,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dO" = (
@@ -2098,7 +1854,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -2106,7 +1861,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dP" = (
@@ -2117,7 +1871,6 @@
 	},
 /obj/structure/chair,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -2125,7 +1878,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dQ" = (
@@ -2136,7 +1888,6 @@
 	icon_off = "secoff";
 	icon_opened = "secopen";
 	icon_state = "sec1";
-	locked = 1;
 	name = "security officer's locker";
 	req_access_txt = "201"
 	},
@@ -2148,7 +1899,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dR" = (
@@ -2158,7 +1908,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dS" = (
@@ -2170,7 +1919,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dT" = (
@@ -2178,37 +1926,29 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dU" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dW" = (
@@ -2217,7 +1957,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dX" = (
@@ -2229,7 +1968,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dY" = (
@@ -2239,7 +1977,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "dZ" = (
@@ -2248,7 +1985,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ea" = (
@@ -2262,7 +1998,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eb" = (
@@ -2272,7 +2007,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ec" = (
@@ -2281,7 +2015,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ed" = (
@@ -2294,7 +2027,6 @@
 	tag = "icon-floorgrime (WEST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ee" = (
@@ -2317,7 +2049,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ef" = (
@@ -2326,12 +2057,10 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Checkpoint Maintenance";
-	req_access_txt = "201";
-	req_one_access_txt = "0"
+	req_access_txt = "201"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eg" = (
@@ -2340,7 +2069,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eh" = (
@@ -2352,7 +2080,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ei" = (
@@ -2366,7 +2093,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ej" = (
@@ -2375,7 +2101,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ek" = (
@@ -2384,7 +2109,6 @@
 	icon_state = "redcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "el" = (
@@ -2392,7 +2116,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "em" = (
@@ -2401,7 +2124,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "en" = (
@@ -2411,14 +2133,12 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eo" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ep" = (
@@ -2429,19 +2149,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eq" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "er" = (
@@ -2451,7 +2167,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "es" = (
@@ -2462,7 +2177,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "et" = (
@@ -2473,7 +2187,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eu" = (
@@ -2490,12 +2203,10 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ev" = (
 /turf/simulated/floor/plating{
-	carbon_dioxide = 0;
 	icon_plating = "asteroidplating";
 	icon_state = "asteroidplating";
 	nitrogen = 0;
@@ -2504,7 +2215,6 @@
 	},
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -2514,10 +2224,8 @@
 "ew" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2528,7 +2236,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ex" = (
@@ -2548,7 +2255,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ey" = (
@@ -2558,7 +2264,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ez" = (
@@ -2567,49 +2272,42 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eA" = (
 /obj/structure/chair/office{
-	tag = "icon-chair (EAST)";
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eB" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eC" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eD" = (
 /obj/structure/chair/office{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eE" = (
@@ -2620,7 +2318,6 @@
 	tag = "icon-floorgrime (WEST)"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eF" = (
@@ -2633,7 +2330,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eG" = (
@@ -2644,7 +2340,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eH" = (
@@ -2654,7 +2349,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eI" = (
@@ -2665,14 +2359,12 @@
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eJ" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eK" = (
@@ -2681,7 +2373,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -2695,8 +2386,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -2704,7 +2394,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eM" = (
@@ -2712,15 +2401,12 @@
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Security Checkpoint";
 	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eN" = (
@@ -2732,14 +2418,12 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eO" = (
 /obj/structure/chair/office{
-	tag = "icon-chair (EAST)";
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -2747,14 +2431,12 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eP" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eQ" = (
@@ -2763,29 +2445,24 @@
 	icon_state = "greencorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Hydroponics Desk";
 	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eS" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eT" = (
@@ -2793,7 +2470,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eU" = (
@@ -2807,7 +2483,6 @@
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/watertank,
@@ -2816,7 +2491,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eV" = (
@@ -2826,7 +2500,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eW" = (
@@ -2837,12 +2510,10 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eX" = (
@@ -2859,7 +2530,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eY" = (
@@ -2871,7 +2541,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "eZ" = (
@@ -2883,7 +2552,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fa" = (
@@ -2892,7 +2560,6 @@
 	icon_state = "redcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fb" = (
@@ -2902,17 +2569,14 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fc" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner";
 	tag = "icon-greencorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fd" = (
@@ -2927,7 +2591,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fe" = (
@@ -2937,26 +2600,21 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ff" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fh" = (
@@ -2967,24 +2625,20 @@
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "Hydroponics APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fi" = (
@@ -2992,16 +2646,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fj" = (
@@ -3009,19 +2660,15 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fk" = (
@@ -3030,15 +2677,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fl" = (
@@ -3046,15 +2690,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fm" = (
@@ -3069,21 +2710,18 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fo" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -3094,7 +2732,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fq" = (
@@ -3103,44 +2740,34 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fr" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ft" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
@@ -3148,7 +2775,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fu" = (
@@ -3161,7 +2787,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fv" = (
@@ -3174,7 +2799,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fw" = (
@@ -3183,7 +2807,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fx" = (
@@ -3191,7 +2814,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -3203,7 +2825,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fy" = (
@@ -3220,7 +2841,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fz" = (
@@ -3228,7 +2848,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "fA" = (
@@ -3236,7 +2855,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -3244,7 +2862,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fB" = (
@@ -3255,20 +2872,16 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fC" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fD" = (
@@ -3281,7 +2894,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fE" = (
@@ -3292,14 +2904,11 @@
 	id = "awaydorm3";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fF" = (
@@ -3308,7 +2917,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fG" = (
@@ -3319,7 +2927,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fH" = (
@@ -3328,7 +2935,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fI" = (
@@ -3345,7 +2951,6 @@
 	icon_state = "greencorner"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fJ" = (
@@ -3355,7 +2960,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fK" = (
@@ -3370,7 +2974,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -3380,14 +2983,12 @@
 "fL" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "fM" = (
 /obj/machinery/smartfridge,
 /turf/simulated/wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "fN" = (
@@ -3402,19 +3003,16 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "fO" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "fP" = (
 /turf/simulated/wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "fQ" = (
@@ -3422,7 +3020,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -3430,14 +3027,12 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fR" = (
 /obj/machinery/light/small,
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -3448,18 +3043,15 @@
 /obj/structure/dresser,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fS" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fT" = (
@@ -3467,7 +3059,6 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fU" = (
@@ -3475,24 +3066,20 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "fV" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fW" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -3502,7 +3089,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fX" = (
@@ -3511,7 +3097,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fY" = (
@@ -3522,14 +3107,12 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "fZ" = (
@@ -3538,7 +3121,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ga" = (
@@ -3546,7 +3128,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gb" = (
@@ -3557,7 +3138,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gc" = (
@@ -3565,34 +3145,28 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ge" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gf" = (
@@ -3603,7 +3177,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gg" = (
@@ -3611,7 +3184,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -3621,7 +3193,6 @@
 "gh" = (
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gi" = (
@@ -3632,7 +3203,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gj" = (
@@ -3642,7 +3212,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gk" = (
@@ -3650,7 +3219,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -3659,21 +3227,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gn" = (
@@ -3688,7 +3253,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "go" = (
@@ -3711,7 +3275,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gp" = (
@@ -3721,7 +3284,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gq" = (
@@ -3729,7 +3291,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gr" = (
@@ -3746,7 +3307,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gs" = (
@@ -3754,7 +3314,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gt" = (
@@ -3763,13 +3322,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gu" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gv" = (
@@ -3781,37 +3338,31 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gw" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gx" = (
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gy" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "gz" = (
 /turf/simulated/wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "gA" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "gB" = (
@@ -3821,7 +3372,6 @@
 	tag = "icon-floorgrime (WEST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gC" = (
@@ -3830,7 +3380,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -3845,7 +3394,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gE" = (
@@ -3856,7 +3404,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gF" = (
@@ -3875,7 +3422,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gG" = (
@@ -3888,7 +3434,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gH" = (
@@ -3900,7 +3445,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gI" = (
@@ -3908,7 +3452,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -3916,7 +3459,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gJ" = (
@@ -3924,7 +3466,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gK" = (
@@ -3933,33 +3474,25 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gL" = (
 /turf/simulated/wall,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gM" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gN" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "gO" = (
@@ -3973,11 +3506,9 @@
 	amount = 23
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "gP" = (
@@ -3987,7 +3518,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gQ" = (
@@ -4002,7 +3532,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "gR" = (
@@ -4010,7 +3539,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -4021,7 +3549,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "gS" = (
@@ -4033,7 +3560,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gT" = (
@@ -4045,7 +3571,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gU" = (
@@ -4057,7 +3582,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gV" = (
@@ -4065,7 +3589,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gW" = (
@@ -4079,7 +3602,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gX" = (
@@ -4089,7 +3611,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "gY" = (
@@ -4098,25 +3619,20 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "gZ" = (
 /obj/machinery/firealarm/no_alarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ha" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -4126,14 +3642,12 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Lab";
-	dir = 2;
 	network = list("UO45","UO45R")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hb" = (
@@ -4141,7 +3655,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hc" = (
@@ -4163,13 +3676,11 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hd" = (
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "he" = (
@@ -4177,7 +3688,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -4190,21 +3700,17 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "hg" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hh" = (
@@ -4217,7 +3723,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hi" = (
@@ -4226,7 +3731,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "hj" = (
@@ -4236,7 +3740,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hk" = (
@@ -4245,7 +3748,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hl" = (
@@ -4254,7 +3756,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hm" = (
@@ -4263,7 +3764,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hn" = (
@@ -4274,7 +3774,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ho" = (
@@ -4284,18 +3783,14 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hp" = (
-/obj/machinery/vending/boozeomat{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hq" = (
@@ -4310,13 +3805,11 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hr" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -4325,7 +3818,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hs" = (
@@ -4336,16 +3828,13 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ht" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/camera{
@@ -4364,7 +3853,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hu" = (
@@ -4376,7 +3864,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "hv" = (
@@ -4388,7 +3875,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "hw" = (
@@ -4399,37 +3885,30 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "hx" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "hy" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "hz" = (
@@ -4441,14 +3920,12 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hA" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "hB" = (
@@ -4459,7 +3936,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "hC" = (
@@ -4467,7 +3943,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hD" = (
@@ -4476,7 +3951,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hE" = (
@@ -4502,18 +3976,14 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hG" = (
@@ -4529,7 +3999,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hH" = (
@@ -4537,7 +4006,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hI" = (
@@ -4554,21 +4022,18 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "hJ" = (
 /obj/structure/table,
 /obj/item/trash/chips,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hK" = (
@@ -4576,20 +4041,17 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hL" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hM" = (
@@ -4599,7 +4061,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hN" = (
@@ -4608,7 +4069,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hO" = (
@@ -4619,7 +4079,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hP" = (
@@ -4632,7 +4091,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hQ" = (
@@ -4648,14 +4106,12 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hR" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -4666,7 +4122,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hS" = (
@@ -4680,7 +4135,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hT" = (
@@ -4694,7 +4148,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hU" = (
@@ -4706,7 +4159,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hV" = (
@@ -4718,7 +4170,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hW" = (
@@ -4734,7 +4185,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "hX" = (
@@ -4743,7 +4193,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "hY" = (
@@ -4751,7 +4200,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -4762,7 +4210,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "hZ" = (
@@ -4774,7 +4221,6 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ia" = (
@@ -4786,63 +4232,54 @@
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ib" = (
 /obj/machinery/gateway,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ic" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "id" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ie" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "if" = (
@@ -4850,13 +4287,11 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ig" = (
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ih" = (
@@ -4866,20 +4301,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ii" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ij" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ik" = (
@@ -4888,7 +4320,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "il" = (
@@ -4903,7 +4334,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "im" = (
@@ -4913,21 +4343,18 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "in" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "io" = (
@@ -4937,7 +4364,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ip" = (
@@ -4948,7 +4374,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iq" = (
@@ -4963,7 +4388,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ir" = (
@@ -4975,12 +4399,10 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "is" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/processor,
@@ -4990,7 +4412,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "it" = (
@@ -4999,7 +4420,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iu" = (
@@ -5011,7 +4431,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iv" = (
@@ -5021,7 +4440,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iw" = (
@@ -5029,7 +4447,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/window{
@@ -5041,15 +4458,13 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking_2{
@@ -5059,7 +4474,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iy" = (
@@ -5068,7 +4482,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iz" = (
@@ -5083,7 +4496,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "iA" = (
@@ -5098,7 +4510,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "iB" = (
@@ -5110,7 +4521,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iC" = (
@@ -5124,7 +4534,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "iD" = (
@@ -5136,7 +4545,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iE" = (
@@ -5149,7 +4557,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "iF" = (
@@ -5158,7 +4565,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iG" = (
@@ -5168,7 +4574,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iH" = (
@@ -5178,7 +4583,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iI" = (
@@ -5188,7 +4592,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iJ" = (
@@ -5197,13 +4600,10 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -5214,7 +4614,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iL" = (
@@ -5228,7 +4627,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iM" = (
@@ -5254,7 +4652,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "iN" = (
@@ -5262,7 +4659,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -5274,7 +4670,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "iO" = (
@@ -5283,16 +4678,13 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "iP" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/camera{
@@ -5303,7 +4695,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iQ" = (
@@ -5311,7 +4702,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iR" = (
@@ -5319,12 +4709,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iS" = (
@@ -5335,7 +4723,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iT" = (
@@ -5343,21 +4730,18 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iV" = (
@@ -5368,15 +4752,13 @@
 	dir = 4
 	},
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iW" = (
@@ -5385,7 +4767,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iX" = (
@@ -5397,19 +4778,16 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "iZ" = (
@@ -5431,7 +4809,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ja" = (
@@ -5443,14 +4820,12 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jc" = (
@@ -5459,33 +4834,27 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jd" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "je" = (
@@ -5497,7 +4866,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jf" = (
@@ -5508,7 +4876,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -5517,7 +4884,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jg" = (
@@ -5537,7 +4903,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jh" = (
@@ -5548,7 +4913,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ji" = (
@@ -5556,7 +4920,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jj" = (
@@ -5565,7 +4928,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jk" = (
@@ -5573,7 +4935,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5581,7 +4942,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jl" = (
@@ -5592,7 +4952,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jm" = (
@@ -5602,7 +4961,6 @@
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jn" = (
@@ -5613,7 +4971,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jo" = (
@@ -5622,7 +4979,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jp" = (
@@ -5633,7 +4989,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jq" = (
@@ -5648,7 +5003,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jr" = (
@@ -5661,23 +5015,18 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "js" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jt" = (
@@ -5687,7 +5036,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ju" = (
@@ -5697,7 +5045,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jv" = (
@@ -5708,7 +5055,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jw" = (
@@ -5720,7 +5066,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jx" = (
@@ -5729,21 +5074,18 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jy" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
-	req_access_txt = "201";
-	req_one_access_txt = "0"
+	req_access_txt = "201"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jz" = (
@@ -5753,7 +5095,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jA" = (
@@ -5767,7 +5108,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jB" = (
@@ -5786,7 +5126,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jC" = (
@@ -5795,7 +5134,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jD" = (
@@ -5804,14 +5142,12 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jE" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jF" = (
@@ -5820,7 +5156,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "jG" = (
@@ -5842,7 +5177,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jH" = (
@@ -5865,14 +5199,12 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jJ" = (
@@ -5882,7 +5214,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jK" = (
@@ -5894,16 +5225,13 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jL" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5915,14 +5243,12 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "jM" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jN" = (
@@ -5931,7 +5257,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jO" = (
@@ -5939,7 +5264,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jP" = (
@@ -5948,14 +5272,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/research{
 	name = "Research Lab";
-	req_access_txt = "201";
-	req_one_access_txt = "0"
+	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jQ" = (
@@ -5964,7 +5286,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jR" = (
@@ -5972,7 +5293,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jS" = (
@@ -5980,7 +5300,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -5992,20 +5311,17 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "jT" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jU" = (
@@ -6015,7 +5331,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jV" = (
@@ -6026,20 +5341,18 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jW" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
 	dir = 1;
 	locked = 0;
 	name = "UO45 Bar APC";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access = null;
 	start_charge = 100
@@ -6048,7 +5361,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jX" = (
@@ -6062,12 +5374,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6077,7 +5388,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jY" = (
@@ -6085,7 +5395,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -6099,7 +5408,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "jZ" = (
@@ -6107,7 +5415,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -6118,7 +5425,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ka" = (
@@ -6126,7 +5432,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -6135,13 +5440,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kb" = (
@@ -6149,7 +5450,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -6157,7 +5457,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kc" = (
@@ -6165,7 +5464,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -6177,7 +5475,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "kd" = (
@@ -6197,7 +5494,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ke" = (
@@ -6206,26 +5502,21 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/command{
 	icon_state = "door_closed";
-	lockdownbyai = 0;
-	locked = 0;
 	name = "Gateway Chamber";
 	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kf" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kg" = (
@@ -6234,7 +5525,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kh" = (
@@ -6243,30 +5533,25 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ki" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kj" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kk" = (
@@ -6276,7 +5561,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kl" = (
@@ -6287,7 +5571,6 @@
 	icon_state = "whitepurple"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "km" = (
@@ -6296,7 +5579,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kn" = (
@@ -6306,7 +5588,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ko" = (
@@ -6317,19 +5598,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kp" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kq" = (
@@ -6339,7 +5617,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kr" = (
@@ -6348,7 +5625,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ks" = (
@@ -6359,7 +5635,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kt" = (
@@ -6370,7 +5645,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ku" = (
@@ -6378,7 +5652,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -6396,7 +5669,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kv" = (
@@ -6408,7 +5680,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kw" = (
@@ -6427,7 +5698,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kx" = (
@@ -6440,14 +5710,12 @@
 /obj/item/multitool,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "ky" = (
 /obj/structure/closet/l3closet/general,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
-	has_gravity = 1;
 	name = "UO45 Central Hall"
 	})
 "kz" = (
@@ -6455,7 +5723,6 @@
 /obj/item/storage/belt/utility,
 /obj/item/clothing/head/welding,
 /obj/structure/sign/biohazard{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/assembly/prox_sensor,
@@ -6466,7 +5733,6 @@
 	tag = "icon-warndark (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kA" = (
@@ -6479,7 +5745,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kB" = (
@@ -6493,35 +5758,30 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kC" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "kD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/basic{
-	tag = "icon-window (EAST)";
-	icon_state = "window";
-	dir = 4
+	dir = 4;
+	tag = "icon-window (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kE" = (
@@ -6539,7 +5799,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kF" = (
@@ -6555,7 +5814,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kG" = (
@@ -6564,7 +5822,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kH" = (
@@ -6572,12 +5829,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kI" = (
@@ -6586,12 +5842,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kJ" = (
@@ -6602,17 +5857,15 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kK" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -6624,13 +5877,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
-	icon_state = "whitepurplecorner";
 	dir = 4;
-	heat_capacity = 1e+006
+	heat_capacity = 1e+006;
+	icon_state = "whitepurplecorner";
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kL" = (
@@ -6640,12 +5892,11 @@
 	tag = "icon-manifold-r-f (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kM" = (
@@ -6658,12 +5909,11 @@
 	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "kN" = (
@@ -6672,7 +5922,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kO" = (
@@ -6685,7 +5934,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kP" = (
@@ -6696,7 +5944,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kQ" = (
@@ -6709,7 +5956,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kR" = (
@@ -6717,12 +5963,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kS" = (
@@ -6731,12 +5976,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kT" = (
@@ -6746,17 +5990,15 @@
 	tag = "icon-manifold-r-f (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kU" = (
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -6768,12 +6010,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kV" = (
@@ -6782,37 +6023,33 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kW" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kY" = (
@@ -6821,7 +6058,6 @@
 	icon_state = "whitepurple"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "kZ" = (
@@ -6829,7 +6065,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -6838,7 +6073,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "la" = (
@@ -6850,7 +6084,6 @@
 	icon_state = "warnwhite"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lb" = (
@@ -6866,7 +6099,6 @@
 	icon_state = "warnwhite"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lc" = (
@@ -6878,7 +6110,6 @@
 	icon_state = "warnwhite"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ld" = (
@@ -6887,7 +6118,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "le" = (
@@ -6905,7 +6135,6 @@
 	tag = "icon-purplecorner (WEST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lf" = (
@@ -6915,25 +6144,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lg" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lh" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "li" = (
@@ -6944,7 +6169,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lj" = (
@@ -6952,14 +6176,12 @@
 	dir = 5
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lk" = (
@@ -6971,7 +6193,6 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -6980,7 +6201,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ll" = (
@@ -6996,7 +6216,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lm" = (
@@ -7004,7 +6223,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction,
@@ -7013,7 +6231,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ln" = (
@@ -7029,13 +6246,11 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lo" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "lp" = (
@@ -7057,7 +6272,6 @@
 	tag = "icon-warndark (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lq" = (
@@ -7065,7 +6279,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -7074,7 +6287,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lr" = (
@@ -7086,7 +6298,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ls" = (
@@ -7094,7 +6305,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7102,7 +6312,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lt" = (
@@ -7110,7 +6319,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -7120,7 +6328,6 @@
 	tag = ""
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -7130,12 +6337,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway Ready Room";
-	dir = 2;
 	network = list("UO45","UO45R")
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lu" = (
@@ -7143,7 +6348,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7152,7 +6356,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lv" = (
@@ -7160,7 +6363,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -7168,7 +6370,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lw" = (
@@ -7177,7 +6378,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7185,14 +6385,11 @@
 	},
 /obj/machinery/door/airlock/command{
 	icon_state = "door_closed";
-	lockdownbyai = 0;
-	locked = 0;
 	name = "Gateway Ready Room";
 	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lx" = (
@@ -7201,7 +6398,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7215,7 +6411,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "ly" = (
@@ -7223,7 +6418,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -7235,7 +6429,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lz" = (
@@ -7243,18 +6436,15 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lA" = (
@@ -7262,16 +6452,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lB" = (
@@ -7279,12 +6466,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7296,11 +6481,9 @@
 	network = list("UO45","UO45R")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lC" = (
@@ -7308,7 +6491,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7318,11 +6500,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lD" = (
@@ -7331,7 +6511,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7342,11 +6521,9 @@
 	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lE" = (
@@ -7354,7 +6531,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7362,11 +6538,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "lF" = (
@@ -7374,7 +6548,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -7394,11 +6567,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lG" = (
@@ -7406,7 +6577,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7414,11 +6584,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lH" = (
@@ -7428,10 +6596,8 @@
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "UO45 Research Division APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -7443,11 +6609,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lI" = (
@@ -7455,27 +6619,22 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lJ" = (
@@ -7492,7 +6651,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lK" = (
@@ -7504,11 +6662,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lL" = (
@@ -7517,11 +6673,9 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lM" = (
@@ -7530,17 +6684,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lN" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -7549,20 +6700,16 @@
 	network = list("UO45","UO45R")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lO" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lP" = (
@@ -7574,16 +6721,12 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "lQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lR" = (
@@ -7594,7 +6737,6 @@
 	tag = "icon-purple (WEST)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lS" = (
@@ -7604,28 +6746,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lT" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lU" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -7634,7 +6772,6 @@
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lV" = (
@@ -7645,14 +6782,12 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lW" = (
@@ -7661,7 +6796,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -7671,7 +6805,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lX" = (
@@ -7682,7 +6815,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "lY" = (
@@ -7691,12 +6823,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 2;
 	network = list("UO45")
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "lZ" = (
@@ -7715,14 +6845,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ma" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "mb" = (
@@ -7742,13 +6870,11 @@
 	tag = "icon-warndark (EAST)"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mc" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "md" = (
@@ -7756,7 +6882,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -7765,7 +6890,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "me" = (
@@ -7773,35 +6897,29 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mf" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mg" = (
 /obj/structure/table,
 /obj/item/newspaper,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mh" = (
@@ -7812,7 +6930,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mi" = (
@@ -7828,7 +6945,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mj" = (
@@ -7840,7 +6956,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mk" = (
@@ -7853,7 +6968,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ml" = (
@@ -7862,23 +6976,19 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mm" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small,
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mn" = (
@@ -7888,7 +6998,6 @@
 	icon_state = "warnwhite"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mo" = (
@@ -7898,14 +7007,12 @@
 	icon_state = "warnwhite"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7913,7 +7020,6 @@
 	tag = "icon-purplecorner (NORTH)"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mq" = (
@@ -7921,7 +7027,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -7936,7 +7041,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mr" = (
@@ -7946,18 +7050,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ms" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mt" = (
@@ -7965,7 +7066,6 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mu" = (
@@ -7973,25 +7073,21 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mv" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mw" = (
@@ -8010,7 +7106,6 @@
 /obj/item/clothing/under/pj/red,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mx" = (
@@ -8018,7 +7113,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -8028,7 +7122,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "my" = (
@@ -8036,14 +7129,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mz" = (
@@ -8055,14 +7146,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "mB" = (
@@ -8078,7 +7167,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "mC" = (
@@ -8089,12 +7177,10 @@
 /obj/item/flashlight,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mD" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/rack{
@@ -8104,13 +7190,11 @@
 /obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mE" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/rack{
@@ -8120,17 +7204,14 @@
 /obj/item/clothing/shoes/magboots,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "UO45 Gateway APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -8143,21 +7224,18 @@
 /obj/item/clothing/shoes/magboots,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mH" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "mI" = (
@@ -8168,7 +7246,6 @@
 	icon_off = "rdsecureoff";
 	icon_opened = "rdsecureopen";
 	icon_state = "rdsecure1";
-	locked = 1;
 	name = "research director's locker";
 	req_access_txt = "201"
 	},
@@ -8182,7 +7259,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mJ" = (
@@ -8191,14 +7267,12 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mL" = (
@@ -8206,7 +7280,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -8217,7 +7290,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mM" = (
@@ -8232,7 +7304,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mN" = (
@@ -8246,7 +7317,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mO" = (
@@ -8256,7 +7326,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mP" = (
@@ -8267,21 +7336,17 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mR" = (
@@ -8292,7 +7357,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mS" = (
@@ -8310,7 +7374,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mT" = (
@@ -8323,7 +7386,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mU" = (
@@ -8334,17 +7396,15 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mV" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "mW" = (
@@ -8355,7 +7415,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mX" = (
@@ -8367,30 +7426,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/door_control{
 	id = "awaydorm5";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
-	icon_state = "wooden_chair";
-	dir = 1
+	dir = 1;
+	tag = "icon-wooden_chair (NORTH)"
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "mZ" = (
@@ -8409,7 +7461,6 @@
 /obj/item/clothing/under/suit_jacket/navy,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "na" = (
@@ -8418,18 +7469,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nc" = (
@@ -8437,14 +7484,11 @@
 	id = "awaydorm7";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nd" = (
@@ -8454,28 +7498,24 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ne" = (
 /obj/structure/chair/comfy/black{
-	tag = "icon-comfychair (EAST)";
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	tag = "icon-comfychair (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nf" = (
 /obj/structure/chair/comfy/black{
-	tag = "icon-comfychair (WEST)";
-	icon_state = "comfychair";
-	dir = 8
+	dir = 8;
+	tag = "icon-comfychair (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -8483,7 +7523,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ng" = (
@@ -8495,7 +7534,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "nh" = (
@@ -8512,7 +7550,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ni" = (
@@ -8522,13 +7559,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "nj" = (
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "nk" = (
@@ -8536,7 +7571,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -8544,15 +7578,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nl" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -8560,7 +7591,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nm" = (
@@ -8571,7 +7601,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nn" = (
@@ -8583,7 +7612,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "no" = (
@@ -8595,7 +7623,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "np" = (
@@ -8604,7 +7631,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nq" = (
@@ -8621,7 +7647,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nr" = (
@@ -8630,7 +7655,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ns" = (
@@ -8638,12 +7662,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
+	dir = 4;
 	icon_state = "whitepurplecorner";
-	dir = 4
+	tag = "icon-whitepurplecorner (EAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nt" = (
@@ -8662,7 +7685,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nu" = (
@@ -8670,7 +7692,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -8681,7 +7702,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nv" = (
@@ -8702,7 +7722,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nw" = (
@@ -8710,7 +7729,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -8719,13 +7737,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nx" = (
@@ -8733,7 +7747,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -8749,7 +7762,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ny" = (
@@ -8761,7 +7773,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nz" = (
@@ -8770,7 +7781,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nA" = (
@@ -8779,14 +7789,12 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nC" = (
@@ -8797,7 +7805,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nD" = (
@@ -8808,7 +7815,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nE" = (
@@ -8820,7 +7826,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nF" = (
@@ -8829,7 +7834,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nG" = (
@@ -8842,7 +7846,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nH" = (
@@ -8854,7 +7857,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "nI" = (
@@ -8862,7 +7864,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -8873,7 +7874,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nJ" = (
@@ -8883,7 +7883,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nK" = (
@@ -8903,12 +7902,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "nL" = (
@@ -8920,16 +7917,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "nM" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -8944,14 +7938,12 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nO" = (
@@ -8959,14 +7951,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nP" = (
@@ -8988,7 +7978,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nQ" = (
@@ -8998,7 +7987,6 @@
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring the research division and the labs within.";
-	dir = 2;
 	name = "research monitor";
 	network = list("UO45R")
 	},
@@ -9008,7 +7996,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nR" = (
@@ -9025,7 +8012,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nS" = (
@@ -9048,16 +8034,13 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nT" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light{
@@ -9072,7 +8055,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nU" = (
@@ -9081,7 +8063,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nV" = (
@@ -9090,7 +8071,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nW" = (
@@ -9110,7 +8090,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "nX" = (
@@ -9119,7 +8098,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nY" = (
@@ -9128,7 +8106,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "nZ" = (
@@ -9137,7 +8114,6 @@
 	},
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oa" = (
@@ -9150,10 +8126,8 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
@@ -9161,7 +8135,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ob" = (
@@ -9169,7 +8142,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9183,7 +8155,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oc" = (
@@ -9191,7 +8162,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9206,7 +8176,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "od" = (
@@ -9214,7 +8183,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9223,7 +8191,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/camera{
 	c_tag = "Dormitories";
-	dir = 2;
 	network = list("UO45")
 	},
 /turf/simulated/floor/plasteel{
@@ -9231,7 +8198,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oe" = (
@@ -9240,7 +8206,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9254,7 +8219,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "of" = (
@@ -9262,7 +8226,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -9282,7 +8245,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "og" = (
@@ -9290,7 +8252,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9302,7 +8263,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oh" = (
@@ -9310,7 +8270,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9322,7 +8281,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oi" = (
@@ -9330,11 +8288,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -9353,7 +8309,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oj" = (
@@ -9361,7 +8316,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9376,7 +8330,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ok" = (
@@ -9384,7 +8337,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9398,7 +8350,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ol" = (
@@ -9406,7 +8357,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9423,7 +8373,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "om" = (
@@ -9431,7 +8380,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "on" = (
@@ -9439,7 +8387,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9450,7 +8397,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oo" = (
@@ -9458,7 +8404,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
@@ -9473,7 +8418,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "op" = (
@@ -9482,7 +8426,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9496,7 +8439,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oq" = (
@@ -9504,12 +8446,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "or" = (
@@ -9523,19 +8463,17 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-y (WEST)";
+	dir = 8;
 	icon_state = "pipe-y";
-	dir = 8
+	tag = "icon-pipe-y (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "os" = (
@@ -9543,7 +8481,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -9556,7 +8493,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ot" = (
@@ -9564,7 +8500,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -9572,7 +8507,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ou" = (
@@ -9581,12 +8515,10 @@
 	charge = 1.5e+006;
 	input_level = 30000;
 	inputting = 0;
-	output_level = 7000;
-	outputting = 1
+	output_level = 7000
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ov" = (
@@ -9595,12 +8527,10 @@
 	charge = 1.5e+006;
 	input_level = 10000;
 	inputting = 0;
-	output_level = 7000;
-	outputting = 1
+	output_level = 7000
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ow" = (
@@ -9611,7 +8541,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ox" = (
@@ -9623,7 +8552,6 @@
 	desc = "A remote control-switch whichs locks the research division down in the event of a biohazard leak or contamination.";
 	id = "UO45_biohazard";
 	name = "Biohazard Door Control";
-	pixel_x = 0;
 	pixel_y = 8;
 	req_access_txt = "201"
 	},
@@ -9631,7 +8559,6 @@
 	desc = "A remote control-switch that controls the privacy shutters.";
 	id = "UO45_rdprivacy";
 	name = "Privacy Shutter Control";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "201"
 	},
@@ -9641,7 +8568,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oy" = (
@@ -9652,7 +8578,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oz" = (
@@ -9667,7 +8592,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oA" = (
@@ -9678,13 +8602,11 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oB" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -9692,7 +8614,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oC" = (
@@ -9704,14 +8625,12 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oE" = (
@@ -9723,7 +8642,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oF" = (
@@ -9731,11 +8649,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oG" = (
@@ -9748,7 +8664,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oH" = (
@@ -9757,14 +8672,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oI" = (
@@ -9775,18 +8688,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oK" = (
@@ -9798,7 +8708,6 @@
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -9806,7 +8715,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oL" = (
@@ -9817,17 +8725,14 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oN" = (
@@ -9835,7 +8740,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -9846,7 +8750,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oO" = (
@@ -9858,7 +8761,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oP" = (
@@ -9870,7 +8772,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oQ" = (
@@ -9883,7 +8784,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oR" = (
@@ -9891,7 +8791,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -9900,7 +8799,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "oS" = (
@@ -9908,7 +8806,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -9916,7 +8813,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "oT" = (
@@ -9924,15 +8820,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -9946,7 +8839,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oU" = (
@@ -9958,7 +8850,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "oV" = (
@@ -9966,7 +8857,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -9974,12 +8864,10 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oW" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman/super{
@@ -9992,17 +8880,15 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "oX" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman{
@@ -10010,12 +8896,11 @@
 	name = "P.A.C.M.A.N.-type portable generator"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "oY" = (
@@ -10026,7 +8911,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -10035,12 +8919,10 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "oZ" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 1
 	},
 /obj/machinery/power/port_gen/pacman{
@@ -10053,14 +8935,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pa" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/engine/air,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pb" = (
@@ -10071,7 +8951,6 @@
 	},
 /turf/simulated/floor/engine/air,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pc" = (
@@ -10086,7 +8965,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pd" = (
@@ -10103,7 +8981,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pe" = (
@@ -10117,7 +8994,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pf" = (
@@ -10130,7 +9006,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pg" = (
@@ -10139,7 +9014,6 @@
 	desc = "A remote control-switch whichs locks the research division down in the event of a biohazard leak or contamination.";
 	id = "UO45_biohazard";
 	name = "Biohazard Door Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "201"
 	},
@@ -10148,7 +9022,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ph" = (
@@ -10158,7 +9031,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pi" = (
@@ -10169,13 +9041,10 @@
 	icon_off = "secoff";
 	icon_opened = "secopen";
 	icon_state = "sec1";
-	locked = 1;
 	name = "security officer's locker";
 	req_access_txt = "201"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/restraints/handcuffs,
 /obj/item/flash,
 /obj/item/reagent_containers/spray/pepper,
@@ -10184,7 +9053,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pj" = (
@@ -10199,7 +9067,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pk" = (
@@ -10208,20 +9075,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pl" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pm" = (
@@ -10237,19 +9100,16 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pn" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "po" = (
@@ -10259,7 +9119,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pp" = (
@@ -10270,14 +9129,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/rust,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pr" = (
@@ -10288,7 +9145,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ps" = (
@@ -10304,18 +9160,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pt" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pu" = (
@@ -10336,7 +9187,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pv" = (
@@ -10345,21 +9195,18 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pw" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "px" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "py" = (
@@ -10368,7 +9215,6 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pz" = (
@@ -10377,7 +9223,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pA" = (
@@ -10385,7 +9230,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -10393,7 +9237,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pB" = (
@@ -10405,7 +9248,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pC" = (
@@ -10413,12 +9255,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pD" = (
@@ -10430,7 +9270,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pE" = (
@@ -10441,12 +9280,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pF" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	external_pressure_bound = 0;
 	frequency = 1443;
 	icon_state = "in";
@@ -10458,18 +9295,15 @@
 	},
 /turf/simulated/floor/engine/air,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pG" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 2;
 	frequency = 1443;
 	id = "UO45_air_in"
 	},
 /turf/simulated/floor/engine/air,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "pH" = (
@@ -10477,7 +9311,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -10485,14 +9318,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pJ" = (
@@ -10504,7 +9335,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pK" = (
@@ -10515,21 +9345,18 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pN" = (
@@ -10539,7 +9366,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pO" = (
@@ -10549,7 +9375,6 @@
 	icon_state = "neutral"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pP" = (
@@ -10564,7 +9389,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pQ" = (
@@ -10572,28 +9396,22 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pR" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/door_control{
 	id = "awaydorm4";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pS" = (
@@ -10602,35 +9420,28 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/wall,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pU" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/door_control{
 	id = "awaydorm6";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pV" = (
@@ -10641,7 +9452,6 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pW" = (
@@ -10652,7 +9462,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pX" = (
@@ -10661,16 +9470,13 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "pY" = (
@@ -10678,7 +9484,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -10686,7 +9491,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "pZ" = (
@@ -10694,18 +9498,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "SMES Room";
-	req_access_txt = "201";
-	req_one_access_txt = "0"
+	req_access_txt = "201"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qa" = (
@@ -10716,7 +9517,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qb" = (
@@ -10725,7 +9525,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a6{
-	has_gravity = 1;
 	name = "UO45 Gateway"
 	})
 "qc" = (
@@ -10733,7 +9532,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qd" = (
@@ -10742,14 +9540,12 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qe" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO45_mair_out_meter";
 	layer = 3.3;
 	name = "Mixed Air Tank Out"
@@ -10757,7 +9553,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qf" = (
@@ -10765,32 +9560,26 @@
 /obj/structure/window/full/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO45_mair_in_meter";
 	layer = 3.3;
 	name = "Mixed Air Tank In"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qg" = (
-/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qi" = (
@@ -10810,7 +9599,6 @@
 	temperature = 80
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qj" = (
@@ -10825,21 +9613,18 @@
 	temperature = 80
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qk" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (WEST)";
-	icon_state = "toilet00";
-	dir = 8
+	dir = 8;
+	tag = "icon-toilet00 (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ql" = (
@@ -10852,16 +9637,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qm" = (
 /obj/machinery/light/small,
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -11;
-	pixel_y = 0
+	pixel_x = -11
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -10870,7 +9652,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qn" = (
@@ -10880,11 +9661,9 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qo" = (
@@ -10896,13 +9675,11 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qp" = (
 /obj/structure/table,
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -10911,11 +9688,9 @@
 /obj/item/hand_labeler,
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qq" = (
@@ -10925,7 +9700,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qr" = (
@@ -10934,39 +9708,32 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qs" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qt" = (
 /obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qu" = (
@@ -10975,29 +9742,23 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qv" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qw" = (
@@ -11007,7 +9768,6 @@
 /obj/structure/dresser,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qx" = (
@@ -11016,7 +9776,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qy" = (
@@ -11025,7 +9784,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qz" = (
@@ -11033,7 +9791,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qA" = (
@@ -11043,7 +9800,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -11057,7 +9813,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -11070,13 +9825,12 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qD" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/computer/monitor/secret{
 	name = "primary power monitoring console"
@@ -11089,7 +9843,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qE" = (
@@ -11097,7 +9850,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -11112,7 +9864,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qF" = (
@@ -11132,7 +9883,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qG" = (
@@ -11148,7 +9898,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qH" = (
@@ -11159,7 +9908,6 @@
 	icon_off = "secureengoff";
 	icon_opened = "secureengopen";
 	icon_state = "secureeng1";
-	locked = 1;
 	name = "engineer's locker";
 	req_access_txt = "201"
 	},
@@ -11178,7 +9926,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qI" = (
@@ -11197,7 +9944,6 @@
 	tag = "icon-arrival (NORTHWEST)"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qJ" = (
@@ -11206,7 +9952,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics";
-	dir = 2;
 	network = list("UO45")
 	},
 /obj/structure/table,
@@ -11215,8 +9960,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm/no_alarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/item/multitool,
@@ -11228,7 +9971,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qK" = (
@@ -11238,7 +9980,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qL" = (
@@ -11247,8 +9988,6 @@
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access = null;
 	target_pressure = 4500
 	},
@@ -11257,7 +9996,6 @@
 	icon_state = "arrival"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qM" = (
@@ -11265,7 +10003,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "qN" = (
@@ -11276,7 +10013,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qO" = (
@@ -11291,7 +10027,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qP" = (
@@ -11299,14 +10034,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qQ" = (
@@ -11315,8 +10048,7 @@
 	},
 /obj/machinery/alarm/monitor/server{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/r_n_d/server/core{
 	id_with_download_string = "3";
@@ -11330,7 +10062,6 @@
 	temperature = 80
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qR" = (
@@ -11346,7 +10077,6 @@
 	temperature = 80
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qS" = (
@@ -11362,7 +10092,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qT" = (
@@ -11380,7 +10109,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qU" = (
@@ -11394,7 +10122,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qV" = (
@@ -11407,7 +10134,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "qW" = (
@@ -11415,7 +10141,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qX" = (
@@ -11429,7 +10154,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qY" = (
@@ -11441,19 +10165,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "qZ" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/pen,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ra" = (
@@ -11462,7 +10183,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rb" = (
@@ -11471,15 +10191,12 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rc" = (
@@ -11488,7 +10205,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rd" = (
@@ -11500,14 +10216,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "re" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rf" = (
@@ -11515,7 +10229,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -11527,18 +10240,15 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rh" = (
@@ -11547,25 +10257,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ri" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rj" = (
 /obj/machinery/firealarm/no_alarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/dispenser{
@@ -11576,7 +10280,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rk" = (
@@ -11587,7 +10290,6 @@
 /obj/item/storage/box,
 /obj/item/storage/box,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -11595,13 +10297,11 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rl" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rm" = (
@@ -11610,20 +10310,16 @@
 	},
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -11634,7 +10330,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rn" = (
@@ -11649,7 +10344,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ro" = (
@@ -11660,7 +10354,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rp" = (
@@ -11669,21 +10362,18 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rq" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
 	dir = 8;
-	locked = 1;
 	name = "UO45 Engineering APC";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access = list(201);
 	start_charge = 100
 	},
@@ -11693,7 +10383,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rr" = (
@@ -11704,7 +10393,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rs" = (
@@ -11712,7 +10400,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -11723,40 +10410,33 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ru" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rv" = (
 /obj/machinery/light,
 /obj/machinery/alarm/monitor{
 	dir = 1;
-	frequency = 1439;
 	locked = 0;
 	pixel_y = -23;
 	req_access = null
@@ -11768,13 +10448,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -11783,7 +10461,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rx" = (
@@ -11793,7 +10470,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ry" = (
@@ -11804,7 +10480,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rz" = (
@@ -11813,7 +10488,6 @@
 	icon_state = "dark"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rA" = (
@@ -11828,7 +10502,6 @@
 	temperature = 80
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rB" = (
@@ -11836,7 +10509,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
@@ -11851,7 +10523,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rC" = (
@@ -11864,7 +10535,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rD" = (
@@ -11880,7 +10550,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rE" = (
@@ -11893,7 +10562,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rF" = (
@@ -11906,21 +10574,16 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rG" = (
 /obj/structure/table,
-/obj/item/storage/box/gloves{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rH" = (
@@ -11937,7 +10600,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rI" = (
@@ -11949,7 +10611,6 @@
 	icon_state = "white"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rJ" = (
@@ -11957,7 +10618,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -11969,7 +10629,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rK" = (
@@ -11980,7 +10639,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rL" = (
@@ -11988,7 +10646,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12001,7 +10658,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "rM" = (
@@ -12009,7 +10665,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12023,7 +10678,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rN" = (
@@ -12031,7 +10685,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12046,7 +10699,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rO" = (
@@ -12072,7 +10724,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rP" = (
@@ -12088,7 +10739,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rQ" = (
@@ -12096,7 +10746,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12112,7 +10761,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rR" = (
@@ -12126,13 +10774,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rS" = (
@@ -12140,11 +10786,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -12160,7 +10804,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rT" = (
@@ -12168,7 +10811,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12183,7 +10825,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rU" = (
@@ -12191,7 +10832,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12200,15 +10840,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rV" = (
@@ -12216,7 +10853,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12230,7 +10866,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "rW" = (
@@ -12243,7 +10878,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rX" = (
@@ -12252,7 +10886,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12262,13 +10895,11 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Reception";
-	req_access_txt = "0"
+	name = "Engineering Reception"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rY" = (
@@ -12282,7 +10913,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "rZ" = (
@@ -12290,7 +10920,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12299,7 +10928,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sa" = (
@@ -12307,7 +10935,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -12318,7 +10945,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sb" = (
@@ -12333,7 +10959,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sc" = (
@@ -12352,7 +10977,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sd" = (
@@ -12360,13 +10984,11 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "se" = (
@@ -12380,9 +11002,7 @@
 	name = "Privacy Shutters"
 	},
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Engineering Reception";
 	req_access_txt = "201"
 	},
@@ -12393,7 +11013,6 @@
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sf" = (
@@ -12406,7 +11025,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sg" = (
@@ -12417,7 +11035,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sh" = (
@@ -12428,7 +11045,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -12436,7 +11052,6 @@
 	icon_state = "whitecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "si" = (
@@ -12451,7 +11066,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sj" = (
@@ -12460,7 +11074,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sk" = (
@@ -12468,11 +11081,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO45_dloop_atm_meter";
 	name = "Distribution Loop"
 	},
@@ -12480,7 +11091,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sl" = (
@@ -12489,18 +11099,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sm" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Mix to Distro";
-	on = 0
+	name = "Mix to Distro"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sn" = (
@@ -12509,14 +11116,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "so" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sp" = (
@@ -12526,7 +11131,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sq" = (
@@ -12540,7 +11144,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sr" = (
@@ -12551,7 +11154,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ss" = (
@@ -12572,7 +11174,6 @@
 	oxygen = 0.01
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "st" = (
@@ -12585,7 +11186,6 @@
 	oxygen = 0.01
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "su" = (
@@ -12594,14 +11194,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "sv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "sw" = (
@@ -12612,7 +11210,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "sx" = (
@@ -12626,7 +11223,6 @@
 	icon_state = "whitecorner"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "sy" = (
@@ -12645,7 +11241,6 @@
 	icon_state = "whitehall"
 	},
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "sz" = (
@@ -12657,7 +11252,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sA" = (
@@ -12669,7 +11263,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sB" = (
@@ -12680,7 +11273,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sC" = (
@@ -12692,15 +11284,12 @@
 	icon_state = "cautioncorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sD" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12710,7 +11299,6 @@
 	icon_state = "cautioncorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sE" = (
@@ -12718,7 +11306,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -12728,7 +11315,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sF" = (
@@ -12738,7 +11324,6 @@
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -12746,7 +11331,6 @@
 	icon_state = "cautioncorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sG" = (
@@ -12756,7 +11340,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sH" = (
@@ -12768,7 +11351,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sI" = (
@@ -12778,7 +11360,6 @@
 	icon_state = "cautioncorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sJ" = (
@@ -12791,7 +11372,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sK" = (
@@ -12805,7 +11385,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sL" = (
@@ -12814,12 +11393,10 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Reception";
-	req_access_txt = "0"
+	name = "Engineering Reception"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sM" = (
@@ -12831,9 +11408,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -12841,7 +11416,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sN" = (
@@ -12850,7 +11424,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sO" = (
@@ -12866,7 +11439,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sP" = (
@@ -12874,7 +11446,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -12885,7 +11456,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sQ" = (
@@ -12894,7 +11464,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sR" = (
@@ -12917,7 +11486,6 @@
 /obj/item/folder/red,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sS" = (
@@ -12937,7 +11505,6 @@
 	icon_state = "green"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sT" = (
@@ -12947,7 +11514,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sU" = (
@@ -12956,7 +11522,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "sV" = (
@@ -12966,7 +11531,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sW" = (
@@ -12974,7 +11538,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
@@ -12982,18 +11545,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sX" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
 	name = "Mix to Filter";
 	on = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "sY" = (
@@ -13002,16 +11562,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
-	name = "UO45 Engineering"
-	})
-"sZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ta" = (
@@ -13021,14 +11571,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tc" = (
@@ -13037,7 +11585,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "td" = (
@@ -13047,12 +11594,10 @@
 	layer = 3.3
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "te" = (
@@ -13063,13 +11608,11 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tf" = (
@@ -13084,7 +11627,6 @@
 	oxygen = 0.01
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tg" = (
@@ -13099,7 +11641,6 @@
 	oxygen = 0.01
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "th" = (
@@ -13107,7 +11648,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -13120,7 +11660,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ti" = (
@@ -13137,7 +11676,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tj" = (
@@ -13148,7 +11686,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tk" = (
@@ -13157,7 +11694,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tl" = (
@@ -13177,7 +11713,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tm" = (
@@ -13185,14 +11720,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tn" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/portables_connector,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -13204,7 +11736,6 @@
 	tag = "icon-escape (NORTH)"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "to" = (
@@ -13213,7 +11744,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tp" = (
@@ -13223,7 +11753,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tq" = (
@@ -13232,7 +11761,6 @@
 	},
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tr" = (
@@ -13243,7 +11771,6 @@
 	},
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ts" = (
@@ -13251,7 +11778,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -13260,20 +11786,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tt" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "arrival"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tu" = (
@@ -13281,7 +11803,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -13294,7 +11815,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tv" = (
@@ -13304,7 +11824,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tw" = (
@@ -13319,7 +11838,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tx" = (
@@ -13327,7 +11845,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -13336,7 +11853,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ty" = (
@@ -13356,7 +11872,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tz" = (
@@ -13374,7 +11889,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tA" = (
@@ -13382,28 +11896,23 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tB" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tD" = (
@@ -13415,7 +11924,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tE" = (
@@ -13430,7 +11938,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tF" = (
@@ -13438,7 +11945,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
@@ -13447,7 +11953,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tG" = (
@@ -13457,12 +11962,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tH" = (
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "UO45_wloop_atm_meter";
 	name = "Waste Loop"
 	},
@@ -13471,7 +11974,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tI" = (
@@ -13482,7 +11984,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tJ" = (
@@ -13494,29 +11995,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "tK" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tM" = (
@@ -13530,7 +12026,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tN" = (
@@ -13539,7 +12034,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tO" = (
@@ -13548,7 +12042,6 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tP" = (
@@ -13556,7 +12049,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -13567,7 +12059,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tQ" = (
@@ -13587,7 +12078,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tR" = (
@@ -13595,7 +12085,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tS" = (
@@ -13603,7 +12092,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -13613,32 +12101,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tT" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/bikehorn/rubberducky,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tU" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tV" = (
@@ -13660,7 +12143,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tW" = (
@@ -13668,7 +12150,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -13680,7 +12161,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tX" = (
@@ -13689,7 +12169,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "tY" = (
@@ -13697,7 +12176,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13706,7 +12184,6 @@
 	icon_state = "browncorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "tZ" = (
@@ -13717,7 +12194,6 @@
 	icon_state = "browncorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "ua" = (
@@ -13728,7 +12204,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ub" = (
@@ -13750,7 +12225,6 @@
 	icon_off = "secoff";
 	icon_opened = "secopen";
 	icon_state = "sec1";
-	locked = 1;
 	name = "security officer's locker";
 	req_access_txt = "201"
 	},
@@ -13761,7 +12235,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uc" = (
@@ -13769,7 +12242,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -13781,7 +12253,6 @@
 /obj/machinery/meter,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ue" = (
@@ -13789,7 +12260,6 @@
 /obj/machinery/meter,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uf" = (
@@ -13798,7 +12268,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -13809,7 +12278,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ug" = (
@@ -13818,7 +12286,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uh" = (
@@ -13829,7 +12296,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ui" = (
@@ -13844,7 +12310,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uj" = (
@@ -13856,7 +12321,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uk" = (
@@ -13867,7 +12331,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ul" = (
@@ -13875,7 +12338,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/binary/pump{
@@ -13885,7 +12347,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "um" = (
@@ -13896,7 +12357,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "un" = (
@@ -13916,7 +12376,6 @@
 	icon_state = "red"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uo" = (
@@ -13936,7 +12395,6 @@
 	icon_state = "blue"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "up" = (
@@ -13951,7 +12409,6 @@
 	icon_state = "blue"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uq" = (
@@ -13962,17 +12419,13 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ur" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 2
-	},
+/obj/machinery/atmospherics/binary/valve,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "us" = (
@@ -13983,7 +12436,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm/monitor{
-	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
@@ -13991,7 +12443,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ut" = (
@@ -14006,7 +12457,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uu" = (
@@ -14016,7 +12466,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "uv" = (
@@ -14031,13 +12480,11 @@
 	icon_state = "caution"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uw" = (
 /turf/simulated/mineral/random/labormineral,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "ux" = (
@@ -14045,14 +12492,12 @@
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uz" = (
@@ -14061,7 +12506,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -14074,24 +12518,18 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uA" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "uB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uC" = (
@@ -14107,7 +12545,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uD" = (
@@ -14115,7 +12552,6 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uE" = (
@@ -14123,7 +12559,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -14134,13 +12569,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uF" = (
 /turf/simulated/wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uG" = (
@@ -14151,7 +12584,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uH" = (
@@ -14159,7 +12591,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/engineering{
@@ -14169,14 +12600,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uJ" = (
@@ -14188,7 +12617,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uK" = (
@@ -14200,16 +12628,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uL" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 2
-	},
+/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uM" = (
@@ -14220,7 +12644,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uN" = (
@@ -14231,7 +12654,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uO" = (
@@ -14239,7 +12661,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14248,7 +12669,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uP" = (
@@ -14258,7 +12678,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "uQ" = (
@@ -14269,14 +12688,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "uS" = (
@@ -14286,7 +12703,6 @@
 	icon_state = "browncorner"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "uT" = (
@@ -14302,7 +12718,6 @@
 	icon_state = "caution"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uU" = (
@@ -14316,20 +12731,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uW" = (
@@ -14337,8 +12749,7 @@
 	dir = 4
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -14346,7 +12757,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uX" = (
@@ -14354,7 +12764,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -14365,7 +12774,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uY" = (
@@ -14376,7 +12784,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "uZ" = (
@@ -14389,9 +12796,7 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = -32
 	},
-/obj/machinery/vending/engivend{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/engivend,
 /obj/machinery/camera{
 	c_tag = "Engineering Foyer";
 	dir = 1;
@@ -14400,7 +12805,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "va" = (
@@ -14409,7 +12813,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vb" = (
@@ -14422,7 +12825,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vc" = (
@@ -14434,7 +12836,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vd" = (
@@ -14445,7 +12846,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "ve" = (
@@ -14456,7 +12856,6 @@
 	},
 /turf/simulated/floor/engine/n2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vf" = (
@@ -14473,7 +12872,6 @@
 	},
 /turf/simulated/floor/engine/n2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vg" = (
@@ -14484,7 +12882,6 @@
 	},
 /turf/simulated/floor/engine/o2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vh" = (
@@ -14501,7 +12898,6 @@
 	},
 /turf/simulated/floor/engine/o2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vi" = (
@@ -14512,7 +12908,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vj" = (
@@ -14523,7 +12918,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vk" = (
@@ -14531,7 +12925,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14540,14 +12933,12 @@
 	icon_state = "brown"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "vl" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "vm" = (
@@ -14557,7 +12948,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -14572,7 +12962,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "vo" = (
@@ -14582,7 +12971,6 @@
 	icon_state = "brown"
 	},
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "vp" = (
@@ -14592,7 +12980,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "vq" = (
@@ -14602,7 +12989,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "vr" = (
@@ -14613,7 +12999,6 @@
 	icon_state = "caution"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vs" = (
@@ -14621,7 +13006,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -14629,7 +13013,6 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vt" = (
@@ -14639,14 +13022,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants{
-	layer = 5
-	},
+/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vu" = (
@@ -14654,7 +13034,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -14666,7 +13045,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vv" = (
@@ -14683,7 +13061,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vw" = (
@@ -14691,7 +13068,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14699,7 +13075,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vx" = (
@@ -14707,7 +13082,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -14727,22 +13101,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vy" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vz" = (
@@ -14757,13 +13127,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vA" = (
@@ -14771,12 +13139,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vB" = (
@@ -14784,7 +13150,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/engineering{
@@ -14793,7 +13158,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vC" = (
@@ -14807,7 +13171,6 @@
 	tag = "icon-caution (SOUTHWEST)"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vD" = (
@@ -14819,7 +13182,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vE" = (
@@ -14830,14 +13192,12 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine/n2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vF" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/engine/n2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vG" = (
@@ -14848,14 +13208,12 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine/o2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/engine/o2,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vI" = (
@@ -14864,31 +13222,26 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vJ" = (
 /turf/simulated/wall/r_wall/rust,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vK" = (
 /turf/simulated/wall/r_wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vL" = (
 /turf/simulated/wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vM" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vN" = (
@@ -14898,7 +13251,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vO" = (
@@ -14907,7 +13259,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14917,7 +13268,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vP" = (
@@ -14929,7 +13279,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vQ" = (
@@ -14938,13 +13287,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vR" = (
@@ -14953,7 +13300,6 @@
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/miner{
@@ -14962,7 +13308,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vS" = (
@@ -14971,7 +13316,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vT" = (
@@ -14989,17 +13333,14 @@
 	icon_state = "yellow"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vU" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "UO45_mining"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vV" = (
@@ -15007,7 +13348,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -15018,7 +13358,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vW" = (
@@ -15030,7 +13369,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vX" = (
@@ -15038,12 +13376,10 @@
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "vY" = (
@@ -15052,35 +13388,29 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "vZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wa" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "UO45_mining"
 	},
 /obj/structure/sign/nosmoking_2{
@@ -15088,7 +13418,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wb" = (
@@ -15096,7 +13425,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wc" = (
@@ -15108,14 +13436,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wd" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "we" = (
@@ -15126,7 +13452,6 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wf" = (
@@ -15135,17 +13460,14 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wg" = (
 /obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wh" = (
@@ -15153,7 +13475,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -15169,11 +13490,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wi" = (
@@ -15181,7 +13500,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15191,7 +13509,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wj" = (
@@ -15206,11 +13523,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wk" = (
@@ -15220,7 +13535,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -15231,8 +13545,8 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -15240,7 +13554,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wm" = (
@@ -15248,12 +13561,11 @@
 /obj/structure/window/full/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wn" = (
@@ -15261,17 +13573,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wo" = (
 /turf/simulated/wall/rust,
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wp" = (
@@ -15281,7 +13590,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wq" = (
@@ -15299,7 +13607,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wr" = (
@@ -15312,7 +13619,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "ws" = (
@@ -15323,14 +13629,11 @@
 	id = "awaydorm8";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wt" = (
@@ -15339,7 +13642,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wu" = (
@@ -15349,7 +13651,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wv" = (
@@ -15357,13 +13658,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "ww" = (
@@ -15374,7 +13673,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wx" = (
@@ -15382,7 +13680,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wy" = (
@@ -15394,11 +13691,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wz" = (
@@ -15406,7 +13701,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -15415,11 +13709,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wA" = (
@@ -15431,7 +13723,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wB" = (
@@ -15450,7 +13741,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wC" = (
@@ -15460,7 +13750,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wD" = (
@@ -15473,26 +13762,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wE" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wF" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wG" = (
@@ -15500,24 +13784,20 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wH" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wI" = (
@@ -15528,7 +13808,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wJ" = (
@@ -15536,24 +13815,19 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wK" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/light/small,
 /obj/structure/mirror{
@@ -15563,7 +13837,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wL" = (
@@ -15577,7 +13850,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wM" = (
@@ -15588,18 +13860,15 @@
 	},
 /obj/item/stamp/ce,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wN" = (
 /obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wO" = (
@@ -15612,7 +13881,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wP" = (
@@ -15623,14 +13891,11 @@
 	id = "awaydorm9";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wQ" = (
@@ -15638,7 +13903,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15646,7 +13910,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wR" = (
@@ -15658,22 +13921,18 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wS" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wT" = (
@@ -15681,7 +13940,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -15689,29 +13947,23 @@
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "wU" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
-	dir = 2;
 	locked = 0;
 	name = "UO45 Mining APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -15734,16 +13986,13 @@
 /obj/item/storage/backpack/satchel_eng,
 /obj/item/clothing/gloves/fingerless,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wV" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "UO45_mining"
 	},
 /obj/machinery/light/small{
@@ -15751,7 +14000,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wW" = (
@@ -15760,7 +14008,6 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wX" = (
@@ -15781,7 +14028,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wY" = (
@@ -15795,15 +14041,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "wZ" = (
@@ -15812,11 +14055,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xa" = (
@@ -15828,11 +14069,9 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xb" = (
@@ -15843,11 +14082,9 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xc" = (
@@ -15856,29 +14093,23 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xd" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xe" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/newscaster{
 	pixel_y = -28
@@ -15891,21 +14122,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xf" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xg" = (
@@ -15914,11 +14141,9 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xh" = (
@@ -15933,12 +14158,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xi" = (
@@ -15950,7 +14173,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xj" = (
@@ -15973,11 +14195,9 @@
 	req_access_txt = "201"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralfull"
 	},
 /area/awaycontent/a3{
-	has_gravity = 1;
 	name = "UO45 Engineering"
 	})
 "xk" = (
@@ -15985,7 +14205,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xl" = (
@@ -16004,7 +14223,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xm" = (
@@ -16015,7 +14233,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xn" = (
@@ -16023,12 +14240,10 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xo" = (
@@ -16036,7 +14251,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xp" = (
@@ -16053,14 +14267,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xr" = (
@@ -16073,7 +14285,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xs" = (
@@ -16083,7 +14294,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xt" = (
@@ -16091,7 +14301,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xu" = (
@@ -16100,28 +14309,23 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xv" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
-	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xw" = (
@@ -16131,20 +14335,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xx" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xy" = (
@@ -16153,7 +14353,6 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xz" = (
@@ -16163,7 +14362,6 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xA" = (
@@ -16176,12 +14374,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xB" = (
@@ -16189,7 +14385,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xC" = (
@@ -16200,7 +14395,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xD" = (
@@ -16208,13 +14402,11 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xE" = (
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xF" = (
@@ -16226,21 +14418,18 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xH" = (
@@ -16256,7 +14445,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xI" = (
@@ -16267,7 +14455,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xJ" = (
@@ -16279,12 +14466,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xK" = (
@@ -16299,12 +14484,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xM" = (
@@ -16320,7 +14503,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xN" = (
@@ -16329,7 +14511,6 @@
 	},
 /turf/simulated/wall,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xO" = (
@@ -16338,7 +14519,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xQ" = (
@@ -16349,18 +14529,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xR" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xS" = (
@@ -16378,14 +14556,12 @@
 	},
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xT" = (
 /obj/machinery/mech_bay_recharge_port{
-	tag = "icon-recharge_port (WEST)";
-	icon_state = "recharge_port";
-	dir = 8
+	dir = 8;
+	tag = "icon-recharge_port (WEST)"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -16393,7 +14569,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "xY" = (
@@ -16402,7 +14577,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "ye" = (
@@ -16415,20 +14589,18 @@
 	temperature = 273.15
 	},
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "yf" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds2";
-	icon_state = "weeds2"
+	icon_state = "weeds2";
+	tag = "icon-weeds2"
 	},
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/human/miner,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16437,8 +14609,8 @@
 	})
 "yg" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds1";
-	icon_state = "weeds1"
+	icon_state = "weeds1";
+	tag = "icon-weeds1"
 	},
 /obj/effect/mob_spawn/human/miner,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -16447,7 +14619,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16460,7 +14631,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a2{
-	has_gravity = 1;
 	name = "UO45 Crew Quarters"
 	})
 "yi" = (
@@ -16473,7 +14643,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16486,7 +14655,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a5{
-	has_gravity = 1;
 	name = "UO45 Research"
 	})
 "yk" = (
@@ -16495,7 +14663,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "yl" = (
@@ -16504,7 +14671,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a4{
-	has_gravity = 1;
 	name = "UO45 Mining"
 	})
 "ym" = (
@@ -16512,7 +14678,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16524,7 +14689,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16533,14 +14697,13 @@
 	})
 "yo" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds1";
-	icon_state = "weeds1"
+	icon_state = "weeds1";
+	tag = "icon-weeds1"
 	},
 /obj/effect/mob_spawn/human/miner,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16549,14 +14712,13 @@
 	})
 "yp" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds2";
-	icon_state = "weeds2"
+	icon_state = "weeds2";
+	tag = "icon-weeds2"
 	},
 /obj/structure/glowshroom/single,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16565,14 +14727,13 @@
 	})
 "yq" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds2";
-	icon_state = "weeds2"
+	icon_state = "weeds2";
+	tag = "icon-weeds2"
 	},
 /obj/structure/bed/nest,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16581,8 +14742,8 @@
 	})
 "yr" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds1";
-	icon_state = "weeds1"
+	icon_state = "weeds1";
+	tag = "icon-weeds1"
 	},
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "red";
@@ -16591,7 +14752,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16600,13 +14760,12 @@
 	})
 "ys" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds2";
-	icon_state = "weeds2"
+	icon_state = "weeds2";
+	tag = "icon-weeds2"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16621,7 +14780,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16630,14 +14788,13 @@
 	})
 "yu" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds1";
-	icon_state = "weeds1"
+	icon_state = "weeds1";
+	tag = "icon-weeds1"
 	},
 /obj/structure/glowshroom/single,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16650,7 +14807,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16659,8 +14815,8 @@
 	})
 "yw" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds2";
-	icon_state = "weeds2"
+	icon_state = "weeds2";
+	tag = "icon-weeds2"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -16671,7 +14827,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16686,7 +14841,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16695,13 +14849,12 @@
 	})
 "yy" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds1";
-	icon_state = "weeds1"
+	icon_state = "weeds1";
+	tag = "icon-weeds1"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16713,7 +14866,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16722,8 +14874,8 @@
 	})
 "yA" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds2";
-	icon_state = "weeds2"
+	icon_state = "weeds2";
+	tag = "icon-weeds2"
 	},
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -16732,7 +14884,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16741,8 +14892,8 @@
 	})
 "yB" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds2";
-	icon_state = "weeds2"
+	icon_state = "weeds2";
+	tag = "icon-weeds2"
 	},
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -16750,7 +14901,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16765,7 +14915,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16774,8 +14923,8 @@
 	})
 "yD" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds1";
-	icon_state = "weeds1"
+	icon_state = "weeds1";
+	tag = "icon-weeds1"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -16787,7 +14936,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16800,7 +14948,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16815,7 +14962,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16824,8 +14970,8 @@
 	})
 "yG" = (
 /obj/structure/alien/weeds{
-	tag = "icon-weeds1";
-	icon_state = "weeds1"
+	icon_state = "weeds1";
+	tag = "icon-weeds1"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -16837,7 +14983,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16856,7 +15001,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16870,7 +15014,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -16886,7 +15029,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaycontent/a7{
 	always_unpowered = 1;
-	has_gravity = 1;
 	name = "UO45 Caves";
 	power_environ = 0;
 	power_equip = 0;
@@ -32267,7 +30409,7 @@ qe
 qI
 qK
 sn
-sZ
+rt
 rl
 sd
 nj

--- a/_maps/map_files/RandomZLevels/wildwest.dmm
+++ b/_maps/map_files/RandomZLevels/wildwest.dmm
@@ -14,8 +14,8 @@
 /area/awaymission/wwvault)
 "ae" = (
 /turf/simulated/floor{
-	tag = "icon-cultdamage5";
-	icon_state = "cultdamage5"
+	icon_state = "cultdamage5";
+	tag = "icon-cultdamage5"
 	},
 /area/awaymission/wwvault)
 "af" = (
@@ -24,8 +24,8 @@
 /area/awaymission/wwvault)
 "ag" = (
 /turf/simulated/floor{
-	tag = "icon-bcircuitoff";
-	icon_state = "bcircuitoff"
+	icon_state = "bcircuitoff";
+	tag = "icon-bcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ah" = (
@@ -41,14 +41,14 @@
 /area/awaymission/wwvault)
 "aj" = (
 /turf/simulated/floor{
-	tag = "icon-cultdamage3";
-	icon_state = "cultdamage3"
+	icon_state = "cultdamage3";
+	tag = "icon-cultdamage3"
 	},
 /area/awaymission/wwvault)
 "ak" = (
 /turf/simulated/floor{
-	tag = "icon-cultdamage6";
-	icon_state = "cultdamage6"
+	icon_state = "cultdamage6";
+	tag = "icon-cultdamage6"
 	},
 /area/awaymission/wwvault)
 "al" = (
@@ -58,8 +58,8 @@
 "am" = (
 /mob/living/simple_animal/hostile/faithless,
 /turf/simulated/floor{
-	tag = "icon-bcircuitoff";
-	icon_state = "bcircuitoff"
+	icon_state = "bcircuitoff";
+	tag = "icon-bcircuitoff"
 	},
 /area/awaymission/wwvault)
 "an" = (
@@ -72,22 +72,22 @@
 /area/awaymission/wwvault)
 "ao" = (
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ap" = (
 /obj/machinery/wish_granter_dark,
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aq" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ar" = (
@@ -95,8 +95,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "as" = (
@@ -104,8 +104,8 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "at" = (
@@ -113,8 +113,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "au" = (
@@ -122,8 +122,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "av" = (
@@ -131,8 +131,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aw" = (
@@ -140,8 +140,8 @@
 	calibrated = 0
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ax" = (
@@ -149,8 +149,8 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ay" = (
@@ -158,35 +158,35 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "az" = (
 /obj/machinery/gateway,
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aA" = (
 /obj/effect/meatgrinder,
 /turf/simulated/floor{
-	tag = "icon-gcircuitoff";
-	icon_state = "gcircuitoff"
+	icon_state = "gcircuitoff";
+	tag = "icon-gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aB" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor{
-	tag = "icon-bcircuitoff";
-	icon_state = "bcircuitoff"
+	icon_state = "bcircuitoff";
+	tag = "icon-bcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aC" = (
 /turf/simulated/floor{
-	tag = "icon-cultdamage2";
-	icon_state = "cultdamage2"
+	icon_state = "cultdamage2";
+	tag = "icon-cultdamage2"
 	},
 /area/awaymission/wwvault)
 "aD" = (
@@ -222,8 +222,8 @@
 "aI" = (
 /obj/machinery/power/smes/magical,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -342,8 +342,8 @@
 /area/awaymission/wwmines)
 "bd" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibup1";
-	icon_state = "gibup1"
+	icon_state = "gibup1";
+	tag = "icon-gibup1"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
@@ -419,32 +419,32 @@
 /area/awaymission/wwmines)
 "bv" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibup1";
-	icon_state = "gibup1"
+	icon_state = "gibup1";
+	tag = "icon-gibup1"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bw" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "bx" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "by" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "bz" = (
@@ -453,9 +453,9 @@
 /area/awaymission/wwmines)
 "bA" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "bB" = (
@@ -472,9 +472,9 @@
 "bE" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/wildwest,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "bF" = (
@@ -496,36 +496,32 @@
 "bI" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /obj/item/gun/projectile/automatic/pistol,
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bJ" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
 "bK" = (
 /obj/structure/table/wood,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bL" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /obj/item/kitchen/knife/butcher,
 /turf/simulated/floor/wood,
@@ -541,47 +537,44 @@
 "bO" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bP" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bQ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "bR" = (
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "bS" = (
 /obj/item/book/manual/chef_recipes,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "bT" = (
@@ -592,29 +585,29 @@
 /obj/item/reagent_containers/food/snacks/meat/syntiflesh,
 /obj/item/reagent_containers/food/snacks/meat/syntiflesh,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "bU" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /turf/space,
 /area/space/nearstation)
 "bV" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -624,32 +617,32 @@
 /area/awaymission/wwgov)
 "bW" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
 "bX" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -663,22 +656,21 @@
 /area/awaymission/wwmines)
 "ca" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/space,
 /area/space/nearstation)
 "cb" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "cc" = (
@@ -686,21 +678,20 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "cd" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "ce" = (
@@ -708,9 +699,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "cf" = (
@@ -731,9 +722,9 @@
 /area/awaymission/wwmines)
 "cj" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -742,20 +733,20 @@
 /area/awaymission/wwgov)
 "cl" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -764,14 +755,14 @@
 /area/awaymission/wwgov)
 "cn" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -781,14 +772,14 @@
 /area/awaymission/wwgov)
 "co" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -801,9 +792,9 @@
 "cq" = (
 /obj/effect/mob_spawn/human/cook,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "cr" = (
@@ -820,14 +811,14 @@
 /area/awaymission/wwgov)
 "cu" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -851,9 +842,9 @@
 	name = "Planer Saul's Journal: Page 4"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "cz" = (
@@ -868,9 +859,8 @@
 /area/awaymission/wwgov)
 "cB" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
@@ -880,25 +870,23 @@
 /area/awaymission/wwgov)
 "cD" = (
 /obj/structure/bookcase{
-	tag = "icon-book-5";
-	icon_state = "book-5"
+	icon_state = "book-5";
+	tag = "icon-book-5"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "cE" = (
 /obj/item/storage/bag/money,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "cF" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
@@ -907,9 +895,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "cH" = (
-/obj/effect/mob_spawn/human/corpse/syndicatecommando{
-	mob_name = "Syndicate Commando"
-	},
+/obj/effect/mob_spawn/human/corpse/syndicatecommando,
 /turf/simulated/floor/carpet,
 /area/awaymission/wwgov)
 "cI" = (
@@ -936,8 +922,8 @@
 /area/awaymission/wwgov)
 "cN" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cO" = (
@@ -950,35 +936,34 @@
 "cP" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cQ" = (
 /obj/machinery/kitchen_machine/microwave,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cR" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cS" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -1013,27 +998,26 @@
 /area/awaymission/wwgov)
 "cY" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "cZ" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -1048,25 +1032,22 @@
 "dc" = (
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "dd" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "de" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
@@ -1078,45 +1059,42 @@
 /area/space/nearstation)
 "dg" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dh" = (
 /mob/living/simple_animal/hostile/creature,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "di" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dj" = (
 /obj/structure/bookcase{
-	tag = "icon-book-5";
-	icon_state = "book-5"
+	icon_state = "book-5";
+	tag = "icon-book-5"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "dk" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1132,17 +1110,15 @@
 "dn" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "do" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1161,19 +1137,19 @@
 /area/awaymission/wwmines)
 "ds" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -1183,14 +1159,14 @@
 /area/awaymission/wwgov)
 "du" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -1212,22 +1188,22 @@
 "dx" = (
 /obj/item/reagent_containers/food/snacks/monkeysdelight,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dy" = (
 /obj/item/reagent_containers/food/snacks/soup/stew,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dz" = (
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dA" = (
@@ -1251,9 +1227,8 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1262,28 +1237,27 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "dG" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -1293,28 +1267,26 @@
 /area/awaymission/wwmines)
 "dI" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /mob/living/simple_animal/hostile/creature,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dJ" = (
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dK" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
@@ -1328,16 +1300,14 @@
 "dM" = (
 /obj/structure/mineral_door/wood,
 /turf/simulated/floor/plating/ironsand{
-	tag = "icon-ironsand1";
-	icon_state = "ironsand1"
+	tag = "icon-ironsand1"
 	},
 /area/awaymission/wwmines)
 "dN" = (
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/simulated/floor/plating/ironsand{
-	tag = "icon-ironsand1";
-	icon_state = "ironsand1"
+	tag = "icon-ironsand1"
 	},
 /area/awaymission/wwmines)
 "dO" = (
@@ -1354,15 +1324,15 @@
 "dQ" = (
 /obj/item/reagent_containers/food/drinks/bottle/wine,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dR" = (
 /obj/item/reagent_containers/food/drinks/bottle/patron,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dS" = (
@@ -1372,8 +1342,8 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_bleft";
-	icon_state = "stage_bleft"
+	icon_state = "stage_bleft";
+	tag = "icon-stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dT" = (
@@ -1392,9 +1362,8 @@
 /area/awaymission/wwmines)
 "dW" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwgov)
@@ -1408,50 +1377,50 @@
 /area/awaymission/wwgov)
 "dZ" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
 "ea" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
 "eb" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -1459,8 +1428,8 @@
 /obj/structure/toilet,
 /mob/living/simple_animal/hostile/creature,
 /turf/simulated/floor/plasteel{
-	tag = "icon-white";
-	icon_state = "white"
+	icon_state = "white";
+	tag = "icon-white"
 	},
 /area/awaymission/wwgov)
 "ed" = (
@@ -1469,18 +1438,17 @@
 /area/awaymission/wwgov)
 "ee" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwgov)
 "ef" = (
 /obj/structure/largecrate,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1492,27 +1460,25 @@
 /area/awaymission/wwgov)
 "eh" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "ei" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "ej" = (
@@ -1528,8 +1494,8 @@
 /area/awaymission/wwmines)
 "em" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
@@ -1541,8 +1507,8 @@
 /area/awaymission/wwmines)
 "eo" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1571,23 +1537,22 @@
 /area/awaymission/wwmines)
 "eu" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
 "ev" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1595,36 +1560,35 @@
 "ew" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "ex" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "ey" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "ez" = (
@@ -1643,29 +1607,28 @@
 "eC" = (
 /obj/item/soap/syndie,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "eD" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "eE" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "eF" = (
@@ -1696,44 +1659,44 @@
 /area/awaymission/wwmines)
 "eL" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /turf/space,
 /area/space/nearstation)
 "eM" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /turf/space,
 /area/space/nearstation)
 "eN" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "eO" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1742,27 +1705,27 @@
 /area/space/nearstation)
 "eP" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/space,
 /area/space/nearstation)
 "eQ" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1773,14 +1736,14 @@
 /area/awaymission/wwrefine)
 "eS" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1788,9 +1751,9 @@
 "eT" = (
 /obj/effect/mine/gas/plasma,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "eU" = (
@@ -1801,9 +1764,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "eW" = (
@@ -1846,14 +1809,14 @@
 /area/awaymission/wwmines)
 "fd" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -1872,9 +1835,9 @@
 "fg" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "fh" = (
@@ -1894,8 +1857,8 @@
 /area/awaymission/wwmines)
 "fj" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
@@ -1906,9 +1869,9 @@
 "fl" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/awaymission/wwmines)
 "fm" = (
@@ -1937,20 +1900,20 @@
 /area/awaymission/wwmines)
 "fq" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
@@ -1975,13 +1938,12 @@
 /area/awaymission/wwrefine)
 "fv" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1995,15 +1957,13 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
 "fy" = (
-/obj/effect/mob_spawn/human/corpse/syndicatecommando{
-	mob_name = "Syndicate Commando"
-	},
+/obj/effect/mob_spawn/human/corpse/syndicatecommando,
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
 "fz" = (
@@ -2013,9 +1973,8 @@
 	icon_state = "cabinet_closed"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -2052,28 +2011,28 @@
 "fG" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "fH" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2091,15 +2050,15 @@
 "fK" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
@@ -2111,8 +2070,8 @@
 /area/awaymission/wwmines)
 "fM" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibup1";
-	icon_state = "gibup1"
+	icon_state = "gibup1";
+	tag = "icon-gibup1"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
@@ -2130,9 +2089,8 @@
 /area/awaymission/wwmines)
 "fQ" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2188,9 +2146,8 @@
 "fZ" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2207,14 +2164,14 @@
 "gb" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2222,16 +2179,15 @@
 "gc" = (
 /obj/structure/sink,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gd" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2248,14 +2204,14 @@
 "gf" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (EAST)";
+	dir = 4;
 	icon_state = "fwindow";
-	dir = 4
+	tag = "icon-fwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2269,9 +2225,8 @@
 /area/awaymission/wwmines)
 "gh" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2297,8 +2252,8 @@
 /area/awaymission/wwgov)
 "gl" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /turf/simulated/wall/mineral/sandstone,
 /area/awaymission/wwmines)
@@ -2325,20 +2280,20 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "gp" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -2354,16 +2309,15 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gu" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibup1";
-	icon_state = "gibup1"
+	icon_state = "gibup1";
+	tag = "icon-gibup1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2372,9 +2326,9 @@
 /area/awaymission/wwmines)
 "gv" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2386,14 +2340,14 @@
 /area/awaymission/wwrefine)
 "gx" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2402,9 +2356,9 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (NORTH)";
+	dir = 1;
 	icon_state = "fwindow";
-	dir = 1
+	tag = "icon-fwindow (NORTH)"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2416,9 +2370,9 @@
 /area/awaymission/wwmines)
 "gA" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -2436,9 +2390,9 @@
 /area/awaymission/wwmines)
 "gE" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2451,8 +2405,8 @@
 /area/awaymission/wwmines)
 "gH" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2461,16 +2415,16 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow";
-	icon_state = "fwindow"
+	icon_state = "fwindow";
+	tag = "icon-fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
 "gJ" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/space/nearstation)
@@ -2490,9 +2444,8 @@
 "gM" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -2518,15 +2471,15 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibdown1";
-	icon_state = "gibdown1"
+	icon_state = "gibdown1";
+	tag = "icon-gibdown1"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gR" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	tag = "icon-gibup1";
-	icon_state = "gibup1"
+	icon_state = "gibup1";
+	tag = "icon-gibup1"
 	},
 /obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
@@ -2548,9 +2501,9 @@
 /area/awaymission/wwgov)
 "he" = (
 /obj/structure/window/reinforced{
-	tag = "icon-fwindow (WEST)";
+	dir = 8;
 	icon_state = "fwindow";
-	dir = 8
+	tag = "icon-fwindow (WEST)"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/grass,

--- a/_maps/map_files/shuttles/admin_admin.dmm
+++ b/_maps/map_files/shuttles/admin_admin.dmm
@@ -60,7 +60,6 @@
 	req_access_txt = "101"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -88,9 +87,8 @@
 /area/shuttle/administration)
 "aq" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -110,9 +108,8 @@
 /area/shuttle/administration)
 "as" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -185,9 +182,8 @@
 /area/shuttle/administration)
 "aD" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -261,7 +257,6 @@
 "aU" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "adminshuttleshutters";
 	name = "Blast Shutters";
@@ -272,25 +267,22 @@
 /area/shuttle/administration)
 "aV" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
 	name = "Blast door control";
 	pixel_x = -5;
 	pixel_y = 35;
-	req_access = list(101);
-	req_access_txt = "0"
+	req_access = list(101)
 	},
 /obj/machinery/door_control{
 	id = "adminshuttleshutters";
 	name = "Shutter control";
 	pixel_x = 5;
 	pixel_y = 35;
-	req_access = list(101);
-	req_access_txt = "0"
+	req_access = list(101)
 	},
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -326,9 +318,8 @@
 "bb" = (
 /obj/machinery/clonepod/upgraded,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -376,9 +367,8 @@
 /area/shuttle/administration)
 "bl" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -427,9 +417,8 @@
 /area/shuttle/administration)
 "bt" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -437,9 +426,8 @@
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -19,7 +19,6 @@
 /obj/machinery/vending/security,
 /obj/machinery/light/spot{
 	dir = 8;
-	icon_state = "tube1";
 	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -111,7 +110,6 @@
 "fF" = (
 /obj/machinery/light/spot{
 	dir = 4;
-	icon_state = "tube1";
 	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -148,7 +146,6 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/light/spot{
 	dir = 1;
-	icon_state = "tube1";
 	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -194,15 +191,13 @@
 /obj/structure/chair,
 /obj/machinery/light/spot{
 	dir = 1;
-	icon_state = "tube1";
 	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/administration)
 "pK" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "propulsion"
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/administration)
@@ -221,7 +216,6 @@
 	},
 /obj/machinery/light/spot{
 	dir = 1;
-	icon_state = "tube1";
 	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/door_control{
@@ -287,8 +281,7 @@
 /area/shuttle/administration)
 "uW" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
+	dir = 4
 	},
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -312,7 +305,6 @@
 "vA" = (
 /obj/machinery/light/spot{
 	dir = 1;
-	icon_state = "tube1";
 	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -332,22 +324,15 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "wH" = (
 /obj/machinery/light/spot{
 	dir = 8;
-	icon_state = "tube1";
 	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -393,7 +378,6 @@
 	},
 /obj/machinery/light/spot{
 	dir = 1;
-	icon_state = "tube1";
 	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -669,16 +653,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -720,15 +698,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -869,7 +841,6 @@
 	},
 /obj/machinery/light/spot{
 	dir = 8;
-	icon_state = "tube1";
 	tag = "icon-tube1 (WEST)"
 	},
 /obj/item/clothing/mask/breath{
@@ -925,10 +896,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/gun/energy/gun/advtaser,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "WV" = (
@@ -944,7 +912,6 @@
 	},
 /obj/machinery/light/spot{
 	dir = 4;
-	icon_state = "tube1";
 	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,

--- a/_maps/map_files/shuttles/admin_hospital.dmm
+++ b/_maps/map_files/shuttles/admin_hospital.dmm
@@ -68,9 +68,8 @@
 "ar" = (
 /obj/machinery/chem_heater,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -92,9 +91,8 @@
 /area/shuttle/administration)
 "av" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -110,7 +108,6 @@
 	},
 /obj/machinery/camera{
 	dir = 8;
-	icon_state = "camera";
 	name = "NHV Asclepius Lobby";
 	network = list("NHV Asclepius")
 	},
@@ -133,9 +130,8 @@
 "aA" = (
 /obj/machinery/computer/cloning,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -173,8 +169,7 @@
 /area/shuttle/administration)
 "aI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -188,7 +183,6 @@
 /area/shuttle/administration)
 "aL" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/plasmareinforced{
@@ -198,8 +192,7 @@
 /area/shuttle/administration)
 "aM" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "propulsion"
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/administration)
@@ -249,7 +242,6 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/camera{
 	dir = 4;
-	icon_state = "camera";
 	name = "NHV Asclepius Chemistry";
 	network = list("NHV Asclepius")
 	},
@@ -269,7 +261,6 @@
 "aV" = (
 /obj/machinery/camera{
 	dir = 8;
-	icon_state = "camera";
 	name = "NHV Asclepius Cloning";
 	network = list("NHV Asclepius")
 	},
@@ -372,7 +363,6 @@
 "bq" = (
 /obj/machinery/camera{
 	c_tag = "Tech Storage";
-	dir = 2;
 	name = "NHV Asclepius Command Center";
 	network = list("NHV Asclepius")
 	},
@@ -385,21 +375,17 @@
 	name = "remote shutter control";
 	pixel_x = -5;
 	pixel_y = 35;
-	req_access = list(101);
-	req_access_txt = "0"
+	req_access = list(101)
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = 24
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "asclblast";
 	name = "blast door control";
 	pixel_x = 5;
 	pixel_y = 35;
-	pixel_z = 0;
-	req_access = list(101);
-	req_access_txt = "0"
+	req_access = list(101)
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -417,7 +403,6 @@
 /area/shuttle/administration)
 "bt" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -426,9 +411,8 @@
 /area/shuttle/administration)
 "bu" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_y = 32
@@ -438,9 +422,8 @@
 "bv" = (
 /obj/machinery/vending/medical,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -466,9 +449,8 @@
 "by" = (
 /obj/machinery/computer/operating,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -505,7 +487,6 @@
 "bG" = (
 /obj/machinery/camera{
 	dir = 4;
-	icon_state = "camera";
 	name = "NHV Asclepius OR 1";
 	network = list("NHV Asclepius")
 	},
@@ -528,9 +509,7 @@
 "bJ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -604,7 +583,6 @@
 	},
 /obj/machinery/camera{
 	dir = 5;
-	icon_state = "camera";
 	name = "NHV Asclepius Central";
 	network = list("NHV Asclepius")
 	},
@@ -612,8 +590,7 @@
 /area/shuttle/administration)
 "cb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/bed{
 	name = "Triage: High Priority"
@@ -641,13 +618,11 @@
 	name = "Canister: \[O2] (CRYO)"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/camera{
 	dir = 4;
-	icon_state = "camera";
 	name = "NHV Asclepius Cryo";
 	network = list("NHV Asclepius")
 	},
@@ -677,7 +652,6 @@
 "ck" = (
 /obj/machinery/camera{
 	dir = 4;
-	icon_state = "camera";
 	name = "NHV Asclepius OR 2";
 	network = list("NHV Asclepius")
 	},
@@ -731,8 +705,7 @@
 /area/shuttle/administration)
 "cu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -742,15 +715,13 @@
 /area/shuttle/administration)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)

--- a/_maps/map_files/shuttles/cargo_base.dmm
+++ b/_maps/map_files/shuttles/cargo_base.dmm
@@ -7,9 +7,8 @@
 /area/shuttle/supply)
 "f" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/supply)
@@ -31,33 +30,29 @@
 /area/shuttle/supply)
 "i" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "j" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
 	layer = 3;
 	name = "Loading Doors";
 	pixel_x = 24;
-	pixel_y = 8;
-	req_access_txt = "0"
+	pixel_y = 8
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor";
 	layer = 3;
 	name = "Loading Doors";
 	pixel_x = 24;
-	pixel_y = -8;
-	req_access_txt = "0"
+	pixel_y = -8
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/supply)
@@ -96,8 +91,8 @@
 /area/space)
 "w" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l";
-	icon_state = "burst_l"
+	icon_state = "burst_l";
+	tag = "icon-burst_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/supply)
@@ -107,8 +102,8 @@
 /area/shuttle/supply)
 "y" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_r";
-	icon_state = "burst_r"
+	icon_state = "burst_r";
+	tag = "icon-burst_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/supply)

--- a/_maps/map_files/shuttles/emergency_bar.dmm
+++ b/_maps/map_files/shuttles/emergency_bar.dmm
@@ -92,9 +92,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair,
 /obj/structure/chair/comfy/shuttle,
@@ -103,14 +102,12 @@
 "az" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aA" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aB" = (
@@ -124,9 +121,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/piano,
 /turf/simulated/floor/plasteel{
@@ -192,15 +188,13 @@
 "aM" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aN" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aO" = (
@@ -227,24 +221,20 @@
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aS" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aT" = (
 /obj/docking_port/mobile/emergency{
-	dir = 4;
 	dwidth = 11;
 	height = 13;
 	name = "The Emergency Escape Bar";
@@ -264,8 +254,7 @@
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aV" = (
@@ -278,15 +267,13 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/beer,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aX" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
+	dir = 4;
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -302,8 +289,7 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "bb" = (
@@ -327,15 +313,13 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/clothing/mask/cigarette/cigar,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "be" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (NORTH)";
-	icon_state = "wooden_chair_wings";
-	dir = 1
+	dir = 1;
+	tag = "icon-wooden_chair_wings (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -344,13 +328,11 @@
 "bf" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "bh" = (
@@ -359,14 +341,12 @@
 	},
 /obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "bi" = (
 /obj/machinery/door/airlock{
-	name = "Toilet";
-	req_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -389,8 +369,7 @@
 "bn" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -401,9 +380,8 @@
 /area/shuttle/escape)
 "bp" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/shower,
 /obj/structure/curtain/open/shower,
@@ -415,8 +393,7 @@
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "br" = (
@@ -426,9 +403,7 @@
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /obj/structure/bed/roller,
 /turf/simulated/floor/mineral/titanium,
@@ -459,20 +434,17 @@
 /area/shuttle/escape)
 "bx" = (
 /obj/machinery/status_display{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)
 "by" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/bed/roller,
@@ -501,9 +473,9 @@
 /area/shuttle/escape)
 "bC" = (
 /obj/machinery/sleeper{
-	tag = "icon-sleeper (NORTH)";
+	dir = 1;
 	icon_state = "sleeper";
-	dir = 1
+	tag = "icon-sleeper (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_clown.dmm
+++ b/_maps/map_files/shuttles/emergency_clown.dmm
@@ -116,9 +116,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/chasm,
 /area/shuttle/escape)
@@ -132,9 +131,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/item/toy/snappop/phoenix,
 /turf/simulated/floor/plasteel{
@@ -174,14 +172,12 @@
 "aL" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/chasm,
 /area/shuttle/escape)
 "aP" = (
 /obj/docking_port/mobile/emergency{
-	dir = 4;
 	dwidth = 11;
 	height = 13;
 	name = "Snappop(tm)!";
@@ -199,13 +195,11 @@
 "aQ" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
@@ -227,9 +221,8 @@
 /obj/item/extinguisher,
 /obj/item/crowbar,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/item/multitool/ai_detect,
 /turf/simulated/floor/noslip,
@@ -280,8 +273,7 @@
 "bb" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -315,9 +307,7 @@
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /obj/structure/bed/roller,
 /turf/simulated/floor/noslip,
@@ -328,28 +318,24 @@
 /area/shuttle/escape)
 "bg" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)
 "bh" = (
 /obj/machinery/status_display{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)
 "bi" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/bed/roller,
@@ -370,9 +356,9 @@
 /area/shuttle/escape)
 "bm" = (
 /obj/machinery/sleeper{
-	tag = "icon-sleeper (NORTH)";
+	dir = 1;
 	icon_state = "sleeper";
-	dir = 1
+	tag = "icon-sleeper (NORTH)"
 	},
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -80,9 +80,8 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
@@ -118,15 +117,15 @@
 /area/shuttle/escape)
 "B" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l";
-	icon_state = "burst_l"
+	icon_state = "burst_l";
+	tag = "icon-burst_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
 "C" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r";
-	icon_state = "propulsion_r"
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -105,8 +105,7 @@
 	network = list("SS13","Research Outpost","Mining Outpost","Telecomms")
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -143,8 +142,7 @@
 "ax" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -250,8 +248,7 @@
 /area/shuttle/escape)
 "aR" = (
 /obj/structure/closet/fireaxecabinet{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -275,15 +272,15 @@
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "aU" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "aV" = (
@@ -297,14 +294,13 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "aW" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -449,8 +445,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bA" = (
@@ -461,8 +457,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bB" = (
@@ -470,14 +466,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bC" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit";
-	req_access_txt = "0";
 	req_one_access_txt = "2;19"
 	},
 /turf/simulated/floor/plasteel{
@@ -493,7 +488,6 @@
 	name = "Shuttle Hatch"
 	},
 /obj/docking_port/mobile/emergency{
-	dir = 4;
 	dwidth = 11;
 	height = 18;
 	timid = 1;
@@ -516,8 +510,8 @@
 "bG" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bH" = (
@@ -538,14 +532,13 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bJ" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -553,24 +546,21 @@
 "bK" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bL" = (
 /obj/structure/reagent_dispensers/fueltank/chem{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bM" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
@@ -582,8 +572,8 @@
 /area/shuttle/escape)
 "bO" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bP" = (
@@ -591,8 +581,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bQ" = (
@@ -600,8 +590,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bR" = (
@@ -633,8 +623,8 @@
 "bV" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bX" = (
@@ -654,13 +644,12 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "ca" = (
@@ -673,8 +662,8 @@
 /obj/item/wrench,
 /obj/item/radio,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cb" = (
@@ -688,13 +677,12 @@
 "cd" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "ce" = (
@@ -709,8 +697,8 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cf" = (
@@ -719,15 +707,15 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cg" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-browncorner (EAST)";
+	dir = 4;
 	icon_state = "browncorner";
-	dir = 4
+	tag = "icon-browncorner (EAST)"
 	},
 /area/shuttle/escape)
 "ch" = (
@@ -750,13 +738,12 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -766,19 +753,17 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cl" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -792,20 +777,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "cp" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "cq" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -817,9 +799,9 @@
 /area/shuttle/escape)
 "cs" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/shuttle/escape)
 "ct" = (
@@ -831,16 +813,15 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whiteblue";
-	dir = 6
+	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/shuttle/escape)
 "cu" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -856,9 +837,9 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/shuttle/escape)
 "cx" = (
@@ -867,15 +848,15 @@
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/shuttle/escape)
 "cy" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/shuttle/escape)
 "cz" = (
@@ -890,40 +871,36 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHEAST)";
+	dir = 5;
 	icon_state = "whiteblue";
-	dir = 5
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/shuttle/escape)
 "cA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/reagent_containers/food/drinks/mug/med,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "cC" = (
 /obj/item/flag/med,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -932,14 +909,12 @@
 /obj/item/storage/backpack/medic,
 /obj/item/storage/belt/medical,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "cE" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -952,7 +927,6 @@
 	},
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -961,7 +935,6 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_dept.dmm
+++ b/_maps/map_files/shuttles/emergency_dept.dmm
@@ -105,8 +105,7 @@
 	network = list("SS13","Research Outpost","Mining Outpost","Telecomms")
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -143,8 +142,7 @@
 "ax" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -208,14 +206,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "aG" = (
 /obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
@@ -225,11 +221,9 @@
 "aI" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -247,20 +241,17 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "aM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -274,8 +265,7 @@
 "aO" = (
 /mob/living/simple_animal/bot/secbot,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aR" = (
@@ -286,8 +276,7 @@
 /area/shuttle/escape)
 "aS" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aT" = (
@@ -300,15 +289,13 @@
 "aU" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aV" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "aW" = (
@@ -342,7 +329,6 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -351,20 +337,17 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/structure/table/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "be" = (
 /obj/machinery/chem_dispenser/beer,
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "bf" = (
@@ -379,9 +362,9 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHEAST)";
+	dir = 5;
 	icon_state = "whiteblue";
-	dir = 5
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/shuttle/escape)
 "bg" = (
@@ -404,8 +387,7 @@
 /obj/machinery/chem_dispenser/soda,
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/shuttle/escape)
 "bj" = (
@@ -432,7 +414,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/plastitanium/red/brig,
@@ -442,7 +423,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -464,7 +444,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/plastitanium/red/brig,
@@ -491,9 +470,9 @@
 /obj/machinery/iv_drip,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/shuttle/escape)
 "by" = (
@@ -527,7 +506,6 @@
 	name = "Shuttle Hatch"
 	},
 /obj/docking_port/mobile/emergency{
-	dir = 4;
 	dwidth = 11;
 	height = 18;
 	timid = 1;
@@ -546,7 +524,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -555,11 +532,9 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -583,7 +558,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
@@ -593,7 +567,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
@@ -603,12 +576,11 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bP" = (
@@ -616,8 +588,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bQ" = (
@@ -625,8 +597,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "bR" = (
@@ -642,7 +614,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium/purple,
@@ -652,7 +623,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/purple,
@@ -704,8 +674,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Escape Shuttle Engineering";
 	normalspeed = 0;
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -726,17 +695,15 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cp" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -744,22 +711,21 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/shuttle/escape)
 "cA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "cD" = (
@@ -767,14 +733,12 @@
 /obj/item/storage/backpack/medic,
 /obj/item/storage/belt/medical,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "cE" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -783,7 +747,6 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -798,7 +761,6 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
@@ -811,9 +773,9 @@
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/shuttle/escape)
 "PY" = (
@@ -828,7 +790,6 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_meta.dmm
+++ b/_maps/map_files/shuttles/emergency_meta.dmm
@@ -24,8 +24,7 @@
 "ai" = (
 /obj/machinery/door/airlock/titanium{
 	id_tag = "s_docking_airlock";
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "0"
+	name = "Emergency Shuttle Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
@@ -80,7 +79,6 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /obj/structure/chair/comfy/shuttle,
@@ -130,16 +128,14 @@
 "aA" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
 "aB" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -184,15 +180,13 @@
 /area/shuttle/escape)
 "aI" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
@@ -258,7 +252,6 @@
 /obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/hardhat,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -293,9 +286,6 @@
 "aS" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 0;
-	req_access_txt = "0";
 	use_power = 0
 	},
 /turf/simulated/wall/mineral/titanium,
@@ -320,8 +310,7 @@
 /obj/machinery/status_display{
 	dir = 4;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -348,8 +337,6 @@
 "bb" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -363,15 +350,12 @@
 /obj/structure/table,
 /obj/item/folder/blue,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bd" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -391,7 +375,6 @@
 /obj/item/stack/medical/ointment,
 /obj/item/stack/medical/bruise_pack,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -414,8 +397,7 @@
 "bl" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -473,7 +455,6 @@
 "bw" = (
 /obj/machinery/sleeper,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -533,8 +514,7 @@
 "bF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/item/reagent_containers/glass/bottle/charcoal{
 	pixel_x = -3
@@ -576,7 +556,6 @@
 	pixel_y = 1
 	},
 /obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
 	pixel_y = -1
 	},
 /obj/item/storage/toolbox/emergency{
@@ -653,8 +632,6 @@
 	pixel_y = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -696,7 +673,6 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -738,7 +714,6 @@
 /area/shuttle/escape)
 "ca" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/space_heater,
@@ -770,9 +745,7 @@
 	},
 /area/shuttle/escape)
 "cc" = (
-/obj/structure/closet/crate/medical{
-	name = "medical crate"
-	},
+/obj/structure/closet/crate/medical,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/o2{
 	pixel_x = 3;
@@ -799,8 +772,6 @@
 /area/shuttle/escape)
 "cd" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -831,8 +802,7 @@
 	},
 /obj/machinery/door/airlock/titanium{
 	id_tag = "s_docking_airlock";
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "0"
+	name = "Emergency Shuttle Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_mil.dmm
+++ b/_maps/map_files/shuttles/emergency_mil.dmm
@@ -29,9 +29,8 @@
 "ak" = (
 /obj/machinery/computer/communications,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -48,9 +47,8 @@
 	network = list("SS13","Telecomms","Research Outpost","Mining Outpost")
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -91,9 +89,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
@@ -104,9 +101,9 @@
 "aJ" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/shuttle/escape)
 "aK" = (
@@ -116,9 +113,9 @@
 	},
 /obj/item/wrench,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/shuttle/escape)
 "aL" = (
@@ -126,22 +123,21 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/shuttle/escape)
 "aM" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHEAST)";
+	dir = 5;
 	icon_state = "whiteblue";
-	dir = 5
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/shuttle/escape)
 "aN" = (
@@ -158,15 +154,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/shuttle/escape)
 "aR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -181,9 +176,7 @@
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
@@ -195,15 +188,14 @@
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/shuttle/escape)
 "aV" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/bed/roller,
@@ -233,9 +225,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whiteblue";
-	dir = 10
+	tag = "icon-whiteblue (SOUTHWEST)"
 	},
 /area/shuttle/escape)
 "aZ" = (
@@ -258,34 +250,28 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
 /area/shuttle/escape)
 "ba" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whiteblue";
-	dir = 6
+	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/shuttle/escape)
 "bc" = (
@@ -316,7 +302,6 @@
 /area/shuttle/escape)
 "bh" = (
 /obj/docking_port/mobile/emergency{
-	dir = 4;
 	dwidth = 11;
 	height = 13;
 	timid = 1;
@@ -339,13 +324,11 @@
 "bj" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -366,9 +349,8 @@
 /area/shuttle/escape)
 "bm" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -377,9 +359,8 @@
 /area/shuttle/escape)
 "bn" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -424,9 +405,8 @@
 	name = "shuttle turret"
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -90,7 +90,6 @@
 "as" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -103,13 +102,11 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/chair/comfy/shuttle,
@@ -118,7 +115,6 @@
 "au" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -135,9 +131,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
@@ -147,7 +142,6 @@
 	},
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -172,7 +166,6 @@
 "aB" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -183,12 +176,10 @@
 "aC" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -204,7 +195,6 @@
 /area/shuttle/escape)
 "aE" = (
 /obj/docking_port/mobile/emergency{
-	dir = 4;
 	dwidth = 11;
 	height = 13;
 	name = "Shuttle 667";
@@ -221,13 +211,11 @@
 "aG" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/item/flag/cult,
 /turf/simulated/floor/engine/cult,
@@ -245,9 +233,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
@@ -278,9 +265,8 @@
 /obj/item/extinguisher,
 /obj/item/crowbar,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
@@ -340,9 +326,8 @@
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
@@ -367,9 +352,9 @@
 /area/shuttle/escape)
 "bg" = (
 /obj/machinery/sleeper{
-	tag = "icon-sleeper (NORTH)";
+	dir = 1;
 	icon_state = "sleeper";
-	dir = 1
+	tag = "icon-sleeper (NORTH)"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/engine/cult,

--- a/_maps/map_files/shuttles/emergency_old.dmm
+++ b/_maps/map_files/shuttles/emergency_old.dmm
@@ -31,7 +31,6 @@
 /area/shuttle/escape)
 "ak" = (
 /obj/docking_port/mobile/emergency{
-	dir = 4;
 	dwidth = 11;
 	height = 13;
 	timid = 1;
@@ -115,9 +114,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -151,13 +149,11 @@
 "aL" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -169,9 +165,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -188,9 +183,8 @@
 /obj/item/extinguisher,
 /obj/item/crowbar,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -213,8 +207,7 @@
 "aV" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -244,28 +237,24 @@
 /area/shuttle/escape)
 "bc" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bd" = (
 /obj/machinery/status_display{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)
 "be" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/bed/roller,
@@ -308,9 +297,9 @@
 /area/shuttle/escape)
 "ev" = (
 /obj/machinery/sleeper{
-	tag = "icon-sleeper (NORTH)";
+	dir = 1;
 	icon_state = "sleeper";
-	dir = 1
+	tag = "icon-sleeper (NORTH)"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -345,9 +334,8 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
@@ -356,9 +344,7 @@
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /obj/structure/bed/roller,
 /turf/simulated/floor/mineral/titanium,

--- a/_maps/map_files/shuttles/ferry_base.dmm
+++ b/_maps/map_files/shuttles/ferry_base.dmm
@@ -5,7 +5,6 @@
 "b" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
 /turf/simulated/wall/mineral/titanium,
@@ -19,9 +18,8 @@
 /area/shuttle/transport)
 "h" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -38,9 +36,8 @@
 /area/shuttle/transport)
 "k" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/titanium/blue,

--- a/_maps/map_files/shuttles/ferry_meat.dmm
+++ b/_maps/map_files/shuttles/ferry_meat.dmm
@@ -5,7 +5,6 @@
 "b" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
 /turf/simulated/wall/mineral/titanium,
@@ -19,9 +18,8 @@
 /area/shuttle/transport)
 "h" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -58,9 +56,8 @@
 /area/shuttle/transport)
 "l" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/gibber,
 /turf/simulated/floor/plasteel{
@@ -81,9 +78,8 @@
 /area/shuttle/transport)
 "o" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/templates/medium_shuttle1.dmm
+++ b/_maps/map_files/templates/medium_shuttle1.dmm
@@ -5,7 +5,6 @@
 "b" = (
 /obj/structure/shuttle/engine/propulsion/burst/left{
 	dir = 8;
-	icon_state = "burst_l";
 	tag = "icon-burst_l (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -14,14 +13,12 @@
 	})
 "c" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered{
@@ -53,8 +50,8 @@
 	})
 "j" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -62,8 +59,8 @@
 "k" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -72,8 +69,8 @@
 /obj/structure/computerframe,
 /obj/item/circuitboard/teleporter,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -82,8 +79,8 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -93,8 +90,8 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/suit/space/eva,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -112,16 +109,16 @@
 	})
 "q" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
 	})
 "r" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -129,8 +126,8 @@
 "s" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -145,8 +142,8 @@
 /obj/machinery/teleport/hub,
 /obj/item/hand_tele,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -156,8 +153,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -165,7 +162,6 @@
 "z" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
 	dir = 8;
-	icon_state = "burst_r";
 	tag = "icon-burst_r (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -178,8 +174,8 @@
 	},
 /obj/machinery/teleport/station,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -187,8 +183,8 @@
 "D" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -196,8 +192,8 @@
 "E" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -205,8 +201,8 @@
 "F" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -214,8 +210,8 @@
 "H" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -224,8 +220,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -233,8 +229,8 @@
 "J" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -245,8 +241,8 @@
 	},
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -256,8 +252,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -265,8 +261,8 @@
 "M" = (
 /obj/machinery/computer,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -276,8 +272,8 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/gloves/color/yellow,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -300,8 +296,8 @@
 /obj/structure/table,
 /obj/item/storage/belt/utility/full/multitool,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -309,8 +305,8 @@
 "R" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -318,8 +314,8 @@
 "S" = (
 /obj/item/radio/beacon,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -332,8 +328,8 @@
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/retro,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"

--- a/_maps/map_files/templates/medium_shuttle2.dmm
+++ b/_maps/map_files/templates/medium_shuttle2.dmm
@@ -5,7 +5,6 @@
 "b" = (
 /obj/structure/shuttle/engine/propulsion/burst/left{
 	dir = 8;
-	icon_state = "burst_l";
 	tag = "icon-burst_l (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -14,14 +13,12 @@
 	})
 "c" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered{
@@ -35,7 +32,6 @@
 "f" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
 	dir = 8;
-	icon_state = "burst_r";
 	tag = "icon-burst_r (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -57,8 +53,8 @@
 	})
 "k" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -71,8 +67,8 @@
 "n" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -85,8 +81,8 @@
 	})
 "p" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -99,8 +95,8 @@
 	})
 "r" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -115,21 +111,21 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
 	})
 "v" = (
 /obj/machinery/sleeper{
-	tag = "icon-sleeper (NORTH)";
+	dir = 1;
 	icon_state = "sleeper";
-	dir = 1
+	tag = "icon-sleeper (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -137,8 +133,8 @@
 "w" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -166,8 +162,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -176,8 +172,8 @@
 /obj/structure/computerframe,
 /obj/item/circuitboard/teleporter,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -186,8 +182,8 @@
 /obj/machinery/teleport/hub,
 /obj/item/hand_tele,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -195,8 +191,8 @@
 "G" = (
 /obj/item/radio/beacon,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -204,8 +200,8 @@
 "H" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -219,8 +215,8 @@
 	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -228,8 +224,8 @@
 "K" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -238,8 +234,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -247,8 +243,8 @@
 "N" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -257,8 +253,8 @@
 /obj/structure/table,
 /obj/item/storage/belt/utility/full/multitool,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -268,8 +264,8 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/gloves/color/yellow,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -279,8 +275,8 @@
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/retro,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -290,8 +286,8 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/suit/space/eva,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -299,8 +295,8 @@
 "U" = (
 /obj/machinery/teleport/station,
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -318,8 +314,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -329,8 +325,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -338,8 +334,8 @@
 "Y" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -347,8 +343,8 @@
 "Z" = (
 /obj/machinery/computer,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"

--- a/_maps/map_files/templates/medium_shuttle3.dmm
+++ b/_maps/map_files/templates/medium_shuttle3.dmm
@@ -4,9 +4,8 @@
 /area/space)
 "b" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	tag = "icon-propulsion (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered{
@@ -19,9 +18,8 @@
 	})
 "d" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	tag = "icon-heater (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered{
@@ -57,7 +55,6 @@
 "n" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -66,9 +63,8 @@
 	})
 "o" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	tag = "icon-heater (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered{
@@ -82,9 +78,8 @@
 	})
 "q" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (EAST)";
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	tag = "icon-heater (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered{
@@ -93,7 +88,6 @@
 "r" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -109,16 +103,16 @@
 "v" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
 	})
 "w" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -128,8 +122,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteyellowfull";
-	icon_state = "whiteyellowfull"
+	icon_state = "whiteyellowfull";
+	tag = "icon-whiteyellowfull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -137,16 +131,16 @@
 "z" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
 	})
 "A" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-dark";
-	icon_state = "dark"
+	icon_state = "dark";
+	tag = "icon-dark"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -159,8 +153,8 @@
 	})
 "D" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"
@@ -169,8 +163,8 @@
 /obj/structure/table,
 /obj/item/storage/firstaid,
 /turf/simulated/floor/plasteel{
-	tag = "icon-bluefull";
-	icon_state = "bluefull"
+	icon_state = "bluefull";
+	tag = "icon-bluefull"
 	},
 /area/ruin/powered{
 	name = "Shuttle"

--- a/_maps/map_files/templates/shelter_1.dmm
+++ b/_maps/map_files/templates/shelter_1.dmm
@@ -4,9 +4,8 @@
 /area/survivalpod)
 "b" = (
 /obj/structure/sign/mining/survival{
-	tag = "icon-survival (NORTH)";
-	icon_state = "survival";
-	dir = 1
+	dir = 1;
+	tag = "icon-survival (NORTH)"
 	},
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)
@@ -45,9 +44,8 @@
 /area/survivalpod)
 "j" = (
 /obj/structure/sign/mining/survival{
-	tag = "icon-survival (EAST)";
-	icon_state = "survival";
-	dir = 4
+	dir = 4;
+	tag = "icon-survival (EAST)"
 	},
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)

--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -27,9 +27,8 @@
 /area/survivalpod)
 "g" = (
 /obj/structure/sign/mining/survival{
-	tag = "icon-survival (NORTH)";
-	icon_state = "survival";
-	dir = 1
+	dir = 1;
+	tag = "icon-survival (NORTH)"
 	},
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)
@@ -79,9 +78,7 @@
 /obj/machinery/shower{
 	pixel_y = 20
 	},
-/turf/simulated/floor/pod{
-	pixel_y = 0
-	},
+/turf/simulated/floor/pod,
 /area/survivalpod)
 "o" = (
 /obj/structure/window/reinforced/survival_pod{
@@ -143,9 +140,8 @@
 /area/survivalpod)
 "x" = (
 /obj/structure/sign/mining/survival{
-	tag = "icon-survival (EAST)";
-	icon_state = "survival";
-	dir = 4
+	dir = 4;
+	tag = "icon-survival (EAST)"
 	},
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)

--- a/_maps/map_files/templates/small_shuttle_1.dmm
+++ b/_maps/map_files/templates/small_shuttle_1.dmm
@@ -36,7 +36,6 @@
 /area/ruin/powered)
 "n" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -66,8 +65,7 @@
 /area/ruin/powered)
 "v" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/mineral/titanium/blue,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes all redundant variables that are declared on the map. (This means any variable declared on the map that is the same as default.)
It is similar to #15438 however touches on more variables, and does not touch the main station levels like that PR.
This brings our various non-station map files in line with proposed changes in #16125
Since it also runs them through SDMM, it will reorder variables into the most optimal order.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Map bloat bad. There is no impact for players, changes are purely backend.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

