### PR TITLE
ORM manual ore insertion fix

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -60,7 +60,7 @@
 	..()
 	ore_buffer = list()
 	// Components
-	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE), INFINITY, FALSE, /obj/item/stack, null, CALLBACK(src, .proc/on_material_insert))
+	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE), INFINITY, FALSE, /obj/item/stack, null, CALLBACK(src, .proc/on_material_insert), TRUE)
 	files = new /datum/research/smelter(src)
 	// Stock parts
 	component_parts = list()
@@ -192,24 +192,32 @@
 		message_sent = TRUE
 
 // Interactions
-/obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)
-	if(exchange_parts(user, W))
+/obj/machinery/mineral/ore_redemption/attackby(obj/item/I, mob/user, params)
+	if(exchange_parts(user, I))
 		return
 	if(!powered())
 		return ..()
 
-	if(istype(W, /obj/item/card/id))
+	if(istype(I, /obj/item/card/id))
 		try_insert_id(user)
 		return
-	else if(istype(W, /obj/item/disk/design_disk))
+
+	else if(istype(I, /obj/item/stack/ore))
+		var/obj/item/stack/ore/O = I
+		to_chat(user, "<span class='notice'>You insert [O.amount] [O.singular_name]\s into [src].</span>")
+		smelt_ore(O)
+		SStgui.update_uis(src) // This is needed
+		return
+
+	else if(istype(I, /obj/item/disk/design_disk))
 		if(!user.drop_item())
 			return
-		W.forceMove(src)
-		inserted_disk = W
+		I.forceMove(src)
+		inserted_disk = I
 		SStgui.update_uis(src)
 		interact(user)
-		user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>", \
-						 	 "<span class='notice'>You insert [W] into [src].</span>")
+		user.visible_message("<span class='notice'>[user] inserts [I] into [src].</span>",
+						 	 "<span class='notice'>You insert [I] into [src].</span>")
 		return
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes inserting ores into the ORM manually not giving any mining points.
This was done by disabling the attackby override on the `/datum/component/material_container` component, and creating a new one on the ORM.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Definitely an oversight to not get any points from inserting ores.

## Changelog
:cl:
fix: Fixed inserting ores into the ORM manually not giving any mining points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
