### PR TITLE
Caps runechat emotes to 100 chars

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -77,7 +77,9 @@
 
 		// Type 1 (Visual) emotes are sent to anyone in view of the item
 		if(m_type & EMOTE_VISUAL)
-			var/runechat_text = copytext(input, 1, 101)
+			var/runechat_text = input
+			if(length(input) > 100)
+				runechat_text = "[copytext(input, 1, 101)]..."
 			var/list/can_see = get_mobs_in_view(1,src)  //Allows silicon & mmi mobs carried around to see the emotes of the person carrying them around.
 			can_see |= viewers(src,null)
 			for(var/mob/O in can_see)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -77,6 +77,7 @@
 
 		// Type 1 (Visual) emotes are sent to anyone in view of the item
 		if(m_type & EMOTE_VISUAL)
+			var/runechat_text = copytext(input, 1, 101)
 			var/list/can_see = get_mobs_in_view(1,src)  //Allows silicon & mmi mobs carried around to see the emotes of the person carrying them around.
 			can_see |= viewers(src,null)
 			for(var/mob/O in can_see)
@@ -91,7 +92,7 @@
 
 				O.show_message(message, m_type)
 				if(O.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
-					O.create_chat_message(src, input, symbol = RUNECHAT_SYMBOL_EMOTE)
+					O.create_chat_message(src, runechat_text, symbol = RUNECHAT_SYMBOL_EMOTE)
 
 		// Type 2 (Audible) emotes are sent to anyone in hear range
 		// of the *LOCATION* -- this is important for pAIs to be heard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
- Caps runechat emotes to 100 chars

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- We don't need huge runechats above peoples head

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_VUcRBJ9nQX](https://user-images.githubusercontent.com/1496804/129263584-99aa989e-7bd5-4471-9923-ae53f93666cc.png)

## Changelog
:cl:
tweak: Runechat emotes are now capped to 100 characters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
