### PR TITLE
Nerfs sorium and LDM

### DIFF
--- a/code/modules/reagents/chemistry/reagents/paradise_pop.dm
+++ b/code/modules/reagents/chemistry/reagents/paradise_pop.dm
@@ -29,7 +29,7 @@
 /datum/reagent/consumable/drink/apple_pocalypse/on_mob_life(mob/living/M)
 	if(prob(1))
 		var/turf/simulated/T = get_turf(M)
-		goonchem_vortex(T, 1, 0)
+		goonchem_vortex(T, TRUE, 0, TRUE) // Ignore the 0 volume
 		to_chat(M, "<span class='notice'>You briefly feel super-massive, like a black hole. Probably just your imagination...</span>")
 	return ..()
 
@@ -119,7 +119,7 @@
 /datum/reagent/consumable/drink/grape_granade/on_mob_life(mob/living/M)
 	if(prob(1))
 		var/turf/simulated/T = get_turf(M)
-		goonchem_vortex(T, 0, 0)
+		goonchem_vortex(T, FALSE, 0, TRUE) // Ignore the 0 volume
 		M.emote("burp")
 		to_chat(M, "<span class='notice'>You feel ready to burst! Oh wait, just a burp...</span>")
 	else if(prob(25))

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -53,8 +53,19 @@
 				for(var/j = 1, j <= rand(1, 3), j++)
 					step(S, pick(NORTH,SOUTH,EAST,WEST))
 
-/proc/goonchem_vortex(turf/T, setting_type, volume)
-	if(setting_type)
+/**
+  * Throws or pulls objects to/from a chem reaction
+  *
+  * Scales the amount of objects thrown with the volume, unless ignore_volume is TRUE
+  *
+  * Arguments:
+  * * T - The turf to use as the throw from/to point
+  * * pull - Do we want to pull objects towards T (TRUE) or push them away from it (FALSE)
+  * * volume - The volume of reagents. Used to scale the effect is ignore_volume = FALSE
+  * * ignore_volume - Do we want to ignore the volume of reagents and just throw regardless
+  */
+/proc/goonchem_vortex(turf/T, pull, volume, ignore_volume = FALSE)
+	if(pull)
 		new /obj/effect/temp_visual/implosion(T)
 		playsound(T, 'sound/effects/whoosh.ogg', 25, 1) //credit to Robinhood76 of Freesound.org for this.
 	else
@@ -64,14 +75,15 @@
 	var/units_per_atom = 5
 	var/atoms_to_move = round(volume / units_per_atom)
 	var/moved_count = 0
-	for(var/atom/movable/X in view(2 + setting_type  + (volume > 30 ? 1 : 0), T))
+	// The ternary below isnt exactly needed, but it makes code more readable because `pull` is a bool
+	for(var/atom/movable/X in view(2 + (pull ? 1 : 0)  + (volume > 30 ? 1 : 0), T))
 		if(istype(X, /obj/effect))
 			continue  //stop pulling smoke and hotspots please
 		if(X && !X.anchored && X.move_resist <= MOVE_FORCE_DEFAULT)
-			if(setting_type)
+			if(pull)
 				X.throw_at(T, 20 + round(volume * 2), 1 + round(volume / 10))
 			else
 				X.throw_at(get_edge_target_turf(T, get_dir(T, X)), 20 + round(volume * 2), 1 + round(volume / 10))
 			moved_count++
-			if(moved_count >= atoms_to_move)
+			if((moved_count >= atoms_to_move) && !ignore_volume)
 				break

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -60,6 +60,10 @@
 	else
 		new /obj/effect/temp_visual/shockwave(T)
 		playsound(T, 'sound/effects/bang.ogg', 25, 1)
+	// PARADISE EDIT: Allow only a certain amount of atoms to be pulled per unit
+	var/units_per_atom = 5
+	var/atoms_to_move = round(volume / units_per_atom)
+	var/moved_count = 0
 	for(var/atom/movable/X in view(2 + setting_type  + (volume > 30 ? 1 : 0), T))
 		if(istype(X, /obj/effect))
 			continue  //stop pulling smoke and hotspots please
@@ -68,3 +72,6 @@
 				X.throw_at(T, 20 + round(volume * 2), 1 + round(volume / 10))
 			else
 				X.throw_at(get_edge_target_turf(T, get_dir(T, X)), 20 + round(volume * 2), 1 + round(volume / 10))
+			moved_count++
+			if(moved_count >= atoms_to_move)
+				break

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -104,7 +104,7 @@
 	var/turf/T = get_turf(holder.my_atom)
 	if(!T)
 		return
-	goonchem_vortex(T, 0, created_volume)
+	goonchem_vortex(T, FALSE, created_volume)
 
 /datum/chemical_reaction/sorium_explosion/sorium
 	name = "sorium_vortex"
@@ -133,7 +133,7 @@
 	var/turf/simulated/T = get_turf(holder.my_atom)
 	if(!T)
 		return
-	goonchem_vortex(T, 1, created_volume)
+	goonchem_vortex(T, TRUE, created_volume)
 
 /datum/chemical_reaction/ldm_implosion/liquid_dark_matter
 	name = "LDM Vortex"


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so sorium and LDM can only launch/pull 1 atom per 5 units of reagent created

## Why It's Good For The Game
You shouldn't be able to launch 20 hatchets into a blob and only use 1 unit of the reagent, to create instakill cheese devices with advanced release grenades. Its awful.

## Changelog
:cl: AffectedArc07
tweak: Sorium and Liquid Dark Matter now limit the amount of atoms (objects and mobs) they can throw, requiring 5 units of each reagent per atom thrown/pulled.
/:cl:
