### PR TITLE
Fixes world/Topic spam limiting

### DIFF
--- a/code/controllers/configuration/sections/system_configuration.dm
+++ b/code/controllers/configuration/sections/system_configuration.dm
@@ -14,6 +14,8 @@
 	var/shutdown_shell_command = null
 	/// 2FA backend server host
 	var/_2fa_auth_host = null
+	/// List of IP addresses which bypass world topic rate limiting
+	var/list/topic_ip_ratelimit_bypass = list()
 
 /datum/configuration_section/system_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
@@ -24,3 +26,5 @@
 	CONFIG_LOAD_STR(medal_hub_password, data["medal_hub_password"])
 	CONFIG_LOAD_STR(shutdown_shell_command, data["shutdown_shell_command"])
 	CONFIG_LOAD_STR(_2fa_auth_host, data["_2fa_auth_host"])
+
+	CONFIG_LOAD_LIST(topic_ip_ratelimit_bypass, data["topic_ip_ratelimit_bypass"])

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -85,15 +85,16 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	TGS_TOPIC
 	log_misc("WORLD/TOPIC: \"[T]\", from:[addr], master:[master], key:[key]")
 
-	// Handle spam prevention
-	if(!GLOB.world_topic_spam_prevention_handlers[address])
-		GLOB.world_topic_spam_prevention_handlers[address] = new /datum/world_topic_spam_prevention_handler
+	// Handle spam prevention, if their IP isnt in the whitelist
+	if(!(addr in GLOB.configuration.system.topic_ip_ratelimit_bypass))
+		if(!GLOB.world_topic_spam_prevention_handlers[addr])
+			GLOB.world_topic_spam_prevention_handlers[addr] = new /datum/world_topic_spam_prevention_handler(addr)
 
-	var/datum/world_topic_spam_prevention_handler/sph = GLOB.world_topic_spam_prevention_handlers[address]
+		var/datum/world_topic_spam_prevention_handler/sph = GLOB.world_topic_spam_prevention_handlers[addr]
 
-	// Lock the user out and cancel their topic if needed
-	if(sph.check_lockout())
-		return
+		// Lock the user out and cancel their topic if needed
+		if(sph.check_lockout())
+			return
 
 	var/list/input = params2list(T)
 

--- a/code/modules/world_topic/_spam_prevention_handler.dm
+++ b/code/modules/world_topic/_spam_prevention_handler.dm
@@ -2,6 +2,8 @@
 #define WORLD_TOPIC_LOCKOUT_TIME 1 MINUTES
 
 /datum/world_topic_spam_prevention_handler
+	/// IP. Used purely for select purposes.
+	var/ip = null
 	/// Amount of strikes. [WORLD_TOPIC_STRIKES_THRESHOLD] strikes is a lockout of [WORLD_TOPIC_LOCKOUT_TIME]
 	var/strikes = 0
 	/// Time of last request
@@ -10,6 +12,9 @@
 	var/locked_out = FALSE
 	/// Unlock time
 	var/unlock_time = 0
+
+/datum/world_topic_spam_prevention_handler/New(_ip)
+	ip = _ip
 
 /**
   * Lockout handler

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -702,7 +702,8 @@ shutdown_on_reboot = false
 #shutdown_shell_command = "taskkill /im dreamdaemon.exe /f"
 # URL for the 2FA backend HTTP host. Do not use https:// or a trailing slash. Comment out to disable
 #_2fa_auth_host = "http://127.0.0.1:8080"
-
+# List of IP addresses to be ignored by the world/Topic rate limiting. Useful if you have other services
+topic_ip_ratelimit_bypass = ["127.0.0.1"]
 
 ################################################################
 


### PR DESCRIPTION
## What Does This PR Do
`world/Topic` will now actually spam prevent on the right IP, thanks `azizonkg `for pointing this out. Also adds the ability to have specific IP addresses ignore the rate limits. This is useful because ALICE lives on a different machine to the gameserver itself.

## Why It's Good For The Game
Bugs bad

## Changelog
:cl:
fix: world/Topic now checks the right IP 
/:cl:
