### PR TITLE
Jani ERT Equipment Tweak

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -409,7 +409,6 @@
 	new /obj/item/soap(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
-	new /obj/item/melee/flyswatter(src)
 	update_icon()
 
 /obj/item/storage/belt/lazarus

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -483,16 +483,15 @@
 		/obj/item/reagent_containers/spray/cleaner = 1,
 		/obj/item/storage/bag/trash = 1,
 		/obj/item/storage/box/lights/mixed = 1,
-		/obj/item/holosign_creator = 1,
-		/obj/item/flashlight = 1)
+		/obj/item/melee/flyswatter = 1)
 
 /datum/outfit/job/centcom/response_team/janitorial/amber
 	name = "RT Janitor (Amber)"
 	suit = /obj/item/clothing/suit/armor/vest/ert/janitor
 	head = /obj/item/clothing/head/helmet/ert/janitor
 	glasses = /obj/item/clothing/glasses/sunglasses
-
-	r_hand = /obj/item/gun/energy/disabler
+	r_pocket = /obj/item/flashlight
+	suit_store = /obj/item/gun/energy/disabler
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/advmop)
@@ -503,7 +502,7 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 
 	r_pocket = /obj/item/scythe/tele
-	l_pocket = /obj/item/gun/energy/gun/mini
+	suit_store = /obj/item/gun/energy/gun/mini
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/janitorial,
@@ -515,18 +514,20 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/janitor/gamma
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	suit_store = /obj/item/gun/energy/gun
-	l_pocket = /obj/item/grenade/clusterbuster/cleaner
 	r_pocket = /obj/item/scythe/tele
 	shoes = /obj/item/clothing/shoes/magboots/advance
 
 	backpack_contents = list(
 		/obj/item/grenade/chem_grenade/antiweed = 2,
+		/obj/item/grenade/clusterbuster/cleaner = 1,
 		/obj/item/storage/box/lights/mixed = 1,
 		/obj/item/storage/bag/trash/bluespace = 1,
-		/obj/item/reagent_containers/spray/cleaner = 1
+		/obj/item/reagent_containers/spray/cleaner = 1,
+		/obj/item/melee/flyswatter = 1
 	)
 
 	cybernetic_implants = list(
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/arm/advmop,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -512,7 +512,7 @@
 /datum/outfit/job/centcom/response_team/janitorial/gamma
 	name = "RT Janitor (Gamma)"
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/janitor/gamma
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	glasses = /obj/item/clothing/glasses/night
 	suit_store = /obj/item/gun/energy/gun
 	r_pocket = /obj/item/scythe/tele
 	shoes = /obj/item/clothing/shoes/magboots/advance


### PR DESCRIPTION
## What Does This PR Do
I was poking around ERT equipment for a wiki project and noticed some inconsistencies and flaws in the Jani ERT equipment.
This PR cleans them up.

**All Jani ERT Levels**
- Flyswatter moved from Jani-belt to backpack
- flashlight is no longer included in the backpack
- All weapons/disablers moved to suit storage
- Now start with a telescopic baton in pocket (only amber had this initially)

**Amber**
- Start with a flashlight in their pocket

**Red**
- No longer starts with a handheld flashlight

**Gamma**
- Gave Nutriment Pump Plus Implant
- Gave NV goggles
- Mr. Proper moved from pocket to backpack

## Why It's Good For The Game
There's no reason why each alert shouldn't have a telescopic baton considering amber has it.
All gamma alert ERTs had Nutriment Pump Plus implant except Jani for some reason, this makes it uniform.
Jani Belt overflowed max-content amount with the flyswatter so it was moved in order to not cause an ugly UI issue.
Red+ do not need flashlights since they have built-in suit headlights
Suit storage is a better place for Disablers and such, prevents spawn friendly fire as well

This was tested for errors by choosing outfits for mobs in the event panel and I encountered no issues.

## Changelog
:cl:
tweak: All Janitorial ERT levels now get telescopic batons
tweak: Added nutriment pump plus implant and NV goggles to Gamma ERT Janitor
tweak: Janitorial ERT inventories cleaned up in general
/:cl:

