### PR TITLE
Remove the chance for cargo shipments to lose items.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -143,7 +143,6 @@
 
 #define MANIFEST_ERROR_NAME		1
 #define MANIFEST_ERROR_COUNT	2
-#define MANIFEST_ERROR_ITEM		4
 
 //Turf wet states
 #define TURF_DRY		0

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -78,8 +78,6 @@
 			errors |= MANIFEST_ERROR_COUNT
 		if(prob(5))
 			errors |= MANIFEST_ERROR_NAME
-		if(prob(5))
-			errors |= MANIFEST_ERROR_ITEM
 		SO.createObject(T, errors)
 
 	SSshuttle.shoppinglist.Cut()
@@ -130,8 +128,6 @@
 								msg += "Destination station incorrect. "
 							else if(slip.erroneous & MANIFEST_ERROR_COUNT)
 								msg += "Packages incorrectly counted. "
-							else if(slip.erroneous & MANIFEST_ERROR_ITEM)
-								msg += "Package incomplete. "
 							msg += "Points refunded.<br>"
 						else if(!slip.erroneous && !denied) // Approving a proper order awards the relatively tiny points_per_slip
 							SSshuttle.points += SSshuttle.points_per_slip
@@ -143,8 +139,6 @@
 									msg += "Destination station incorrect."
 								else if(slip.erroneous & MANIFEST_ERROR_COUNT)
 									msg += "Packages incorrectly counted."
-								else if(slip.erroneous & MANIFEST_ERROR_ITEM)
-									msg += "We found unshipped items on our dock."
 								msg += "  Be more vigilant.<br>"
 							else
 								pointsEarned = round(SSshuttle.points_per_crate - slip.points)
@@ -345,16 +339,6 @@
 		if(CritCrate.content_mob)
 			var/mob/crittername = CritCrate.content_mob
 			slip.info += "<li>[initial(crittername.name)]</li>"
-
-	if((errors & MANIFEST_ERROR_ITEM))
-		//secure and large crates cannot lose items
-		if(findtext("[object.containertype]", "/secure/") || findtext("[object.containertype]","/largecrate/"))
-			errors &= ~MANIFEST_ERROR_ITEM
-		else
-			var/lostAmt = max(round(Crate.contents.len/10), 1)
-			//lose some of the items
-			while(--lostAmt >= 0)
-				qdel(pick(Crate.contents))
 
 	//manifest finalisation
 	slip.info += "</ul><br>"


### PR DESCRIPTION
## What Does This PR Do

This PR removes the chance for cargo shipments to lose items.

## Why It's Good For The Game

Losing shipment items has no benefit and is not fun. Cargo on Paradise is already a mess of logistics, people moving in and out of the office, crates being dragged around, wrapped, mailed, manifests, requests, and stamping, etc. Losing shipment items is not anything that can be prevented by the crew, and only serves to frustrate both cargo and the crew waiting for their items.

The other two random events, wrong station and wrong crate count, are both fine to keep, since they don't result in the loss of any expected items, just a handful of cargo points, which is never noticed once disks come. Wrong station crates are simply rejected and sent back, and wrong count only changes the content of the manifest, not any of the shipped crates.

## Changelog
:cl:
del: Cargo items will no longer be lost in transit.
/:cl:
