### PR TITLE
HONK Mech and Reticence Mech Fix

### DIFF
--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -6,6 +6,7 @@
 	var/list/steps
 	var/atom/holder
 	var/result
+	var/index
 	var/list/steps_desc
 	var/taskpath = null // Path of job objective completed.
 
@@ -128,7 +129,6 @@
 			return TRUE
 
 /datum/construction/reversible
-	var/index
 
 /datum/construction/reversible/New(atom)
 	..()
@@ -168,7 +168,6 @@
 #define state_prev "prev"
 
 /datum/construction/reversible2
-	var/index
 	var/base_icon = "durand"
 
 /datum/construction/reversible2/New(atom)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -791,7 +791,7 @@
 /datum/construction/reversible/mecha/honker/action(atom/used_atom,mob/user as mob)
 	return check_step(used_atom,user)
 
-/datum/construction/reversible/mecha/honker/custom_action(step, atom/used_atom, mob/user)
+/datum/construction/reversible/mecha/honker/custom_action(index, diff, atom/used_atom, mob/user)
 	if(!..())
 		return 0
 
@@ -860,7 +860,7 @@
 /datum/construction/reversible/mecha/reticence/action(atom/used_atom,mob/user)
 	return check_step(used_atom,user)
 
-/datum/construction/reversible/mecha/reticence/custom_action(step, atom/used_atom, mob/user)
+/datum/construction/reversible/mecha/reticence/custom_action(index, diff, atom/used_atom, mob/user)
 	if(!..())
 		return 0
 

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -767,13 +767,13 @@
 /datum/construction/mecha/honker_chassis/spawn_result()
 	..("Honker")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/mecha/honker(const_holder)
+	const_holder.construct = new /datum/construction/reversible/mecha/honker(const_holder)
 	const_holder.density = 1
 	qdel(src)
 	return
 
 
-/datum/construction/mecha/honker
+/datum/construction/reversible/mecha/honker
 	result = "/obj/mecha/combat/honker"
 	steps = list(list("key"=/obj/item/bikehorn),//1
 					 list("key"=/obj/item/clothing/shoes/clown_shoes),//2
@@ -788,10 +788,10 @@
 					 list("key"=/obj/item/bikehorn),//11
 					 )
 
-/datum/construction/mecha/honker/action(atom/used_atom,mob/user as mob)
+/datum/construction/reversible/mecha/honker/action(atom/used_atom,mob/user as mob)
 	return check_step(used_atom,user)
 
-/datum/construction/mecha/honker/custom_action(step, atom/used_atom, mob/user)
+/datum/construction/reversible/mecha/honker/custom_action(step, atom/used_atom, mob/user)
 	if(!..())
 		return 0
 
@@ -800,7 +800,7 @@
 		user.visible_message("HONK!")
 
 	//TODO: better messages.
-	switch(step)
+	switch(index)
 		if(10)
 			user.visible_message("[user] installs the central control module into the [holder].", "You install the central control module into the [holder].")
 			qdel(used_atom)
@@ -839,12 +839,12 @@
 /datum/construction/mecha/reticence_chassis/spawn_result()
 	..("Reticence")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/mecha/reticence(const_holder)
+	const_holder.construct = new /datum/construction/reversible/mecha/reticence(const_holder)
 	const_holder.density = 1
 	qdel(src)
 	return
 
-/datum/construction/mecha/reticence
+/datum/construction/reversible/mecha/reticence
 	result = "/obj/mecha/combat/reticence"
 	steps = list(list("key"=/obj/effect/dummy/mecha_emote_step),//1
 					 list("key"=/obj/item/clothing/suit/suspenders),//2
@@ -857,10 +857,10 @@
 					 list("key"=/obj/item/circuitboard/mecha/reticence/main),//9
 					 )
 
-/datum/construction/mecha/reticence/action(atom/used_atom,mob/user)
+/datum/construction/reversible/mecha/reticence/action(atom/used_atom,mob/user)
 	return check_step(used_atom,user)
 
-/datum/construction/mecha/reticence/custom_action(step, atom/used_atom, mob/user)
+/datum/construction/reversible/mecha/reticence/custom_action(step, atom/used_atom, mob/user)
 	if(!..())
 		return 0
 
@@ -870,7 +870,7 @@
 		qdel(used_atom)
 
 	//TODO: better messages.
-	switch(step)
+	switch(index)
 		if(9)
 			user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central control module into the [holder].</span>")
 			qdel(used_atom)

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -218,11 +218,11 @@
 	emote = e
 
 /obj/item/mecha_parts/chassis/reticence/hear_message(mob/living/M, msg)
-	if(!istype(M) || !istype(construct, /datum/construction/mecha/reticence))
+	if(!istype(M) || !istype(construct, /datum/construction/reversible/mecha/reticence))
 		return
 	// is the current step the dummy emote object?
 	var/list/steps = construct.steps
-	if(steps[steps.len]["key"] == /obj/effect/dummy/mecha_emote_step)
+	if(steps[construct.index]["key"] == /obj/effect/dummy/mecha_emote_step)
 		construct.action(new /obj/effect/dummy/mecha_emote_step(msg), M)
 
 /obj/item/mecha_parts/part/reticence_torso


### PR DESCRIPTION
## What Does This PR Do
Fixes #16267 and Fixes #16490 (Credit to @botka4aet for the fix) Making the HONK and Reticence mechs able to be constructed normally.
## Why It's Good For The Game
Bugs are not good.

## Changelog
:cl:
fix: Fixed HONK and Reticence mechs not being constructible.
/:cl: