### PR TITLE
Adds feedback for defibbing and scanning husked people

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -265,7 +265,7 @@ REAGENT SCANNER
 		to_chat(user, "<span class='notice'>Subject's genes are stable.</span>")
 
 	if(HAS_TRAIT(H, TRAIT_HUSK))
-		to_chat(user, "<span class='danger'>Subject is husked. Application of synthflesh is recommended. </span>")
+		to_chat(user, "<span class='danger'>Subject is husked. Application of synthflesh is recommended.</span>")
 
 /obj/item/healthanalyzer/attack_self(mob/user)
 	toggle_mode()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -264,6 +264,9 @@ REAGENT SCANNER
 	else
 		to_chat(user, "<span class='notice'>Subject's genes are stable.</span>")
 
+	if(HAS_TRAIT(H, TRAIT_HUSK))
+		to_chat(user, "<span class='danger'>Subject is husked. Application of synthflesh is recommended. </span>")
+
 /obj/item/healthanalyzer/attack_self(mob/user)
 	toggle_mode()
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -445,6 +445,8 @@
 							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")
 						else if(total_burn >= 180 || total_brute >= 180)
 							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Severe tissue damage detected.</span>")
+						else if(HAS_TRAIT(H, TRAIT_HUSK))
+							user.visible_message("<span class='notice'>[defib] buzzes: Resucitation failed: Subject is husked.</span>")
 						else if(ghost)
 							if(!ghost.can_reenter_corpse) // DNR or AntagHUD
 								user.visible_message("<span class='notice'>[defib] buzzes: Resucitation failed: No electrical brain activity detected.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
health scanners and defibs now tell you if the target is husked when you use them on people.

## Why It's Good For The Game
Helps reduce malpracticebay morguing someone who is revivable because they are blind and they cannot see that they are husked. Also makes the fact that synthflesh dehusks people more common knowledge.

## Changelog
:cl:
tweak: health scanners and defibs give feedback when used on husked people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
