### PR TITLE
Makes important terror spiders bold on hivemind.

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -486,11 +486,11 @@
 	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
-/datum/language/terrorspider/broadcast(mob/living/speaker, message)
-	if(istype(speaker, /mob/living/simple_animal/hostile/poison/terror_spider))
+/datum/language/terrorspider/broadcast(mob/living/speaker, message, speaker_mask)
+	if(isterrorspider(speaker))
 		var/mob/living/simple_animal/hostile/poison/terror_spider/T = speaker
 		if(T.spider_tier >= 3 || istype(T, /mob/living/simple_animal/hostile/poison/terror_spider/white)) //I think whites are important enough for this, but it can be changed. Defines not global, 3 must be used.
-			..(speaker,"<font size=3><b>[message]</b></font>")
+			..(speaker, "<font size=3><b>[message]</b></font>")
 			return
 	..(speaker, message)
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -486,7 +486,7 @@
 	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
-/datum/language/terrorspider/broadcast(mob/living/speaker, message, speaker_mask)
+/datum/language/terrorspider/broadcast(mob/living/speaker, message)
 	if(istype(speaker, /mob/living/simple_animal/hostile/poison/terror_spider))
 		var/mob/living/simple_animal/hostile/poison/terror_spider/T = speaker
 		if(T.spider_tier >= 3 || istype(T, /mob/living/simple_animal/hostile/poison/terror_spider/white)) //I think whites are important enough for this, but it can be changed. Defines not global, 3 must be used.

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -489,7 +489,7 @@
 /datum/language/terrorspider/broadcast(mob/living/speaker, message, speaker_mask)
 	if(isterrorspider(speaker))
 		var/mob/living/simple_animal/hostile/poison/terror_spider/T = speaker
-		if(T.spider_tier >= 3 || istype(T, /mob/living/simple_animal/hostile/poison/terror_spider/white)) //I think whites are important enough for this, but it can be changed. Defines not global, 3 must be used.
+		if(T.loudspeaker)
 			..(speaker, "<font size=3><b>[message]</b></font>")
 			return
 	..(speaker, message)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -486,6 +486,14 @@
 	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
+/datum/language/terrorspider/broadcast(mob/living/speaker, message, speaker_mask)
+	if(istype(speaker, /mob/living/simple_animal/hostile/poison/terror_spider))
+		var/mob/living/simple_animal/hostile/poison/terror_spider/T = speaker
+		if(T.spider_tier >= 3 || istype(T, /mob/living/simple_animal/hostile/poison/terror_spider/white)) //I think whites are important enough for this, but it can be changed. Defines not global, 3 must be used.
+			..(speaker,"<font size=3><b>[message]</b></font>")
+			return
+	..(speaker, message)
+
 /datum/language/ling
 	name = "Changeling"
 	desc = "Although they are normally wary and suspicious of each other, changelings can commune over a distance."

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -25,6 +25,7 @@
 	regen_points_per_kill = 200 // >2x normal, since they're food reprocessors
 	idle_ventcrawl_chance = 5
 	spider_tier = TS_TIER_3
+	loudspeaker = TRUE
 	spider_opens_doors = 2
 	web_type = /obj/structure/spider/terrorweb/mother
 	var/datum/action/innate/terrorspider/ventsmash/ventsmash_action

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -26,6 +26,7 @@
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	idle_ventcrawl_chance = 0
 	spider_tier = TS_TIER_3
+	loudspeaker = TRUE
 	spider_opens_doors = 2
 	web_type = /obj/structure/spider/terrorweb/purple
 	ai_spins_webs = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -33,6 +33,7 @@
 	projectilesound = 'sound/weapons/pierce.ogg'
 	projectiletype = /obj/item/projectile/terrorqueenspit
 	spider_tier = TS_TIER_4
+	loudspeaker = TRUE
 	spider_opens_doors = 2
 	web_type = /obj/structure/spider/terrorweb/queen
 	var/spider_spawnfrequency = 1200 // 120 seconds. Default for player queens and NPC queens on station. Awaymission queens have this changed in New()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -137,7 +137,8 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	var/killcount = 0
 	var/busy = 0 // leave this alone!
 	var/spider_tier = TS_TIER_1 // 1 for red,gray,green. 2 for purple,black,white, 3 for prince, mother. 4 for queen
-	var/loudspeaker = FALSE // Does this terror speak loudly on the terror hivemind?
+	/// Does this terror speak loudly on the terror hivemind?
+	var/loudspeaker = FALSE
 	var/hasdied = 0
 	var/list/spider_special_drops = list()
 	var/attackstep = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -137,6 +137,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	var/killcount = 0
 	var/busy = 0 // leave this alone!
 	var/spider_tier = TS_TIER_1 // 1 for red,gray,green. 2 for purple,black,white, 3 for prince, mother. 4 for queen
+	var/loudspeaker = FALSE // Does this terror speak loudly on the terror hivemind?
 	var/hasdied = 0
 	var/list/spider_special_drops = list()
 	var/attackstep = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
@@ -20,6 +20,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	spider_tier = TS_TIER_2
+	loudspeaker = TRUE
 	web_type = /obj/structure/spider/terrorweb/white
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds a loudspeaker variable to terror spiders, which if the variable is true, they speak in a bigger font on the terror spider hive mind.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Terrors listening to their queen / princess / white / mother / empress leader is good, and making them bold may help make it easier to hear them in the hivemind.


## Changelog
:cl:
tweak: Tier 3 or greater terror spiders, as well as white terrors, now speak louder on the terror hivemind.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
