### PR TITLE
Lets CC relay link to tcomns cores without password

### DIFF
--- a/code/game/machinery/tcomms/presets.dm
+++ b/code/game/machinery/tcomms/presets.dm
@@ -29,4 +29,5 @@
 	network_id = "CENTCOMM-RELAY"
 	autolink_id = "STATION-CORE"
 	hidden_link = TRUE
+	password_bypass = TRUE
 

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -19,6 +19,8 @@
 	var/linked = FALSE
 	/// Is this link invisible on the hub?
 	var/hidden_link = FALSE
+	/// Does this relay need a password to connect to hubs?
+	var/password_bypass = FALSE
 
 /**
   * Initializer for the relay.
@@ -210,6 +212,10 @@
 				return
 			var/obj/machinery/tcomms/core/C = locate(params["addr"])
 			if(istype(C, /obj/machinery/tcomms/core))
+				if(password_bypass)
+					AddLink(C)
+					to_chat(usr, "<span class='notice'>Successfully linked to <b>[C.network_id]</b>.</span>")
+					return
 				var/user_pass = input(usr, "Please enter core password","Password Entry")
 				// Check the password
 				if(user_pass == C.link_password)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Add a variable to relays that lets them link to tcomns cores without a password. Only the relay at CC has this by default.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Trying to talk to ERT as a NNO / SOO can be a pain with the relay down, as you try to talk, you fail, you check the relay, station relay is gone / depowered. Now you have to find the new relay. It could be anywhere. RND. Robotics. Atmos. Bridge. Security. Mechanics. Who knows, you probably have to sdql it. After that, you view its password, then go back to your relay to enter the password, then you can talk.

This changes it to a nice simple go to relay > link to core, no password required

## Changelog
:cl:
tweak: The relay at CC no longer needs a password to connect to telecomns cores.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
