### PR TITLE
Fixes a runtime with vampires.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -732,6 +732,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(mind)
 		mind.active = TRUE
 		mind.transfer_to(new_char)
+		if(mind.vampire)
+			mind.vampire.owner = new_char
+			mind.vampire.powers.Cut()
+			mind.vampire.check_vampire_upgrade(FALSE)
 	else
 		new_char.key = key
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
vampires no longer spew out runtimes and actually get their powers when they are reincarnated by admins.

the runtime happens every 2 seconds on a vampires life because the vampire datum's `owner` var is nulled out.

## Why It's Good For The Game
bug bad, runtime bad.

## Changelog
:cl:
fix: admins can now reincarnate vampires.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
