### PR TITLE
Lets revivers potentially heal you out of shock

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -336,7 +336,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/reviver
 	name = "Reviver implant"
-	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
+	desc = "This implant will attempt to heal you out of critical condition. For the faint of heart!"
 	icon_state = "chest_implant"
 	implant_color = "#AD0000"
 	origin_tech = "materials=5;programming=4;biotech=4"
@@ -361,6 +361,11 @@
 			addtimer(CALLBACK(src, .proc/heal), 30)
 		else
 			reviving = FALSE
+			if(owner.HasDisease(new /datum/disease/critical/shock(0)) && prob(15)) //If they are no longer in crit, but have shock, and pass a 15% chance:
+				for(var/datum/disease/critical/shock/S in owner.viruses)
+					S.cure()
+					revive_cost += 150
+					to_chat(owner, "<span class='notice'>You feel better.</span>")
 			return
 	cooldown = revive_cost + world.time
 	revive_cost = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Updates revivers description from ""revive you if you lose consciousness" to "heal you out of critical condition"

Makes revivers have a 15% chance per every other life tick to heal shock, so long as you are out of crit.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Revivers kinda suck right now. Very slow healing, kills you if emp'd, but most importantly, does not heal shock, which means if you receive shock, and have a reviver, you still will progress to stage 2 crit, and from there to heart attack, without medical attention soon. 

This PR makes the reviver better at stabilizing you, by making it potentially able to heal shock (but not stage 2 crit) if you are not longer in critical condition. This PR does not adjust healing values, or make it heal you to 25 HP as a way to cure stage 1 crit, however those could be options in potential future PRs. This just makes reviver that little bit better for stabilizing you so long as you are not in a dangerous situation.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Reviver implants now stabilize the user better, by having a chance to heal shock when the user is not in critical condition.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
