### PR TITLE
Fixes syndicate teleporter saving throw bug

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -273,20 +273,20 @@ effective or pretty fucking useless.
 /obj/item/teleporter/proc/dir_correction(mob/user) //Direction movement, screws with teleport distance and saving throw, and thus must be removed first
 	var/temp_direction = user.dir
 	switch(temp_direction)
-		if(NORTHEAST || SOUTHEAST)
+		if(NORTHEAST, SOUTHEAST)
 			user.dir = EAST
-		if(NORTHWEST || SOUTHWEST)
+		if(NORTHWEST, SOUTHWEST)
 			user.dir = WEST
 
 /obj/item/teleporter/proc/panic_teleport(mob/user, turf/destination, direction = NORTH)
 	var/saving_throw
 	switch(direction)
-		if(NORTH || SOUTH)
+		if(NORTH, SOUTH)
 			if(prob(50))
 				saving_throw = EAST
 			else
 				saving_throw = WEST
-		if(EAST || WEST)
+		if(EAST, WEST)
 			if(prob(50))
 				saving_throw = NORTH
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Makes the syndicate teleporter switch for the saving throw work in the directions south and west.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs / broken code bad

## Changelog
:cl:
fix: Fixed syndicate teleporter saving teleport not working as intended in some directions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
