### PR TITLE
Brig cell door timer fix

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -36071,7 +36071,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
+	id = "Cell 2";
 	name = "Cell 2 Locker"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -36171,11 +36171,6 @@
 	},
 /area/security/brig)
 "bzp" = (
-/obj/machinery/door_timer/cell_4{
-	id = "Cell 3";
-	layer = 4;
-	name = "Cell 3"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -36938,7 +36933,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
-	id = "Cell 4";
+	id = "Cell 2";
 	name = "Cell 2";
 	req_access_txt = "2"
 	},
@@ -38308,7 +38303,7 @@
 	dir = 1
 	},
 /obj/machinery/flasher{
-	id = "Cell 4";
+	id = "Cell 2";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -38326,13 +38321,10 @@
 /area/security/brig)
 "bCQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door_timer/cell_4{
-	dir = 8;
-	layer = 4;
-	name = "Cell 2";
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door_timer/cell_2{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -40085,7 +40077,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 5";
+	id = "Cell 1";
 	name = "Cell 1 Locker"
 	},
 /obj/item/radio/intercom{
@@ -41253,7 +41245,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
-	id = "Cell 5";
+	id = "Cell 1";
 	name = "Cell 1";
 	req_access_txt = "2"
 	},
@@ -42129,7 +42121,7 @@
 	dir = 1
 	},
 /obj/machinery/flasher{
-	id = "Cell 5";
+	id = "Cell 1";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -51382,16 +51374,14 @@
 	},
 /area/security/brig)
 "caP" = (
-/obj/machinery/door_timer/cell_4{
-	id = "Cell 5";
-	layer = 4;
-	name = "Cell 5"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	tag = ""
+	},
+/obj/machinery/door_timer/cell_5{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -52550,8 +52540,8 @@
 	c_tag = "Brig Cell 4"
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
+	id = "Cell 5";
+	name = "Cell 5 Locker"
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
@@ -54211,6 +54201,10 @@
 /obj/machinery/treadmill_monitor{
 	id = "Cell 4";
 	pixel_y = -32
+	},
+/obj/machinery/flasher{
+	id = "Cell 5";
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -104300,13 +104294,10 @@
 /area/security/permasolitary)
 "gDv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door_timer/cell_5{
-	dir = 8;
-	layer = 4;
-	name = "Cell 1";
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door_timer/cell_1{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -107239,6 +107230,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
+"uiw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door_timer/cell_3{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/security/brig)
 "ujH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -107417,8 +107428,8 @@
 /area/crew_quarters/theatre)
 "uYc" = (
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
+	id = "Cell 3";
+	name = "Cell 3 Locker"
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Cell 2"
@@ -107587,7 +107598,7 @@
 /area/security/permasolitary)
 "vvQ" = (
 /obj/machinery/door_timer/cell_4{
-	layer = 4
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -107997,10 +108008,6 @@
 /area/medical/surgery1)
 "xIo" = (
 /obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 5";
-	pixel_y = -28
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_y = -28
@@ -160954,7 +160961,7 @@ bkj
 bvr
 bsL
 biv
-bzn
+uiw
 bAV
 uYc
 bEy

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12074,11 +12074,6 @@
 	c_tag = "Brig - Hallway - Port";
 	dir = 1
 	},
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -12087,22 +12082,20 @@
 	},
 /area/security/brig)
 "aBl" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
+/obj/machinery/door_timer/cell_4{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/brig)
 "aBn" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
+/obj/machinery/door_timer/cell_5{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -18770,12 +18763,6 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "aPm" = (
-/obj/machinery/door_timer{
-	dir = 1;
-	id = "Cell 4";
-	name = "Cell 4";
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -21108,15 +21095,11 @@
 	},
 /area/storage/primary)
 "aUx" = (
-/obj/machinery/door_timer{
-	dir = 1;
-	id = "Cell 5";
-	name = "Cell 5";
-	pixel_y = 32
+/obj/machinery/door_timer/cell_1{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "redcorner"
 	},
 /area/security/brig)
 "aUy" = (
@@ -33884,12 +33867,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"buL" = (
-/obj/structure/transit_tube{
-	icon_state = "D-SE"
-	},
-/turf/space,
-/area/space/nearstation)
 "buM" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NW"
@@ -52676,12 +52653,6 @@
 "chk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"chl" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -78507,6 +78478,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"glM" = (
+/obj/machinery/door_timer/cell_2{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
+/area/security/brig)
 "gnJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79672,6 +79651,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"jZd" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/security/brig)
 "kez" = (
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -79766,13 +79753,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/space,
-/area/space/nearstation)
-"ktv" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
 /turf/space,
 /area/space/nearstation)
 "ktX" = (
@@ -109364,7 +109344,7 @@ atr
 aFz
 atr
 aAc
-aFz
+aUx
 aKc
 aDO
 aFh
@@ -110392,7 +110372,7 @@ aDg
 asS
 aqJ
 lgv
-aFz
+glM
 aKc
 aDO
 aFi
@@ -110649,7 +110629,7 @@ aEV
 aJy
 aOY
 aZb
-aBl
+aFl
 akD
 akD
 akD
@@ -111420,7 +111400,7 @@ aFz
 amE
 aqJ
 lgv
-aFl
+jZd
 aKc
 aDO
 aFj
@@ -111677,7 +111657,7 @@ aFB
 ayw
 aOY
 aZb
-aBn
+aFz
 akD
 akD
 akD
@@ -112960,7 +112940,7 @@ akD
 aFg
 aFX
 aKc
-atr
+aBl
 lgv
 aFA
 amE
@@ -113217,7 +113197,7 @@ akD
 amE
 amE
 amx
-aUx
+alF
 lgv
 vDc
 amE
@@ -113988,7 +113968,7 @@ akD
 aFg
 aGE
 aKc
-atr
+aBn
 lgv
 aFz
 amE
@@ -127922,7 +127902,7 @@ bRg
 bRg
 bRg
 bRg
-chl
+bKc
 ciW
 ckl
 cij
@@ -128940,7 +128920,7 @@ cmL
 nMx
 cmL
 kto
-ktv
+cmN
 bIu
 abq
 bMj
@@ -130724,7 +130704,7 @@ cmL
 cmL
 cmL
 cmL
-ktv
+cmN
 bwL
 aaa
 abq
@@ -134322,7 +134302,7 @@ aaa
 aaa
 aaa
 abq
-buL
+bqY
 bwW
 bxk
 aaa

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -8758,12 +8758,10 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "aua" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/door_timer/cell_1{
-	dir = 1;
-	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -8943,12 +8941,10 @@
 	},
 /area/security/permabrig)
 "aum" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/door_timer/cell_3{
-	dir = 1;
-	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -10780,9 +10776,6 @@
 	},
 /area/security/prison/cell_block/A)
 "axH" = (
-/obj/machinery/door_timer/cell_2{
-	layer = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -10794,6 +10787,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/light,
+/obj/machinery/door_timer/cell_2{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -10823,9 +10819,6 @@
 	},
 /area/security/prison/cell_block/A)
 "axJ" = (
-/obj/machinery/door_timer/cell_4{
-	layer = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10835,6 +10828,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door_timer/cell_4{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -11049,13 +11045,11 @@
 /area/security/lobby)
 "ayn" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door_timer/cell_5{
-	dir = 4;
-	layer = 4;
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/door_timer/cell_5{
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -20,6 +20,7 @@
 	req_access = list(ACCESS_BRIG)
 	anchored = 1    		// can't pick it up
 	density = 0       		// can walk through it.
+	layer = WALL_OBJ_LAYER
 	var/id = null     		// id of door it controls.
 	var/releasetime = 0		// when world.timeofday reaches it - release the prisoner
 	var/timing = 0    		// boolean, true/1 timer is on, false/0 means it's not timing
@@ -124,8 +125,6 @@
 	Radio.listening = 0
 	Radio.config(list("Security" = 0))
 	Radio.follow_target = src
-
-	set_pixel_offsets_from_dir(32, -32, 32, -32)
 
 	spawn(20)
 		for(var/obj/machinery/door/window/brigdoor/M in GLOB.airlocks)
@@ -452,47 +451,29 @@
 		I.overlays += ID
 	return I
 
-
 /obj/machinery/door_timer/cell_1
 	name = "Cell 1"
 	id = "Cell 1"
-	dir = 2
-	pixel_y = -32
-
 
 /obj/machinery/door_timer/cell_2
 	name = "Cell 2"
 	id = "Cell 2"
-	dir = 2
-	pixel_y = -32
-
 
 /obj/machinery/door_timer/cell_3
 	name = "Cell 3"
 	id = "Cell 3"
-	dir = 2
-	pixel_y = -32
-
 
 /obj/machinery/door_timer/cell_4
 	name = "Cell 4"
 	id = "Cell 4"
-	dir = 2
-	pixel_y = -32
-
 
 /obj/machinery/door_timer/cell_5
 	name = "Cell 5"
 	id = "Cell 5"
-	dir = 2
-	pixel_y = -32
-
 
 /obj/machinery/door_timer/cell_6
 	name = "Cell 6"
 	id = "Cell 6"
-	dir = 4
-	pixel_x = 32
 
 #undef FONT_SIZE
 #undef FONT_COLOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes this bug by removing all of the hardcoded pixel offsets on brig cell door timers:
![image](https://user-images.githubusercontent.com/57483089/126074348-268e085d-e066-434e-ae18-3fbe267804f5.png)

Also tweaks the positioning of the Meta and Delta cell timers for consistency, and fixes some incorrectly linked lockers and flashes.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Subtypes are better than map instances in most cases, but for pixel offsets it makes a lot more sense for them to be individually edited rather than set in the code directly. Hardcoded pixel offsets on an object is just bad practice when it comes to mapping and standardisation.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
### Metastation timer location change:
**Before:**
![before](https://user-images.githubusercontent.com/57483089/126074683-c3a38891-495d-46b3-95d6-69af0a0b4c38.png)
**After:**
![after](https://user-images.githubusercontent.com/57483089/126074684-1b3b8d6d-b089-41d1-9f68-cc193a4c7f4d.png)


## Changelog
:cl:
tweak: Tweaked the location of the cell door timers on Metastation.
fix: Fixed the cell 5 door timer floating in the doorway on Boxstation.
fix: Fixed some cell lockers and flashes not being correctly linked on Metastation and Deltastation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
