### PR TITLE
Early stage viruses no longer show on medical HUD

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -50,6 +50,10 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 	var/stage = 1
 	var/max_stages = 0
 	var/stage_prob = 4
+	/// The fraction of stages the virus must at least be at to show up on medical HUDs. Rounded up.
+	var/discovery_threshold = 0.5
+	/// If TRUE, this virus will show up on medical HUDs. Automatically set when it reaches mid-stage.
+	var/discovered = FALSE
 
 	//Other
 	var/list/viable_mobtypes = list() //typepaths of viable mobs
@@ -82,6 +86,9 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 	if(!cure)
 		if(prob(stage_prob))
 			stage = min(stage + 1,max_stages)
+			if(!discovered && stage >= CEILING(max_stages * discovery_threshold, 1)) // Once we reach a late enough stage, medical HUDs can pick us up even if we regress
+				discovered = TRUE
+				affected_mob.med_hud_set_status()
 	else
 		if(prob(cure_chance))
 			stage = max(stage - 1, 1)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -90,6 +90,8 @@
 /mob/living/carbon/proc/has_virus()
 	for(var/thing in viruses)
 		var/datum/disease/D = thing
+		if(!D.discovered) // Early-stage viruses should not show up on med HUD (though health analywers can still pick them up)
+			continue
 		if((!(D.visibility_flags & HIDDEN_SCANNER)) && (D.severity != NONTHREAT))
 			return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Makes it so viruses no longer show on medical HUDs until they reach the halfway point of their max stages. Health analysers and body scanners still pick the viruses up no matter the stage.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Biohazard 7 events (and intentional virus releases) are generally very underwhelming due to the fact patient 0's can be detected instantly by anyone with a medical HUD (silicons or roaming doctors). By initially hiding the virus until it reaches a later stage, this PRs allows viruses to spread even if a little to make outbreaks more challenging.
Additionally, most viruses have early-stage symptoms and this should motivate people to get a check-up.

## Changelog
:cl:
tweak: Viruses no longer show on medical HUDs until they reach mid-stage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
