### PR TITLE
Slight nerf and tweak to the Chiropteran Screech vampire ability

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -265,6 +265,8 @@
 	for(var/mob/living/carbon/C in hearers(4))
 		if(C == user)
 			continue
+		if(!affects(C))
+			continue
 		if(ishuman(C))
 			var/mob/living/carbon/human/H = C
 			if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
@@ -275,8 +277,6 @@
 				C.Stuttering(10)
 				C.Jitter(50)
 				continue
-		if(!affects(C))
-			continue
 		to_chat(C, "<span class='warning'><font size='3'><b>You hear an ear piercing shriek and your senses dull!</font></b></span>")
 		C.Weaken(4)
 		C.AdjustEarDamage(0, 20)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -286,7 +286,7 @@
 	for(var/obj/structure/window/W in view(4))
 		W.deconstruct(FALSE)
 	for(var/obj/machinery/light/L in view(6))
-		L.deconstruct(FALSE)
+		L.break_light_tube()
 	playsound(user.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
 
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -272,10 +272,10 @@
 			if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 				continue
 			if(H.check_ear_prot() >= HEARING_PROTECTION_MINOR)
-				to_chat(C, "<span class='warning'><font size='3'><b>You hear a dull shriek and instinctively cover your ears!</font></b></span>")
-				C.Confused(10)
-				C.Stuttering(10)
-				C.Jitter(50)
+				to_chat(H, "<span class='warning'><font size='3'><b>You hear a dull shriek and instinctively cover your ears!</font></b></span>")
+				H.Confused(10)
+				H.Stuttering(10)
+				H.Jitter(50)
 				continue
 		to_chat(C, "<span class='warning'><font size='3'><b>You hear an ear piercing shriek and your senses dull!</font></b></span>")
 		C.Weaken(4)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -269,9 +269,15 @@
 			var/mob/living/carbon/human/H = C
 			if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 				continue
+			if(H.check_ear_prot() >= HEARING_PROTECTION_MINOR)
+				to_chat(C, "<span class='warning'><font size='3'><b>You hear a dull shriek and instinctively cover your ears!</font></b></span>")
+				C.Confused(10)
+				C.Stuttering(10)
+				C.Jitter(50)
+				continue
 		if(!affects(C))
 			continue
-		to_chat(C, "<span class='warning'><font size='3'><b>You hear a ear piercing shriek and your senses dull!</font></b></span>")
+		to_chat(C, "<span class='warning'><font size='3'><b>You hear an ear piercing shriek and your senses dull!</font></b></span>")
 		C.Weaken(4)
 		C.AdjustEarDamage(0, 20)
 		C.Stuttering(20)
@@ -279,6 +285,8 @@
 		C.Jitter(150)
 	for(var/obj/structure/window/W in view(4))
 		W.deconstruct(FALSE)
+	for(var/obj/machinery/light/L in view(6))
+		L.deconstruct(FALSE)
 	playsound(user.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Bowman headsets now reduce the screech's effect, negating the stun, but it is now also capable of breaking light bulbs (slightly further than windows).

- fixes a small grammatical issue in "aN ear piercing shriek".
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

With earmuffs being fixed, the screech has become downright broken against security : Either they all deafen themselves - kind of going against any and all form of RP and teamplay - or they get an entire platoon downed at the press of a single button.

This aims to tune it down, while still being an extremely competent form of crowd control against civillian crew, and getting the extra benefit of breaking lights ! (Which kiiiinda makes sense seeing as it breaks reinforced windows like paper :eyes:)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Being screeched at while wearing a bowman headset now confuses rather than stun.
add: Screech now breaks lights in a six tile radius
fix: fixed a grammatical error in "You hear aN ear piercing shriek and your senses dull!"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
