### PR TITLE
Can't have infinite EMP implant charges anymore

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -273,6 +273,12 @@
 /atom/proc/HasProximity(atom/movable/AM)
 	return
 
+/**
+ * Proc which will make the atom act accordingly to an EMP.
+ * This proc can sleep depending on the implementation. So assume it sleeps!
+ *
+ * severity - The severity of the EMP. Either EMP_HEAVY or EMP_LIGHT
+ */
 /atom/proc/emp_act(severity)
 	return
 

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -1,12 +1,12 @@
 /**
- * Will cause an EMP pulse on the given epicenter.
+ * Will cause an EMP on the given epicenter.
  * This proc can sleep depending on the affected objects. So assume it sleeps!
  *
- * epicenter - The center of the EMP pulse. Can be an atom, as long as the given atom is on a turf (in)directly
+ * epicenter - The center of the EMP. Can be an atom, as long as the given atom is on a turf (in)directly
  * heavy_range - The max distance from the epicenter where objects will be get heavy EMPed
  * light_range - The max distance from the epicenter where objects will get light EMPed
  * log - Whether or not this action should be logged or not. Will use the cause if provided
- * cause - The cause of the EMP pulse. Used for the logging
+ * cause - The cause of the EMP. Used for the logging
  */
 /proc/empulse(turf/epicenter, heavy_range, light_range, log = FALSE, cause = null)
 	if(!epicenter) return

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -1,3 +1,13 @@
+/**
+ * Will cause an EMP pulse on the given epicenter.
+ * This proc can sleep depending on the affected objects. So assume it sleeps!
+ *
+ * epicenter - The center of the EMP pulse. Can be an atom, as long as the given atom is on a turf (in)directly
+ * heavy_range - The max distance from the epicenter where objects will be get heavy EMPed
+ * light_range - The max distance from the epicenter where objects will get light EMPed
+ * log - Whether or not this action should be logged or not. Will use the cause if provided
+ * cause - The cause of the EMP pulse. Used for the logging
+ */
 /proc/empulse(turf/epicenter, heavy_range, light_range, log = FALSE, cause = null)
 	if(!epicenter) return
 

--- a/code/game/objects/items/weapons/implants/implant_misc.dm
+++ b/code/game/objects/items/weapons/implants/implant_misc.dm
@@ -58,7 +58,7 @@
 
 /obj/item/implant/emp/activate()
 	uses--
-	empulse(imp_in, 3, 5, 1)
+	INVOKE_ASYNC(GLOBAL_PROC, .proc/empulse, get_turf(imp_in), 3, 5, 1)
 	if(!uses)
 		qdel(src)
 


### PR DESCRIPTION
## What Does This PR Do
Makes the EMP implant call `empulse` async. Fixing certain cases where you could make an infinite use EMP implant.
Also adds some documentation

## Why It's Good For The Game
Fixes an exploit

## Changelog
:cl:
fix: Can't make an infinite use EMP implant anymore
/:cl: