### PR TITLE
Allow borgs to remotely control morgue trays

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -123,6 +123,9 @@
 	update()
 	return
 
+/obj/structure/morgue/attack_ai(mob/user)
+	attack_hand(user)
+
 /obj/structure/morgue/attackby(P as obj, mob/user as mob, params)
 	if(istype(P, /obj/item/pen))
 		var/t = rename_interactive(user, P)


### PR DESCRIPTION
Fixes #16425
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Lets borgs and AIs remotely toggle morgue trays. 

## Why It's Good For The Game
Lets medical borgs help with fetching/putting away corpses.

## Changelog
:cl:
tweak: Borgs and AIs can now remotely control morgue trays. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
