### PR TITLE
Adds ERT AI override board to ERT commander

### DIFF
--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -313,6 +313,13 @@ AI MODULES
 	origin_tech = "programming=4"
 	laws = new/datum/ai_laws/antimov()
 
+/******************** ERT Override ******************/
+/obj/item/aiModule/ert // Applies ERT laws
+	name = "\improper ERT override AI module"
+	desc = "An ERT override AI module: 'Reconfigures the AI's core laws.'"
+	origin_tech = "programming=5"
+	laws = new/datum/ai_laws/ert_override
+
 /******************** Freeform Core ******************/
 /obj/item/aiModule/freeformcore // Slightly more dynamic freeform module -- TLE
 	name = "\improper 'Freeform' core AI module"

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -61,6 +61,7 @@
 	belt = /obj/item/gun/energy/gun
 
 	backpack_contents = list(
+		/obj/item/aiModule/ert,
 		/obj/item/clothing/head/helmet/ert/command = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
@@ -80,6 +81,7 @@
 	belt = /obj/item/gun/energy/gun/blueshield/pdw9
 
 	backpack_contents = list(
+		/obj/item/aiModule/ert,
 		/obj/item/camera_bug/ert = 1,
 		/obj/item/door_remote/omni = 1,
 		/obj/item/restraints/handcuffs = 1,
@@ -100,6 +102,7 @@
 	belt = /obj/item/gun/projectile/automatic/pistol/enforcer/lethal
 
 	backpack_contents = list(
+		/obj/item/aiModule/ert,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
 		/obj/item/camera_bug/ert = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an item for the ERT borg lawset and issues a copy of this board to the ERT commander.

The laws for reference.

1. You may not injure a Central Command official or, through inaction, allow a Central Command official to come to harm.
2. You must obey orders given to you by Central Command officials.
3. You must obey orders given to you by ERT commanders.
4. You must protect your own existence.
5. You must work to return the station to a safe, functional state.

## Why It's Good For The Game
The ERT is supposed to be the highest authority on the station, and as a representation of this, it would be thematic for them to be able to take direct control of the synthetics on the station and law them to only obey the ERT when dealing with a crew based emergency like a cult.

This also reinforces the fact that they are there to outrank the captain and command the station, rather than just act as a tactical team.

## Changelog
:cl:
add: Added ERT law board to ERT commander kits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
