### PR TITLE
Ensure only pistol-type weapons can be holstered

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -358,6 +358,7 @@
 	item_state = "alienpistol"
 	origin_tech = "combat=4;magnets=7;powerstorage=3;abductor=3"
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
+	can_holster = TRUE
 
 /obj/item/paper/abductor
 	name = "Dissection Guide"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -56,7 +56,7 @@
 	var/knife_x_offset = 0
 	var/knife_y_offset = 0
 
-	var/can_holster = TRUE
+	var/can_holster = FALSE  // Anything that can be holstered should be manually set
 
 	var/list/upgrades = list()
 

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -31,6 +31,7 @@
 	can_flashlight = 0 // Can't attach or detach the flashlight, and override it's icon update
 	actions_types = list(/datum/action/item_action/toggle_gunlight)
 	shaded_charge = FALSE
+	can_holster = TRUE  // Pistol sized, so it should fit into a holster
 
 /obj/item/gun/energy/gun/mini/Initialize(mapload, ...)
 	gun_light = new /obj/item/flashlight/seclite(src)
@@ -53,6 +54,7 @@
 	ammo_x_offset = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	shaded_charge = FALSE
+	can_holster = TRUE
 
 /obj/item/gun/energy/gun/blueshield
 	name = "advanced stun revolver"
@@ -63,6 +65,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos)
 	ammo_x_offset = 1
 	shaded_charge = TRUE
+	can_holster = TRUE
 
 /obj/item/gun/energy/gun/blueshield/pdw9
 	name = "PDW-9 taser pistol"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -37,6 +37,7 @@
 	origin_tech = "combat=4;materials=4;biotech=5;plasmatech=6"
 	ammo_type = list(/obj/item/ammo_casing/energy/declone)
 	ammo_x_offset = 1
+	can_holster = TRUE
 
 /obj/item/gun/energy/decloner/update_icon()
 	..()
@@ -56,6 +57,7 @@
 	modifystate = 1
 	ammo_x_offset = 1
 	selfcharge = 1
+	can_holster = TRUE
 
 // Meteor Gun //
 /obj/item/gun/energy/meteorgun
@@ -109,6 +111,7 @@
 	can_flashlight = 0
 	max_mod_capacity = 0
 	empty_state = null
+	can_holster = TRUE
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 	name = "energy crossbow"
@@ -151,6 +154,7 @@
 	force = 12
 	sharp = 1
 	can_charge = 0
+	can_holster = TRUE
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)
 	. = ..()
@@ -289,6 +293,7 @@
 	clumsy_check = 0
 	selfcharge = 1
 	ammo_x_offset = 3
+	can_holster = TRUE  // you'll never see it coming
 
 /obj/item/gun/energy/toxgun
 	name = "plasma pistol"
@@ -300,6 +305,7 @@
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/toxplasma)
 	shaded_charge = 1
+	can_holster = TRUE
 
 // Energy Sniper //
 /obj/item/gun/energy/sniperrifle
@@ -624,6 +630,7 @@
 	selfcharge = 1
 	ammo_x_offset = 3
 	var/mimic_type = /obj/item/gun/projectile/automatic/pistol //Setting this to the mimicgun type does exactly what you think it will.
+	can_holster = TRUE
 
 /obj/item/gun/energy/mimicgun/newshot()
 	var/obj/item/ammo_casing/energy/mimic/M = ammo_type[select]

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -16,6 +16,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/shock_revolver)
 	can_flashlight = 0
 	shaded_charge = FALSE
+	can_holster = TRUE  // Pistol size
 
 /obj/item/gun/energy/gun/advtaser
 	name = "hybrid taser"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -6,6 +6,7 @@
 	origin_tech = "combat=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 3
+	can_holster = TRUE  // Pistol size
 
 /obj/item/gun/energy/shock_revolver
 	name = "tesla revolver"
@@ -16,7 +17,8 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/shock_revolver)
 	can_flashlight = 0
 	shaded_charge = FALSE
-	can_holster = TRUE  // Pistol size
+	can_holster = TRUE
+
 
 /obj/item/gun/energy/gun/advtaser
 	name = "hybrid taser"
@@ -27,6 +29,7 @@
 	ammo_x_offset = 2
 	flight_x_offset = 15
 	shaded_charge = FALSE
+	can_holster = TRUE  // Pistol size
 
 /obj/item/gun/energy/gun/advtaser/cyborg
 	name = "cyborg taser"
@@ -46,6 +49,7 @@
 	origin_tech = "combat=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 3
+	can_holster = TRUE
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -18,6 +18,7 @@
 	origin_tech = null
 	clumsy_check = 0
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses magic instead
+	can_holster = FALSE // Nothing here is a gun, and therefore shouldn't really fit into a holster
 
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi' //not really a gun and some toys use these inhands
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -4,7 +4,6 @@
 	var/select = 1
 	can_tactical = TRUE
 	can_suppress = 1
-	can_holster = FALSE
 	burst_size = 3
 	fire_delay = 2
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -143,6 +142,7 @@
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	fire_sound = 'sound/weapons/gunshots/gunshot_pistol.ogg'
 	burst_size = 2
+	can_holster = TRUE // it's a mini-uzi after all
 
 //M-90gl Carbine//
 /obj/item/gun/projectile/automatic/m90

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -9,6 +9,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/grenadelauncher
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
+	can_holster = FALSE  // Not your normal revolver
 
 /obj/item/gun/projectile/revolver/grenadelauncher/attackby(obj/item/A, mob/user, params)
 	..()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -5,6 +5,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder
 	origin_tech = "combat=3;materials=2"
 	fire_sound = 'sound/weapons/gunshots/gunshot_strong.ogg'
+	can_holster = TRUE
 
 /obj/item/gun/projectile/revolver/New()
 	..()
@@ -158,6 +159,7 @@
 	fire_sound_text = null
 	lefthand_file = null
 	righthand_file = null
+	can_holster = FALSE // Get your fingers out of there!
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 	clumsy_check = 0 //Stole your uplink! Honk!
 	needs_permit = 0 //go away beepsky

--- a/code/modules/projectiles/guns/projectile/toy.dm
+++ b/code/modules/projectiles/guns/projectile/toy.dm
@@ -26,6 +26,7 @@
 	can_suppress = 0
 	burst_size = 1
 	fire_delay = 0
+	can_holster = TRUE
 	actions_types = list()
 
 /obj/item/gun/projectile/automatic/toy/pistol/update_icon()

--- a/code/modules/projectiles/guns/projectile/toy.dm
+++ b/code/modules/projectiles/guns/projectile/toy.dm
@@ -43,7 +43,7 @@
 	..()
 
 /obj/item/gun/projectile/automatic/toy/pistol/enforcer
-	name = "Foam Enforcer"
+	name = "foam Enforcer"
 	desc = "A foam-shooting version of the Enforcer meant to be used for training new cadets who can't be trusted with rubber bullets."
 	icon_state = "enforcer"
 	mag_type = /obj/item/ammo_box/magazine/toy/enforcer

--- a/code/modules/projectiles/guns/projectile/toy.dm
+++ b/code/modules/projectiles/guns/projectile/toy.dm
@@ -44,7 +44,7 @@
 
 /obj/item/gun/projectile/automatic/toy/pistol/enforcer
 	name = "Foam Enforcer"
-	desc = "A foam shooting version of the Enforcer meant to be used for training new caddets who can't be trusted with rubber bullets."
+	desc = "A foam-shooting version of the Enforcer meant to be used for training new cadets who can't be trusted with rubber bullets."
 	icon_state = "enforcer"
 	mag_type = /obj/item/ammo_box/magazine/toy/enforcer
 	can_flashlight = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

First inception of this PR fixes #16518, where foam force pistols (including the foam enforcer) could not be holstered, despite the description specifically stating that it's `A small, easily concealable toy handgun.` Turns out the rabbit hole went a bit deeper, and now we're reworking holstering in general to be disabled by default.
The base gun datum had `can_holster = TRUE`, which trickled down to all energy guns, spells, and everything else that didn't disable it by default. This ensures that items being holstered is a manual process.

(Fixes #16542 as well)

Also fixes a typo in the foam enforcer description while I'm looking there.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The purpose of a sholder holster seems to be to store small, single-hand weapons, and the notion of what can and can't be holstered seems to have been left wide open by default. This hopes to fix that (and hopefully let foam guns be holstered).

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![img](https://i.imgur.com/i3ztaog.png)

## Changelog
:cl:
fix: Foam force pistols (including enforcer), as well as revolvers, can now be holstered.
fix: Only pistol-like energy guns can be holstered, rather than every single one.
fix: Wands and wizard items can no longer be holstered.
spellcheck: Fix grammar in foam enforcer description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
