### PR TITLE
Refactors runechat_msg_location to use UIDs

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -106,8 +106,8 @@
 		to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span>[speaker.GetAltName()] [track][verb], \"[message]\"</span>")
 
 		// Create map text message
-		if (client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) // can_hear is checked up there on L99
-			create_chat_message(speaker.runechat_msg_location, message_clean, italics)
+		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) // can_hear is checked up there on L99
+			create_chat_message(locateUID(speaker.runechat_msg_location), message_clean, italics)
 
 		if(speech_sound && (get_dist(speaker, src) <= world.view && src.z == speaker.z))
 			var/turf/source = speaker? get_turf(speaker) : get_turf(src)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -111,8 +111,8 @@ I'm using this for Stat to give it a more nifty interface to work with
 
 /mob/living/carbon/brain/update_runechat_msg_location()
 	if(ismecha(loc))
-		runechat_msg_location = loc
+		runechat_msg_location = loc.UID()
 	else if(container)
-		runechat_msg_location = container
+		runechat_msg_location = container.UID()
 	else
-		runechat_msg_location = src
+		return ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1939,9 +1939,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 /mob/living/carbon/human/update_runechat_msg_location()
 	if(ismecha(loc))
-		runechat_msg_location = loc
+		runechat_msg_location = loc.UID()
 	else
-		runechat_msg_location = src
+		return ..()
 
 /mob/living/carbon/human/verb/Examine_OOC()
 	set name = "Examine Meta-Info (OOC)"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1251,7 +1251,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	var/rendered = "<i><span class='game say'>Relayed Speech: <span class='name'>[name_used]</span> [message]</span></i>"
 	if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
 		var/message_clean = combine_message(message_pieces, null, M)
-		create_chat_message(M.runechat_msg_location, message_clean)
+		create_chat_message(locateUID(M.runechat_msg_location), message_clean)
 	show_message(rendered, 2)
 
 /mob/living/silicon/ai/proc/malfhacked(obj/machinery/power/apc/apc)
@@ -1371,8 +1371,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 /mob/living/silicon/ai/update_runechat_msg_location()
 	if(istype(loc, /obj/item/aicard) || ismecha(loc))
-		runechat_msg_location = loc
+		runechat_msg_location = loc.UID()
 	else
-		runechat_msg_location = src
+		return ..()
 
 #undef TEXT_ANNOUNCEMENT_COOLDOWN

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -520,6 +520,6 @@
 
 /mob/living/silicon/pai/update_runechat_msg_location()
 	if(istype(loc, /obj/item/paicard))
-		runechat_msg_location = loc
+		runechat_msg_location = loc.UID()
 	else
-		runechat_msg_location = src
+		return ..()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -65,6 +65,6 @@
 
 /mob/living/simple_animal/shade/update_runechat_msg_location()
 	if(istype(loc, /obj/item/soulstone))
-		runechat_msg_location = loc
+		runechat_msg_location = loc.UID()
 	else
-		runechat_msg_location = src
+		return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -32,7 +32,6 @@
 		GLOB.alive_mob_list += src
 	set_focus(src)
 	prepare_huds()
-	runechat_msg_location = src
 	update_runechat_msg_location()
 	. = ..()
 
@@ -1454,9 +1453,11 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 /**
  * Updates the mob's runechat maptext display location.
+ *
+ * By default, we set this to the src mob's `UID()`.
  */
 /mob/proc/update_runechat_msg_location()
-	return
+	runechat_msg_location = UID()
 
 GLOBAL_LIST_INIT(holy_areas, typecacheof(list(
 	/area/chapel

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -201,5 +201,5 @@
 
 	/// Overrides the health HUD element state if set.
 	var/health_hud_override = HEALTH_HUD_OVERRIDE_NONE
-	/// The location our runechat message should appear. Should be src by default.
-	var/atom/runechat_msg_location
+	/// A soft reference to the location where this mob's runechat message will appear. Uses `UID()`.
+	var/runechat_msg_location


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Refactors the `runechat_msg_location` var on mobs to use soft refs (UIDs) over hard refs.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Soft refs are better than hard refs here.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
N/A
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
