### PR TITLE
Immolator lasers now immolate all mobs

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -142,7 +142,7 @@
 
 /obj/item/projectile/beam/immolator/on_hit(atom/target, blocked = 0)
 	. = ..()
-	if(istype(target, /mob/living/))
+	if(isliving(target)
 		var/mob/living/M = target
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -142,7 +142,7 @@
 
 /obj/item/projectile/beam/immolator/on_hit(atom/target, blocked = 0)
 	. = ..()
-	if(isliving(target)
+	if(isliving(target))
 		var/mob/living/M = target
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -142,8 +142,8 @@
 
 /obj/item/projectile/beam/immolator/on_hit(atom/target, blocked = 0)
 	. = ..()
-	if(istype(target, /mob/living/carbon))
-		var/mob/living/carbon/M = target
+	if(istype(target, /mob/living/))
+		var/mob/living/M = target
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Changes the check on immolators from carbon mobs to living mobs.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Blobbernaughts and cyborgs can light on fire, why not have immolators work on them too, especially when we have the code for catching on fire on the base living mob, if we want other animals to catch on fire.


## Changelog
:cl:

tweak: Immolators can now light all flammable mobs on fire, rather than just carbon mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
