### PR TITLE
Lavaland has had rivers this whole fucking time.

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -62,7 +62,7 @@ SUBSYSTEM_DEF(mapping)
 	log_startup_progress("Populating lavaland...")
 	var/lavaland_setup_timer = start_watch()
 	seedRuins(list(level_name_to_num(MINING)), GLOB.configuration.ruins.lavaland_ruin_budget, /area/lavaland/surface/outdoors/unexplored, GLOB.lava_ruins_templates)
-	spawn_rivers(list(level_name_to_num(MINING)))
+	spawn_rivers(level_name_to_num(MINING))
 	log_startup_progress("Successfully populated lavaland in [stop_watch(lavaland_setup_timer)]s.")
 
 	// Now we make a list of areas for teleport locs


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Pass a z-level to /proc/spawn_rivers.

Probably a copy-and-paste mistake from the line above, /proc/spawn_rivers
was being passed a list instead of an integer, causing there to never be
any acceptable locations stored in `possible_locs`.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lavaland will now have considerably more lava. It works fine with ruins and the other tunnels generated in rock.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![Paradise Station 13-07_33_27](https://user-images.githubusercontent.com/59303604/130227799-d91d61a9-40ee-41ba-8d27-bbcf0a6cc32f.png)
![Paradise Station 13-07_34_55](https://user-images.githubusercontent.com/59303604/130227806-f8aff9b5-0119-4967-8d8c-3c414e4d903a.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Lavaland mapgen now has a higher chance to spawn rivers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
