### PR TITLE
'Fit Viewport' & Scoreboard refactor

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -33,8 +33,9 @@ GLOBAL_VAR_INIT(gravity_is_on, 1) //basically unused, just one admin verb..
 // Recall time limit:  2 hours
 GLOBAL_VAR_INIT(recall_time_limit, 72000) //apparently used for the comm console
 
-//////SCORE STUFF
+//////SCORE STUFF // TODO: Refactor to use less globals
 //Goonstyle scoreboard
+GLOBAL_VAR_INIT(scoreboard, null) // Variable to save the scoreboard string once it's been generated
 GLOBAL_VAR_INIT(score_crewscore, 0) // this is the overall var/score for the whole round
 GLOBAL_VAR_INIT(score_stuffshipped, 0) // how many useful items have cargo shipped out?
 GLOBAL_VAR_INIT(score_stuffharvested, 0) // how many harvests have hydroponics done?

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -33,45 +33,6 @@ GLOBAL_VAR_INIT(gravity_is_on, 1) //basically unused, just one admin verb..
 // Recall time limit:  2 hours
 GLOBAL_VAR_INIT(recall_time_limit, 72000) //apparently used for the comm console
 
-//////SCORE STUFF // TODO: Refactor to use less globals
-//Goonstyle scoreboard
-GLOBAL_VAR_INIT(scoreboard, null) // Variable to save the scoreboard string once it's been generated
-GLOBAL_VAR_INIT(score_crewscore, 0) // this is the overall var/score for the whole round
-GLOBAL_VAR_INIT(score_stuffshipped, 0) // how many useful items have cargo shipped out?
-GLOBAL_VAR_INIT(score_stuffharvested, 0) // how many harvests have hydroponics done?
-GLOBAL_VAR_INIT(score_oremined, 0) // obvious
-GLOBAL_VAR_INIT(score_researchdone, 0)
-GLOBAL_VAR_INIT(score_eventsendured, 0) // how many random events did the station survive?
-GLOBAL_VAR_INIT(score_powerloss, 0) // how many APCs have poor charge?
-GLOBAL_VAR_INIT(score_escapees, 0) // how many people got out alive?
-GLOBAL_VAR_INIT(score_deadcrew, 0) // dead bodies on the station, oh no
-GLOBAL_VAR_INIT(score_mess, 0) // how much poo, puke, gibs, etc went uncleaned
-GLOBAL_VAR_INIT(score_meals, 0)
-GLOBAL_VAR_INIT(score_disease, 0) // how many rampant, uncured diseases are on board the station
-GLOBAL_VAR_INIT(score_deadcommand, 0) // used during rev, how many command staff perished
-GLOBAL_VAR_INIT(score_arrested, 0) // how many traitors/revs/whatever are alive in the brig
-GLOBAL_VAR_INIT(score_traitorswon, 0) // how many traitors were successful?
-GLOBAL_VAR_INIT(score_allarrested, 0) // did the crew catch all the enemies alive?
-GLOBAL_VAR_INIT(score_opkilled, 0) // used during nuke mode, how many operatives died?
-GLOBAL_VAR_INIT(score_disc, 0) // is the disc safe and secure?
-GLOBAL_VAR_INIT(score_nuked, 0) // was the station blown into little bits?
-GLOBAL_VAR_INIT(score_nuked_penalty, 0) //penalty for getting blown to bits
-
-	// these ones are mainly for the stat panel
-GLOBAL_VAR_INIT(score_powerbonus, 0) // if all APCs on the station are running optimally, big bonus
-GLOBAL_VAR_INIT(score_messbonus, 0) // if there are no messes on the station anywhere, huge bonus
-GLOBAL_VAR_INIT(score_deadaipenalty, 0) // is the AI dead? if so, big penalty
-GLOBAL_VAR_INIT(score_foodeaten, 0) // nom nom nom
-GLOBAL_VAR_INIT(score_clownabuse, 0) // how many times a clown was punched, struck or otherwise maligned
-GLOBAL_VAR(score_richestname) // this is all stuff to show who was the richest alive on the shuttle
-GLOBAL_VAR(score_richestjob)  // kinda pointless if you dont have a money system i guess
-GLOBAL_VAR_INIT(score_richestcash, 0)
-GLOBAL_VAR(score_richestkey)
-GLOBAL_VAR(score_dmgestname) // who had the most damage on the shuttle (but was still alive)
-GLOBAL_VAR(score_dmgestjob)
-GLOBAL_VAR_INIT(score_dmgestdamage, 0)
-GLOBAL_VAR(score_dmgestkey)
-
 #define TAB "&nbsp;&nbsp;&nbsp;&nbsp;"
 
 GLOBAL_VAR_INIT(timezoneOffset, 0) // The difference betwen midnight (of the host computer) and 0 world.ticks.

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -61,6 +61,8 @@ SUBSYSTEM_DEF(ticker)
 	var/end_state = "undefined"
 	/// Time the real reboot kicks in
 	var/real_reboot_time = 0
+	/// Datum used to generate the end of round scoreboard.
+	var/datum/scoreboard/score = null
 
 /datum/controller/subsystem/ticker/Initialize()
 	login_music = pick(\
@@ -136,6 +138,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/setup()
 	cultdat = setupcult()
+	score = new()
 
 	// Create and announce mode
 	if(GLOB.master_mode == "secret")
@@ -482,7 +485,8 @@ SUBSYSTEM_DEF(ticker)
 		if(findtext("[handler]","auto_declare_completion_"))
 			call(mode, handler)()
 
-	scoreboard()
+	// Display the scoreboard window
+	score.scoreboard()
 
 	// Declare the completion of the station goals
 	mode.declare_station_goal_completion()

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -439,54 +439,55 @@
 	return newname
 
 
-/datum/game_mode/nuclear/set_scoreboard_gvars()
+/datum/game_mode/nuclear/set_scoreboard_vars()
+	var/datum/scoreboard/scoreboard = SSticker.score
 	var/foecount = 0
+
 	for(var/datum/mind/M in SSticker.mode.syndicates)
 		foecount++
 		if(!M || !M.current)
-			GLOB.score_opkilled++
+			scoreboard.score_ops_killed++
 			continue
 
 		if(M.current.stat == DEAD)
-			GLOB.score_opkilled++
+			scoreboard.score_ops_killed++
 
 		else if(M.current.restrained())
-			GLOB.score_arrested++
+			scoreboard.score_arrested++
 
-	if(foecount == GLOB.score_arrested)
-		GLOB.score_allarrested = 1
+	if(foecount == scoreboard.score_arrested)
+		scoreboard.all_arrested = TRUE // how the hell did they manage that
 
-	for(var/obj/machinery/nuclearbomb/nuke in GLOB.machines)
-		if(nuke.r_code == "Nope")	continue
+	var/obj/machinery/nuclearbomb/syndicate/nuke = locate() in GLOB.poi_list
+	if(nuke?.r_code != "Nope")
 		var/area/A = get_area(nuke)
 
 		var/list/thousand_penalty = list(/area/solar)
 		var/list/fiftythousand_penalty = list(/area/security/main, /area/security/brig, /area/security/armoury, /area/security/checkpoint2)
 
 		if(is_type_in_list(A, thousand_penalty))
-			GLOB.score_nuked_penalty = 1000
+			scoreboard.nuked_penalty = 1000
 
 		else if(is_type_in_list(A, fiftythousand_penalty))
-			GLOB.score_nuked_penalty = 50000
+			scoreboard.nuked_penalty = 50000
 
 		else if(istype(A, /area/engine))
-			GLOB.score_nuked_penalty = 100000
+			scoreboard.nuked_penalty = 100000
 
 		else
-			GLOB.score_nuked_penalty = 10000
+			scoreboard.nuked_penalty = 10000
 
-		break
-
-		var/killpoints = GLOB.score_opkilled * 250
-		var/arrestpoints = GLOB.score_arrested * 1000
-		GLOB.score_crewscore += killpoints
-		GLOB.score_crewscore += arrestpoints
-		if(GLOB.score_nuked)
-			GLOB.score_crewscore -= GLOB.score_nuked_penalty
+	var/killpoints = scoreboard.score_ops_killed * 250
+	var/arrestpoints = scoreboard.score_arrested * 1000
+	scoreboard.crewscore += killpoints
+	scoreboard.crewscore += arrestpoints
+	if(scoreboard.nuked)
+		scoreboard.crewscore -= scoreboard.nuked_penalty
 
 
 
 /datum/game_mode/nuclear/get_scoreboard_stats()
+	var/datum/scoreboard/scoreboard = SSticker.score
 	var/foecount = 0
 	var/crewcount = 0
 
@@ -533,11 +534,11 @@
 
 	dat += "<br>"
 
-	dat += "<b>Operatives Arrested:</b> [GLOB.score_arrested] ([GLOB.score_arrested * 1000] Points)<br>"
-	dat += "<b>All Operatives Arrested:</b> [GLOB.score_allarrested ? "Yes" : "No"] (Score tripled)<br>"
+	dat += "<b>Operatives Arrested:</b> [scoreboard.score_arrested] ([scoreboard.score_arrested * 1000] Points)<br>"
+	dat += "<b>All Operatives Arrested:</b> [scoreboard.all_arrested ? "Yes" : "No"] (Score tripled)<br>"
 
-	dat += "<b>Operatives Killed:</b> [GLOB.score_opkilled] ([GLOB.score_opkilled * 1000] Points)<br>"
-	dat += "<b>Station Destroyed:</b> [GLOB.score_nuked ? "Yes" : "No"] (-[GLOB.score_nuked_penalty] Points)<br>"
+	dat += "<b>Operatives Killed:</b> [scoreboard.score_ops_killed] ([scoreboard.score_ops_killed * 1000] Points)<br>"
+	dat += "<b>Station Destroyed:</b> [scoreboard.nuked ? "Yes" : "No"] (-[scoreboard.nuked_penalty] Points)<br>"
 	dat += "<hr>"
 
 	return dat

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -370,44 +370,45 @@
 		text += "<br>"
 		to_chat(world, text)
 
-/datum/game_mode/revolution/set_scoreboard_gvars()
+/datum/game_mode/revolution/set_scoreboard_vars()
+	var/datum/scoreboard/scoreboard = SSticker.score
 	var/foecount = 0
+
 	for(var/datum/mind/M in SSticker.mode.head_revolutionaries)
 		foecount++
 		if(!M || !M.current)
-			GLOB.score_opkilled++
+			scoreboard.score_ops_killed++
 			continue
 
 		if(M.current.stat == DEAD)
-			GLOB.score_opkilled++
+			scoreboard.score_ops_killed++
 
 		else if(M.current.restrained())
-			GLOB.score_arrested++
+			scoreboard.score_arrested++
 
-	if(foecount == GLOB.score_arrested)
-		GLOB.score_allarrested = 1
+	if(foecount == scoreboard.score_arrested)
+		scoreboard.all_arrested = TRUE
 
-	for(var/thing in GLOB.human_list)
-		var/mob/living/carbon/human/player = thing
-		if(player.mind)
-			var/role = player.mind.assigned_role
-			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director"))
-				if(player.stat == DEAD)
-					GLOB.score_deadcommand++
+	for(var/I in GLOB.human_list)
+		var/mob/living/carbon/human/H = I
+		if(H.stat == DEAD && H.mind?.assigned_role)
+			if(H.mind.assigned_role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director"))
+				scoreboard.score_dead_command++
 
 
-	var/arrestpoints = GLOB.score_arrested * 1000
-	var/killpoints = GLOB.score_opkilled * 500
-	var/comdeadpts = GLOB.score_deadcommand * 500
-	if(GLOB.score_traitorswon)
-		GLOB.score_crewscore -= 10000
+	var/arrestpoints = scoreboard.score_arrested * 1000
+	var/killpoints = scoreboard.score_ops_killed * 500
+	var/comdeadpts = scoreboard.score_dead_command * 500
+	if(scoreboard.score_greentext)
+		scoreboard.crewscore -= 10000
 
-	GLOB.score_crewscore += arrestpoints
-	GLOB.score_crewscore += killpoints
-	GLOB.score_crewscore -= comdeadpts
+	scoreboard.crewscore += arrestpoints
+	scoreboard.crewscore += killpoints
+	scoreboard.crewscore -= comdeadpts
 
 
 /datum/game_mode/revolution/get_scoreboard_stats()
+	var/datum/scoreboard/scoreboard = SSticker.score
 	var/foecount = 0
 	var/comcount = 0
 	var/revcount = 0
@@ -444,12 +445,12 @@
 	dat += "<b>Number of Surviving Loyal Crew:</b> [loycount]<br>"
 
 	dat += "<br>"
-	dat += "<b>Revolution Heads Arrested:</b> [GLOB.score_arrested] ([GLOB.score_arrested * 1000] Points)<br>"
-	dat += "<b>All Revolution Heads Arrested:</b> [GLOB.score_allarrested ? "Yes" : "No"] (Score tripled)<br>"
+	dat += "<b>Revolution Heads Arrested:</b> [scoreboard.score_arrested] ([scoreboard.score_arrested * 1000] Points)<br>"
+	dat += "<b>All Revolution Heads Arrested:</b> [scoreboard.all_arrested ? "Yes" : "No"] (Score tripled)<br>"
 
-	dat += "<b>Revolution Heads Slain:</b> [GLOB.score_opkilled] ([GLOB.score_opkilled * 500] Points)<br>"
-	dat += "<b>Command Staff Slain:</b> [GLOB.score_deadcommand] (-[GLOB.score_deadcommand * 500] Points)<br>"
-	dat += "<b>Revolution Successful:</b> [GLOB.score_traitorswon ? "Yes" : "No"] (-[GLOB.score_traitorswon * 10000] Points)<br>"
+	dat += "<b>Revolution Heads Slain:</b> [scoreboard.score_ops_killed] ([scoreboard.score_ops_killed * 500] Points)<br>"
+	dat += "<b>Command Staff Slain:</b> [scoreboard.score_dead_command] (-[scoreboard.score_dead_command * 500] Points)<br>"
+	dat += "<b>Revolution Successful:</b> [scoreboard.score_greentext ? "Yes" : "No"] (-[scoreboard.score_greentext * 10000] Points)<br>"
 	dat += "<HR>"
 
 	return dat

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -152,12 +152,8 @@
 	GLOB.score_crewscore -= messpoints
 	GLOB.score_crewscore -= plaguepoints
 
-	// Show the score - might add "ranks" later
-	to_chat(world, "<b>The crew's final score is:</b>")
-	to_chat(world, "<b><font size='4'>[GLOB.score_crewscore]</font></b>")
-
 	// Generate the score panel
-	var/dat = "<b>Round Statistics and Score</b><br><hr>"
+	var/list/dat = list("<b>Round Statistics and Score</b><br><hr>")
 	if(mode)
 		dat += mode.get_scoreboard_stats()
 
@@ -214,11 +210,14 @@
 		if(NANOTRANSEN_FINEST to INFINITY) score_rating = 							"Nanotrasen's Finest"
 
 	dat += "<b><u>RATING:</u></b> [score_rating]"
-	src << browse(dat, "window=roundstats;size=500x600")
+	GLOB.scoreboard = jointext(dat, "")
 
 	for(var/mob/E in GLOB.player_list)
-		if(E.client && !E.get_preference(PREFTOGGLE_DISABLE_SCOREBOARD))
-			E << browse(dat, "window=roundstats;size=500x600")
+		if(E.client)
+			to_chat(E, "<b>The crew's final score is:</b>")
+			to_chat(E, "<b><font size='4'><a href='?src=[E.UID()];scoreboard=1'>[GLOB.score_crewscore]</a></font></b>")
+			if(!E.get_preference(PREFTOGGLE_DISABLE_SCOREBOARD))
+				E << browse(GLOB.scoreboard, "window=roundstats;size=500x600")
 
 // A recursive function to properly determine the wealthiest escapee
 /datum/controller/subsystem/ticker/proc/get_score_container_worth(atom/C, level=0)

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -1,3 +1,5 @@
+GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been generated
+
 //Thresholds for Score Ratings
 #define SINGULARITY_DESERVES_BETTER -3500
 #define SINGULARITY_FODDER -3000
@@ -14,186 +16,275 @@
 #define PRIDE_OF_SCIENCE 4000
 #define NANOTRANSEN_FINEST 5000
 
-/datum/controller/subsystem/ticker/proc/scoreboard()
-	//Print a list of antagonists to the server log
+/datum/scoreboard
+	/// Overall combined score for the whole round.
+	var/crewscore = 0
+	/// How many useful items have cargo shipped out?
+	var/score_things_shipped = 0
+	/// How many harvests have hydroponics done?
+	var/score_things_harvested = 0
+	/// How much ore has been mined on the mining z level?
+	var/score_ore_mined = 0
+	/// How much research was done by science?
+	var/score_research_done = 0
+	/// How many random events did the station survive?
+	var/score_events_endured = 0
+	/// How many APCs have poor charge?
+	var/score_power_loss = 0
+	/// How many people got out alive?
+	var/score_escapees = 0
+	/// How many people /didn't/ get out alive?
+	var/score_dead_crew = 0
+	/// How much blood, puke, stains etc went uncleaned?
+	var/score_mess = 0
+	/// How many meals were made?
+	var/score_meals = 0
+	/// How many rampant, uncured diseases are on board the station?
+	var/score_disease = 0
+	/// How many command members died? (Revolution)
+	var/score_dead_command = 0
+	/// How many antagonists are alive in the brig? (Nuke ops & Revolution)
+	var/score_arrested = 0
+	/// How many operatives were killed? (Nuke ops & Revolution)
+	var/score_ops_killed = 0
+	/// How much noms were had by the crew?
+	var/score_food_eaten = 0
+	/// How many times was the clown punched, struck, or otherwise maligned?
+	var/score_clown_abuse = 0
+
+	// Booleans //
+	/// Were the antagonists successful?
+	var/score_greentext = FALSE
+	/// Did the crew catch all of the antags alive?
+	var/all_arrested = FALSE
+	/// Is the NAD safe and secure?
+	var/disc_secure = FALSE
+
+	// Points penalties/bonuses //
+	/// If all APCs on the station are running optimally, big bonus.
+	var/power_bonus = FALSE
+	/// If there are no messes on the station anywhere, huge bonus.
+	var/mess_bonus = FALSE
+	/// If the AI is dead, big points penalty.
+	var/dead_ai = FALSE
+	/// Was the station blown into little bits?
+	var/nuked = FALSE
+	/// Points penalty for being blown to little bits.
+	var/nuked_penalty = 0
+
+	// Player Stats //
+	/// What was the name of the richest person on the shuttle?
+	var/richest_name = ""
+	/// What was the ckey of the richest person on the shuttle?
+	var/richest_key = ""
+	/// What was the job of the richest person on the shuttle?
+	var/richest_job = ""
+	/// How much money did the richest person on the shuttle have?
+	var/richest_cash = 0
+
+	/// What was the name of the most injured person on the shuttle?
+	var/damaged_name
+	/// What was the ckey of the most injured person on the shuttle?
+	var/damaged_key
+	/// What was the job of the most injured person on the shuttle?
+	var/damaged_job
+	/// How damaged was the most injured person on the shuttle?
+	var/damaged_health
+
+
+/datum/scoreboard/proc/scoreboard()
+	// Print a list of antagonists to the server log.
+	log_antags()
+
+	for(var/_I in GLOB.mob_list)
+		var/mob/M = _I
+		if(is_station_level(M.z))
+			check_station_player(M)
+		else if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME && istype(get_area(M), SSshuttle.emergency.areaInstance))
+			check_shuttle_player(M)
+
+	check_apc_power()
+	check_cleanables()
+
+	generate_scoreboard()
+
+/datum/scoreboard/proc/log_antags()
 	var/list/total_antagonists = list()
-	//Look into all mobs in world, dead or alive
-	for(var/datum/mind/Mind in SSticker.minds)
-		var/temprole = Mind.special_role
-		if(temprole)							//if they are an antagonist of some sort.
-			if(temprole in total_antagonists)	//If the role exists already, add the name to it
-				total_antagonists[temprole] += ", [Mind.name]([Mind.key])"
-			else
-				total_antagonists.Add(temprole) //If the role doesnt exist in the list, create it and add the mob
-				total_antagonists[temprole] += ": [Mind.name]([Mind.key])"
+	// Look into all mobs in the world, dead or alive
+	for(var/mind in SSticker.minds)
+		var/datum/mind/M = mind
+		var/role = M.special_role
 
-	//Now print them all into the log!
+		// If they're an antagonist of some sort.
+		if(role)
+			if(total_antagonists[role]) // If the role exists already, add the name to it.
+				total_antagonists[role] += ", [M.name]([M.key])"
+			else // If the role doesn't exist in the list, create it and add the mob
+				total_antagonists[role] += ": [M.name]([M.key])"
+
+	// Now print them all into the log!
 	log_game("Antagonists at round end were...")
-	for(var/i in total_antagonists)
-		log_game("[i]s[total_antagonists[i]].")
-
-	// Score Calculation and Display
-
-	// Who is alive/dead, who escaped
-	for(var/mob/living/silicon/ai/I in GLOB.mob_list)
-		if(I.stat == DEAD && is_station_level(I.z))
-			GLOB.score_deadaipenalty++
-			GLOB.score_deadcrew++
-
-	for(var/thing in GLOB.human_list)
-		var/mob/living/carbon/human/I = thing
-		if(I.stat == DEAD && is_station_level(I.z))
-			GLOB.score_deadcrew++
-
-	if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME)
-		for(var/mob/living/player in GLOB.mob_list)
-			if(player.client)
-				if(player.stat != DEAD)
-					var/turf/location = get_turf(player.loc)
-					var/area/escape_zone = locate(/area/shuttle/escape)
-					if(location in escape_zone)
-						GLOB.score_escapees++
+	for(var/I in total_antagonists)
+		log_game("[I]s[total_antagonists[I]].")
 
 
+/datum/scoreboard/proc/check_station_player(mob/M)
+	if(!is_station_level(M.z) || M.stat < DEAD)
+		return
+	if(isAI(M))
+		dead_ai = TRUE
+		score_dead_crew++
+	else if(ishuman(M))
+		score_dead_crew++
 
-	var/cash_score = 0
-	var/dmg_score = 0
+/datum/scoreboard/proc/check_shuttle_player(mob/M)
+	if(!M.mind || M.stat == DEAD || !ishuman(M))
+		return
+	var/mob/living/carbon/human/H = M
 
-	if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME)
-		for(var/thing in GLOB.human_list)
-			var/mob/living/carbon/human/E = thing
-			cash_score = 0
-			dmg_score = 0
-			var/turf/location = get_turf(E.loc)
-			var/area/escape_zone = SSshuttle.emergency.areaInstance
+	score_escapees++
 
-			if(E.stat != DEAD && (location in escape_zone)) // Escapee Scores
-				cash_score = get_score_container_worth(E)
+	var/cash_score = get_score_container_worth(H)
+	if(cash_score > richest_cash)
+		richest_cash = cash_score
+		richest_name = H.real_name
+		richest_job = H.job
+		richest_key = H.key
 
-				if(cash_score > GLOB.score_richestcash)
-					GLOB.score_richestcash = cash_score
-					GLOB.score_richestname = E.real_name
-					GLOB.score_richestjob = E.job
-					GLOB.score_richestkey = E.key
+	var/damage_score = H.getBruteLoss() + H.getFireLoss() + H.getToxLoss() + H.getOxyLoss()
+	if(damage_score > damaged_health)
+		damaged_health = damage_score
+		damaged_name = H.real_name
+		damaged_job = H.job
+		damaged_key = H.key
 
-				dmg_score = E.getBruteLoss() + E.getFireLoss() + E.getToxLoss() + E.getOxyLoss()
-				if(dmg_score > GLOB.score_dmgestdamage)
-					GLOB.score_dmgestdamage = dmg_score
-					GLOB.score_dmgestname = E.real_name
-					GLOB.score_dmgestjob = E.job
-					GLOB.score_dmgestkey = E.key
+// A recursive function to properly determine the wealthiest escapee
+/datum/scoreboard/proc/get_score_container_worth(atom/C, level = 0)
+	. = 0
+	if(level >= 5)
+		// in case the containers recurse or something
+		return 0
 
-	if(SSticker && SSticker.mode)
-		SSticker.mode.set_scoreboard_gvars()
+	for(var/obj/item/card/id/id in C.contents)
+		var/datum/money_account/A = get_money_account(id.associated_account_number)
+		// has an account?
+		if(A)
+			. += A.money
+	for(var/obj/item/stack/spacecash/cash in C.contents)
+		. += cash.amount
+	for(var/obj/item/storage/S in C.contents)
+		. += .(S, level + 1)
 
+/datum/scoreboard/proc/check_apc_power()
+	for(var/_A in GLOB.apcs)
+		var/obj/machinery/power/apc/A = _A
+		if(!is_station_level(A.z))
+			continue
+		var/obj/item/stock_parts/cell/C = A.cell
+		if(!C || C.charge < 2300)
+			score_power_loss++ //200 charge leeway
 
-	// Check station's power levels
-	for(var/thing in GLOB.apcs)
-		var/obj/machinery/power/apc/A = thing
-		if(!is_station_level(A.z)) continue
-		for(var/obj/item/stock_parts/cell/C in A.contents)
-			if(C.charge < 2300)
-				GLOB.score_powerloss++ //200 charge leeway
-
-
-	// Check how much uncleaned mess is on the station
-	for(var/obj/effect/decal/cleanable/M in world)
-		if(!is_station_level(M.z)) continue
-		if(istype(M, /obj/effect/decal/cleanable/blood/gibs))
-			GLOB.score_mess += 3
-
-		if(istype(M, /obj/effect/decal/cleanable/blood))
-			GLOB.score_mess += 1
-
-		if(istype(M, /obj/effect/decal/cleanable/vomit))
-			GLOB.score_mess += 1
-
-
-	// Bonus Modifiers
-	var/deathpoints = GLOB.score_deadcrew * 25 //done
-	var/researchpoints = GLOB.score_researchdone * 30
-	var/eventpoints = GLOB.score_eventsendured * 50
-	var/escapoints = GLOB.score_escapees * 25 //done
-	var/harvests = GLOB.score_stuffharvested * 5
-	var/shipping = GLOB.score_stuffshipped * 5
-	var/mining = GLOB.score_oremined * 2 //done, might want polishing
-	var/meals = GLOB.score_meals * 5
-	var/power = GLOB.score_powerloss * 20
-	var/messpoints
-	if(GLOB.score_mess != 0)
-		messpoints = GLOB.score_mess //done
-	var/plaguepoints = GLOB.score_disease * 30
+/datum/scoreboard/proc/check_cleanables()
+	for(var/obj/effect/decal/cleanable/C in world)
+		if(!is_station_level(C.z))
+			continue
+		if(istype(C, /obj/effect/decal/cleanable/blood/gibs))
+			score_mess += 3
+		else if(istype(C, /obj/effect/decal/cleanable/blood))
+			score_mess += 1
+		else if(istype(C, /obj/effect/decal/cleanable/vomit))
+			score_mess += 1
 
 
-	// Good Things
-	GLOB.score_crewscore += shipping
-	GLOB.score_crewscore += harvests
-	GLOB.score_crewscore += mining
-	GLOB.score_crewscore += researchpoints
-	GLOB.score_crewscore += eventpoints
-	GLOB.score_crewscore += escapoints
+/datum/scoreboard/proc/generate_scoreboard()
+	// Point modifiers
+	var/points_events_endured = score_events_endured	 * 50
+	var/points_research_done = score_research_done		 * 30
+	var/points_disease = score_disease					 * 30
+	var/points_dead_crew = score_dead_crew				 * 25
+	var/points_escapees = score_escapees				 * 25
+	var/points_power_loss = score_power_loss			 * 20
+	var/points_things_harvested = score_things_harvested * 5
+	var/points_things_shipped = score_things_shipped	 * 5
+	var/points_meals = score_meals						 * 5
+	var/points_ore_mined = score_ore_mined				 * 2
 
-	if(power == 0)
-		GLOB.score_crewscore += 2500
-		GLOB.score_powerbonus = 1
+	// Bonuses
+	crewscore += points_events_endured
+	crewscore += points_research_done
+	crewscore += points_escapees
+	crewscore += points_things_harvested
+	crewscore += points_things_shipped
+	crewscore += points_meals
+	crewscore += points_ore_mined
 
+	if(!score_power_loss)
+		crewscore += 2500
+		power_bonus = TRUE
 
-	GLOB.score_crewscore += meals
-	if(GLOB.score_allarrested) // This only seems to be implemented for Rev and Nukies. -DaveKorhal
-		GLOB.score_crewscore *= 3 // This needs to be here for the bonus to be applied properly
+	if(!score_mess)
+		crewscore += 1500
+		mess_bonus = TRUE
 
+	if(all_arrested) // This only seems to be implemented for Rev and Nukies. -DaveKorhal
+		crewscore *= 3 // This needs to be here for the bonus to be applied properly
 
-	GLOB.score_crewscore -= deathpoints
-	if(GLOB.score_deadaipenalty)
-		GLOB.score_crewscore -= 250
-	GLOB.score_crewscore -= power
+	// Penalties
+	crewscore -= points_dead_crew
+	crewscore -= points_power_loss
+	crewscore -= points_disease
+	crewscore -= score_mess
 
+	if(dead_ai)
+		crewscore -= 250
 
-	GLOB.score_crewscore -= messpoints
-	GLOB.score_crewscore -= plaguepoints
 
 	// Generate the score panel
 	var/list/dat = list("<b>Round Statistics and Score</b><br><hr>")
-	if(mode)
-		dat += mode.get_scoreboard_stats()
+	if(SSticker.mode)
+		dat += SSticker.mode.get_scoreboard_stats()
 
 	dat += {"
 	<b><u>General Statistics</u></b><br>
 	<u>The Good</u><br>
-	<b>Ore Mined:</b> [GLOB.score_oremined] ([GLOB.score_oremined * 2] Points)<br>"}
-	if(SSshuttle.emergency.mode == SHUTTLE_ENDGAME) dat += "<b>Shuttle Escapees:</b> [GLOB.score_escapees] ([GLOB.score_escapees * 25] Points)<br>"
-	dat += {"
-	<b>Whole Station Powered:</b> [GLOB.score_powerbonus ? "Yes" : "No"] ([GLOB.score_powerbonus * 2500] Points)<br><br>
+	<b>Ore Mined:</b> [score_ore_mined] ([points_ore_mined] Points)<br>"}
+	if(score_escapees)
+		dat += "<b>Shuttle Escapees:</b> [score_escapees] ([points_escapees] Points)<br>"
+	dat += "<b>Whole Station Powered:</b> [power_bonus ? "Yes" : "No"] ([power_bonus * 2500] Points)<br>"
+	dat += "<b>Whole Station Cleaned:</b> [mess_bonus ? "Yes" : "No"] ([mess_bonus * 1500] Points)<br><br>"
 
-	<U>The Bad</U><br>
-	<b>Dead bodies on Station:</b> [GLOB.score_deadcrew] (-[GLOB.score_deadcrew * 25] Points)<br>
-	<b>Uncleaned Messes:</b> [GLOB.score_mess] (-[GLOB.score_mess] Points)<br>
-	<b>Station Power Issues:</b> [GLOB.score_powerloss] (-[GLOB.score_powerloss * 20] Points)<br>
-	<b>AI Destroyed:</b> [GLOB.score_deadaipenalty ? "Yes" : "No"] (-[GLOB.score_deadaipenalty * 250] Points)<br><br>
+	dat += "<U>The Bad</U><br>"
+	dat += "<b>Dead bodies on Station:</b> [score_dead_crew] (-[points_dead_crew] Points)<br>"
+	if(!mess_bonus)
+		dat += "<b>Uncleaned Messes:</b> [score_mess] (-[score_mess] Points)<br>"
+	if(!power_bonus)
+		dat += "<b>Station Power Issues:</b> [score_power_loss] (-[points_power_loss] Points)<br>"
+	dat += {"
+	<b>AI Destroyed:</b> [dead_ai ? "Yes" : "No"] (-[dead_ai * 250] Points)<br><br>
 
 	<U>The Weird</U><br>
-	<b>Food Eaten:</b> [GLOB.score_foodeaten] bites/sips<br>
-	<b>Times a Clown was Abused:</b> [GLOB.score_clownabuse]<br><br>
-	"}
-	if(GLOB.score_escapees)
-		dat += {"<b>Richest Escapee:</b> [GLOB.score_richestname], [GLOB.score_richestjob]: $[num2text(GLOB.score_richestcash,50)] ([GLOB.score_richestkey])<br>
-		<b>Most Battered Escapee:</b> [GLOB.score_dmgestname], [GLOB.score_dmgestjob]: [GLOB.score_dmgestdamage] damage ([GLOB.score_dmgestkey])<br>"}
+	<b>Food Eaten:</b> [score_food_eaten] bites/sips.<br>
+	<b>Times a Clown was Abused:</b> [score_clown_abuse]<br><br>"}
+	if(score_escapees)
+		dat += "<b>Richest Escapee:</b> [richest_name], [richest_job]: $[num2text(richest_cash, 50)] ([richest_key])<br>"
+		if(damaged_health)
+			dat += "<b>Most Battered Escapee:</b> [damaged_name], [damaged_job]: [damaged_health] damage ([damaged_key])<br>"
 	else
 		if(SSshuttle.emergency.mode <= SHUTTLE_STRANDED)
 			dat += "The station wasn't evacuated!<br>"
 		else
 			dat += "No-one escaped!<br>"
 
-	dat += mode.declare_job_completion()
+	dat += SSticker.mode.declare_job_completion()
 
 	dat += {"
 	<hr><br>
-	<b><u>FINAL SCORE: [GLOB.score_crewscore]</u></b><br>
+	<b><u>FINAL SCORE: [crewscore]</u></b><br>
 	"}
 
 	var/score_rating = "The Aristocrats!"
-	switch(GLOB.score_crewscore)
-		if(-99999 to SINGULARITY_DESERVES_BETTER) score_rating = 					"Even the Singularity Deserves Better"
+	switch(crewscore)
+		if(-INFINITY to SINGULARITY_DESERVES_BETTER) score_rating = 				"Even the Singularity Deserves Better"
 		if(SINGULARITY_DESERVES_BETTER+1 to SINGULARITY_FODDER) score_rating = 		"Singularity Fodder"
 		if(SINGULARITY_FODDER+1 to ALL_FIRED) score_rating = 						"You're All Fired"
 		if(ALL_FIRED+1 to WASTE_OF_OXYGEN) score_rating = 							"A Waste of Perfectly Good Oxygen"
@@ -215,31 +306,15 @@
 	for(var/mob/E in GLOB.player_list)
 		if(E.client)
 			to_chat(E, "<b>The crew's final score is:</b>")
-			to_chat(E, "<b><font size='4'><a href='?src=[E.UID()];scoreboard=1'>[GLOB.score_crewscore]</a></font></b>")
+			to_chat(E, "<b><font size='4'><a href='?src=[E.UID()];scoreboard=1'>[crewscore]</a></font></b>")
 			if(!E.get_preference(PREFTOGGLE_DISABLE_SCOREBOARD))
 				E << browse(GLOB.scoreboard, "window=roundstats;size=500x600")
 
-// A recursive function to properly determine the wealthiest escapee
-/datum/controller/subsystem/ticker/proc/get_score_container_worth(atom/C, level=0)
-	if(level >= 5)
-		// in case the containers recurse or something
-		return 0
-	else
-		. = 0
-		for(var/obj/item/card/id/id in C.contents)
-			var/datum/money_account/A = get_money_account(id.associated_account_number)
-			// has an account?
-			if(A)
-				. += A.money
-		for(var/obj/item/stack/spacecash/cash in C.contents)
-			. += cash.amount
-		for(var/obj/item/storage/S in C.contents)
-			. += .(S, level + 1)
 
 /datum/game_mode/proc/get_scoreboard_stats()
 	return null
 
-/datum/game_mode/proc/set_scoreboard_gvars()
+/datum/game_mode/proc/set_scoreboard_vars()
 	return null
 
 #undef SINGULARITY_DESERVES_BETTER

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -247,6 +247,70 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 			if(send)
 				to_chat(target, "<span class='ooc'><span class='looc'>LOOC<span class='prefix'>[prefix]: </span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>")
 
+
+// Ported from /tg/, full credit to SpaceManiac and Timberpoes.
+/client/verb/fit_viewport()
+	set name = "Fit Viewport"
+	set desc = "Fit the size of the map window to match the viewport."
+	set category = "OOC"
+
+	// Fetch aspect ratio
+	var/list/view_size = getviewsize(view)
+	var/aspect_ratio = view_size[1] / view_size[2]
+
+	// Calculate desired pixel width using window size and aspect ratio
+	var/list/sizes = params2list(winget(src, "mainwindow.mainvsplit;mapwindow", "size"))
+
+	// Client closed the window? Some other error? This is unexpected behaviour, let's CRASH with some info.
+	if(!sizes["mapwindow.size"])
+		CRASH("sizes does not contain mapwindow.size key. This means a winget() failed to return what we wanted. --- sizes var: [sizes] --- sizes length: [length(sizes)]")
+
+	var/list/map_size = splittext(sizes["mapwindow.size"], "x")
+
+	// Looks like we didn't expect mapwindow.size to be "ixj" where i and j are numbers.
+	// If we don't get our expected 2 outputs, let's give some useful error info.
+	if(length(map_size) != 2)
+		CRASH("map_size of incorrect length --- map_size var: [map_size] --- map_size length: [length(map_size)]")
+
+
+	var/height = text2num(map_size[2])
+	var/desired_width = round(height * aspect_ratio)
+	if(text2num(map_size[1]) == desired_width)
+		// Nothing to do.
+		return
+
+	var/list/split_size = splittext(sizes["mainwindow.mainvsplit.size"], "x")
+	var/split_width = text2num(split_size[1])
+
+	// Avoid auto-resizing the statpanel and chat into nothing.
+	desired_width = min(desired_width, split_width - 300)
+
+	// Calculate and apply a best estimate
+	// +4 pixels are for the width of the splitter's handle
+	var/pct = 100 * (desired_width + 4) / split_width
+	winset(src, "mainwindow.mainvsplit", "splitter=[pct]")
+
+	// Apply an ever-lowering offset until we finish or fail
+	var/delta
+	for(var/safety in 1 to 10)
+		var/after_size = winget(src, "mapwindow", "size")
+		map_size = splittext(after_size, "x")
+		var/produced_width = text2num(map_size[1])
+
+		if(produced_width == desired_width)
+			// Success!
+			return
+		else if(isnull(delta))
+			// Calculate a probably delta based on the difference
+			delta = 100 * (desired_width - produced_width) / split_width
+		else if((delta > 0 && produced_width > desired_width) || (delta < 0 && produced_width < desired_width))
+			// If we overshot, halve the delta and reverse direction
+			delta = -delta / 2
+
+	pct += delta
+	winset(src, "mainwindow.mainvsplit", "splitter=[pct]")
+
+
 /mob/proc/get_looc_source()
 	return src
 

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -73,7 +73,7 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(H.mind && H.mind.assigned_role == "Clown")
-			GLOB.score_clownabuse++
+			SSticker.score.score_clown_abuse++
 	return ..()
 
 /obj/item/clothing/under/rank/clown/sexy

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -19,7 +19,7 @@
 	pixel_x = rand(0, 16) - 8
 	pixel_y = rand(0, 8) - 8
 	if(is_mining_level(z))
-		GLOB.score_oremined++ //When ore spawns, increment score.  Only include ore spawned on mining level (No Clown Planet)
+		SSticker.score.score_ore_mined++ //When ore spawns, increment score.  Only include ore spawned on mining level (No Clown Planet)
 
 /obj/item/stack/ore/welder_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1042,7 +1042,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		if(!forceFed(toEat, user, fullness))
 			return 0
 	consume(toEat, bitesize_override, can_taste_container = toEat.can_taste)
-	GLOB.score_foodeaten++
+	SSticker.score.score_food_eaten++
 	return 1
 
 /mob/living/carbon/proc/selfFeed(obj/item/reagent_containers/food/toEat, fullness)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -890,7 +890,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(href_list["flavor_change"])
 		update_flavor_text()
 
-	return
+	if(href_list["scoreboard"])
+		usr << browse(GLOB.scoreboard, "window=roundstats;size=500x600")
 
 // The src mob is trying to strip an item from someone
 // Defined in living.dm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Ports the 'Fit Viewport' verb from /tg/station, which does exactly as the name suggests and auto-resizes the game screen to fit properly, no black borders.
TG's version has a preference setting to make it automatically resize, but I figured that:
A. It's not exactly a hassle to click the button manually.
B. It'd need a new preference flag, verb, etc. And there's already *way* too many of those.

Also refactored the scoreboard system to only use a single global variable rather than thirty three, and made the 'Crew Score' number in chat at the end of a round a link, which re-opens the scoreboard window.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
For the 'Fit Viewport' verb, I'm sure I can't be the only one who gets pretty irritated sometimes by the tiny black borders on the sides of the screen. I probably try resizing the window at least once a round to get them as small as possible. This verb will remove all of that effort entirely, and just do it for you.

The scoreboard re-opening thing is pretty unrelated, but it's another thing that's been bugging me for ages now so I figured I'd just bundle it in here anyway. I've got a pretty irritating muscle memory reaction now to close the scoreboard the second it appears, so it'd definitely be nice to be able to properly look at it occasionally.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/57483089/124360182-5949b900-dc20-11eb-8ff4-cabf65124edb.mp4

## Changelog
:cl:
add: Added a 'Fit Viewport' verb to the OOC tab, which resizes the game window to remove black borders.
add: Changed the 'Crew Score' number at the end of a round to be a link which re-opens the scoreboard window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
