### PR TITLE
Adds Fake Blindfold 

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -218,11 +218,13 @@
 
 /obj/effect/proc_holder/spell/vampire/mob_aoe/glare/cast(list/targets, mob/user = usr)
 	user.visible_message("<span class='warning'>[user]'s eyes emit a blinding flash!</span>")
-	if(istype(user:glasses, /obj/item/clothing/glasses/sunglasses/blindfold))
-		var/obj/item/clothing/glasses/sunglasses/blindfold/B = user:glasses
-		if(B.tint)
-			to_chat(user, "<span class='warning'>You're blindfolded!</span>")
-			return
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(istype(H.glasses, /obj/item/clothing/glasses/sunglasses/blindfold))
+			var/obj/item/clothing/glasses/sunglasses/blindfold/B = H.glasses
+			if(B.tint)
+				to_chat(user, "<span class='warning'>You're blindfolded!</span>")
+				return
 	for(var/mob/living/target in targets)
 		if(!affects(target))
 			continue

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -219,8 +219,10 @@
 /obj/effect/proc_holder/spell/vampire/mob_aoe/glare/cast(list/targets, mob/user = usr)
 	user.visible_message("<span class='warning'>[user]'s eyes emit a blinding flash!</span>")
 	if(istype(user:glasses, /obj/item/clothing/glasses/sunglasses/blindfold))
-		to_chat(user, "<span class='warning'>You're blindfolded!</span>")
-		return
+		var/obj/item/clothing/glasses/sunglasses/blindfold/B = user:glasses
+		if(B.tint)
+			to_chat(user, "<span class='warning'>You're blindfolded!</span>")
+			return
 	for(var/mob/living/target in targets)
 		if(!affects(target))
 			continue

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -241,6 +241,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("white beanie", /obj/item/clothing/head/beanie, 2), \
 	null, \
 	new/datum/stack_recipe("blindfold", /obj/item/clothing/glasses/sunglasses/blindfold, 3), \
+	new/datum/stack_recipe("tattered blindfold", /obj/item/clothing/glasses/sunglasses/blindfold/fake, 2), \
 	))
 
 /obj/item/stack/sheet/cloth

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -396,9 +396,10 @@
 	prescription_upgradable = 0
 
 /obj/item/clothing/glasses/sunglasses/blindfold/fake
-    name = "tattered blindfold"
-    flash_protect = 0
-    tint = 0
+	name = "tattered blindfold"
+	desc = "A see-through blindfold perfect for cheating at games like pin the stunbaton on the clown."
+	flash_protect = 0
+	tint = 0
 
 /obj/item/clothing/glasses/sunglasses/prescription
 	prescription = 1

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -397,10 +397,6 @@
 
 /obj/item/clothing/glasses/sunglasses/blindfold/fake
     name = "tattered blindfold"
-    desc = "A see-through blindfold perfect for cheating at games like pin the stunbaton on the clown."
-    icon_state = "blindfold"
-    item_state = "blindfold"
-    prescription_upgradable = FALSE
     flash_protect = 0
     tint = 0
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -395,6 +395,15 @@
 	tint = 3				//to make them blind
 	prescription_upgradable = 0
 
+/obj/item/clothing/glasses/sunglasses/blindfold/fake
+    name = "tattered blindfold"
+    desc = "A see-through blindfold perfect for cheating at games like pin the stunbaton on the clown."
+    icon_state = "blindfold"
+    item_state = "blindfold"
+    prescription_upgradable = FALSE
+    flash_protect = 0
+    tint = 0
+
 /obj/item/clothing/glasses/sunglasses/prescription
 	prescription = 1
 


### PR DESCRIPTION
## What Does This PR Do
This is purely meant for cosmetic value and games/tricks. Currently if you'd like to wear a blindfold but still be able to see, options are: being a cultist using the zealots blindfold or getting chameleon glasses. Otherwise, you'd have to be blind.

## Why It's Good For The Game
This is purely meant for cosmetic value and games/tricks. Currently if you'd like to wear a blindfold but still be able to see, the only options being a cultist using the zealots blindfold or getting chameleon glasses. Otherwise, you'd have to be blind.

## Images of changes
![image](https://user-images.githubusercontent.com/68139038/128590519-4139ddbb-fd12-44e1-ad96-fe6246ebbc08.png)
![image](https://user-images.githubusercontent.com/68139038/128590521-19daa745-810c-47c0-9c48-a43841e8ead4.png)

## Changelog
:cl:
add: Adds Fake blindfold, craftable with two cloth sheets.
/:cl: