### PR TITLE
Prevents wand of door creation working on indestructible walls

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -130,9 +130,11 @@
 	. = ..()
 	var/atom/T = target.loc
 	if(isturf(target) && target.density)
-		CreateDoor(target)
+		if(!(istype(target, /turf/simulated/wall/indestructible)))
+			CreateDoor(target)
 	else if(isturf(T) && T.density)
-		CreateDoor(T)
+		if(!(istype(T, /turf/simulated/wall/indestructible)))
+			CreateDoor(T)
 	else if(istype(target, /obj/machinery/door))
 		OpenDoor(target)
 	else if(istype(target, /obj/structure/closet))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents wand of door creation working on indestructible walls

## Why It's Good For The Game
You cannot use the wand in the wizards layer however you could use it with an ERT shuttle to exploit and steal admin things. exploits not good

## Changelog
:cl:
fix: door creation wands respect indestructible walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
