### PR TITLE
Fixes an abductor camera console exploit

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -75,7 +75,7 @@
 		for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 			if(!C.can_use())
 				continue
-			if(C.network&networks)
+			if(length(C.network & networks))
 				camera_location = get_turf(C)
 				break
 		if(camera_location)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes the abductor 'Human Observation Console' starting on the CentComm z level rather than the station one.
Because of this, abductors are currently able to reliably teleport to any location on the z level after following a few steps.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I won't go into detail on the steps to exploit this obviously, but currently abductor teams have very easy access to:

Instagib rifles (Which admittedly they can't use),
Wizard melee weapons (Which they *can* use),
Adminordrazine bottles,
Literally every syndicate implanter,
Above all access ID cards,
Sol trader equipment,
Vox raider equipment,
Sleeping carp scrolls,
(Limited) SST equipment,
And finally the 'Toolbox of Robustness'. A syndicate toolbox with a `force` value of 100,000,000.

Realistically the only thing stopping them from abusing this is the risk that an admin will be told.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Prevents this from happening:
(Tested on a live server with no adminbus involved)
![image](https://user-images.githubusercontent.com/57483089/124368569-3d630900-dc5a-11eb-9f26-9bf5b3cf319f.png)

## Changelog
:cl:
fix: Fixed abductor camera consoles starting on the CentComm z level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
