### PR TITLE
Fixes a small bug with cling revive

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -7,8 +7,8 @@
 
 //Revive from regenerative stasis
 /datum/action/changeling/revive/sting_action(mob/living/carbon/user)
-	user.revive()
 	REMOVE_TRAIT(user, TRAIT_FAKEDEATH, "changeling")
+	user.revive()
 	user.updatehealth("revive sting")
 	user.update_blind_effects()
 	user.update_blurry_effects()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
you no longer have to rest twice in order to move after cling revive when you are faking your death

## Why It's Good For The Game
bugs bad

lesson learnt. Test your PR after deconflicting it from a major refactor.

## Changelog
:cl:
fix: you no longer have to rest twice in order to move after using cling revive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
