### PR TITLE
Adds RCD and RPD to Cryo Storage; Fixes Cryo Storage Logic

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -346,7 +346,7 @@
 
 
 /obj/machinery/cryopod/proc/handle_contents(obj/item/I)
-	if(I.contents.len) //Make sure we catch anything not handled by qdel() on the items.
+	if(length(I.contents)) //Make sure we catch anything not handled by qdel() on the items.
 		if(should_preserve_item(I) != CRYO_DESTROY) // Don't remove the contents of things that need preservation
 			return
 		for(var/obj/item/O in I.contents)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -257,7 +257,7 @@
 		/obj/item/clothing/gloves/color/black/forensics
 		/obj/item/rcd
 		/obj/item/rpd
-		/obj/item/gun/projectile/revolver/detective
+		/obj/item/gun/projectile/revolver/detective,
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -257,7 +257,8 @@
 		/obj/item/clothing/gloves/color/black/forensics,
 		/obj/item/rcd,
 		/obj/item/rpd,
-		/obj/item/gun/projectile/revolver/detective
+		/obj/item/gun/projectile/revolver/detective,
+        /obj/item/clothing/accessory/holster/armpit
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -257,7 +257,7 @@
 		/obj/item/clothing/gloves/color/black/forensics
 		/obj/item/rcd
 		/obj/item/rpd
-		/obj/item/gun/projectile/revolver/detective,
+		/obj/item/gun/projectile/revolver/detective
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -253,10 +253,10 @@
 		/obj/item/key,
 		/obj/item/door_remote,
 		/obj/item/autopsy_scanner,
-		/obj/item/holosign_creator/atmos
-		/obj/item/clothing/gloves/color/black/forensics
-		/obj/item/rcd
-		/obj/item/rpd
+		/obj/item/holosign_creator/atmos,
+		/obj/item/clothing/gloves/color/black/forensics,
+		/obj/item/rcd,
+		/obj/item/rpd,
 		/obj/item/gun/projectile/revolver/detective
 	)
 	// These items will NOT be preserved

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -256,9 +256,7 @@
 		/obj/item/holosign_creator/atmos,
 		/obj/item/clothing/gloves/color/black/forensics,
 		/obj/item/rcd,
-		/obj/item/rpd,
-		/obj/item/gun/projectile/revolver/detective,
-        /obj/item/clothing/accessory/holster/armpit
+		/obj/item/rpd
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -254,6 +254,10 @@
 		/obj/item/door_remote,
 		/obj/item/autopsy_scanner,
 		/obj/item/holosign_creator/atmos
+		/obj/item/clothing/gloves/color/black/forensics
+		/obj/item/rcd
+		/obj/item/rpd
+		/obj/item/gun/projectile/revolver/detective
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -10,7 +10,9 @@
 	w_class = WEIGHT_CLASS_NORMAL // so it doesn't fit in pockets
 
 /obj/item/clothing/accessory/holster/Destroy()
-	QDEL_NULL(holstered)
+	if(holstered?.loc == src) // Gun still in the holster
+		holstered.forceMove(loc)
+	holstered = null
 	return ..()
 
 //subtypes can override this to specify what can be holstered


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds the RCD, RPD, .38 Mars Special (Detective's revolver), and Forensic Gloves to the cryo "preserve" list so that they aren't obliterated when the user forgets to drop them before cryoing. Fixes #16347 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
RCDs and RPDs are incredibly useful items which are inconvenient for engineering to lose, and the detective's revolver and gloves are literally irreplaceable if the roundstart detective goes to cryo with them.


## Changelog
:cl:
add: Adds the RCD, RPD, .38 Mars Special, and Forensics Gloves to the cryo storage "preserve" list.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
