### PR TITLE
Better equips med ERT for the basics

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -321,12 +321,11 @@
 		/obj/item/clothing/head/helmet/ert/medical = 1,
 		/obj/item/clothing/mask/surgical = 1,
 		/obj/item/storage/firstaid/adv = 1,
-		/obj/item/storage/firstaid/regular = 1,
+		/obj/item/storage/firstaid/doctor = 1,
 		/obj/item/storage/box/autoinjectors = 1,
 		/obj/item/roller = 1,
 		/obj/item/storage/pill_bottle/ert = 1,
 		/obj/item/flashlight = 1,
-		/obj/item/healthupgrade = 1,
 		/obj/item/handheld_defibrillator = 1
 	)
 
@@ -349,13 +348,12 @@
 	backpack_contents = list(
 		/obj/item/clothing/mask/surgical = 1,
 		/obj/item/storage/firstaid/toxin = 1,
-		/obj/item/storage/firstaid/brute = 1,
-		/obj/item/storage/firstaid/fire = 1,
+		/obj/item/storage/firstaid/doctor = 1,
+		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/storage/box/autoinjectors = 1,
 		/obj/item/roller = 1,
 		/obj/item/clothing/shoes/magboots = 1,
 		/obj/item/bodyanalyzer = 1,
-		/obj/item/healthupgrade = 1,
 		/obj/item/handheld_defibrillator = 1
 	)
 
@@ -378,9 +376,10 @@
 
 	backpack_contents = list(
 		/obj/item/bodyanalyzer/advanced = 1,
+		/obj/item/storage/firstaid/doctor = 1,
+		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/extinguisher/mini = 1,
 		/obj/item/roller = 1,
-		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/handheld_defibrillator = 1
 
 		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds doctor first aid kits to all levels of medic ERTS, so they start with auto menders for brute / burn, so they can actually heal dead people effectively.

Gives the red ERT an advanced first aid kit and doctor first aid kit, rather than a brute and a burn one.

Removes analyzer upgrade as there is no need for it, as medical ert now have an upgraded analyzer in their first aid kit.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Medical ERT is great, but it helps to actually be able to heal damage on dead people as an ERT. A gamma ERT member currently can not heal a dead person, barring using a medbeam on them. It relies way too much on fancy tech, rather then having something reliable and simple. Thus, auto menders for all.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: All medical ERT levels have a doctor first aid kit.
tweak: Removes red medical ERT brute and burn first aid kit, for an advanced and doctor first aid kit.
tweak: Removes Health analyzer upgrade from med ERT, as they now have an upgraded analyzer at all levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
