### PR TITLE
Simple mob GC Optimisations

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -59,6 +59,10 @@
 
 	SetCollectBehavior()
 
+/mob/living/simple_animal/hostile/mining_drone/Destroy()
+	QDEL_NULL(stored_gun)
+	return ..()
+
 /mob/living/simple_animal/hostile/mining_drone/emp_act(severity)
 	adjustHealth(100 / severity)
 	to_chat(src, "<span class='userdanger'>NOTICE: EMP detected, systems damaged!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -312,6 +312,8 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/Destroy()
 	GLOB.ts_spiderlist -= src
+	var/datum/atom_hud/U = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	U.remove_hud_from(src)
 	handle_dying()
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -140,7 +140,6 @@
 	if (T && AIStatus == AI_Z_OFF)
 		SSidlenpcpool.idle_mobs_by_zlevel[T.z] -= src
 
-	QDEL_LIST(actions)
 	return ..()
 
 /mob/living/simple_animal/handle_atom_del(atom/A)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -140,6 +140,7 @@
 	if (T && AIStatus == AI_Z_OFF)
 		SSidlenpcpool.idle_mobs_by_zlevel[T.z] -= src
 
+	QDEL_LIST(actions)
 	return ..()
 
 /mob/living/simple_animal/handle_atom_del(atom/A)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -20,6 +20,7 @@
 			AA.viewers -= src
 		viewing_alternate_appearances = null
 	LAssailant = null
+	runechat_msg_location = null
 	return ..()
 
 /mob/Initialize(mapload)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -8,6 +8,7 @@
 		spellremove(src)
 	mobspellremove(src)
 	QDEL_LIST(viruses)
+	QDEL_LIST(actions)
 	ghostize()
 	QDEL_LIST_ASSOC_VAL(tkgrabbed_objects)
 	for(var/I in tkgrabbed_objects)


### PR DESCRIPTION
## What Does This PR Do

Fixes #16358

Makes some more simple mobs GC correctly (in most cases), namely terror spiders, minebots, swarmers, and any of those that have actions.

## Why It's Good For The Game
When there are terror spiders or the terror spider gateway, the CPU spends a significant amount of time deleting them as they do not GC correctly, in a recent round there was upwards of a full minute of CPU time spent purely on this.

## Images of changes
![image](https://user-images.githubusercontent.com/29551695/125541490-f9abcb89-33f7-462d-ac97-409876b755b9.png)
![image](https://user-images.githubusercontent.com/29551695/125541512-afc2643f-2e20-43e3-a65d-51dcb3cfc0a9.png)
![image](https://user-images.githubusercontent.com/29551695/125541528-b63ace3a-5760-48f0-9a82-f7f1bf36ef1a.png)


## Changelog
:cl: CornMyCob
fix: More simple mobs should now GC correctly
/:cl:
