### PR TITLE
Adds a discord message if the last mentor logs out

### DIFF
--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -7,14 +7,18 @@
 	create_log(MISC_LOG, "Logged out")
 	// `holder` is nil'd out by now, so we check the `admin_datums` array directly
 	//Only report this stuff if we are currently playing.
-	if(GLOB.admin_datums[ckey] && SSticker && SSticker.current_state == GAME_STATE_PLAYING)
+	if(GLOB.admin_datums[ckey] && SSticker.current_state == GAME_STATE_PLAYING)
 		var/datum/admins/temp_admin = GLOB.admin_datums[ckey]
-		// Triggers on people with banhammer power only - no mentors tripping the alarm
-		if(temp_admin.rights & R_BAN)
+		if(temp_admin.rights & R_MENTOR)
+			var/list/mentorcounter = staff_countup(R_MENTOR)
+			if(mentorcounter[1] == 0) // No active mentors
+				SSdiscord.send2discord_simple(DISCORD_WEBHOOK_MENTOR, "[key_name(src)] logged out - 0 active mentors, [mentorcounter[2]] non-mentor staff, [mentorcounter[3]] inactive mentors.")
+
+		else if(temp_admin.rights & R_BAN)
 			message_admins("Admin logout: [key_name_admin(src)]")
 			var/list/admincounter = staff_countup(R_BAN)
 			if(admincounter[1] == 0) // No active admins
-				SSdiscord.send2discord_simple(DISCORD_WEBHOOK_ADMIN, "[key_name(src)] logged out - No active admins, [admincounter[2]] non-admin staff, [admincounter[3]] inactive staff.")
+				SSdiscord.send2discord_simple(DISCORD_WEBHOOK_ADMIN, "[key_name(src)] logged out - 0 active admins, [admincounter[2]] non-admin staff, [admincounter[3]] inactive staff.")
 
 	..()
 	update_morgue()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds the 'X has logged out, no admins online' message which admins get for mentors too, to avoid the issue of nobody realising that there's not been any mentors online for the last few hours because there haven't been any mentorhelps.
Pretty much the same premise as #15533, but as more of a informational notice than an urgent warning.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Aside from being another thing to help stop this from happening:
![image](https://user-images.githubusercontent.com/57483089/125288135-af4fe800-e315-11eb-8d67-a09bc94aa546.png)
There's also a pretty high chance that people don't mhelp if they notice that there's no mentors online, so in theory this will avoid that too.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![unknown](https://user-images.githubusercontent.com/57483089/125287608-0d300000-e315-11eb-9872-a85d1411e7d4.png)

## Changelog
:cl:
add: Added a discord message for mentors if the last mentor logs out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
