### PR TITLE
Compression only CPR

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1613,7 +1613,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	else
 		visible_message("<span class='danger'>[src] is trying to perform chest compressions on [H.name]!</span>", "<span class='danger'>You try to perform chest compressions on [H.name]!</span>")
 
-	if(do_mob(src, H, 40))
+	if(do_mob(src, H, 4 SECONDS))
 		if(H.health <= HEALTH_THRESHOLD_CRIT)
 			H.adjustOxyLoss(-15 * cpr_modifier)
 			H.SetLoseBreath(0)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1608,10 +1608,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		return
 	H.receiving_cpr = TRUE
 	var/cpr_modifier = get_cpr_mod(H)
-	if(cpr_modifier == CPR_RESCUE_BREATHS)
-		visible_message("<span class='danger'>[src] is trying to perform chest compressions and rescue breaths on [H.name]!</span>", "<span class='danger'>You try to perform chest compressions and rescue breaths on [H.name]!</span>")
-	else
-		visible_message("<span class='danger'>[src] is trying to perform chest compressions on [H.name]!</span>", "<span class='danger'>You try to perform chest compressions on [H.name]!</span>")
+	visible_message("<span class='danger'>[src] is trying to perform CPR on [H.name]!</span>", "<span class='danger'>You try to perform CPR on [H.name]!</span>")
 
 	if(do_mob(src, H, 4 SECONDS))
 		if(H.health <= HEALTH_THRESHOLD_CRIT)
@@ -1621,7 +1618,8 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			H.updatehealth("cpr")
 			visible_message("<span class='danger'>[src] performs CPR on [H.name]!</span>", "<span class='notice'>You perform CPR on [H.name].</span>")
 
-			to_chat(H, "<span class='notice'>You feel a breath of fresh air enter your lungs. It feels good.</span>")
+			if(cpr_modifier == CPR_RESCUE_BREATHS)
+				to_chat(H, "<span class='notice'>You feel a breath of fresh air enter your lungs. It feels good.</span>")
 			H.receiving_cpr = FALSE
 			add_attack_logs(src, H, "CPRed", ATKLOG_ALL)
 			return TRUE
@@ -1630,9 +1628,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		to_chat(src, "<span class='danger'>You need to stay still while performing CPR!</span>")
 
 /mob/living/carbon/human/proc/get_cpr_mod(mob/living/carbon/human/H)
-	if((head && (head.flags_cover & HEADCOVERSMOUTH)) || (wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH) && !wear_mask.mask_adjusted))
-		return CPR_CHEST_COMPRESSION_ONLY
-	if((H.head && (H.head.flags_cover & HEADCOVERSMOUTH)) || (H.wear_mask && (H.wear_mask.flags_cover & MASKCOVERSMOUTH) && !H.wear_mask.mask_adjusted))
+	if(is_mouth_covered() || H.is_mouth_covered())
 		return CPR_CHEST_COMPRESSION_ONLY
 	if(!H.check_has_mouth() || !check_has_mouth())
 		return CPR_CHEST_COMPRESSION_ONLY

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1638,6 +1638,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		return CPR_CHEST_COMPRESSION_ONLY
 	return CPR_RESCUE_BREATHS
 
+#undef CPR_CHEST_COMPRESSION_ONLY
+#undef CPR_RESCUE_BREATHS
+
 /mob/living/carbon/human/canBeHandcuffed()
 	if(get_num_arms() >= 2)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
based on https://www.paradisestation.org/forum/topic/21293-allow-compression-only-cpr/

CPR can now be done with a mask on and such at 75% effectiveness.


## Why It's Good For The Game
more realism, chest compressions make up the majority of CPR. Makes the CPR feature less clunky to use and allows races like IPC/vox/plasmamen to actually do it.

## Changelog
:cl:
tweak: CPR can be done without a mouth or while wearing a mask at 75% effectiveness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
