### PR TITLE
Fixes a spelling error with the Odysseus mech's exosuit syringe gun. 

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -483,7 +483,7 @@
 		if(R.can_synth && add_known_reagent(R.id, R.name))
 			occupant_message("Reagent analyzed, identified as [R.name] and added to database.")
 			send_byjax(chassis.occupant,"msyringegun.browser","reagents_form",get_reagents_form())
-	occupant_message("Analyzis complete.")
+	occupant_message("Analysis complete.")
 	return 1
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/proc/add_known_reagent(r_id,r_name)


### PR DESCRIPTION
## What Does This PR Do
Fixes a spelling error with the odysseus mech when analyzing something with the syringe gun it says "analyzis complete" as opposed to "analysis" complete. 
## Why It's Good For The Game
spelling error bad, fix good. 

## Changelog
:cl:
spellcheck: Fixed a few typo when using the odysseus syringe gun that said "analyzis complete" to say "analysis complete" 
/:cl:
