### PR TITLE
Fixes 'Face while pulling' oversights

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -16,9 +16,10 @@
 	desc = "A generic vending machine."
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "generic"
-	layer = 2.9
-	anchored = 1
-	density = 1
+	layer = BELOW_OBJ_LAYER
+	anchored = TRUE
+	density = TRUE
+	face_while_pulling = TRUE
 	max_integrity = 300
 	integrity_failure = 100
 	armor = list(melee = 20, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -13,6 +13,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 100
+	face_while_pulling = TRUE
 	/// The maximum number of items the fridge can hold. Multiplicated by the matter bin component's rating.
 	var/max_n_of_items = 1500
 	/// Associative list (/text => /number) tracking the amounts of a specific item held by the fridge.

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -168,8 +168,13 @@
 			direct = newdir
 			n = get_step(mob, direct)
 
-	. = mob.SelfMove(n, direct, delay)
-	if(mob.pulling?.face_while_pulling)
+	var/prev_pulling_loc = null
+	if(mob.pulling)
+		prev_pulling_loc = mob.pulling.loc
+
+	. = mob.SelfMove(n, direct, delay) // The actual movement
+
+	if(prev_pulling_loc && mob.pulling?.face_while_pulling && (mob.pulling.loc != prev_pulling_loc))
 		mob.setDir(get_dir(mob, mob.pulling)) // Face welding tanks and stuff when pulling
 	else
 		mob.setDir(direct)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds `face_while_pulling` to vending machines and smartfridges, since them not having it in the first place was an oversight on my part.
Also fixes walking over an open locker while pulling it looking very odd, since the mob would always turn to face the center point.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Both are unintentional oversights from #15201.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/57483089/128738959-4648c391-305d-4adb-aee7-d5dae6840f7e.mp4

https://user-images.githubusercontent.com/57483089/128738967-bfb06120-7835-40e8-a5b9-cc31f536f104.mp4


## Changelog
:cl:
tweak: Added vending machines and smartfridges to the 'Face while pulling' list.
fix: Fixed walking over an open locker while pulling it still rotating the character's direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
