### PR TITLE
Fixes grammer / bugs with supermater sliver and nuke core objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -389,7 +389,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 
 		steal_target = O
 		explanation_text = "Steal [steal_target]. One was last seen in [get_location()]. "
-		if(length(O.protected_jobs))
+		if(length(O.protected_jobs) && O.job_possession)
 			explanation_text += "It may also be in the possession of the [english_list(O.protected_jobs, and_text = " or ")]."
 		if(steal_target.special_equipment)
 			give_kit(steal_target.special_equipment)

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -14,6 +14,8 @@
 	var/location_override
 	/// Do we have a special item we give to somewhen when they get this objective?
 	var/special_equipment = null
+	///If a steal objective has forbiden jobs, and the forbiden jobs would not be in the possession of this item, set this to false
+	var/job_possession = TRUE
 
 /datum/theft_objective/proc/check_completion(datum/mind/owner)
 	if(!owner.current)
@@ -144,13 +146,14 @@
 	name = "a supermatter sliver"
 	typepath = /obj/item/nuke_core/supermatter_sliver
 	protected_jobs = list("Chief Engineer", "Engineer", "Atmospheric Technician") //Unlike other steal objectives, all jobs in the department have easy access, and would not be noticed at all stealing this
-	location_override = "Engineering. You can use the box and instructions provided to harvest the sliver."
+	location_override = "Engineering. You can use the box and instructions provided to harvest the sliver"
 	special_equipment = /obj/item/storage/box/syndie_kit/supermatter
+	job_possession = FALSE //The CE / engineers / atmos techs do not carry around supermater slivers.
 
 /datum/theft_objective/plutonium_core
 	name = "the plutonium core from the stations nuclear device"
 	typepath = /obj/item/nuke_core/plutonium
-	location_override = "the Vault. You can use the box and instructions provided to remove the core, with some extra tools."
+	location_override = "the Vault. You can use the box and instructions provided to remove the core, with some extra tools"
 	special_equipment = /obj/item/storage/box/syndie_kit/nuke
 
 /datum/theft_objective/number

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -14,7 +14,7 @@
 	var/location_override
 	/// Do we have a special item we give to somewhen when they get this objective?
 	var/special_equipment = null
-	/// If a steal objective has forbiden jobs, and the forbiden jobs would not be in the possession of this item, set this to false
+	/// If a steal objective has forbidden jobs, and the forbidden jobs would not be in the possession of this item, set this to false
 	var/job_possession = TRUE
 
 /datum/theft_objective/proc/check_completion(datum/mind/owner)

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -14,7 +14,7 @@
 	var/location_override
 	/// Do we have a special item we give to somewhen when they get this objective?
 	var/special_equipment = null
-	///If a steal objective has forbiden jobs, and the forbiden jobs would not be in the possession of this item, set this to false
+	/// If a steal objective has forbiden jobs, and the forbiden jobs would not be in the possession of this item, set this to false
 	var/job_possession = TRUE
 
 /datum/theft_objective/proc/check_completion(datum/mind/owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Removes extra period on supermater sliver / nuke core objectives.

Adds a variable to steal objectives. If this is false, the protected jobs of an objective will not be listed as having the steal item in their protection. This is used for the supermatter sliver objective, as atmos techs / engineers / the CE do not carry around supermater slivers.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs / extra periods bad, lying about the objective is bad.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fixed extra periods in the supermater sliver / nuke core objective
fix: Fixed the supermater sliver objective saying the CE/ engineers/ atmos techs might carry the sliver around on them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
