### PR TITLE
Nerfs Clown PDA Slip Stun

### DIFF
--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -39,7 +39,7 @@
 	ttone = "honk"
 
 /obj/item/pda/clown/ComponentInitialize()
-	AddComponent(/datum/component/slippery, src, 8, 5, 100)
+	AddComponent(/datum/component/slippery, src, 3, 3, 100)
 
 /obj/item/pda/mime
 	default_cartridge = /obj/item/cartridge/mime


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR nerfs the duration of the slip on the Clown's PDA bringing it roughly in line with their banana
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The stun on this thing currently is way too long being comparable to lube in its length, for a non sec or command based job this is absurd as starting equipment. Bringing the duration more in line with their banana still allows for it to be useful both as a minor offensive/defensive tool and for comedy skits while preventing it from being an absurd slipping tool.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Clown PDA slip duration reduced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
