### PR TITLE
Give ashwalkers a handheld defib

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -195,6 +195,7 @@
 /obj/item/stack/sheet/cloth/ten,
 /obj/item/stack/medical/splint,
 /obj/item/storage/firstaid/adv,
+/obj/item/handheld_defibrillator,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "aF" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Addresses #16360 by giving ash-walkers a handheld defib in their medical crate.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If ash-walkers can still get cardiac arrest, let's at least give them a way to treat it. Handheld defibs don't revive, so this shouldn't have any balance implications, either.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Handheld defib to ash-walker nest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
