### PR TITLE
Fixes rad contamination being 10x stronger than intended

### DIFF
--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -109,6 +109,7 @@
 		var/atom/thing = k
 		if(QDELETED(thing))
 			continue
+		strength = strength / RAD_DOSAGE_MULTIPLIER //We don't want contamination murdering everyone instantly
 		thing.rad_act(strength)
 
 		// This list should only be for types which don't get contaminated but you want to look in their contents


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes an unintended issue from #16147 where radiation contamination was giving 10x the intended radiation dosage. This is done by dividing the rad wave strength by x10 (thus balancing it out as rad_act calls were multiplied by 10).
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No, you should not be able to give someone 22k rads by just walking near them.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes glowing green men being mini-SM crystals in terms of rads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
