### PR TITLE
Allows admins to cryo cyborgs and AI's in player panel

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -777,12 +777,10 @@
 		O.force_eject_occupant(person_to_cryo)
 	var/list/free_cryopods = list()
 	for(var/obj/machinery/cryopod/P in GLOB.machines)
-		if(ishuman(person_to_cryo))
-			if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))
-				free_cryopods += P
-		else
-			if(!P.occupant && istype(P, /obj/machinery/cryopod/robot))
-				free_cryopods += P
+		if(P.occupant)
+			continue
+		if((ishuman(person_to_cryo) && istype(get_area(P), /area/crew_quarters/sleep)) || istype(P, /obj/machinery/cryopod/robot))
+			free_cryopods += P
 	var/obj/machinery/cryopod/target_cryopod = null
 	if(free_cryopods.len)
 		target_cryopod = safepick(free_cryopods)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -769,7 +769,7 @@
 	return ..()
 
 
-/proc/cryo_ssd(mob/living/carbon/person_to_cryo)
+/proc/cryo_ssd(mob/living/person_to_cryo)
 	if(istype(person_to_cryo.loc, /obj/machinery/cryopod))
 		return 0
 	if(isobj(person_to_cryo.loc))
@@ -777,8 +777,12 @@
 		O.force_eject_occupant(person_to_cryo)
 	var/list/free_cryopods = list()
 	for(var/obj/machinery/cryopod/P in GLOB.machines)
-		if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))
-			free_cryopods += P
+		if(ishuman(person_to_cryo))
+			if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))
+				free_cryopods += P
+		else
+			if(!P.occupant && istype(P, /obj/machinery/cryopod/robot))
+				free_cryopods += P
 	var/obj/machinery/cryopod/target_cryopod = null
 	if(free_cryopods.len)
 		target_cryopod = safepick(free_cryopods)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -756,8 +756,7 @@
 	var/mob/living/silicon/robot/R = occupant
 	if(!istype(R)) return ..()
 
-	R.contents -= R.mmi
-	qdel(R.mmi)
+	QDEL_NULL(R.mmi)
 	for(var/obj/item/I in R.module) // the tools the borg has; metal, glass, guns etc
 		for(var/obj/item/O in I) // the things inside the tools, if anything; mainly for janiborg trash bags
 			O.loc = R

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2302,7 +2302,8 @@
 		if(!check_rights(R_ADMIN))
 			return
 		var/mob/living/M = locateUID(href_list["cryossd"])
-		if(!ishuman(M) && !issilicon(M))
+		var/human = ishuman(M)
+		if(!human && !issilicon(M))
 			to_chat(usr, "<span class='warning'>This can only be used on humans and silicons.</span>")
 			return
 		if(!href_list["cryoafk"] && !isLivingSSD(M))
@@ -2314,7 +2315,7 @@
 		if(istype(M.loc, /obj/machinery/cryopod))
 			var/obj/machinery/cryopod/P = M.loc
 			P.despawn_occupant()
-			if(ishuman(M))
+			if(human)
 				var/mob/living/carbon/human/H = M
 				log_admin("[key_name(usr)] despawned [H.job] [H] in cryo.")
 				message_admins("[key_name_admin(usr)] despawned [H.job] [H] in cryo.")
@@ -2322,7 +2323,7 @@
 				log_admin("[key_name(usr)] despawned [M] in cryo.")
 				message_admins("[key_name_admin(usr)] despawned [M] in cryo.")
 		else if(cryo_ssd(M))
-			if(ishuman(M))
+			if(human)
 				var/mob/living/carbon/human/H = M
 				log_admin("[key_name(usr)] sent [H.job] [H] to cryo.")
 				message_admins("[key_name_admin(usr)] sent [H.job] [H] to cryo.")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2301,26 +2301,39 @@
 	else if(href_list["cryossd"])
 		if(!check_rights(R_ADMIN))
 			return
-		var/mob/living/carbon/human/H = locateUID(href_list["cryossd"])
-		if(!istype(H))
-			to_chat(usr, "<span class='warning'>This can only be used on instances of type /mob/living/carbon/human</span>")
+		var/mob/living/M= locateUID(href_list["cryossd"])
+		if(!ishuman(M) && !issilicon(M))
+			to_chat(usr, "<span class='warning'>This can only be used on humans and silicons</span>")
 			return
-		if(!href_list["cryoafk"] && !isLivingSSD(H))
+		if(!href_list["cryoafk"] && !isLivingSSD(M))
 			to_chat(usr, "<span class='warning'>This can only be used on living, SSD players.</span>")
 			return
-		if(istype(H.loc, /obj/machinery/cryopod))
-			var/obj/machinery/cryopod/P = H.loc
+		if(isAI(M))
+			var/mob/living/silicon/ai/A = M
+			A.cryo_AI()
+		if(istype(M.loc, /obj/machinery/cryopod))
+			var/obj/machinery/cryopod/P = M.loc
 			P.despawn_occupant()
-			log_admin("[key_name(usr)] despawned [H.job] [H] in cryo.")
-			message_admins("[key_name_admin(usr)] despawned [H.job] [H] in cryo.")
-		else if(cryo_ssd(H))
-			log_admin("[key_name(usr)] sent [H.job] [H] to cryo.")
-			message_admins("[key_name_admin(usr)] sent [H.job] [H] to cryo.")
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				log_admin("[key_name(usr)] despawned [H.job] [H] in cryo.")
+				message_admins("[key_name_admin(usr)] despawned [H.job] [H] in cryo.")
+			else //robot
+				log_admin("[key_name(usr)] despawned [M] in cryo.")
+				message_admins("[key_name_admin(usr)] despawned [M] in cryo.")
+		else if(cryo_ssd(M))
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				log_admin("[key_name(usr)] sent [H.job] [H] to cryo.")
+				message_admins("[key_name_admin(usr)] sent [H.job] [H] to cryo.")
+			else
+				log_admin("[key_name(usr)] sent [M] to cryo.")
+				message_admins("[key_name_admin(usr)] sent [M] to cryo.")
 			if(href_list["cryoafk"]) // Warn them if they are send to storage and are AFK
-				to_chat(H, "<span class='danger'>The admins have moved you to cryo storage for being AFK. Please eject yourself (right click, eject) out of the cryostorage if you want to avoid being despawned.</span>")
-				SEND_SOUND(H, sound('sound/effects/adminhelp.ogg'))
-				if(H.client)
-					window_flash(H.client)
+				to_chat(M, "<span class='danger'>The admins have moved you to cryo storage for being AFK. Please eject yourself (right click, eject) out of the cryostorage if you want to avoid being despawned.</span>")
+				SEND_SOUND(M, sound('sound/effects/adminhelp.ogg'))
+				if(M.client)
+					window_flash(M.client)
 	else if(href_list["FaxReplyTemplate"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2301,9 +2301,9 @@
 	else if(href_list["cryossd"])
 		if(!check_rights(R_ADMIN))
 			return
-		var/mob/living/M= locateUID(href_list["cryossd"])
+		var/mob/living/M = locateUID(href_list["cryossd"])
 		if(!ishuman(M) && !issilicon(M))
-			to_chat(usr, "<span class='warning'>This can only be used on humans and silicons</span>")
+			to_chat(usr, "<span class='warning'>This can only be used on humans and silicons.</span>")
 			return
 		if(!href_list["cryoafk"] && !isLivingSSD(M))
 			to_chat(usr, "<span class='warning'>This can only be used on living, SSD players.</span>")

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -9,8 +9,10 @@ GLOBAL_LIST_EMPTY(empty_playable_ai_cores)
 	if(alert("WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo and robotic storage). Are you entirely sure you want to do this?",
 					"Wipe Core", "No", "No", "Yes") != "Yes")
 		return
+	cryo_AI()
 
-	// We warned you.
+/mob/living/silicon/ai/proc/cryo_AI()
+
 	GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(loc)
 	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
 

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -12,7 +12,6 @@ GLOBAL_LIST_EMPTY(empty_playable_ai_cores)
 	cryo_AI()
 
 /mob/living/silicon/ai/proc/cryo_AI()
-
 	GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(loc)
 	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -296,7 +296,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		else
 			to_chat(src, "<span class='boldannounce'>Oops! Something went very wrong, your MMI was unable to receive your mind. You have been ghosted. Please make a bug report so we can fix this bug.</span>")
 			ghostize()
-			error("A borg has been destroyed, but its MMI lacked a brainmob, so the mind could not be transferred. Player: [ckey].")
+			log_runtime(EXCEPTION("A borg has been destroyed, but its MMI lacked a brainmob, so the mind could not be transferred. Player: [ckey]."), src)
 		mmi = null
 	if(connected_ai)
 		connected_ai.connected_robots -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Removes the is human checks for cryoing mobs, instead checks for human or silicon.
If the mob is an AI, it will wipe the core of the SSD AI.
If it is a human, it works as before.
If it is a robot, it finds a robotic storage.
Applies the same to despawning mobs in cryo, if it is a robot in storage it can now be cryo'd

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to cryo ssd borgs / AI's easily without having to call procs or possess the mob is good.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Admins can now cryo cyborgs and AI's like humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
