### PR TITLE
Fire-safety closet extinguisher tweak

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -71,18 +71,18 @@
 	icon_opened = "fireclosetopen"
 
 /obj/structure/closet/firecloset/populate_contents()
+	new /obj/item/extinguisher(src)
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/tank/internals/oxygen/red(src)
-	new /obj/item/extinguisher(src)
 	new /obj/item/clothing/head/hardhat/red(src)
 
 /obj/structure/closet/firecloset/full/populate_contents()
+	new /obj/item/extinguisher(src)
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/flashlight(src)
 	new /obj/item/tank/internals/oxygen/red(src)
-	new /obj/item/extinguisher(src)
 	new /obj/item/clothing/head/hardhat/red(src)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Changes the order of the items in the fire-safety closet so that the fire extinguisher spawns on top of everything else.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This has got to the the smallest nitpick ever, but trying to pixel hunt for the very top of the fire extinguisher when someone's burning to death in the other room has been a surprisingly common cause of irritation.
Obviously alt clicking and right clicking are options to get around it, but despite that I still find myself spending upwards of ten seconds trying to pick it up manually.
It could just be me who gets this, but I can't see any downsides to making it a bit more user friendly.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
**Before:**
![image](https://user-images.githubusercontent.com/57483089/126882840-dadf88c3-6894-440d-add1-db086a2f78ee.png)
**After:**
![image](https://user-images.githubusercontent.com/57483089/126882949-367c8587-3d81-4315-aeab-727285d1aa70.png)
*(I don't know what's going on with the sprite layering underneath, but the objects are still spawning in the correct order. It just seems to be very inconsistent.)*

## Changelog
:cl:
tweak: Changed the item order of fire-safety closets so that the extinguisher spawns on top.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
