### PR TITLE
Removes Cling/Vamp CQC

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -292,10 +292,9 @@
 	if(user.mind && (user.mind.changeling || user.mind.vampire)) //Prevents changelings and vampires from being able to learn it
 		if(user.mind && user.mind.changeling) //Changelings
 			to_chat(user, "<span class ='warning'>We try multiple times, but we simply cannot grasp the basics of CQC!</span>")
-			return
 		else //Vampires
 			to_chat(user, "<span class ='warning'>Your blood lust distracts you from the basics of CQC!</span>")
-			return
+		return
 
 	to_chat(user, "<span class='boldannounce'>You remember the basics of CQC.</span>")
 	var/datum/martial_art/cqc/CQC = new(null)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -289,12 +289,13 @@
 /obj/item/CQC_manual/attack_self(mob/living/carbon/human/user)
 	if(!istype(user) || !user)
 		return
-	if(user.mind && (user.mind.changeling || user.mind.vampire)) //Prevents changelings and vampires from being able to learn it
-		if(user.mind && user.mind.changeling) //Changelings
-			to_chat(user, "<span class ='warning'>We try multiple times, but we simply cannot grasp the basics of CQC!</span>")
-		else //Vampires
-			to_chat(user, "<span class ='warning'>Your blood lust distracts you from the basics of CQC!</span>")
-		return
+	if(user.mind) //Prevents changelings and vampires from being able to learn it
+		if(user.mind.changeling) //Changelings
+			to_chat(user, "<span class='warning'>We try multiple times, but we simply cannot grasp the basics of CQC!</span>")
+			return
+		else if(user.mind.vampire) //Vampires
+			to_chat(user, "<span class='warning'>Your blood lust distracts you from the basics of CQC!</span>")
+			return
 
 	to_chat(user, "<span class='boldannounce'>You remember the basics of CQC.</span>")
 	var/datum/martial_art/cqc/CQC = new(null)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -289,8 +289,15 @@
 /obj/item/CQC_manual/attack_self(mob/living/carbon/human/user)
 	if(!istype(user) || !user)
 		return
-	to_chat(user, "<span class='boldannounce'>You remember the basics of CQC.</span>")
+	if(user.mind && (user.mind.changeling || user.mind.vampire)) //Prevents changelings and vampires from being able to learn it
+		if(user.mind && user.mind.changeling) //Changelings
+			to_chat(user, "<span class ='warning'>We try multiple times, but we simply cannot grasp the basics of CQC!</span>")
+			return
+		else //Vampires
+			to_chat(user, "<span class ='warning'>Your blood lust distracts you from the basics of CQC!</span>")
+			return
 
+	to_chat(user, "<span class='boldannounce'>You remember the basics of CQC.</span>")
 	var/datum/martial_art/cqc/CQC = new(null)
 	CQC.teach(user)
 	user.drop_item()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes the ability to get CQC as a Changeling or Vampire.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I am a very, very, very vocal user of CQC. I thoroughly enjoy using it as a stealth weapon as an Antagonist and use it quite literally every round I roll Traitor. It is a very strong skill and can easily destroy anyone who isnt expecting it or doesnt have ranged weapons to use to defend themselves at a distance. That being said, given that CQC has been changed recently to be much like CQC by making its passive buff into an activateable ability, it seems odd that one martial art is barred from use while the other is not.

Cling and Vamps already have a myriad of stuns, stims, and combat buffs. Giving them more insta-stuns, combat buffs, and a free kidnapping if done right seems to go against the very ideal that Carp sets as a precedent by being unusable.

The only issue that I can see is a Cling/Tot or Vamp/Tot rolling the Bond Kit and being unable to use the CQC Manual inside. My argument would be they can ALSO pull Carp from a surplus/super surplus and be just as badly out of luck. If the Bundle is the only thing that causes issues I can look into a possible workaround with that specific one.

## Changelog
:cl:
add: Added check for vampire/changeling to CQC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
