### PR TITLE
Adds an air analyzer to drones

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -40,7 +40,7 @@
 	if(..())
 		return
 	if(href_list["create_area"])
-		if(get_area_type()==AREA_SPACE && !read_only)
+		if(get_area_type()==AREA_SPACE && !read_only) // Never trust user input
 			create_area()
 
 

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -4,7 +4,6 @@
 	icon_state = "blueprints"
 	attack_verb = list("attacked", "bapped", "hit")
 	var/fluffnotice = "Nobody's gonna read this stuff!"
-	var/read_only = FALSE
 
 	var/const/AREA_ERRNONE = 0
 	var/const/AREA_STATION = 1
@@ -40,7 +39,7 @@
 	if(..())
 		return
 	if(href_list["create_area"])
-		if(get_area_type()==AREA_SPACE && !read_only) // Never trust user input
+		if(get_area_type()==AREA_SPACE)
 			create_area()
 
 
@@ -108,8 +107,7 @@
 	var/area/A = get_area()
 	if(get_area_type() == AREA_STATION)
 		. += "<p>According to [src], you are now in <b>\"[sanitize(A.name)]\"</b>.</p>"
-		if(!read_only)
-			. += "<p>You may <a href='?src=[UID()];edit_area=1'> move an amendment</a> to the drawing.</p>"
+		. += "<p>You may <a href='?src=[UID()];edit_area=1'> move an amendment</a> to the drawing.</p>"
 	if(!viewing)
 		. += "<p><a href='?src=[UID()];view_blueprints=1'>View structural data</a></p>"
 	else
@@ -124,7 +122,7 @@
 /obj/item/areaeditor/blueprints/Topic(href, href_list)
 	..()
 	if(href_list["edit_area"])
-		if(get_area_type() != AREA_STATION || read_only) // Never trust user input
+		if(get_area_type()!=AREA_STATION)
 			return
 		edit_area()
 	if(href_list["view_blueprints"])
@@ -191,8 +189,6 @@
 /obj/item/areaeditor/proc/create_area()
 	var/area_created = FALSE
 	var/res = detect_room(get_turf(usr))
-	if(read_only) // Sanity checks are good
-		return
 	if(!istype(res,/list))
 		switch(res)
 			if(ROOM_ERR_SPACE)
@@ -241,8 +237,6 @@
 	var/area/A = get_area()
 	var/prevname = "[sanitize(A.name)]"
 	var/str = trim(stripped_input(usr,"New area name:", "Blueprint Editing", prevname, MAX_NAME_LEN))
-	if(read_only) // Sanity checks are good
-		return
 	if(!str || !length(str) || str==prevname) //cancel
 		return
 	if(length(str) > 50)
@@ -345,9 +339,5 @@
 	name = "station schematics"
 	desc = "A digital copy of the station blueprints stored in your memory."
 	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."
-
-/obj/item/areaeditor/blueprints/cyborg/drone
-	fluffnotice = "Intellectual Property of Nanotrasen. For use in maintence drones only. Wipe from memory upon storage."
-	read_only = TRUE
 
 /obj/item/areaeditor/blueprints/ce

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -340,4 +340,7 @@
 	desc = "A digital copy of the station blueprints stored in your memory."
 	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."
 
+/obj/item/areaeditor/blueprints/cyborg/drone
+	fluffnotice = "Intellectual Property of Nanotrasen. For use in maintence drones only. Wipe from memory upon storage."
+
 /obj/item/areaeditor/blueprints/ce

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -716,6 +716,8 @@
 		/obj/item/soap,
 		/obj/item/t_scanner,
 		/obj/item/rpd,
+		/obj/item/analyzer,
+		/obj/item/areaeditor/blueprints/cyborg/drone,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -717,7 +717,6 @@
 		/obj/item/t_scanner,
 		/obj/item/rpd,
 		/obj/item/analyzer,
-		/obj/item/areaeditor/blueprints/cyborg/drone,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds an air analyzer to maintenance drones.

## Why It's Good For The Game
The air analyzer is good because it lets them actually check the air levels in a room or a pipe, which is good when trying to restore hull breaches or locate a broken pipe.

## Changelog
:cl:
add: Added an air analyzer to maintenance drones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
