### PR TITLE
Add a hand labeler to scichem

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -6,6 +6,19 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"aac" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/table,
+/obj/item/radio/electropack,
+/obj/item/assembly/signaler,
+/obj/item/healthanalyzer,
+/obj/item/hand_labeler,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/misc_lab)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -64203,18 +64216,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
-"cBZ" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/structure/table,
-/obj/item/radio/electropack,
-/obj/item/assembly/signaler,
-/obj/item/healthanalyzer,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/misc_lab)
 "cCa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -133967,7 +133968,7 @@ cuQ
 bGG
 cyR
 cAP
-cBZ
+aac
 cDw
 cDb
 cEt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a hand labeler to scichem

## Why It's Good For The Game
Lets scientists label their grenades. The experimentor gets one so scichem should get a labeler too.

## Images of changes
![Capture](https://user-images.githubusercontent.com/85434590/126861596-be5fe956-1072-4618-b48c-90f5f3eb9a4e.PNG)


## Changelog
:cl:
add: Added a hand labeler to scichem
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
