### PR TITLE
Changes "aquariam" to "aquarium"

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	new/datum/stack_recipe/window("fulltile window", /obj/structure/window/full/basic, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("fishbowl", /obj/machinery/fishtank/bowl, 1, time = 10), \
 	new/datum/stack_recipe("fish tank", /obj/machinery/fishtank/tank, 3, time = 20, on_floor = TRUE), \
-	new/datum/stack_recipe("wall aquariam", /obj/machinery/fishtank/wall, 4, time = 40, on_floor = TRUE) \
+	new/datum/stack_recipe("wall aquarium", /obj/machinery/fishtank/wall, 4, time = 40, on_floor = TRUE) \
 ))
 
 /obj/item/stack/sheet/glass


### PR DESCRIPTION
## What Does This PR Do
Fixes the craftable recipe name of aquarium as it used to be "aquariam". 

## Why It's Good For The Game
spelling error bad, correct spelling good. 

## Changelog
:cl:
fix: Changed "aquariam" in the crafting recipe to "aquarium". 
/:cl:
