### PR TITLE
Repository Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ Heads of Staff and Maintainers have the final say on Pull Requests. While thumbs
 
 After a twenty four hour minimum waiting period, Pull Requests can be merged once they receive approval from both a Head of Staff and a Maintainer. An exception is made for refactors and fixes, which may be merged at a Maintainer's discretion with no waiting period.
 
-Heads of Staff and Maintainers are not obligated to publicly state their objections to a Pull Request. Attacking or berating either of these roles over an objection will not be tolerated. Additionally, whining over the closure of a PR, the existence of an objection, or similar behaviour, will not be tolerated.
+While normally provided, Heads of Staff and Maintainers are not obligated to publicly state their objections to a Pull Request. Attacking or berating either of these roles over an objection will not be tolerated. Additionally, whining over the closure of a PR, the existence of an objection, or similar behaviour, will not be tolerated.
 
 ### PR Expectations
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Important
 
-The Paradise GitHub is not exempt from community and server rules, especially rules 0, 1, and 4. An inability to abide by the rules on the GitHub will result in disciplinary action up to, or including, a repository ban.
+The Paradise GitHub is not exempt from Paradise Station community and server rules, especially rules 0, 1, and 4. An inability to abide by the rules on the GitHub will result in disciplinary action up to, or including, a repository ban.
 
 ## General Expectations
 
@@ -18,7 +18,7 @@ Maintainers reserve the right to permanently revoke access from the repository i
 
 ### PR Approval/Objection Info
 
-Heads of Staff and Maintainers have final say on Pull Requests. While thumbs ratios are generally taken into account, they do not dictate whether or not a PR will be merged.
+Heads of Staff and Maintainers have the final say on Pull Requests. While thumbs ratios are generally taken into account, they do not dictate whether or not a PR will be merged.
 
 After a twenty four hour minimum waiting period, Pull Requests can be merged once they receive approval from both a Head of Staff and a Maintainer. An exception is made for refactors and fixes, which may be merged at a Maintainer's discretion with no waiting period.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,13 +12,13 @@ Under no circumstances are users to be attacked for their ideas or contributions
 
 "Merge-nagging" or similar behaviour is not acceptable. Comments of this nature will result in warnings or an outright ban from the repository depending on general behaviour.
 
-If you exhibit behaviour that's considered to be a net-negative to the community (offensive commentary, repeat violations, constant nagging, personal attacks, etc.), you may be banned from other Paradise services (discord, forums, server, wiki, etc.)
+If you exhibit behaviour that's considered to be a net-negative to the community (offensive commentary, repeat violations, constant nagging, personal attacks, etc.), you may be banned from other Paradise services (Discord, forums, server, wiki, etc.)
 
 Maintainers reserve the right to permanently revoke access from the repository if your behaviour is considered to be a net negative.
 
 ### PR Approval/Objection Info
 
-Heads of Staff and Maintainers have the final say on Pull Requests. While thumbs ratios are generally taken into account, they do not dictate whether or not a PR will be merged.
+Heads of Staff and Maintainers have the final say on Pull Requests. While thumbsup/thumbsdown reaction ratios are generally taken into account, they do not dictate whether or not a PR will be merged.
 
 After a twenty four hour minimum waiting period, Pull Requests can be merged once they receive approval from both a Head of Staff and a Maintainer. An exception is made for refactors and fixes, which may be merged at a Maintainer's discretion with no waiting period.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Important
+
+The Paradise GitHub is not exempt from community and server rules, especially rules 0, 1, and 4. An inability to abide by the rules on the GitHub will result in disciplinary action up to, or including, a repository ban.
+
+## General Expectations
+
+### PR Discussion
+
+Comments on Pull Requests should remain relevant to the PR in question and not derail discussions.
+
+Under no circumstances are users to be attacked for their ideas or contributions. While constructive criticism is encouraged, toxicity or general mean-spirited behaviour will not be tolerated. All participants on a given PR or issue are expected to be civil. Failure to do so will result in disciplinary action.
+
+"Merge-nagging" or similar behaviour is not acceptable. Comments of this nature will result in warnings or an outright ban from the repository depending on general behaviour.
+
+If you exhibit behaviour that's considered to be a net-negative to the community (offensive commentary, repeat violations, constant nagging, personal attacks, etc.), you may be banned from other Paradise services (discord, forums, server, wiki, etc.)
+
+Maintainers reserve the right to permanently revoke access from the repository if your behaviour is considered to be a net negative.
+
+### PR Approval/Objection Info
+
+Heads of Staff and Maintainers have final say on Pull Requests. While thumbs ratios are generally taken into account, they do not dictate whether or not a PR will be merged.
+
+After a twenty four hour minimum waiting period, Pull Requests can be merged once they receive approval from both a Head of Staff and a Maintainer. An exception is made for refactors and fixes, which may be merged at a Maintainer's discretion with no waiting period.
+
+Heads of Staff and Maintainers are not obligated to publicly state their objections to a Pull Request. Attacking or berating either of these roles over an objection will not be tolerated. Additionally, whining over the closure of a PR, the existence of an objection, or similar behaviour, will not be tolerated.
+
+### PR Expectations
+
+All Pull Requests are expected to be tested prior to submission. If a submitted Pull Request fails to pass CI checks, the likelihood of it being merged will be significantly lower. If you can't take the time to compile/test your Pull Request, do not expect a warm reception.
+
+It is expected that contributors discuss larger design changes on the forums prior to coding a Pull Request. The amount of time spent on any given Pull Request is not relevant. Maintainers are not responsible for contributors wasting their time creating features nobody asked for.
+
+Barring highly specific circumstances (such as single line changes, submissions from advanced users, or changes to repo documentation), we will not accept Pull Requests utilising the web editor.
+
+Pull Requests regarding heavy-handed nerfs, particularly immediately after said mechanic was used, will be tagged with `I ded pls nerf`. A bad experience with a particular mechanic is not a justification for nerfing it.
+
+Reactionary revert PRs are not tolerated under any circumstances. Posting a revert immediately after a Pull Request is merged will result in a repoban.


### PR DESCRIPTION
## What Does This PR Do
Uploads a code of conduct to the repository. This was drafted by me, improved vastly by @Shadeykins (❤️), and has been approved by @Fox-McCloud and @Necaladun 

## Why It's Good For The Repo
Its about time we lay some ground rules on the repo so we have actual policy around things, as theres no real framework for this.

## Changelog
N/A, repo only