### PR TITLE
Helmets no longer protect you from bible brain damage

### DIFF
--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -97,9 +97,8 @@
 				"<span class='danger'>May the power of [deity_name] compel you to be healed!</span>")
 			playsound(loc, "punch", 25, 1, -1)
 		else
-			if(!istype(H.head, /obj/item/clothing/head/helmet))
-				M.adjustBrainLoss(10)
-				to_chat(M, "<span class='warning'>You feel dumber.</span>")
+			M.adjustBrainLoss(10)
+			to_chat(M, "<span class='warning'>You feel dumber.</span>")
 			H.visible_message("<span class='danger'>[user] beats [H == user ? "[user.p_them()]self" : "[H]"] over the head with [src]!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)
 	else


### PR DESCRIPTION
## What Does This PR Do
Bapping someone wearing a helmet with a bible will now inflict the brain damage if the chance rolls for it.

## Why It's Good For The Game
Currently, chaplains can use the bible to infinitely bap people wearing helmets for infinite healing.
This is bad for antagonists with front-lines such as Blob or Terror Spiders.
This is bad for antagonists on the run as they can now get away with any damage as long as they don't break something, as they can heal it back at record time.

## Changelog
:cl:
tweak: Wearing helmets no longer protects you from brain damage when struck by a bible.
/:cl: