### PR TITLE
The Great Delta Secpoint Removal

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -11967,11 +11967,11 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics/abandoned_garden)
 "aGO" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-y"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "aGP" = (
@@ -13913,13 +13913,9 @@
 	},
 /area/quartermaster/storage)
 "aKC" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -41985,32 +41981,32 @@
 	},
 /area/engine/break_room)
 "bMy" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bMz" = (
-/obj/structure/table/wood,
 /obj/machinery/light{
 	dir = 1;
 	on = 1
 	},
+/obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bMA" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/item/radio/intercom{
+	pixel_x = 29;
+	pixel_y = -1
+	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
@@ -42850,10 +42846,15 @@
 /turf/simulated/wall,
 /area/engine/break_room)
 "bOh" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cautioncorner"
+	},
+/area/hallway/primary/port)
 "bOi" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
@@ -42868,24 +42869,32 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "bOm" = (
-/obj/structure/sign/poster/contraband/atmosia_independence{
-	pixel_x = 32
-	},
+/obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bOn" = (
-/obj/machinery/firealarm{
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/power/apc{
 	dir = 8;
+	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "cautioncorner"
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/area/hallway/primary/port)
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "yellow"
+	},
+/area/engine/break_room)
 "bOo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -44043,7 +44052,7 @@
 	},
 /area/engine/break_room)
 "bQv" = (
-/obj/machinery/vending/chinese,
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -44988,28 +44997,20 @@
 	},
 /area/hallway/primary/central)
 "bSk" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bSl" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/table,
 /obj/item/storage/box/donkpockets,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -45018,8 +45019,8 @@
 "bSm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/engine/break_room)
 "bSo" = (
@@ -46187,12 +46188,6 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "bUv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -46202,17 +46197,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bUw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -46244,14 +46240,13 @@
 	},
 /area/engine/break_room)
 "bUz" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal,
+/obj/structure/sign/poster/contraband/atmosia_independence{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -47273,7 +47268,9 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "yellow"
@@ -47287,18 +47284,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bWx" = (
-/obj/structure/table/wood,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -47313,9 +47310,11 @@
 	pixel_x = 28;
 	pixel_y = -32
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "yellow"
@@ -47698,8 +47697,7 @@
 /area/hallway/primary/port)
 "bXB" = (
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -47736,11 +47734,9 @@
 	dir = 8;
 	network = list("SS13","Security")
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -72503,7 +72499,7 @@
 "cWO" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/contraband/lamarr{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -101013,6 +101009,12 @@
 	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
+"pzo" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/engine/break_room)
 "pBz" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/suit/browntrenchcoat,
@@ -102176,6 +102178,15 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/security/permasolitary)
+"uHe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research)
 "uJk" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -130375,8 +130386,8 @@ bGH
 bIF
 bKr
 bMw
-bOh
 bQs
+bOn
 bSk
 bUv
 bWu
@@ -130633,8 +130644,8 @@ byl
 byl
 bQs
 bQs
-byl
 bSl
+bIA
 bUw
 bWv
 bwP
@@ -130890,7 +130901,7 @@ bID
 byl
 bMy
 bQt
-bQt
+pzo
 bSm
 bUx
 bWw
@@ -131660,11 +131671,11 @@ bGN
 bIK
 bKw
 byl
+bQs
+bQs
+bQs
 byl
 byl
-bwP
-bwP
-bwP
 bwP
 bXU
 bXU
@@ -131916,8 +131927,8 @@ bty
 bGO
 bWz
 bWz
+bOh
 bWz
-bOn
 bWz
 bWz
 bUA
@@ -136833,7 +136844,7 @@ cHx
 cXU
 cZt
 dau
-dau
+uHe
 dau
 dau
 dau

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -46181,11 +46181,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Break Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bUv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -47291,11 +47295,12 @@
 	},
 /area/engine/break_room)
 "bWx" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /obj/structure/chair/comfy/brown{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -72727,6 +72732,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -75057,6 +75063,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "white"
@@ -99847,6 +99854,12 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/security/securearmoury)
+"kMe" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research)
 "kOC" = (
 /obj/structure/table,
 /obj/item/storage/fancy/crayons,
@@ -100772,6 +100785,12 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/starboard)
+"ocZ" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/engine/break_room)
 "odY" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solars"
@@ -100819,6 +100838,15 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
+"omJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research)
 "osS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -101009,12 +101037,6 @@
 	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
-"pzo" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
-/area/engine/break_room)
 "pBz" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/suit/browntrenchcoat,
@@ -101689,6 +101711,13 @@
 	icon_state = "neutralfull"
 	},
 /area/security/brig)
+"sLl" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/medical/medbay2)
 "sPS" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -102178,15 +102207,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/security/permasolitary)
-"uHe" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research)
 "uJk" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -130901,7 +130921,7 @@ bID
 byl
 bMy
 bQt
-pzo
+ocZ
 bSm
 bUx
 bWw
@@ -136844,7 +136864,7 @@ cHx
 cXU
 cZt
 dau
-uHe
+omJ
 dau
 dau
 dau
@@ -138132,7 +138152,7 @@ cMb
 cNB
 cPk
 cRa
-cMm
+kMe
 cMm
 cMm
 cWO
@@ -150721,7 +150741,7 @@ cUA
 cMz
 cJt
 cLf
-cMC
+sLl
 cOi
 cMC
 cSP

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -66654,10 +66654,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cLa" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -13919,6 +13919,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -44004,6 +44005,9 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"
@@ -46141,6 +46145,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 2;
 	icon_state = "pipe-j2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -67147,9 +67147,7 @@
 	pixel_x = -28;
 	pixel_y = 30
 	},
-/obj/structure/chair/comfy/purp{
-	dir = 4
-	},
+/obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -67164,7 +67162,6 @@
 	dir = 1;
 	on = 1
 	},
-/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -67174,9 +67171,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/structure/chair/comfy/purp{
-	dir = 8
-	},
+/obj/structure/chair/comfy/purp,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -67800,15 +67795,7 @@
 	},
 /area/medical/research)
 "cNA" = (
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 4
-	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -68711,6 +68698,7 @@
 	},
 /area/medical/research)
 "cPl" = (
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -70108,11 +70096,6 @@
 	},
 /area/toxins/xenobiology)
 "cSj" = (
-/obj/structure/table/wood,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
@@ -70889,15 +70872,17 @@
 	},
 /area/medical/research)
 "cTJ" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
+/obj/structure/chair/comfy/purp,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "cTL" = (
-/obj/machinery/vending/snack,
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -71701,15 +71686,19 @@
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "cVj" = (
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "cVl" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = -1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -72247,7 +72236,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/vending/cola,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -72494,7 +72486,7 @@
 /area/toxins/lab)
 "cWN" = (
 /obj/structure/chair/comfy/purp{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -72502,18 +72494,16 @@
 	},
 /area/medical/research)
 "cWO" = (
-/obj/structure/table/wood,
 /obj/machinery/light,
-/obj/structure/sign/poster/contraband/lamarr{
-	pixel_y = -32
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "cWP" = (
-/obj/structure/chair/comfy/purp{
-	dir = 8
+/obj/structure/table/wood,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -99606,6 +99596,15 @@
 	icon_state = "red"
 	},
 /area/security/warden)
+"jCG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research)
 "jCU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -99854,12 +99853,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/security/securearmoury)
-"kMe" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
 "kOC" = (
 /obj/structure/table,
 /obj/item/storage/fancy/crayons,
@@ -100785,12 +100778,6 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/starboard)
-"ocZ" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
-/area/engine/break_room)
 "odY" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solars"
@@ -100838,15 +100825,6 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
-"omJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research)
 "osS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -100868,6 +100846,12 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/fore2)
+"ouI" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/engine/break_room)
 "oBE" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/vending_refill/coffee,
@@ -101466,6 +101450,13 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/brig)
+"rGJ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/medical/medbay2)
 "rNi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -101711,13 +101702,6 @@
 	icon_state = "neutralfull"
 	},
 /area/security/brig)
-"sLl" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "cmo"
-	},
-/area/medical/medbay2)
 "sPS" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -102059,6 +102043,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
+"ufn" = (
+/obj/structure/chair/comfy/purp{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/medical/research)
 "uiw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -102603,6 +102596,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permasolitary)
+"wjr" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research)
 "wmQ" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -130921,7 +130920,7 @@ bID
 byl
 bMy
 bQt
-ocZ
+ouI
 bSm
 bUx
 bWw
@@ -136864,7 +136863,7 @@ cHx
 cXU
 cZt
 dau
-omJ
+jCG
 dau
 dau
 dau
@@ -137899,7 +137898,7 @@ cSj
 cTJ
 cVj
 cWN
-cZt
+cIW
 cYv
 cKF
 dbV
@@ -138152,11 +138151,11 @@ cMb
 cNB
 cPk
 cRa
-kMe
+wjr
 cMm
 cMm
 cWO
-cZt
+cIW
 cYz
 cKF
 dbV
@@ -138407,13 +138406,13 @@ ddn
 cZt
 cMc
 cPl
-cPl
+ufn
 cRb
 cWu
 cTL
 cVl
 cWP
-cZt
+cIW
 cYA
 cKF
 dbV
@@ -150741,7 +150740,7 @@ cUA
 cMz
 cJt
 cLf
-sLl
+rGJ
 cOi
 cMC
 cSP

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -73282,13 +73282,6 @@
 "cYP" = (
 /turf/simulated/wall,
 /area/medical/psych)
-"cYQ" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/simulated/floor/noslip,
-/area/medical/medbay)
 "cYR" = (
 /obj/machinery/light{
 	dir = 1;
@@ -73298,15 +73291,12 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "white"
+	icon_state = "freezerfloor"
 	},
 /area/medical/medbay)
 "cYS" = (
 /obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8
-	},
+/obj/machinery/shower,
 /turf/simulated/floor/noslip,
 /area/medical/medbay)
 "cYU" = (
@@ -73755,8 +73745,7 @@
 /area/medical/medbay)
 "cZL" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "white"
+	icon_state = "freezerfloor"
 	},
 /area/medical/medbay)
 "cZM" = (
@@ -99539,6 +99528,12 @@
 	icon_state = "dark"
 	},
 /area/security/processing)
+"jkP" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/engine/break_room)
 "jkU" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -99596,15 +99591,6 @@
 	icon_state = "red"
 	},
 /area/security/warden)
-"jCG" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research)
 "jCU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -100344,6 +100330,12 @@
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard)
+"muI" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research)
 "muK" = (
 /obj/structure/sink{
 	dir = 8;
@@ -100375,6 +100367,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"mzQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research)
 "mDm" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -100846,12 +100847,6 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/fore2)
-"ouI" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
-/area/engine/break_room)
 "oBE" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/vending_refill/coffee,
@@ -101450,13 +101445,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/brig)
-"rGJ" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "cmo"
-	},
-/area/medical/medbay2)
 "rNi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -101857,6 +101845,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permasolitary)
+"tsN" = (
+/obj/structure/chair/comfy/purp{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/medical/research)
 "tvq" = (
 /obj/structure/table,
 /obj/item/toy/figure/crew/syndie,
@@ -102043,15 +102040,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
-"ufn" = (
-/obj/structure/chair/comfy/purp{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple"
-	},
-/area/medical/research)
 "uiw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -102596,12 +102584,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permasolitary)
-"wjr" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
 "wmQ" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -102886,6 +102868,13 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/maintenance/auxsolarstarboard)
+"xKN" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/medical/medbay2)
 "xKW" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/simulated/floor/plasteel{
@@ -130920,7 +130909,7 @@ bID
 byl
 bMy
 bQt
-ouI
+jkP
 bSm
 bUx
 bWw
@@ -136863,7 +136852,7 @@ cHx
 cXU
 cZt
 dau
-jCG
+mzQ
 dau
 dau
 dau
@@ -138151,7 +138140,7 @@ cMb
 cNB
 cPk
 cRa
-wjr
+muI
 cMm
 cMm
 cWO
@@ -138406,7 +138395,7 @@ ddn
 cZt
 cMc
 cPl
-ufn
+tsN
 cRb
 cWu
 cTL
@@ -148178,7 +148167,7 @@ cSI
 cUg
 aQo
 cYP
-cYQ
+cYS
 cZL
 cKO
 aRT
@@ -150740,7 +150729,7 @@ cUA
 cMz
 cJt
 cLf
-rGJ
+xKN
 cOi
 cMC
 cSP

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -44008,6 +44008,10 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"
@@ -46148,6 +46152,10 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -11957,8 +11957,12 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics/abandoned_garden)
 "aGO" = (
-/turf/simulated/wall,
-/area/security/checkpoint/supply)
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/quartermaster/storage)
 "aGP" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor/west{
@@ -12517,35 +12521,29 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aIa" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
-/obj/item/book/manual/security_space_law,
-/obj/item/radio,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/structure/chair/sofa/right,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aIb" = (
 /obj/machinery/light{
 	dir = 1;
 	on = 1
 	},
-/obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	pixel_y = 26
 	},
-/obj/machinery/recharger,
+/obj/structure/chair/sofa,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aIc" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -12558,11 +12556,12 @@
 	pixel_x = 25;
 	pixel_y = 32
 	},
+/obj/structure/chair/sofa/left,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aId" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -12570,7 +12569,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "browncorner"
 	},
 /area/quartermaster/storage)
 "aIe" = (
@@ -13185,27 +13184,38 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aJi" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11
 	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
-"aJj" = (
-/obj/machinery/computer/secure_data,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11
+	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "white"
 	},
-/area/security/checkpoint/supply)
-"aJk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/area/medical/medbay)
+"aJj" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
+"aJk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitebluecorner"
+	},
+/area/medical/medbay)
 "aJm" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -13217,7 +13227,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "brown"
 	},
 /area/quartermaster/storage)
 "aJo" = (
@@ -13884,83 +13894,50 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aKA" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/door/airlock/medical{
+	name = "Psych Office";
+	req_access_txt = "64"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
+/area/medical/psych)
 "aKB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/computer/security,
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/security/checkpoint/supply)
-"aKC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
+"aKC" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "aKD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aKE" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Supply Break Room";
+	req_access_txt = "31"
 	},
 /turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aKF" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "brown"
 	},
 /area/quartermaster/storage)
 "aKG" = (
@@ -14610,12 +14587,12 @@
 	},
 /area/quartermaster/office)
 "aMb" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
-"aMc" = (
-/obj/machinery/computer/supplycomp,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14623,17 +14600,26 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	dir = 1;
+	icon_state = "white"
 	},
-/area/security/checkpoint/supply)
+/area/medical/medbay)
+"aMc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/quartermaster/storage)
 "aMd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -14645,13 +14631,14 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aMe" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aMf" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -14742,15 +14729,6 @@
 "aMv" = (
 /turf/simulated/wall/r_wall,
 /area/security/execution)
-"aMw" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = null;
-	name = "Security Cargo Post";
-	req_access_txt = "63"
-	},
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/supply)
 "aMx" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -15119,23 +15097,15 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/machinery/door_timer{
-	id = "Cargo Cell";
-	name = "Cargo Cell Timer";
-	pixel_y = -32
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aNr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -15146,34 +15116,33 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aNs" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Storage";
+	c_tag = "Cargo Break Room";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aNt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "browncorner"
 	},
 /area/quartermaster/storage)
 "aNu" = (
@@ -15195,26 +15164,13 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "Cargo Cell";
-	name = "Cargo Cell Door";
-	req_access_txt = "63"
+/obj/machinery/door/airlock/mining/glass{
+	name = "Supply Break Room";
+	req_access_txt = "31"
 	},
 /turf/simulated/floor/plasteel,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aNw" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/warning_stripes/yellow,
@@ -15704,16 +15660,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aOw" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aOx" = (
 /turf/simulated/wall,
 /area/crew_quarters/theatre)
@@ -15836,13 +15791,11 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aOO" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
 	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aOP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15850,28 +15803,12 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	id = "Cargo Cell";
-	name = "Cargo Cell";
-	req_access_txt = "63"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aOQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16536,35 +16473,14 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
-"aQj" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
 "aQk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cargo Cell"
-	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aQl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16572,26 +16488,18 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aQm" = (
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aQn" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -16601,22 +16509,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"aQo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 8;
-	name = "Security Desk";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Security Desk"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/supply)
 "aQp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -17344,11 +17236,13 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aRQ" = (
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aRR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17356,45 +17250,18 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "red"
+	dir = 7;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aRS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/chair{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/supply)
-"aRT" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aRU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -18086,18 +17953,7 @@
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/security/checkpoint/supply)
-"aTo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aTp" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
@@ -18109,12 +17965,8 @@
 	dir = 4
 	},
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
-/area/security/checkpoint/supply)
+/area/quartermaster/storage)
 "aTr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -18150,17 +18002,8 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"aTv" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/quartermaster/storage)
 "aTw" = (
 /obj/structure/table/reinforced,
-/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -33583,13 +33426,14 @@
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "bwV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/kitchen_machine/microwave,
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = -32
 	},
+/obj/structure/table/reinforced,
+/mob/living/simple_animal/bot/floorbot,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 9;
+	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bwW" = (
@@ -33597,19 +33441,22 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 1;
+	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bwX" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 22
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 5;
+	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bwY" = (
@@ -34291,28 +34138,25 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "byt" = (
-/obj/structure/table/reinforced,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/item/storage/box/donkpockets,
+/obj/structure/rack,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/engine/break_room)
-"byu" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "byv" = (
-/obj/machinery/vending/cola,
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 4;
+	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "byx" = (
@@ -35118,13 +34962,8 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/engine/break_room)
-"bzT" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "bzV" = (
@@ -35786,12 +35625,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
-"bBm" = (
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/engine/break_room)
 "bBn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -35940,17 +35773,10 @@
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"bBC" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "yellow"
-	},
-/area/engine/break_room)
 "bBE" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellow"
+	dir = 4;
+	icon_state = "cautioncorner"
 	},
 /area/engine/break_room)
 "bBF" = (
@@ -37389,29 +37215,6 @@
 	icon_state = "caution"
 	},
 /area/engine/break_room)
-"bDz" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_y = 5
-	},
-/obj/item/pen/multi,
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"bDA" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/item/storage/briefcase,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "bDB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37434,14 +37237,16 @@
 	},
 /area/hallway/primary/port)
 "bDD" = (
-/obj/structure/chair/office/light{
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/start{
-	name = "Psychiatrist"
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "bDE" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/status_display{
@@ -38047,17 +37852,13 @@
 	},
 /area/engine/gravitygenerator)
 "bEH" = (
-/obj/structure/sign/poster/random{
-	pixel_x = 32
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "bEI" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -39160,12 +38961,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
 	tag = ""
 	},
 /obj/effect/landmark{
@@ -40273,16 +40068,6 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
-"bIH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
 "bII" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -40410,26 +40195,6 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/primary)
-"bIW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/area/security/checkpoint/engineering)
 "bIX" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -41187,9 +40952,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"bKs" = (
-/turf/simulated/wall,
-/area/security/checkpoint/engineering)
 "bKt" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -41234,7 +40996,7 @@
 "bKw" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bKy" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/ai_status_display{
@@ -42165,40 +41927,38 @@
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"bMx" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/checkpoint/engineering)
 "bMy" = (
-/obj/structure/chair{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bMz" = (
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bMA" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "engcell"
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
-"bMB" = (
-/turf/simulated/wall/r_wall,
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bMC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -42219,8 +41979,8 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/simulated/floor/carpet,
-/area/medical/psych)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "bME" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -42833,9 +42593,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/aisat)
-"bNO" = (
-/turf/simulated/floor/carpet,
-/area/medical/psych)
 "bNP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/flasher{
@@ -42860,13 +42617,6 @@
 	icon_state = "vault"
 	},
 /area/turret_protected/aisat)
-"bNQ" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/medical/psych)
 "bNR" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
@@ -43060,26 +42810,15 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
-"bOk" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/security/checkpoint/engineering)
-"bOl" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/area/security/checkpoint/engineering)
 "bOm" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+/obj/structure/sign/poster/contraband/atmosia_independence{
+	pixel_x = 32
 	},
-/area/security/checkpoint/engineering)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/engine/break_room)
 "bOn" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -44231,51 +43970,21 @@
 /area/engine/engineering)
 "bQs" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/plating,
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bQt" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/engineering)
-"bQu" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	id = "engcell";
-	name = "Engineering Cell";
-	req_access_txt = "63"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	dir = 8;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bQv" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/vending/chinese,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "yellow"
 	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bQw" = (
 /obj/machinery/camera{
 	c_tag = "Port Hallway South";
@@ -45214,27 +44923,17 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central)
-"bSj" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
 "bSk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bSl" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -45245,36 +44944,20 @@
 	name = "north bump";
 	pixel_y = 24
 	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bSm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/door_timer{
-	dir = 10;
-	id = "engcell";
-	name = "Engineering Cell Timer";
-	pixel_y = 32
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "yellowcorner"
 	},
-/area/security/checkpoint/engineering)
-"bSn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bSo" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Central";
@@ -46388,7 +46071,6 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "bUs" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -46400,6 +46082,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -46417,44 +46103,20 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/fore)
 "bUu" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "bUv" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4";
@@ -46466,22 +46128,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bUw" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -46490,60 +46149,43 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bUx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/security/checkpoint/engineering)
-"bUy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bUz" = (
-/obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/item/book/manual/security_space_law,
-/obj/item/radio,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bUA" = (
 /obj/machinery/light{
 	dir = 8
@@ -47105,10 +46747,6 @@
 	icon_state = "vault"
 	},
 /area/engine/break_room)
-"bVz" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
-/area/security/checkpoint/medical)
 "bVA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -47190,10 +46828,6 @@
 	icon_state = "dark"
 	},
 /area/construction/hallway)
-"bVI" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
-/area/security/checkpoint/medical)
 "bVJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -47550,7 +47184,6 @@
 /area/magistrateoffice)
 "bWt" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "bWu" = (
@@ -47562,46 +47195,46 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bWv" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/machinery/computer/station_alert,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 0;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bWw" = (
 /obj/machinery/light,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
-/obj/machinery/computer/security,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
-/area/security/checkpoint/engineering)
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "yellow"
+	},
+/area/engine/break_room)
 "bWx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/table/wood,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
-/obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 0;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bWy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
@@ -47609,11 +47242,14 @@
 	pixel_x = 28;
 	pixel_y = -32
 	},
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "red"
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bWz" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -47694,6 +47330,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -48022,7 +47661,7 @@
 /area/hallway/primary/starboard)
 "bXE" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Security Checkpoint";
+	c_tag = "Engineering Break Room";
 	dir = 8;
 	network = list("SS13","Security")
 	},
@@ -48030,12 +47669,12 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "yellow"
 	},
-/area/security/checkpoint/engineering)
+/area/engine/break_room)
 "bXF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48238,11 +47877,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"bYd" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/security/checkpoint/engineering)
 "bYe" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -54559,15 +54193,12 @@
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Break Room";
+	req_access_txt = "10"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/checkpoint/engineering)
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "clp" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
@@ -55105,11 +54736,9 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard2)
 "cmt" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "cmv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -63813,19 +63442,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/gateway)
-"cEm" = (
-/obj/machinery/door_control{
-	id = "psychoffice";
-	name = "Privacy Shutters Control";
-	pixel_x = -25
-	},
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "cEn" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
@@ -64140,9 +63756,9 @@
 	},
 /area/hallway/primary/central)
 "cFd" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/obj/item/rack_parts,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "cFe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -65194,53 +64810,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Psych Office";
-	req_access_txt = "64"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/wood,
-/area/medical/psych)
-"cGG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"cGH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/area/maintenance/starboard)
 "cGI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65257,12 +64829,9 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Psych Office Maintenance";
-	req_access = "64"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
-/area/medical/psych)
+/area/maintenance/starboard)
 "cGJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65847,28 +65416,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"cHR" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "psychoffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/psych)
-"cHS" = (
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"cHT" = (
-/obj/structure/closet/secure_closet/psychiatrist,
-/obj/item/clipboard{
-	pixel_x = -5
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "cHV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67029,25 +66576,23 @@
 /turf/simulated/wall,
 /area/medical/medbay)
 "cKZ" = (
-/obj/structure/chair/comfy/lime{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/medical/psych)
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "cLa" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/carpet,
-/area/medical/psych)
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "cLb" = (
-/obj/structure/bed/psych,
-/turf/simulated/floor/carpet,
-/area/medical/psych)
-"cLc" = (
-/turf/simulated/wall,
-/area/medical/psych)
+/obj/structure/table_frame,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "cLd" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -67521,9 +67066,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/medical/research)
-"cLZ" = (
-/turf/simulated/wall,
-/area/security/checkpoint/science)
 "cMa" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -67532,19 +67074,15 @@
 	pixel_x = -28;
 	pixel_y = 30
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 4
+/obj/structure/chair/comfy/purp{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/security/science,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cMb" = (
-/obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 28
@@ -67553,27 +67091,24 @@
 	dir = 1;
 	on = 1
 	},
-/obj/machinery/recharger,
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cMc" = (
-/obj/structure/table/reinforced,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/structure/chair/comfy/purp{
+	dir = 8
 	},
-/obj/item/book/manual/security_space_law,
-/obj/item/radio,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cMd" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -67720,12 +67255,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay)
-"cMx" = (
-/turf/simulated/wall,
-/area/security/checkpoint/medical)
-"cMy" = (
-/turf/simulated/wall/r_wall,
-/area/security/checkpoint/medical)
 "cMz" = (
 /turf/simulated/wall,
 /area/medical/medbay2)
@@ -68197,35 +67726,27 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
-"cNz" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/science)
 "cNA" = (
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = 24
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cNB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/science)
-"cNC" = (
-/obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "white"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cND" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -68510,44 +68031,38 @@
 /turf/space,
 /area/space/nearstation)
 "cOa" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/security_space_law,
-/obj/item/radio,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+/obj/structure/chair/comfy/lime{
+	dir = 4
 	},
-/area/security/checkpoint/medical)
+/obj/machinery/door_control{
+	id = "psychoffice";
+	name = "Privacy Shutters Control";
+	pixel_x = -25
+	},
+/turf/simulated/floor/carpet,
+/area/medical/psych)
 "cOb" = (
-/obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/recharger,
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 25
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/carpet,
+/area/medical/psych)
 "cOc" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/closet/secure_closet/security/med,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28;
 	pixel_y = 30
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
+/obj/structure/bed/psych,
+/turf/simulated/floor/carpet,
+/area/medical/psych)
 "cOd" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
@@ -69091,29 +68606,11 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical)
 "cPj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/checkpoint/science)
-"cPk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -69121,45 +68618,25 @@
 	icon_state = "2-8";
 	tag = ""
 	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/medical/research)
+"cPk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/science)
-"cPl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
-/obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	icon_state = "white"
 	},
-/area/security/checkpoint/science)
-"cPm" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/science)
+/area/medical/research)
 "cPn" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69351,41 +68828,26 @@
 /area/medical/medbay)
 "cPO" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "psychoffice";
+	name = "Privacy Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/checkpoint/medical)
-"cPP" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/computer/secure_data,
-/obj/machinery/door_control{
-	id = "medbayfoyer";
-	layer = 3.3;
-	name = "Medbay Foyer Doors";
-	normaldoorcontrol = 1;
-	pixel_x = -25
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
+/area/medical/psych)
 "cPQ" = (
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/medical)
+/turf/simulated/floor/carpet,
+/area/medical/psych)
 "cPR" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+/obj/item/twohanded/required/kirbyplants,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/carpet,
+/area/medical/psych)
 "cPS" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -69675,32 +69137,18 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+/obj/machinery/door/airlock/research{
+	name = "Research Break Room";
+	req_access_txt = "47"
 	},
-/area/security/checkpoint/science)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research)
 "cQx" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -69991,35 +69439,31 @@
 	},
 /area/maintenance/port)
 "cQZ" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cRa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/science)
-"cRb" = (
-/obj/machinery/computer/mecha,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "white"
 	},
-/area/security/checkpoint/science)
-"cRc" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/security/checkpoint/science)
+/area/medical/research)
+"cRb" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/medical/research)
 "cRd" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -70127,80 +69571,33 @@
 /area/medical/medbay)
 "cRp" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
+	d2 = 8;
+	icon_state = "2-8";
 	tag = ""
 	},
-/obj/machinery/computer/security{
-	network = list("Medical")
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cRq" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/medical)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cRr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+/obj/structure/closet/secure_closet/psychiatrist,
+/obj/item/clipboard{
+	pixel_x = -5
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
-"cRs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cRt" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -70621,42 +70018,19 @@
 	},
 /area/toxins/xenobiology)
 "cSj" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/table/wood,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/power/apc{
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
 	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+	icon_state = "whitepurple"
 	},
-/obj/machinery/door_timer{
-	dir = 10;
-	id = "scicell";
-	name = "Science Cell Timer";
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/security/checkpoint/science)
-"cSk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cSl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -70855,43 +70229,31 @@
 "cSI" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/computer/crew,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
-"cSJ" = (
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
+"cSJ" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
-/turf/simulated/floor/plasteel,
-/area/security/checkpoint/medical)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cSK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+/obj/machinery/ai_status_display{
+	pixel_x = 32
 	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cSL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71437,48 +70799,20 @@
 	},
 /area/medical/research)
 "cTJ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/science)
-"cTK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	id = "scicell";
-	name = "Science Cell";
-	req_access_txt = "1"
-	},
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cTL" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/vending/snack,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
 	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/science)
+/area/medical/research)
 "cTM" = (
 /obj/machinery/processor{
 	desc = "A machine used to process slimes and retrieve their extract.";
@@ -71661,51 +70995,27 @@
 	},
 /area/medical/medbay)
 "cUg" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Security Checkpoint";
+	c_tag = "Psychiatrist's Office";
 	dir = 4;
 	network = list("Medical","SS13","Security")
 	},
-/obj/machinery/door_timer{
-	dir = 10;
-	id = "medcell";
-	name = "Medical Cell Timer";
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
+/obj/structure/cable,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cUh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start{
+	name = "Psychiatrist"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cUi" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -71713,11 +71023,8 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cUj" = (
 /obj/machinery/light{
 	dir = 8
@@ -72303,72 +71610,22 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
-"cVi" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/science)
 "cVj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/chair{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
-"cVk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cVl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "scicell"
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cVm" = (
 /obj/machinery/smartfridge/secure/extract,
 /obj/machinery/light_switch{
@@ -72409,17 +71666,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
-"cVp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "scicell";
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/security/checkpoint/science)
 "cVq" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -72650,44 +71896,19 @@
 	},
 /area/medical/medbay)
 "cVQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 5
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	id = "medcell";
-	name = "Medical Cell";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/security/checkpoint/medical)
+/obj/item/pen/multi,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cVR" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/medical)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/item/storage/briefcase,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "cVS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72928,24 +72149,20 @@
 	},
 /area/maintenance/port)
 "cWu" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/camera{
-	c_tag = "Research Security Checkpoint";
+	c_tag = "Research Break Room";
 	dir = 8;
 	network = list("Research","SS13","Security")
 	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cWv" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -73186,31 +72403,33 @@
 	},
 /area/toxins/lab)
 "cWN" = (
-/obj/structure/chair{
+/obj/structure/chair/comfy/purp{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cWO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/table/wood,
+/obj/machinery/light,
+/obj/structure/sign/poster/contraband{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cWP" = (
+/obj/structure/chair/comfy/purp{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "red"
+	icon_state = "whitepurple"
 	},
-/area/security/checkpoint/science)
+/area/medical/research)
 "cWQ" = (
 /obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/decal/warning_stripes/northwest,
@@ -73455,72 +72674,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
-"cXs" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/medical)
-"cXt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
-"cXu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
-"cXv" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "medcell"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
-"cXw" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/medical)
 "cXy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -73846,21 +72999,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
-"cYp" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/science)
 "cYq" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -74061,63 +73199,35 @@
 	},
 /area/medical/medbay)
 "cYP" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/security/checkpoint/medical)
+/turf/simulated/wall,
+/area/medical/psych)
 "cYQ" = (
-/obj/structure/chair{
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
+/turf/simulated/floor/noslip,
+/area/medical/medbay)
 "cYR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 1;
+	icon_state = "white"
 	},
-/area/security/checkpoint/medical)
+/area/medical/medbay)
 "cYS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/security/checkpoint/medical)
-"cYT" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/checkpoint/medical)
+/turf/simulated/floor/noslip,
+/area/medical/medbay)
 "cYU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74565,33 +73675,12 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay)
-"cZK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/security/checkpoint/medical)
 "cZL" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/checkpoint/medical)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "white"
+	},
+/area/medical/medbay)
 "cZM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -75267,20 +74356,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
-"dbf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whiteblue"
-	},
-/area/medical/medbay)
 "dbg" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -75299,15 +74374,6 @@
 	},
 /area/medical/medbay)
 "dbj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -75903,14 +74969,14 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
+	dir = 1;
 	icon_state = "white"
 	},
 /area/medical/medbay)
@@ -86281,7 +85347,6 @@
 	},
 /area/medical/research)
 "dxx" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -86294,8 +85359,6 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -87603,21 +86666,12 @@
 	},
 /area/crew_quarters/hor)
 "dzT" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "1-4";
+	tag = "90Curve"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -88278,8 +87332,8 @@
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Science Break Room";
+/obj/machinery/door/airlock/maintenance{
+	name = "Science Maintenance";
 	req_access_txt = "47"
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -88949,61 +88003,33 @@
 	pixel_y = 27
 	},
 /turf/simulated/floor/plasteel,
-/area/medical/research)
+/area/maintenance/apmaint)
 "dCP" = (
-/obj/structure/table/wood,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "neutral"
 	},
-/area/medical/research)
+/area/maintenance/apmaint)
 "dCQ" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
-/obj/structure/sign/poster/official/report_crimes{
-	pixel_y = 32
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/medical/research)
+/area/maintenance/apmaint)
 "dCR" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 28
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/medical/research)
-"dCS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/medical/research)
-"dCT" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "neutral"
-	},
-/area/medical/research)
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "dCU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -89628,10 +88654,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
-"dEb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/medical/research)
 "dEc" = (
 /obj/structure/chair{
 	dir = 4
@@ -89639,66 +88661,12 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
-"dEd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/medical/research)
 "dEe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/medical/research)
-"dEf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
-"dEg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
-"dEh" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/medical/research)
+/area/maintenance/apmaint)
 "dEi" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -89944,54 +88912,18 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plating,
-/area/medical/research)
+/area/maintenance/apmaint)
 "dEN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/medical/research)
-"dEO" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
-"dEP" = (
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
-"dEQ" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
+/area/maintenance/apmaint)
 "dER" = (
 /obj/machinery/camera{
 	c_tag = "Experimention Lab";
@@ -90191,47 +89123,22 @@
 	},
 /area/toxins/storage)
 "dFo" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/medical/research)
-"dFp" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
-"dFq" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
-"dFr" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/medical/research)
-"dFs" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/item/storage/box/donkpockets,
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
+"dFr" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
 	},
-/obj/item/clipboard,
-/obj/item/folder,
+/area/maintenance/apmaint)
+"dFs" = (
+/obj/structure/table_frame/wood,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/medical/research)
+/area/maintenance/apmaint)
 "dFt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90425,14 +89332,6 @@
 	icon_state = "grimy"
 	},
 /area/library/abandoned)
-"dFT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Science Break Room";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel,
-/area/medical/research)
 "dFU" = (
 /obj/structure/chair{
 	dir = 1
@@ -90480,16 +89379,13 @@
 /area/maintenance/apmaint)
 "dFZ" = (
 /obj/machinery/light/small,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/structure/toilet{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
-/area/medical/research)
+/area/maintenance/apmaint)
 "dGa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -90501,46 +89397,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
-"dGb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
-/area/medical/research)
-"dGc" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/machinery/vending/cola,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
-/area/medical/research)
-"dGd" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
-/area/medical/research)
 "dGe" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "neutral"
-	},
-/area/medical/research)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "dGf" = (
 /turf/simulated/floor/plasteel,
 /area/maintenance/apmaint)
@@ -91032,10 +89893,10 @@
 /area/maintenance/starboardsolar)
 "dGY" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Science Toilet"
+	name = "abandoned Toilet"
 	},
 /turf/simulated/floor/plasteel,
-/area/medical/research)
+/area/maintenance/apmaint)
 "dGZ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -91435,29 +90296,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
-"dHI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
 /area/maintenance/apmaint)
 "dHJ" = (
 /obj/structure/cable{
@@ -91913,16 +90751,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "dIC" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/wardrobe/toxins_white,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "neutral"
 	},
-/area/medical/research)
+/area/maintenance/apmaint)
 "dID" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -92277,17 +91112,8 @@
 /turf/simulated/wall,
 /area/chapel/main)
 "dJy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Break Room Maintenance";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "dJA" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -98512,19 +97338,15 @@
 /area/chapel/main)
 "dXy" = (
 /obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Research Break Room";
-	dir = 8;
-	network = list("Research","SS13")
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/item/trash/fried_vox,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/medical/research)
+/area/maintenance/apmaint)
 "dXz" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -100223,12 +99045,14 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "hzb" = (
 /obj/machinery/light{
 	dir = 4
@@ -129399,7 +128223,7 @@ aOg
 bwV
 byt
 bzS
-bBC
+bEV
 bDt
 bEV
 bQp
@@ -129654,9 +128478,9 @@ aYK
 buv
 aOg
 bwW
-byu
-bBm
-bBE
+bIA
+bIA
+bIA
 bDu
 bEW
 bGC
@@ -129912,7 +128736,7 @@ buw
 bvK
 bwX
 byv
-bzT
+bKr
 bBE
 bDw
 bEX
@@ -131207,7 +130031,7 @@ bIA
 bMv
 byl
 bQr
-bSj
+bWt
 bUu
 bWt
 bQr
@@ -131717,14 +130541,14 @@ aOg
 byl
 bGJ
 byl
-bKs
-bMx
-bMx
-bKs
+byl
+bQs
+bQs
+byl
 bSl
 bUw
 bWv
-bMB
+bwP
 bZC
 cfg
 cdn
@@ -131974,14 +130798,14 @@ aOg
 bFd
 bGK
 bID
-bQt
+byl
 bMy
-bOk
+bQt
 bQt
 bSm
 bUx
 bWw
-bMB
+bwP
 bZD
 cbv
 cdo
@@ -132230,15 +131054,15 @@ bBM
 aOg
 bFe
 bGM
-bIH
-bIW
+bzW
+byl
 bMz
-bOl
-bQu
-bSn
-bUy
+bIA
+bIA
+bIA
+bGC
 bWx
-bYd
+bwP
 bZD
 cbw
 cdp
@@ -132488,14 +131312,14 @@ aOg
 bFf
 bGL
 bII
-bQv
+byl
 bMA
 bOm
 bQv
 bXE
 bUz
 bWy
-bMB
+bwP
 bZE
 cbx
 cdq
@@ -132746,13 +131570,13 @@ bFg
 bGN
 bIK
 bKw
-bKs
-bKs
-bKs
-bMB
-bMB
-bMB
-bMB
+byl
+byl
+byl
+bwP
+bwP
+bwP
+bwP
 bXU
 bXU
 bXU
@@ -138689,16 +137513,16 @@ cHA
 cIz
 cHA
 cHA
-cLZ
-cLZ
-cNz
+cZt
+cZt
+cZt
 cQw
-cRc
-cLZ
-cLZ
-cVi
-cRc
-cLZ
+cZt
+cZt
+cIW
+cIW
+cIW
+cZt
 cZt
 cZu
 cZy
@@ -138946,7 +137770,7 @@ chc
 cGx
 cHB
 bvV
-cLZ
+cZt
 cMa
 cNA
 cPj
@@ -138955,7 +137779,7 @@ cSj
 cTJ
 cVj
 cWN
-cTJ
+cZt
 cYv
 cKF
 dbV
@@ -138978,13 +137802,13 @@ dwi
 dwi
 dwi
 dwi
-cKr
-cKr
-cKr
-cKr
-cKr
-cZt
-dbM
+dFm
+dFm
+dFm
+dFm
+dFm
+ddy
+dku
 dHE
 dEi
 dJx
@@ -139203,16 +138027,16 @@ cDd
 cGy
 xqH
 ddm
-cLZ
+cZt
 cMb
 cNB
 cPk
 cRa
-cSk
-cTK
-cVk
+cMm
+cMm
+cMm
 cWO
-cYp
+cZt
 cYz
 cKF
 dbV
@@ -139237,11 +138061,11 @@ dzP
 dBd
 cKr
 dCO
-dEb
+dCU
 dEL
 dGY
 dFZ
-dbM
+dku
 dHL
 dIA
 dJx
@@ -139460,16 +138284,16 @@ cEL
 bqu
 cHC
 ddn
-cLZ
+cZt
 cMc
-cNC
-cPl
+cRb
+cRb
 cRb
 cWu
 cTL
 cVl
 cWP
-cTL
+cZt
 cYA
 cKF
 dbV
@@ -139493,12 +138317,12 @@ dyJ
 dzQ
 dBe
 cKr
-cZt
-dFT
-cZt
-cZt
-cZt
-cZt
+ddy
+dGf
+ddy
+ddy
+ddy
+ddy
 dPw
 dID
 dJx
@@ -139717,16 +138541,16 @@ cFp
 dxV
 ddl
 cIV
-cLZ
-cLZ
-cNz
-cPm
-cRc
-cLZ
-cLZ
-cTL
-cVp
-cLZ
+cZt
+cIW
+cIW
+cIW
+cIW
+cZt
+cZt
+cZt
+cZt
+cZt
 cZt
 dtS
 dbV
@@ -139751,11 +138575,11 @@ dVd
 dBf
 cKr
 dCP
-dEd
+ddv
 dEN
 dFo
 dIC
-cZt
+ddy
 dHH
 dKZ
 dXa
@@ -140009,11 +138833,11 @@ dwi
 cKr
 dCQ
 dEe
-dEO
-dFp
-dGb
+dFr
+dFr
+dID
 dJy
-dHI
+dHE
 dID
 dJx
 dKk
@@ -140265,11 +139089,11 @@ dXv
 cRd
 cZt
 dCR
-dEf
-dEP
-dFq
-dGc
-cZt
+dFr
+dFr
+dOO
+dID
+ddy
 dHJ
 dbp
 dJx
@@ -140517,16 +139341,16 @@ dyL
 dkW
 cZH
 dxx
-dyL
+cNx
 dzT
 dbj
 dBh
-dCS
-dEg
-dEQ
+dik
 dFr
-dGd
-cZt
+dOO
+dFr
+dID
+ddy
 ddt
 dOO
 dJx
@@ -140778,12 +139602,12 @@ cSt
 dzU
 cSt
 cZt
-dCT
-dEh
+dFY
+dcQ
 dXy
 dFs
 dGe
-cZt
+ddy
 dHK
 dIE
 dJx
@@ -141035,12 +139859,12 @@ dql
 dql
 dql
 cZt
-cZt
-cZt
-cZt
-cZt
-cZt
-dbM
+ddy
+ddy
+ddy
+ddy
+ddy
+dku
 dHA
 ddy
 dJx
@@ -146072,15 +144896,15 @@ aCE
 aDN
 aDP
 aFI
-aGO
-aGO
-aJi
-aKA
+ayD
+ayD
+aFR
+aFR
 aOw
-aGO
-aGO
-aQj
-aMb
+ayD
+ayD
+aFR
+aFR
 aTn
 aUT
 aWs
@@ -146329,7 +145153,7 @@ aCF
 aCI
 aDR
 aFJ
-aGO
+ayD
 aIa
 aJj
 aKB
@@ -146338,7 +145162,7 @@ aNq
 aOO
 aQk
 aRQ
-aTo
+aTq
 aUU
 aWr
 aNm
@@ -146586,10 +145410,10 @@ aCG
 aDj
 aEH
 aFK
-aGO
+ayD
 aIb
-aJk
-aKC
+aRX
+aEU
 aMd
 aNr
 aOP
@@ -146843,13 +145667,13 @@ aCH
 aDQ
 aEP
 aFL
-aGO
+ayD
 aIc
 aMe
 aKD
-aMe
+aKD
 aNs
-aKE
+aGO
 aQm
 aRS
 aTq
@@ -147100,15 +145924,15 @@ ayA
 aDS
 ayA
 ayA
-aGO
-aGO
-aMw
+ayD
+ayD
+aFR
 aKE
-aQo
-aGO
-aGO
-aJi
-aRT
+aFR
+ayD
+ayD
+aFR
+aFR
 aTn
 ayD
 bai
@@ -148459,7 +147283,7 @@ cKY
 cMv
 cNY
 cPM
-cSH
+aJi
 cSH
 cSH
 cki
@@ -148716,7 +147540,7 @@ cKY
 cMw
 cKV
 cKV
-cKV
+aJk
 cKV
 cUf
 cRo
@@ -148908,7 +147732,7 @@ aOS
 aCN
 aWz
 azL
-aTv
+aTw
 aUZ
 aWy
 aBS
@@ -148963,23 +147787,23 @@ cxn
 cxn
 cxn
 cxn
-cLc
-cLc
-cHR
+cxn
+cxn
+bng
 cGF
-cHR
-cLc
-cLc
-cMx
-cMx
-cPO
-cPO
-cPO
-cMx
-cMx
-cXs
+bng
+bng
+bng
 cYP
-cMx
+cYP
+cPO
+aKA
+cPO
+cYP
+cYP
+cYP
+cJg
+cJg
 dci
 ddM
 dfr
@@ -149220,26 +148044,26 @@ cxn
 cyB
 cAc
 cBE
-cLc
-cEm
+cyB
+cxn
 cFd
 hos
 cmt
 bMD
 cKZ
-bVz
+cYP
 cOa
-cPP
+cPQ
 cRp
 cSI
 cUg
-cPO
-cXt
+aKC
+cYP
 cYQ
-cPO
-cKV
-dqW
-cSF
+cZL
+cKO
+aMb
+cSA
 cJg
 dgS
 cMp
@@ -149477,26 +148301,26 @@ cxn
 cyC
 cAd
 cBF
-cLc
-bDz
+cAc
+cxn
 bDD
-cGG
-cHS
-bNO
+cGJ
+boG
+boG
 cLa
-cMy
+cYP
 cOb
 cPQ
 cRq
 cSJ
 cUh
 cVQ
-cXu
+cYP
 cYR
-cZK
-dbf
+cZL
+cUn
 dct
-cSF
+dea
 cKY
 dgU
 diL
@@ -149734,26 +148558,26 @@ cxn
 cyD
 bBk
 cAc
-cLc
-bDA
+cyD
+cxn
 bEH
-cGH
-cHT
-bNQ
+cGJ
+boG
+boG
 cLb
-bVI
+cYP
 cOc
 cPR
 cRr
 cSK
 cUi
 cVR
-cXv
+cYP
 cYS
 cZL
-cKO
-dqW
-dea
+cKV
+aMb
+cSF
 cJg
 dgV
 diK
@@ -149991,23 +148815,23 @@ cxn
 cxn
 cAe
 cxn
-cLc
-cLc
-cLc
+cxn
+cxn
+bng
 cGI
-cLc
-cLc
-cLc
-cMx
-cMx
-cXw
-cRs
+cJp
+dfK
+bng
 cYP
-cMx
-cMx
-cXw
-cYT
-cMx
+cYP
+cYP
+cYP
+cYP
+cYP
+cYP
+cYP
+cJg
+cJg
 daZ
 dcn
 ddU

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -40044,7 +40044,8 @@
 /area/engine/break_room)
 "bIz" = (
 /obj/structure/disposalpipe/sortjunction{
-	name = "CE's Junction"
+	name = "CE's Junction";
+	sortType = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -48569,7 +48570,8 @@
 /area/engine/engineering)
 "bZy" = (
 /obj/structure/disposalpipe/sortjunction{
-	name = "Engineering Junction"
+	name = "Engineering Junction";
+	sortType = 4
 	},
 /obj/structure/cable{
 	d1 = 1;

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -11383,6 +11383,9 @@
 "aFI" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "aFJ" = (
@@ -11392,12 +11395,19 @@
 	},
 /area/quartermaster/sorting)
 "aFK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
 "aFL" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "brown"
@@ -11957,12 +11967,13 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics/abandoned_garden)
 "aGO" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/simulated/floor/plasteel{
+/obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "yellow"
+	icon_state = "pipe-y"
 	},
-/area/quartermaster/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/quartermaster/sorting)
 "aGP" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor/west{
@@ -12557,6 +12568,7 @@
 	pixel_y = 32
 	},
 /obj/structure/chair/sofa/left,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
@@ -13184,19 +13196,14 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aJi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 11
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "brown"
 	},
-/area/medical/medbay)
+/area/quartermaster/sorting)
 "aJj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -13205,17 +13212,12 @@
 	},
 /area/quartermaster/storage)
 "aJk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner"
+	icon_state = "yellow"
 	},
-/area/medical/medbay)
+/area/quartermaster/storage)
 "aJm" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -13894,19 +13896,15 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aKA" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psych Office";
-	req_access_txt = "64"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/item/twohanded/required/kirbyplants,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/medical/psych)
+/area/medical/research)
 "aKB" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -13915,11 +13913,18 @@
 	},
 /area/quartermaster/storage)
 "aKC" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research)
 "aKD" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -14587,20 +14592,16 @@
 	},
 /area/quartermaster/office)
 "aMb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "white"
 	},
 /area/medical/medbay)
@@ -14634,6 +14635,7 @@
 /area/quartermaster/storage)
 "aMe" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -14729,6 +14731,18 @@
 "aMv" = (
 /turf/simulated/wall/r_wall,
 /area/security/execution)
+"aMw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitebluecorner"
+	},
+/area/medical/medbay)
 "aMx" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -15131,6 +15145,10 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Break Room";
 	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -16473,6 +16491,20 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
+"aQj" = (
+/obj/machinery/door/airlock/medical{
+	name = "Psych Office";
+	req_access_txt = "64"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/medical/psych)
 "aQk" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -16509,6 +16541,11 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"aQo" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "aQp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -17262,6 +17299,24 @@
 	icon_state = "yellow"
 	},
 /area/quartermaster/storage)
+"aRT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "white"
+	},
+/area/medical/medbay)
 "aRU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -68637,6 +68692,12 @@
 	icon_state = "white"
 	},
 /area/medical/research)
+"cPl" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/medical/research)
 "cPn" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69459,10 +69520,21 @@
 	},
 /area/medical/research)
 "cRb" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
 	},
+/area/medical/research)
+"cRc" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/medical/research)
 "cRd" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -73632,20 +73704,17 @@
 	},
 /area/medical/research)
 "cZH" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -78886,9 +78955,9 @@
 	},
 /area/medical/research)
 "djM" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -79445,7 +79514,6 @@
 	},
 /area/medical/research)
 "dkW" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -82510,7 +82578,6 @@
 	},
 /area/hallway/primary/aft)
 "drN" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -86032,7 +86099,6 @@
 /turf/simulated/floor/plating,
 /area/toxins/server)
 "dyL" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -88661,12 +88727,6 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
-"dEe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/maintenance/apmaint)
 "dEi" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -88922,6 +88982,12 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
+	},
+/area/maintenance/apmaint)
+"dEP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
 	},
 /area/maintenance/apmaint)
 "dER" = (
@@ -89397,6 +89463,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
+"dGc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/maintenance/apmaint)
 "dGe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -138286,8 +138358,8 @@ cHC
 ddn
 cZt
 cMc
-cRb
-cRb
+cPl
+cPl
 cRb
 cWu
 cTL
@@ -138545,7 +138617,7 @@ cZt
 cIW
 cIW
 cIW
-cIW
+cRc
 cZt
 cZt
 cZt
@@ -138802,7 +138874,7 @@ cKw
 cMd
 cND
 cPn
-cRd
+aKA
 cSm
 cZt
 cTU
@@ -138832,10 +138904,10 @@ dwi
 dwi
 cKr
 dCQ
-dEe
+dEP
 dFr
 dFr
-dID
+dGc
 dJy
 dHE
 dID
@@ -139059,7 +139131,7 @@ cKx
 cMe
 cMf
 cPo
-cRe
+aKC
 cSn
 cTB
 cUY
@@ -139090,9 +139162,9 @@ cRd
 cZt
 dCR
 dFr
-dFr
+dEP
 dOO
-dID
+dGc
 ddy
 dHJ
 dbp
@@ -139602,7 +139674,7 @@ cSt
 dzU
 cSt
 cZt
-dFY
+dCJ
 dcQ
 dXy
 dFs
@@ -144638,7 +144710,7 @@ aBJ
 aCD
 aCf
 aDO
-aFE
+aGO
 aGL
 aHZ
 aJh
@@ -145152,7 +145224,7 @@ aBL
 aCF
 aCI
 aDR
-aFJ
+aJi
 ayD
 aIa
 aJj
@@ -145667,13 +145739,13 @@ aCH
 aDQ
 aEP
 aFL
-ayD
+wXI
 aIc
 aMe
 aKD
 aKD
 aNs
-aGO
+aJk
 aQm
 aRS
 aTq
@@ -147283,7 +147355,7 @@ cKY
 cMv
 cNY
 cPM
-aJi
+aMb
 cSH
 cSH
 cki
@@ -147540,7 +147612,7 @@ cKY
 cMw
 cKV
 cKV
-aJk
+aMw
 cKV
 cUf
 cRo
@@ -147797,7 +147869,7 @@ bng
 cYP
 cYP
 cPO
-aKA
+aQj
 cPO
 cYP
 cYP
@@ -148057,12 +148129,12 @@ cPQ
 cRp
 cSI
 cUg
-aKC
+aQo
 cYP
 cYQ
 cZL
 cKO
-aMb
+aRT
 cSA
 cJg
 dgS
@@ -148576,7 +148648,7 @@ cYP
 cYS
 cZL
 cKV
-aMb
+aRT
 cSF
 cJg
 dgV


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR removes the security checkpoints from around the NSS Kerberos, and converts them to break rooms in most cases. In the case of medical, I moved the psychiatrists office down, and converted the unused space into a maintenance closet area. I also added a radiation shower space below the psych office to make it not seem so huge. For science, since they had an existing break room, I removed the existing one and made it "run down" to fit the general grunge feel to maintenance. Engineering had a break nook that I adjusted to just be some extra tools and a free floorbot.

This PR also (as a result of me adding some extra disposals) fixes a the CE and Engineering disposal junctions, as well as making it so that garbage doesn't end up in the law office.

I also added some extra holopads to medbay where they seemed to be lacking, as I was already adding holopads to parts of medical.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Map parity. Cyberiad doesn't have security checkpoints, Kerberos shouldn't either.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
**Old Research**
![Research Old](https://user-images.githubusercontent.com/16112919/128980217-1664b704-bf53-4ee7-a1c7-54db036afe81.png)

![Research Old 2](https://user-images.githubusercontent.com/16112919/128980261-e14ef126-3fc4-4a4d-b204-a8a9ea776d0c.png)

**New Research**
![Research New](https://user-images.githubusercontent.com/16112919/128980298-6ef150b4-ee97-467b-82fc-c7675da8c9c3.png)

![Research New 2](https://user-images.githubusercontent.com/16112919/128980307-a0440619-b19f-4b4e-b943-bc51acf7c830.png)

**Old Engineering**
![Engi Old 2](https://user-images.githubusercontent.com/16112919/128980438-a98b0d21-25db-4740-98e6-4b16c02c0b94.png)

![Engi Old](https://user-images.githubusercontent.com/16112919/128980443-dec4a6d5-e75f-4012-9be7-fcba58f73d48.png)

**New Engineering**
![Engi New](https://user-images.githubusercontent.com/16112919/128980478-0775f26d-9fca-4ac2-8f64-7ec2b71b214b.png)

![Engi New 2](https://user-images.githubusercontent.com/16112919/128980490-5ef0fbf0-69c6-409e-891b-0badc7c17fd9.png)

**Old Cargo**
![Cargo Old](https://user-images.githubusercontent.com/16112919/128980515-ac4d72b7-3e2e-4f7e-bcbf-ba4e73f337ad.png)

**New Cargo**
![Cargo New](https://user-images.githubusercontent.com/16112919/128980544-8146e4e4-2847-4190-87d8-67c6eae584f5.png)

**Old Psych**
![Psych Old](https://user-images.githubusercontent.com/16112919/128980639-b046c559-3191-4864-943f-2f6ab50584f1.png)

**New Psych**
![Psych New](https://user-images.githubusercontent.com/16112919/128980676-ec1855f5-422d-43c2-9693-2985de9aa7d1.png)



## Changelog
:cl:LightFire53
add: NSS Kerberos departmental break rooms
del: NSS Kerberos departmental Security Checkpoints
tweak: NSS Kerberos Psych Office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
