### PR TITLE
[WIP] Multi instance support

### DIFF
--- a/code/controllers/configuration/configuration_core.dm
+++ b/code/controllers/configuration/configuration_core.dm
@@ -44,12 +44,24 @@ GLOBAL_DATUM_INIT(configuration, /datum/server_configuration, new())
 	var/datum/configuration_section/url_configuration/url
 	/// Holder for the voting configuration datum
 	var/datum/configuration_section/vote_configuration/vote
+	/// Raw data. Stored here to avoid passing data between procs constantly
+	var/list/raw_data = list()
 
 
 /datum/server_configuration/Destroy(force)
 	SHOULD_CALL_PARENT(FALSE)
 	// This is going to stay existing. I dont care.
 	return QDEL_HINT_LETMELIVE
+
+/datum/server_configuration/vv_get_var(var_name)
+	if(var_name == "raw_data") // NO!
+		return FALSE
+	. = ..()
+
+/datum/server_configuration/vv_edit_var(var_name, var_value)
+	if(var_name == "raw_data") // NO!
+		return FALSE
+	. = ..()
 
 /datum/server_configuration/CanProcCall(procname)
 	return FALSE // No thanks
@@ -83,32 +95,81 @@ GLOBAL_DATUM_INIT(configuration, /datum/server_configuration, new())
 	if(!fexists(config_file))
 		config_file = "config/example/config.toml" // Fallback to example if user hasnt setup config properly
 	var/raw_json = rustg_toml2json(config_file)
-	var/list/raw_config_data = json_decode(raw_json)
+	raw_data = json_decode(raw_json)
 
 	// Now pass through all our stuff
-	admin.load_data(raw_config_data["admin_configuration"])
-	afk.load_data(raw_config_data["afk_configuration"])
-	custom_sprites.load_data(raw_config_data["custom_sprites_configuration"])
-	database.load_data(raw_config_data["database_configuration"])
-	discord.load_data(raw_config_data["discord_configuration"])
-	event.load_data(raw_config_data["event_configuration"])
-	gamemode.load_data(raw_config_data["gamemode_configuration"])
-	gateway.load_data(raw_config_data["gateway_configuration"])
-	general.load_data(raw_config_data["general_configuration"])
-	ipintel.load_data(raw_config_data["ipintel_configuration"])
-	jobs.load_data(raw_config_data["job_configuration"])
-	logging.load_data(raw_config_data["logging_configuration"])
-	mc.load_data(raw_config_data["mc_configuration"])
-	movement.load_data(raw_config_data["movement_configuration"])
-	overflow.load_data(raw_config_data["overflow_configuration"])
-	ruins.load_data(raw_config_data["ruin_configuration"])
-	system.load_data(raw_config_data["system_configuration"])
-	url.load_data(raw_config_data["url_configuration"])
-	vote.load_data(raw_config_data["voting_configuration"])
+	safe_load(admin, "admin_configuration")
+	safe_load(afk, "afk_configuration")
+	safe_load(custom_sprites, "custom_sprites_configuration")
+	safe_load(database, "database_configuration")
+	safe_load(discord, "discord_configuration")
+	safe_load(event, "event_configuration")
+	safe_load(gamemode, "gamemode_configuration")
+	safe_load(gateway, "gateway_configuration")
+	safe_load(general, "general_configuration")
+	safe_load(ipintel, "ipintel_configuration")
+	safe_load(jobs, "job_configuration")
+	safe_load(logging, "logging_configuration")
+	safe_load(mc, "mc_configuration")
+	safe_load(movement, "movement_configuration")
+	safe_load(overflow, "overflow_configuration")
+	safe_load(ruins, "ruin_configuration")
+	safe_load(system, "system_configuration")
+	safe_load(url, "url_configuration")
+	safe_load(vote, "voting_configuration")
+
+	// Clear our list to save RAM
+	raw_data = list()
 
 	// And report the load
 	DIRECT_OUTPUT(world.log, "Config loaded in [stop_watch(start)]s")
 
+// Proc to load up instance-specific overrides
+/datum/server_configuration/proc/load_overrides()
+	var/override_file = "config/overrides_[world.port].toml"
+	if(!fexists(override_file))
+		DIRECT_OUTPUT(world.log, "Overrides not found for this instance.")
+		return
+
+	DIRECT_OUTPUT(world.log, "Overrides found for this instance. Loading them.")
+	var/start = start_watch() // Time tracking
+
+	var/raw_json = rustg_toml2json(override_file)
+	raw_data = json_decode(raw_json)
+
+	// Now safely load our overrides.
+	// Due to the nature of config wrappers, only vars that exist in the config file are applied to the config datums.
+	// This means that an override missing a key doesnt null it out from the main server
+	safe_load(admin, "admin_configuration")
+	safe_load(afk, "afk_configuration")
+	safe_load(custom_sprites, "custom_sprites_configuration")
+	safe_load(database, "database_configuration")
+	safe_load(discord, "discord_configuration")
+	safe_load(event, "event_configuration")
+	safe_load(gamemode, "gamemode_configuration")
+	safe_load(gateway, "gateway_configuration")
+	safe_load(general, "general_configuration")
+	safe_load(ipintel, "ipintel_configuration")
+	safe_load(jobs, "job_configuration")
+	safe_load(logging, "logging_configuration")
+	safe_load(mc, "mc_configuration")
+	safe_load(movement, "movement_configuration")
+	safe_load(overflow, "overflow_configuration")
+	safe_load(ruins, "ruin_configuration")
+	safe_load(system, "system_configuration")
+	safe_load(url, "url_configuration")
+	safe_load(vote, "voting_configuration")
+
+	// Clear our list to save RAM
+	raw_data = list()
+
+	// And report the load
+	DIRECT_OUTPUT(world.log, "Config overrides loaded in [stop_watch(start)]s")
+
+// Only loads the data for a config section if that key exists in the JSON
+/datum/server_configuration/proc/safe_load(datum/configuration_section/CS, section)
+	if(!isnull(raw_data[section]))
+		CS.load_data(raw_data[section])
 
 /datum/configuration_section
 	/// See __config_defines.dm

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -20,7 +20,10 @@ GLOBAL_LIST_INIT(map_transition_config, list(CC_TRANSITION_CONFIG))
 
 	//temporary file used to record errors with loading config and the database, moved to log directory once logging is set up
 	GLOB.config_error_log = GLOB.world_game_log = GLOB.world_runtime_log = GLOB.sql_log = "data/logs/config_error.log"
-	GLOB.configuration.load_configuration()
+	GLOB.configuration.load_configuration() // Load up the base config.toml
+	// Load up overrides for this specific instance, based on port
+	// If this instance is listening on port 6666, the server will look for config/overrides_6666.toml
+	GLOB.configuration.load_overrides()
 
 	// Right off the bat, load up the DB
 	SSdbcore.CheckSchemaVersion() // This doesnt just check the schema version, it also connects to the db! This needs to happen super early! I cannot stress this enough!


### PR DESCRIPTION
## Important

Please keep the feedback on this PR towards the implementation of this itself, not towards the context of a server split, that is a discussion for the forums. Anyone straying discussion from this implementation to discussion on whether we should split or not will be laughed at, have their comments removed, and told to use the forums.

## What Does This PR Do

This PR implements the framework for multiple instances of Paracode sharing the same database and configuration folder. Servers will be able to use the same configuration but also allow support for overrides between each server based on port, since thats unique per server. For example, both servers will load `config.toml`, but only the server listening on port 6666 will load `overrides_6666.toml`.

Todo list:
- [x] Config overrides
- [ ] Server ID tag in config
- [ ] Preventing players from logging into both servers at the same time to game unlocks or break data
- [ ] Saving said server ID tag in the database for things such as rounds (We can lookup the server ID for notes and bans based on the round ID, treating it as a foreign key)
- [ ] A peering subsystem so players can be presented with a server hop verb as well as the servers having a means to topic with eachother
- [ ] Cross-server asay (maybe even bridge it to discord)
- [ ] Cross-server notifications (Round has ended on server X, Server Y is now starting up. Map is Z Station)

## Why It's Good For The Game
Not having multiple instance support has been a bit of a drag on us for a while, and has prevented us from experimenting with split instances and other stuff of that nature, since the 

## Changelog
No changelog, purely backend stuff.