### PR TITLE
Fixes directional access on the Medbay and Security doors

### DIFF
--- a/code/game/objects/effects/mapping_helpers.dm
+++ b/code/game/objects/effects/mapping_helpers.dm
@@ -83,7 +83,9 @@
 	if(!mapload)
 		log_world("### MAP WARNING, [src] spawned outside of mapload!")
 		return
-	var/obj/machinery/door/door = locate(/obj/machinery/door) in loc
+	var/obj/machinery/door/door = locate(/obj/machinery/door/airlock) in loc
+	if(!door)
+		door = locate(/obj/machinery/door/window) in loc
 	if(door)
 		door.unres_sides ^= dir
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes #16537, which was caused in #16501 due to me not noticing that firelocks and lockdown poddoors are also door subtypes.

For the record I *did* test that PR a lot, but only with new mapedited airlocks and windoors, so they never had any firelocks under them.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Mistake on my part, sorry.

## Changelog
:cl:
fix: Fixed the Medbay and Security front doors not having directional access set.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
