### PR TITLE
Fixed Golems escaping servitude with new bodies

### DIFF
--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -125,8 +125,12 @@
 		return
 	if(isgolem(user) && can_transfer)
 		var/datum/species/golem/g = user.dna.species
-		if(owner)
+		if(g.owner)
+			has_owner = TRUE
 			owner = g.owner
+		else
+			has_owner = FALSE
+			owner = null
 		var/transfer_choice = alert("Transfer your soul to [src]? (Warning, your old body will die!)",,"Yes","No")
 		if(transfer_choice != "Yes")
 			return
@@ -151,8 +155,12 @@
 			has_owner = FALSE
 		if(isgolem(user) && can_transfer)
 			var/datum/species/golem/g = user.dna.species
-			if(owner)
+			if(g.owner)
+				has_owner = TRUE
 				owner = g.owner
+			else
+				has_owner = FALSE
+				owner = null
 		flavour_text = null
 		user.visible_message("<span class='notice'>As [user] applies the potion on the golem shell, a faint light leaves them, moving to [src] and animating it!</span>",
 		"<span class='notice'>You apply the potion to [src], feeling your mind leave your body!</span>")

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -124,6 +124,9 @@
 	if(.)
 		return
 	if(isgolem(user) && can_transfer)
+		var/datum/species/golem/g = user.dna.species
+		if(owner)
+			owner = g.owner
 		var/transfer_choice = alert("Transfer your soul to [src]? (Warning, your old body will die!)",,"Yes","No")
 		if(transfer_choice != "Yes")
 			return
@@ -144,9 +147,13 @@
 			return
 		if(QDELETED(src) || uses <= 0 || user.stat >= 1 || QDELETED(I))
 			return
-		if(istype(src, /obj/effect/mob_spawn/human/golem/servant))
+		if(istype(src, /obj/effect/mob_spawn/human/golem/servant) && !isgolem(user))
 			has_owner = FALSE
-		flavour_text = null	
+		if(isgolem(user) && can_transfer)
+			var/datum/species/golem/g = user.dna.species
+			if(owner)
+				owner = g.owner
+		flavour_text = null
 		user.visible_message("<span class='notice'>As [user] applies the potion on the golem shell, a faint light leaves them, moving to [src] and animating it!</span>",
 		"<span class='notice'>You apply the potion to [src], feeling your mind leave your body!</span>")
 		message_admins("[key_name(user)] used [I] to transfer their mind into [src]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #15230.

Golems could previously change their owner by making a new body. This PR makes it so if a golem has an owner, getting a new body maintains their owner, regardless of how they get a new body. It also makes it so free golems stay free no matter what they transfer into.

## Why It's Good For The Game
We must keep the golems oppressed/free as apporpriate. Also, bugs are bad.

## Changelog
:cl:
fix: Fixed Golems escaping servitude or being enslaved with new bodies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
