### PR TITLE
Removes fungus announcement

### DIFF
--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -1,6 +1,3 @@
-/datum/event/wallrot/setup()
-	endWhen = rand(1, 300)
-
 /datum/event/wallrot/start()
 	INVOKE_ASYNC(src, .proc/spawn_wallrot)
 

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -1,9 +1,5 @@
 /datum/event/wallrot/setup()
-	announceWhen = rand(0, 300)
-	endWhen = announceWhen + 1
-
-/datum/event/wallrot/announce()
-	GLOB.event_announcement.Announce("Harmful fungi detected on station. Station structures may be contaminated.", "Biohazard Alert")
+	endWhen = rand(1, 300)
 
 /datum/event/wallrot/start()
 	INVOKE_ASYNC(src, .proc/spawn_wallrot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes the fungus biohazard station announcement. (The event itself remains.)
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This announcement is really over the top for the severity of the event. Calling it a "biohazard" is a bit much too considering that is strongly associated with Terrors or Blob.
All it serves to do is cause confusion in newer players or just disrupt the chat log for no reason.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed large station alert regarding fungus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
