### PR TITLE
Allows players to name seed packs to keep track of modified plants

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -230,13 +230,6 @@
 		var/can_insert = disk && disk.gene && disk.gene.can_add(seed)
 		var/can_extract = disk && !disk.read_only
 
-		dat += "<div class='line'><h3>Variant</h3></div><div class='statusDisplay'><table>"
-		dat += "<tr><td width='260px'>[(seed.variant == "") ? "None" : seed.variant]</td>"
-		dat += "<td><a href='?src=[UID()];set_v=1'>Edit</a></td>"
-		if(seed.variant != "")
-			dat += "<td><a href='?src=[UID()];del_v=1'>Remove</a></td>"
-		dat += "</tr></table></div>"
-
 		dat += "<div class='line'><h3>Core Genes</h3></div><div class='statusDisplay'><table>"
 		for(var/a in core_genes)
 			var/datum/plant_gene/G = a
@@ -284,6 +277,13 @@
 			if(can_insert && istype(disk.gene, /datum/plant_gene/trait))
 				dat += "<a href='?src=[UID()];op=insert'>Insert: [disk.gene.get_name()]</a>"
 			dat += "</div>"
+
+		dat += "<div class='line'><h3>Variant</h3></div><div class='statusDisplay'><table>"
+		dat += "<tr><td width='260px'>[(seed.variant == "") ? "None" : seed.variant]</td>"
+		dat += "<td><a href='?src=[UID()];set_v=1'>Edit</a></td>"
+		if(seed.variant != "")
+			dat += "<td><a href='?src=[UID()];del_v=1'>Remove</a></td>"
+		dat += "</tr></table></div>"
 	else
 		dat += "<br>No sample found.<br><span class='highlight'>Please, insert a plant sample to use this device.</span>"
 	popup.set_content(dat)

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -279,9 +279,9 @@
 			dat += "</div>"
 
 		dat += "<div class='line'><h3>Variant</h3></div><div class='statusDisplay'><table>"
-		dat += "<tr><td width='260px'>[(seed.variant == "") ? "None" : seed.variant]</td>"
+		dat += "<tr><td width='260px'>[seed.variant ? seed.variant : "None"]</td>"
 		dat += "<td><a href='?src=[UID()];set_v=1'>Edit</a></td>"
-		if(seed.variant != "")
+		if(seed.variant)
 			dat += "<td><a href='?src=[UID()];del_v=1'>Remove</a></td>"
 		dat += "</tr></table></div>"
 	else
@@ -405,7 +405,7 @@
 	else if(href_list["del_v"])
 		if(!seed)
 			return
-		seed.variant = ""
+		seed.variant = null
 		seed.apply_variant_name()
 
 	interact(usr)

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -401,7 +401,7 @@
 	else if(href_list["set_v"])
 		if(!seed)
 			return
-		var/V = sanitize(stripped_input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant, MAX_MESSAGE_LEN))
+		var/V = sanitize(stripped_input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant, 64))
 		if((!Adjacent(usr)) || (!seed))
 			return
 		seed.variant = V

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -401,11 +401,7 @@
 	else if(href_list["set_v"])
 		if(!seed)
 			return
-		var/V = input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant) as text|null
-		if(!issilicon(usr) && !Adjacent(usr) || isnull(V) || !seed)
-			return
-		seed.variant = copytext(sanitize(html_encode(trim(V))), 1, 64)
-		seed.apply_variant_name()
+		seed.variant_prompt(usr, src)
 	else if(href_list["del_v"])
 		if(!seed)
 			return

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -407,6 +407,7 @@
 			return
 		seed.variant = null
 		seed.apply_variant_name()
+		to_chat(usr, "<span class='notice'>You remove the [seed.plantname]'s variant designation.</span>")
 
 	interact(usr)
 

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -230,6 +230,10 @@
 		var/can_insert = disk && disk.gene && disk.gene.can_add(seed)
 		var/can_extract = disk && !disk.read_only
 
+		dat += "<div class='line'><h3>Variant</h3></div><div class='statusDisplay'><table>"
+		dat += "<tr><td width='260px'>[(seed.variant == "") ? "None" : seed.variant]</td>"
+		dat += "<td><a href='?src=[UID()];variant=1'>Edit</a></td></tr></table></div>"
+
 		dat += "<div class='line'><h3>Core Genes</h3></div><div class='statusDisplay'><table>"
 		for(var/a in core_genes)
 			var/datum/plant_gene/G = a
@@ -391,6 +395,14 @@
 	else if(href_list["abort"])
 		operation = ""
 		target = null
+	else if(href_list["variant"])
+		if(!seed)
+			return
+		var/V = sanitize(stripped_input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant, MAX_MESSAGE_LEN))
+		if((!Adjacent(usr)) || (!seed))
+			return
+		seed.variant = V
+		seed.apply_variant_name()
 
 	interact(usr)
 

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -232,7 +232,9 @@
 
 		dat += "<div class='line'><h3>Variant</h3></div><div class='statusDisplay'><table>"
 		dat += "<tr><td width='260px'>[(seed.variant == "") ? "None" : seed.variant]</td>"
-		dat += "<td><a href='?src=[UID()];variant=1'>Edit</a></td></tr></table></div>"
+		dat += "<td><a href='?src=[UID()];set_v=1'>Edit</a></td>"
+		dat += "<td><a href='?src=[UID()];del_v=1'>Remove</a></td>"
+		dat += "</tr></table></div>"
 
 		dat += "<div class='line'><h3>Core Genes</h3></div><div class='statusDisplay'><table>"
 		for(var/a in core_genes)
@@ -395,13 +397,18 @@
 	else if(href_list["abort"])
 		operation = ""
 		target = null
-	else if(href_list["variant"])
+	else if(href_list["set_v"])
 		if(!seed)
 			return
 		var/V = sanitize(stripped_input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant, MAX_MESSAGE_LEN))
 		if((!Adjacent(usr)) || (!seed))
 			return
 		seed.variant = V
+		seed.apply_variant_name()
+	else if(href_list["del_v"])
+		if(!seed)
+			return
+		seed.variant = ""
 		seed.apply_variant_name()
 
 	interact(usr)

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -402,16 +402,12 @@
 		if(!seed)
 			return
 		var/V = input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant) as text|null
-		if(!issilicon(usr) && !Adjacent(usr))
-			return
-		if(isnull(V))
+		if(!issilicon(usr) && !Adjacent(usr) || isnull(V) || !seed)
 			return
 		seed.variant = copytext(sanitize(html_encode(trim(V))), 1, 64)
 		seed.apply_variant_name()
 	else if(href_list["del_v"])
 		if(!seed)
-			return
-		if(!issilicon(usr) && !Adjacent(usr))
 			return
 		seed.variant = ""
 		seed.apply_variant_name()

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -401,13 +401,17 @@
 	else if(href_list["set_v"])
 		if(!seed)
 			return
-		var/V = sanitize(stripped_input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant, 64))
-		if((!Adjacent(usr)) || (!seed))
+		var/V = input(usr, "Choose variant name:", "Plant Variant Naming", seed.variant) as text|null
+		if(!issilicon(usr) && !Adjacent(usr))
 			return
-		seed.variant = V
+		if(isnull(V))
+			return
+		seed.variant = copytext(sanitize(html_encode(trim(V))), 1, 64)
 		seed.apply_variant_name()
 	else if(href_list["del_v"])
 		if(!seed)
+			return
+		if(!issilicon(usr) && !Adjacent(usr))
 			return
 		seed.variant = ""
 		seed.apply_variant_name()

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -233,7 +233,8 @@
 		dat += "<div class='line'><h3>Variant</h3></div><div class='statusDisplay'><table>"
 		dat += "<tr><td width='260px'>[(seed.variant == "") ? "None" : seed.variant]</td>"
 		dat += "<td><a href='?src=[UID()];set_v=1'>Edit</a></td>"
-		dat += "<td><a href='?src=[UID()];del_v=1'>Remove</a></td>"
+		if(seed.variant != "")
+			dat += "<td><a href='?src=[UID()];del_v=1'>Remove</a></td>"
 		dat += "</tr></table></div>"
 
 		dat += "<div class='line'><h3>Core Genes</h3></div><div class='statusDisplay'><table>"

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -42,7 +42,7 @@
 		seed.prepare_result(src)
 		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5 //Makes the resulting produce's sprite larger or smaller based on potency!
 		add_juice()
-		if(seed.variant && seed.variant != "")
+		if(seed.variant)
 			name += " \[[seed.variant]]"
 
 /obj/item/reagent_containers/food/snacks/grown/Destroy()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -42,6 +42,8 @@
 		seed.prepare_result(src)
 		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5 //Makes the resulting produce's sprite larger or smaller based on potency!
 		add_juice()
+		if(seed.variant && seed.variant != "")
+			name += " \[[seed.variant]]"
 
 /obj/item/reagent_containers/food/snacks/grown/Destroy()
 	QDEL_NULL(seed)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -344,7 +344,10 @@
 /obj/machinery/hydroponics/examine(user)
 	. = ..()
 	if(myseed)
-		. += "<span class='info'>It has <span class='name'>[myseed.plantname]</span> planted.</span>"
+		if(myseed.variant != "")
+			. += "<span class='info'>It has the <span class='name'>[myseed.variant]</span> variant of <span class='name'>[myseed.plantname]</span> planted.</span>"
+		else
+			. += "<span class='info'>It has <span class='name'>[myseed.plantname]</span> planted.</span>"
 		if (dead)
 			. += "<span class='warning'>It's dead!</span>"
 		else if (harvest)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -344,7 +344,7 @@
 /obj/machinery/hydroponics/examine(user)
 	. = ..()
 	if(myseed)
-		if(myseed.variant != "")
+		if(myseed.variant)
 			. += "<span class='info'>It has the <span class='name'>[myseed.variant]</span> variant of <span class='name'>[myseed.plantname]</span> planted.</span>"
 		else
 			. += "<span class='info'>It has <span class='name'>[myseed.plantname]</span> planted.</span>"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -878,7 +878,8 @@
 			plant_hud_set_status()
 		adjustWeeds(-10) //Has a side effect of cleaning up those nasty weeds
 		update_icon()
-
+	else if(istype(O, /obj/item/pen) && myseed)
+		myseed.variant_prompt(user, src) // adj parameter makes Adjacent use the tray instead of the seed (which would always fail)
 	else
 		return ..()
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -879,7 +879,7 @@
 		adjustWeeds(-10) //Has a side effect of cleaning up those nasty weeds
 		update_icon()
 	else if(istype(O, /obj/item/pen) && myseed)
-		myseed.variant_prompt(user, src) // adj parameter makes Adjacent use the tray instead of the seed (which would always fail)
+		myseed.variant_prompt(user, src)
 	else
 		return ..()
 

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -109,6 +109,7 @@
 
 /datum/seed_pile
 	var/name = ""
+	var/variant = ""
 	var/lifespan = 0	//Saved stats
 	var/endurance = 0
 	var/maturation = 0
@@ -117,8 +118,9 @@
 	var/potency = 0
 	var/amount = 0
 
-/datum/seed_pile/New(name, life, endur, matur, prod, yie, poten, am = 1)
+/datum/seed_pile/New(name, variant, life, endur, matur, prod, yie, poten, am = 1)
 	src.name = name
+	src.variant = variant
 	src.lifespan = life
 	src.endurance = endur
 	src.maturation = matur
@@ -145,9 +147,9 @@
 	if (contents.len == 0)
 		dat += "<font color='red'>No seeds</font>"
 	else
-		dat += "<table cellpadding='3' style='text-align:center;'><tr><td>Name</td><td>Lifespan</td><td>Endurance</td><td>Maturation</td><td>Production</td><td>Yield</td><td>Potency</td><td>Stock</td></tr>"
+		dat += "<table cellpadding='3' style='text-align:center;'><tr><td>Name</td><td>Variant</td><td>Lifespan</td><td>Endurance</td><td>Maturation</td><td>Production</td><td>Yield</td><td>Potency</td><td>Stock</td></tr>"
 		for (var/datum/seed_pile/O in piles)
-			dat += "<tr><td>[O.name]</td><td>[O.lifespan]</td><td>[O.endurance]</td><td>[O.maturation]</td>"
+			dat += "<tr><td>[O.name]</td><td>[O.variant]</td><td>[O.lifespan]</td><td>[O.endurance]</td><td>[O.maturation]</td>"
 			dat += "<td>[O.production]</td><td>[O.yield]</td><td>[O.potency]</td><td>"
 			dat += "<a href='byond://?src=[src.UID()];name=[O.name];li=[O.lifespan];en=[O.endurance];ma=[O.maturation];pr=[O.production];yi=[O.yield];pot=[O.potency]'>Vend</a> ([O.amount] left)</td></tr>"
 		dat += "</table>"
@@ -203,9 +205,9 @@
 	O.forceMove(src)
 	. = 1
 	for (var/datum/seed_pile/N in piles)
-		if (O.plantname == N.name && O.lifespan == N.lifespan && O.endurance == N.endurance && O.maturation == N.maturation && O.production == N.production && O.yield == N.yield && O.potency == N.potency)
+		if (O.plantname == N.name && O.variant == N.variant && O.lifespan == N.lifespan && O.endurance == N.endurance && O.maturation == N.maturation && O.production == N.production && O.yield == N.yield && O.potency == N.potency)
 			++N.amount
 			return
 
-	piles += new /datum/seed_pile(O.plantname, O.lifespan, O.endurance, O.maturation, O.production, O.yield, O.potency)
+	piles += new /datum/seed_pile(O.plantname, O.variant, O.lifespan, O.endurance, O.maturation, O.production, O.yield, O.potency)
 	return

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -341,12 +341,13 @@
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
 /obj/item/seeds/proc/apply_variant_name()
-	var/P = findtext(name, "\[")
 	var/V = (variant == "") ? "" : (" \[" + variant + "]") // If we have a non-empty variant add it to the name
-	if (P != 0)
-		name = copytext(name, 1, P - 1) + V // If there was already a variant in the name remove it
-	else
-		name += V
+	var/N = initial(name)
+	if(copytext(name, 1, 13) == "experimental") // Don't delete 'experimental'
+		N = "experimental " + N
+	name = N + V
+	if(GetComponent(/datum/component/label))
+		GetComponent(/datum/component/label).apply_label() // Don't delete labels
 
 
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -332,9 +332,9 @@
 		if(!Adjacent(user)) //prevent remote naming of seeds
 			return
 		if(V == "" && variant != "")
-			user.show_message("You remove the variant designation from the [plantname].")
+			user.show_message("<span class='info'>You remove the variant designation from the [plantname].</span>")
 		else if(V != "")
-			user.show_message("You designate the [plantname] as the [V] variant.")
+			user.show_message("<span class='info'>You designate the [plantname] as the [V] variant.</span>")
 		variant = V
 		apply_variant_name()
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -339,11 +339,13 @@
 	if(!adj.Adjacent(user) || isnull(V))
 		return
 	variant = copytext(sanitize(html_encode(trim(V))), 1, 64)
+	if(variant == "")
+		variant == null
 	to_chat(user, "<span class='notice'>You [variant ? "change" : "remove"] the [plantname]'s variant designation.</span>")
 	apply_variant_name()
 
 /obj/item/seeds/proc/apply_variant_name()
-	var/V = (variant == "") ? "" : " \[[variant]]" // If we have a non-empty variant add it to the name
+	var/V = variant ? " \[[variant]]" : "" // If we have a non-empty variant add it to the name
 	var/N = initial(name)
 	if(copytext(name, 1, 13) == "experimental") // Don't delete 'experimental'
 		N = "experimental " + N

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -339,14 +339,10 @@
 	var/V = input(user, "Choose variant name:", "Plant Variant Naming", variant) as text|null
 	if(isnull(V)) // Did the user cancel?
 		return
-	if(container)
-		if(loc != container) // Was the seed removed from the container?
-			return
-		if(!container.Adjacent(user)) // No remote renaming
-			return
-	else
-		if(!Adjacent(user)) // No remote renaming
-			return
+	if(container && (loc != container)) // Was the seed removed from the container, if there is a container?
+		return
+	if(!(container ? container : src).Adjacent(user)) // Is the user next to the seed/container?
+		return
 	variant = copytext(sanitize(html_encode(trim(V))), 1, 64) // Sanitization must happen after null check because it converts nulls to empty strings
 	if(variant == "")
 		variant = null

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -10,7 +10,7 @@
 	var/plantname = "Plants"		// Name of plant when planted.
 	var/product						// A type path. The thing that is created when the plant is harvested.
 	var/species = ""				// Used to update icons. Should match the name in the sprites unless all icon_* are overriden.
-	var/variant = ""				// Optional custom name to track modified plants. Can be set with pen or from gene modder.
+	var/variant = null				// Optional custom name to track modified plants. Can be set with pen or from gene modder.
 
 	var/growing_icon = 'icons/obj/hydroponics/growing.dmi' //the file that stores the sprites of the growing plant from this seed.
 	var/icon_grow					// Used to override grow icon (default is "[species]-grow"). You can use one grow icon for multiple closely related plants with it.
@@ -335,6 +335,7 @@
 
 // adj parameter changes what Adjacent is called from, such as the gene modder or a tray
 /obj/item/seeds/proc/variant_prompt(mob/user, obj/item/container = null)
+	var/prev = variant
 	var/V = input(user, "Choose variant name:", "Plant Variant Naming", variant) as text|null
 	if(isnull(V)) // Did the user cancel?
 		return
@@ -349,7 +350,8 @@
 	variant = copytext(sanitize(html_encode(trim(V))), 1, 64) // Sanitization must happen after null check because it converts nulls to empty strings
 	if(variant == "")
 		variant = null
-	to_chat(user, "<span class='notice'>You [variant ? "change" : "remove"] the [plantname]'s variant designation.</span>")
+	if(prev != variant)
+		to_chat(user, "<span class='notice'>You [variant ? "change" : "remove"] the [plantname]'s variant designation.</span>")
 	apply_variant_name()
 
 /obj/item/seeds/proc/apply_variant_name()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -341,7 +341,7 @@
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
 /obj/item/seeds/proc/apply_variant_name()
-	var/V = (variant == "") ? "" : (" \[" + variant + "]") // If we have a non-empty variant add it to the name
+	var/V = (variant == "") ? "" : " \[[variant]]" // If we have a non-empty variant add it to the name
 	var/N = initial(name)
 	if(copytext(name, 1, 13) == "experimental") // Don't delete 'experimental'
 		N = "experimental " + N

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -328,7 +328,7 @@
 
 		return
 	if(istype(O, /obj/item/pen))
-		var/V = sanitize(stripped_input(user, "Choose variant name:", "Plant Variant Naming", variant, MAX_MESSAGE_LEN))
+		var/V = sanitize(stripped_input(user, "Choose variant name:", "Plant Variant Naming", variant, 64))
 		if(!Adjacent(user)) //prevent remote naming of seeds
 			return
 		if(V == "" && variant != "")

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -334,11 +334,19 @@
 
 
 // adj parameter changes what Adjacent is called from, such as the gene modder or a tray
-/obj/item/seeds/proc/variant_prompt(mob/user, obj/item/adj = src)
+/obj/item/seeds/proc/variant_prompt(mob/user, obj/item/container = null)
 	var/V = input(user, "Choose variant name:", "Plant Variant Naming", variant) as text|null
-	if(!adj.Adjacent(user) || isnull(V))
+	if(isnull(V)) // Did the user cancel?
 		return
-	variant = copytext(sanitize(html_encode(trim(V))), 1, 64)
+	if(container)
+		if(loc != container) // Was the seed removed from the container?
+			return
+		if(!container.Adjacent(user)) // No remote renaming
+			return
+	else
+		if(!Adjacent(user)) // No remote renaming
+			return
+	variant = copytext(sanitize(html_encode(trim(V))), 1, 64) // Sanitization must happen after null check because it converts nulls to empty strings
 	if(variant == "")
 		variant = null
 	to_chat(user, "<span class='notice'>You [variant ? "change" : "remove"] the [plantname]'s variant designation.</span>")

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -340,7 +340,7 @@
 		return
 	variant = copytext(sanitize(html_encode(trim(V))), 1, 64)
 	if(variant == "")
-		variant == null
+		variant = null
 	to_chat(user, "<span class='notice'>You [variant ? "change" : "remove"] the [plantname]'s variant designation.</span>")
 	apply_variant_name()
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -340,10 +340,10 @@
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
 /obj/item/seeds/proc/apply_variant_name()
-	var/P = findtext(name, "-")
-	var/V = (variant == "") ? "" : (" - " + variant)
+	var/P = findtext(name, "\[")
+	var/V = (variant == "") ? "" : (" \[" + variant + "]") // If we have a non-empty variant add it to the name
 	if (P != 0)
-		name = copytext(name, 1, P - 1) + V
+		name = copytext(name, 1, P - 1) + V // If there was already a variant in the name remove it
 	else
 		name += V
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -10,6 +10,7 @@
 	var/plantname = "Plants"		// Name of plant when planted.
 	var/product						// A type path. The thing that is created when the plant is harvested.
 	var/species = ""				// Used to update icons. Should match the name in the sprites unless all icon_* are overriden.
+	var/variant = ""				// Can be set by players with a pen to help remember what a modified plant does.
 
 	var/growing_icon = 'icons/obj/hydroponics/growing.dmi' //the file that stores the sprites of the growing plant from this seed.
 	var/icon_grow					// Used to override grow icon (default is "[species]-grow"). You can use one grow icon for multiple closely related plants with it.
@@ -83,11 +84,13 @@
 	S.potency = potency
 	S.weed_rate = weed_rate
 	S.weed_chance = weed_chance
+	S.variant = variant
 	S.genes = list()
 	for(var/g in genes)
 		var/datum/plant_gene/G = g
 		S.genes += G.Copy()
 	S.reagents_add = reagents_add.Copy() // Faster than grabbing the list from genes.
+	S.apply_variant_name()
 	return S
 
 /obj/item/seeds/proc/get_gene(typepath)
@@ -324,9 +327,25 @@
 			to_chat(user, "<span class='notice'>[text]</span>")
 
 		return
+	if (istype(O, /obj/item/pen))
+		var/V = sanitize(stripped_input(user, "Choose variant name:", "Plant Variant Naming", variant, MAX_MESSAGE_LEN))
+		if (!Adjacent(user)) //prevent remote naming of seeds
+			return
+		if (V == "" && variant != "")
+			user.show_message("You remove the variant designation from the [plantname].")
+		else if(V != "")
+			user.show_message("You designate the [plantname] as the [V] variant.")
+		variant = V
+		apply_variant_name()
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
-
+/obj/item/seeds/proc/apply_variant_name()
+	var/P = findtext(name, "-")
+	var/V = (variant == "") ? "" : (" - " + variant)
+	if (P != 0)
+		name = copytext(name, 1, P - 1) + V
+	else
+		name += V
 
 
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -333,7 +333,6 @@
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
 
-// adj parameter changes what Adjacent is called from, such as the gene modder or a tray
 /obj/item/seeds/proc/variant_prompt(mob/user, obj/item/container = null)
 	var/prev = variant
 	var/V = input(user, "Choose variant name:", "Plant Variant Naming", variant) as text|null

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -337,6 +337,7 @@
 			user.show_message("<span class='info'>You designate the [plantname] as the [V] variant.</span>")
 		variant = V
 		apply_variant_name()
+		return
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
 /obj/item/seeds/proc/apply_variant_name()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -328,10 +328,13 @@
 
 		return
 	if(istype(O, /obj/item/pen))
-		var/V = sanitize(stripped_input(user, "Choose variant name:", "Plant Variant Naming", variant, 64))
-		if(!Adjacent(user)) //prevent remote naming of seeds
+		var/V = input(user, "Choose variant name:", "Plant Variant Naming", variant) as text|null
+		if(!Adjacent(user))
 			return
-		if(V == "" && variant != "")
+		if(isnull(V))
+			return
+		V = copytext(sanitize(html_encode(trim(V))), 1, 64)
+		if((V == "") && (variant != ""))
 			user.show_message("<span class='info'>You remove the variant designation from the [plantname].</span>")
 		else if(V != "")
 			user.show_message("<span class='info'>You designate the [plantname] as the [V] variant.</span>")

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -320,18 +320,18 @@
 	return
 
 /obj/item/seeds/attackby(obj/item/O, mob/user, params)
-	if (istype(O, /obj/item/plant_analyzer))
+	if(istype(O, /obj/item/plant_analyzer))
 		to_chat(user, "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>.</span>")
 		var/text = get_analyzer_text()
 		if(text)
 			to_chat(user, "<span class='notice'>[text]</span>")
 
 		return
-	if (istype(O, /obj/item/pen))
+	if(istype(O, /obj/item/pen))
 		var/V = sanitize(stripped_input(user, "Choose variant name:", "Plant Variant Naming", variant, MAX_MESSAGE_LEN))
-		if (!Adjacent(user)) //prevent remote naming of seeds
+		if(!Adjacent(user)) //prevent remote naming of seeds
 			return
-		if (V == "" && variant != "")
+		if(V == "" && variant != "")
 			user.show_message("You remove the variant designation from the [plantname].")
 		else if(V != "")
 			user.show_message("You designate the [plantname] as the [V] variant.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a 'variant' var to seed packs which can be set by players with a pen or with the dna modifier. This variable is shown in the pack's name, in the seed extractor, in the dna modifier and in hydroponic trays' examine. Extracting seed packs from named seeds will keep the name.

## Why It's Good For The Game
Helps keep track of what modified plants do, for example a tomato plant labeled 'healing' and another labeled 'acid', or a gaia plant labeled 'perrenial densified chemicals'.

## Images of changes
![2021-07-17 14-23-00](https://user-images.githubusercontent.com/85434590/126037577-4a3931eb-f447-4d90-acad-859e9bfa99e8.gif)
The gif doesn't show the dna modifier UI because I messed up the window capture. Sorry.
![Capture1](https://user-images.githubusercontent.com/85434590/126038014-5584c221-0854-4d53-a66b-bd209a60b48e.PNG)
![Capture2](https://user-images.githubusercontent.com/85434590/126038015-78492638-40e3-4a38-af1d-2b6d13011f52.PNG)
![Capture1](https://user-images.githubusercontent.com/85434590/126043095-5f72f75c-fc54-40be-9076-b359473fc479.PNG)




## Changelog
:cl:
add: Adds a 'variant' var to seed packets which can be set by using a pen on seeds or a tray, or from the dna modifier. It shows up in the packet's name, in plant trays examine, in the seed extractor, in the dna modifier and in harvested plants. This is intended to help keep track of what modified plants do, such as wheat labeled 'healing'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
