### PR TITLE
Fixes 'Build Mode' layering

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -118,5 +118,8 @@
 #define SPLASHSCREEN_LAYER 23
 #define SPLASHSCREEN_PLANE 23
 
+// This should always be on top.
+#define HUD_PLANE_BUILDMODE 30
+
 ///Plane master controller keys
 #define PLANE_MASTERS_GAME "plane_masters_game"

--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -180,4 +180,5 @@
 
 #define HUD_LAYER_SCREEN 20
 
-#define HUD_LAYER_BUILDMODE 30
+// Planes are above layers, and this should always be on top.
+#define HUD_PLANE_BUILDMODE 30

--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -176,9 +176,3 @@
 //1 = standard hud
 //2 = reduced hud (just hands and intent switcher)
 //3 = no hud (for screenshots)
-
-
-#define HUD_LAYER_SCREEN 20
-
-// Planes are above layers, and this should always be on top.
-#define HUD_PLANE_BUILDMODE 30

--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -1,7 +1,7 @@
 /obj/screen/buildmode
 	icon = 'icons/misc/buildmode.dmi'
 	var/datum/click_intercept/buildmode/bd
-	layer = HUD_LAYER_BUILDMODE
+	plane = HUD_PLANE_BUILDMODE
 
 /obj/screen/buildmode/New(bld)
 	bd = bld


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes the admin 'Build Mode' buttons showing below regular HUD buttons like spells and actions under some circumstances.
This was caused by the cooldown overlay on action buttons using the `plane` system, which takes rendering priority over the `layer`.
(Fixes #16544)

http://www.byond.com/docs/ref/#/atom/var/plane
https://www.byond.com/docs/ref/#/{notes}/renderer
https://github.com/ParadiseSS13/Paradise/blob/d03fc7ea1ceeb67ebdde2d3d885a0e091a267fcc/code/datums/action.dm#L542-L552

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Admin tools shouldn't ever be blocked by regular ingame stuff.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
**Before:**
![Paradise Test NSS Cyberiad 2021-08-15 015619](https://user-images.githubusercontent.com/57483089/129463697-5eec1b27-791e-48ac-ae8b-127c0a662eb9.png)

**After:**
![Paradise Test NSS Cyberiad 2021-08-15 014211](https://user-images.githubusercontent.com/57483089/129463700-2c2029e7-541c-469f-8936-5e16f40b3fe3.png)


## Changelog
:cl:
fix: Fixed the admin 'Build Mode' buttons sometimes rendering below normal HUD icons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
