### PR TITLE
Fixes runtimes caused by null client preferences

### DIFF
--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -126,10 +126,11 @@
 	qdel(query)
 	return 1
 
-/datum/preferences/proc/load_character(client/C,slot)
+/datum/preferences/proc/load_character(client/C, slot)
 	saved = FALSE
 
-	if(!slot)	slot = default_slot
+	if(!slot)
+		slot = default_slot
 	slot = sanitize_integer(slot, 1, max_save_slots, initial(default_slot))
 	if(slot != default_slot)
 		default_slot = slot
@@ -141,6 +142,10 @@
 			qdel(firstquery)
 			return
 		qdel(firstquery)
+
+	if(!C) // If the client disconnected during the query, try again later.
+		qdel(src)
+		return
 
 	// Let's not have this explode if you sneeze on the DB
 	var/datum/db_query/query = SSdbcore.NewQuery({"SELECT

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -145,7 +145,7 @@
 
 	if(!C) // If the client disconnected during the query, try again later.
 		qdel(src)
-		return
+		return TRUE
 
 	// Let's not have this explode if you sneeze on the DB
 	var/datum/db_query/query = SSdbcore.NewQuery({"SELECT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes #16058 (`Runtime in preferences_mysql.dm,199: Cannot read null.ckey`) and related runtimes by adding a check in `load_character()` to ensure that the client still exists after the first DB query, and deleting their preferences datum if not, so that it can be remade later.

Tested by adding a `qdel(C)` on the line above. It does also seem to work fine if the datum isn't deleted, but I can imagine that it not being able to load fully could cause problems later on.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I can only speak for the runtime logs I have downloaded of course, but based on those this seems to be an incredibly common error.

## Changelog
:cl:
fix: Fixed multiple runtimes caused by clients disconnecting before the game has fully loaded their preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
