### PR TITLE
Make bee hitbox much smaller, except if the bee attacks someone

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -31,7 +31,6 @@
 	move_to_delay = 0
 	obj_damage = 0
 	environment_smash = 0
-	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	density = FALSE
 	mob_size = MOB_SIZE_TINY
@@ -162,6 +161,7 @@
 	else
 		. = ..()
 		if(. && isliving(target) && (!client || a_intent == INTENT_HARM))
+			make_opaque()
 			var/mob/living/L = target
 			if(L.reagents)
 				if(beegent)
@@ -169,6 +169,19 @@
 					L.reagents.add_reagent(beegent.id, rand(1, 5))
 				else
 					L.reagents.add_reagent("spidertoxin", 5)
+
+/mob/living/simple_animal/hostile/poison/bees/proc/make_opaque()
+	// If a bee attacks someone, make it very easy to hit for a while
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
+	addtimer(CALLBACK(src, /mob/living/simple_animal/hostile/poison/bees/proc/reset_opacity), 1 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE)
+
+/mob/living/simple_animal/hostile/poison/bees/proc/reset_opacity()
+	if(!mind)
+		mouse_opacity = initial(mouse_opacity)
+
+/mob/living/simple_animal/hostile/poison/bees/sentience_act()
+	. = ..()
+	make_opaque()
 
 /mob/living/simple_animal/hostile/poison/bees/proc/assign_reagent(datum/reagent/R)
 	if(istype(R))
@@ -233,6 +246,7 @@
  	desc = "She's the queen of bees, BZZ BZZ"
  	icon_base = "queen"
  	isqueen = TRUE
+ 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 
 //the Queen doesn't leave the box on her own, and she CERTAINLY doesn't pollinate by herself
@@ -324,6 +338,7 @@
 	search_objects = FALSE //these bees don't care about trivial things like plants, especially when there is havoc to sow
 	bee_syndicate = TRUE
 	var/list/master_and_friends = list()
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 /mob/living/simple_animal/hostile/poison/bees/syndi/New()
 	beegent = GLOB.chemical_reagents_list["facid"] //Prepare to die

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -50,6 +50,8 @@
 	var/isqueen = FALSE
 	var/bee_syndicate = FALSE
 	var/icon_base = "bee"
+	var/last_attack = 0
+	var/opacity_time = 1 MINUTES
 	var/static/list/bee_icons = list()
 	var/static/beehometypecache = typecacheof(/obj/structure/beebox)
 	var/static/hydroponicstypecache = typecacheof(/obj/machinery/hydroponics)
@@ -172,11 +174,13 @@
 
 /mob/living/simple_animal/hostile/poison/bees/proc/make_opaque()
 	// If a bee attacks someone, make it very easy to hit for a while
+	last_attack = world.time
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	addtimer(CALLBACK(src, /mob/living/simple_animal/hostile/poison/bees/proc/reset_opacity), 1 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE)
 
-/mob/living/simple_animal/hostile/poison/bees/proc/reset_opacity()
-	if(!mind)
+/mob/living/simple_animal/hostile/poison/bees/Life(seconds, times_fired)
+	. = ..()
+	var/diff = world.time - last_attack
+	if(diff >= opacity_time)
 		mouse_opacity = initial(mouse_opacity)
 
 /mob/living/simple_animal/hostile/poison/bees/sentience_act()

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -179,6 +179,8 @@
 
 /mob/living/simple_animal/hostile/poison/bees/Life(seconds, times_fired)
 	. = ..()
+	if(mind || (mouse_opacity == initial(mouse_opacity)))
+		return
 	var/diff = world.time - last_attack
 	if(diff >= opacity_time)
 		mouse_opacity = initial(mouse_opacity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes opacity from bees.
If a bee attacks someone, it will be made opaque for one minute.
If a bee becomes sentient, it will permanently become opaque.
Syndicate bees are STILL opaque.
## Why It's Good For The Game
Trying to do botany with bees is very annoying because you have to constantly alt-click when bees are on trays.
Since it's much rarer for someone to want to click on a bee than to want to click on a plant tray, it's better to make the bee hitbox smaller.
Hostile bees are temporarily made opaque, and syndicate bees are always opaque, so this won't make bees harder to fight.
Sentient bees are also made opaque so they can't cause too much trouble.

## Changelog
:cl:
tweak: Bee hitbox no longer covers the entire tile by default. If that bee attacks someone, it covers the tile for one minute. Queen, syndie and sentient bees are not changed and still cover the tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
