### PR TITLE
Deletes attack_log_old and all related vars/procs

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -302,10 +302,8 @@ This is always put in the attack log.
 	var/mob/MT = target
 	if(istype(MU))
 		MU.create_log(ATTACK_LOG, what_done, target, get_turf(user))
-		MU.create_attack_log("<font color='red'>Attacked [target_str]: [what_done]</font>")
 	if(istype(MT))
 		MT.create_log(DEFENSE_LOG, what_done, user, get_turf(MT))
-		MT.create_attack_log("<font color='orange'>Attacked by [user_str]: [what_done]</font>")
 	log_attack(user_str, target_str, what_done)
 
 	var/loglevel = ATKLOG_MOST

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -40,7 +40,7 @@
 
 /datum/proc/vv_get_var(var_name)
 	switch(var_name)
-		if("attack_log_old", "debug_log")
+		if("debug_log")
 			return debug_variable(var_name, vars[var_name], 0, src, sanitize = FALSE)
 		if("vars")
 			return debug_variable(var_name, list(), 0, src)

--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -142,7 +142,6 @@
 		user.mind.AddSpell(S)
 		to_chat(user, "<span class='notice'>You flip through the pages. Your understanding of the boundaries of reality increases. You can cast [spellname]!</span>")
 		user.create_log(MISC_LOG, "learned the spell [spellname] ([S])")
-		user.create_attack_log("<font color='orange'>[key_name(user)] learned the spell [spellname] ([S]).</font>")
 		onlearned(user)
 
 /obj/item/spellbook/oneuse/mime/recoil(mob/user)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -148,7 +148,6 @@ GLOBAL_LIST_EMPTY(all_cults)
 			var/datum/action/innate/toggle_clumsy/A = new
 			A.Grant(cult_mind.current)
 		SEND_SOUND(cult_mind.current, sound('sound/ambience/antag/bloodcult.ogg'))
-		cult_mind.current.create_attack_log("<span class='danger'>Has been converted to the cult!</span>")
 		cult_mind.current.create_log(CONVERSION_LOG, "converted to the cult")
 
 		if(jobban_isbanned(cult_mind.current, ROLE_CULTIST) || jobban_isbanned(cult_mind.current, ROLE_SYNDICATE))

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -268,7 +268,6 @@
 	if(abductor_mind in abductors)
 		SSticker.mode.abductors -= abductor_mind
 		abductor_mind.special_role = null
-		abductor_mind.current.create_attack_log("<span class='danger'>No longer abductor</span>")
 		abductor_mind.current.create_log(CONVERSION_LOG, "No longer abductor")
 		if(issilicon(abductor_mind.current))
 			to_chat(abductor_mind.current, "<span class='userdanger'>You have been turned into a robot! You are no longer an abductor.</span>")

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -66,7 +66,6 @@
 		operative_mind.special_role = null
 		for(var/datum/objective/nuclear/O in operative_mind.objectives)
 			operative_mind.objectives -= O
-		operative_mind.current.create_attack_log("<span class='danger'>No longer nuclear operative</span>")
 		operative_mind.current.create_log(CONVERSION_LOG, "No longer nuclear operative")
 		if(issilicon(operative_mind.current))
 			to_chat(operative_mind.current, "<span class='userdanger'>You have been turned into a robot! You are no longer a Syndicate operative.</span>")

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -245,7 +245,6 @@
 		carbon_mob.flash_eyes(1, 1)
 	rev_mind.current.Stun(5)
 	to_chat(rev_mind.current, "<span class='danger'><FONT size = 3> You are now a revolutionary! Help your cause. Do not harm your fellow freedom fighters. You can identify your comrades by the red \"R\" icons, and your leaders by the blue \"R\" icons. Help them kill the heads to win the revolution!</FONT></span>")
-	rev_mind.current.create_attack_log("<font color='red'>Has been converted to the revolution!</font>")
 	rev_mind.current.create_log(CONVERSION_LOG, "converted to the revolution")
 	rev_mind.special_role = SPECIAL_ROLE_REV
 	update_rev_icons_added(rev_mind)
@@ -264,7 +263,6 @@
 	if((rev_mind in revolutionaries) || remove_head)
 		revolutionaries -= rev_mind
 		rev_mind.special_role = null
-		rev_mind.current.create_attack_log("<font color='red'>Has renounced the revolution!</font>")
 		rev_mind.current.create_log(CONVERSION_LOG, "renounced the revolution")
 		if(beingborged)
 			to_chat(rev_mind.current, "<span class='danger'><FONT size = 3>The frame's firmware detects and deletes your neural reprogramming! You remember nothing[remove_head ? "." : " but the name of the one who flashed you."]</FONT></span>")

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -157,7 +157,6 @@ Made by Xhuis
 		shadowling_thralls += new_thrall_mind
 		new_thrall_mind.special_role = SPECIAL_ROLE_SHADOWLING_THRALL
 		update_shadow_icons_added(new_thrall_mind)
-		new_thrall_mind.current.create_attack_log("<span class='danger'>Became a thrall</span>")
 		new_thrall_mind.current.create_log(CONVERSION_LOG, "Became a thrall")
 		new_thrall_mind.current.add_language("Shadowling Hivemind")
 		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_shadow_walk(null))
@@ -180,7 +179,6 @@ Made by Xhuis
 	if(!istype(thrall_mind) || !(thrall_mind in shadowling_thralls) || !isliving(thrall_mind.current))
 		return 0 //If there is no mind, the mind isn't a thrall, or the mind's mob isn't alive, return
 	shadowling_thralls.Remove(thrall_mind)
-	thrall_mind.current.create_attack_log("<span class='danger'>Dethralled</span>")
 	thrall_mind.current.create_log(CONVERSION_LOG, "Dethralled")
 	thrall_mind.special_role = null
 	update_shadow_icons_removed(thrall_mind)
@@ -238,7 +236,6 @@ Made by Xhuis
 	if(!istype(ling_mind) || !(ling_mind in shadows)) return 0
 	update_shadow_icons_removed(ling_mind)
 	shadows.Remove(ling_mind)
-	ling_mind.current.create_attack_log("<span class='danger'>Deshadowlinged</span>")
 	ling_mind.current.create_log(CONVERSION_LOG, "Deshadowlinged")
 	ling_mind.special_role = null
 	for(var/obj/effect/proc_holder/spell/S in ling_mind.spell_list)

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -363,7 +363,6 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	if(vampire_mind in vampires)
 		SSticker.mode.vampires -= vampire_mind
 		vampire_mind.special_role = null
-		vampire_mind.current.create_attack_log("<span class='danger'>De-vampired</span>")
 		vampire_mind.current.create_log(CONVERSION_LOG, "De-vampired")
 		if(vampire_mind.vampire)
 			vampire_mind.vampire.remove_vampire_powers()

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -108,7 +108,6 @@ GLOBAL_VAR_INIT(summon_magic_triggered, FALSE)
 		SSticker.mode.traitors += H.mind
 
 		H.mind.add_antag_datum(/datum/antagonist/survivalist/guns)
-		H.create_attack_log("<font color='red'>was made into a survivalist, and trusts no one!</font>")
 		H.create_log(CONVERSION_LOG, "was made into a survivalist")
 
 	var/gun_type = pick(GLOB.summoned_guns)
@@ -130,7 +129,6 @@ GLOBAL_VAR_INIT(summon_magic_triggered, FALSE)
 		SSticker.mode.traitors += H.mind
 
 		H.mind.add_antag_datum(/datum/antagonist/survivalist/magic)
-		H.create_attack_log("<font color='red'>was made into a survivalist, and trusts no one!</font>")
 		H.create_log(CONVERSION_LOG, "was made into a survivalist")
 
 	var/magic_type = pick(GLOB.summoned_magic)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -915,7 +915,6 @@
 		user.mind.AddSpell(S)
 		to_chat(user, "<span class='notice'>you rapidly read through the arcane book. Suddenly you realize you understand [spellname]!</span>")
 		user.create_log(MISC_LOG, "learned the spell [spellname] ([S])")
-		user.create_attack_log("<font color='orange'>[key_name(user)] learned the spell [spellname] ([S]).</font>")
 		onlearned(user)
 
 /obj/item/spellbook/oneuse/proc/recoil(mob/user)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -57,7 +57,6 @@
 	if(wizard_mind in wizards)
 		SSticker.mode.wizards -= wizard_mind
 		wizard_mind.special_role = null
-		wizard_mind.current.create_attack_log("<span class='danger'>De-wizarded</span>")
 		wizard_mind.current.create_log(CONVERSION_LOG, "De-wizarded")
 		wizard_mind.current.spellremove(wizard_mind.current)
 		wizard_mind.current.faction = list("Station")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -282,7 +282,6 @@ About the new airlock wires panel:
 	else if(duration)	//electrify door for the given duration seconds
 		if(user)
 			shockedby += text("\[[time_stamp()]\] - [user](ckey:[user.ckey])")
-			user.create_attack_log("<font color='red'>Electrified the [name] at [x] [y] [z]</font>")
 			add_attack_logs(user, src, "Electrified", ATKLOG_ALL)
 		else
 			shockedby += text("\[[time_stamp()]\] - EMP)")

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -133,7 +133,6 @@
 			outmsg = "<span class='notice'>You hit the lens of [C] with [src], temporarily disabling the camera!</span>"
 
 			log_admin("[key_name(user)] EMPd a camera with a laser pointer")
-			user.create_attack_log("[key_name(user)] EMPd a camera with a laser pointer")
 			add_attack_logs(user, C, "EMPd with [src]", ATKLOG_ALL)
 		else
 			outmsg = "<span class='info'>You missed the lens of [C] with [src].</span>"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -886,19 +886,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	log_admin("[key_name(src)] has [SSshuttle.emergencyNoEscape ? "denied" : "allowed"] the shuttle to be called.")
 	message_admins("[key_name_admin(usr)] has [SSshuttle.emergencyNoEscape ? "denied" : "allowed"] the shuttle to be called.")
 
-/client/proc/cmd_admin_attack_log(mob/M as mob in GLOB.mob_list)
-	set category = "Admin"
-	set name = "Attack Log"
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	to_chat(usr, text("<span class='danger'>Attack Log for []</span>", mob))
-	for(var/t in M.attack_log_old)
-		to_chat(usr, t)
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Attack Log") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-
 /client/proc/everyone_random()
 	set category = "Event"
 	set name = "Make Everyone Random"

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -279,7 +279,6 @@
 		add_attack_logs(user, occupant, "Gibbed in [src]", !!occupant.ckey ? ATKLOG_FEW : ATKLOG_ALL)
 
 	else //this looks ugly but it's better than a copy-pasted startgibbing proc override
-		occupant.create_attack_log("Was gibbed by <b>an autogibber (\the [src])</b>")
 		add_attack_logs(src, occupant, "gibbed")
 
 	occupant.emote("scream")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -55,7 +55,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/turf/T
 	if(ismob(body))
 		T = get_turf(body)				//Where is the body located?
-		attack_log_old = body.attack_log_old	//preserve our attack logs by copying them to our ghost
 
 		var/mutable_appearance/MA = copy_appearance(body)
 		if(body.mind && body.mind.name)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -264,7 +264,6 @@
 /mob/living/verb/succumb()
 	set hidden = 1
 	if(InCritical())
-		create_attack_log("[src] has ["succumbed to death"] with [round(health, 0.1)] points of health!")
 		create_log(MISC_LOG, "has succumbed to death with [round(health, 0.1)] points of health")
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		// super check for weird mobs, including ones that adjust hp

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -31,7 +31,6 @@
 			if(ghost)
 				to_chat(ghost, "<span class='ghostalert'>Your cyborg shell has been repaired, re-enter if you want to continue!</span> (Verbs -> Ghost -> Re-enter corpse)")
 				ghost << sound('sound/effects/genetics.ogg')
-			create_attack_log("revived, trigger reason: [reason]")
 			create_log(MISC_LOG, "revived, trigger reason: [reason]")
 
 	diag_hud_set_status()

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -6,7 +6,6 @@
 		return 0
 	else if(stat == UNCONSCIOUS)
 		return 0
-	create_attack_log("<font color='red'>Fallen unconscious at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Fallen unconscious", ATKLOG_ALL)
 	log_game("[key_name(src)] fell unconscious at [atom_loc_line(get_turf(src))]")
 	stat = UNCONSCIOUS
@@ -23,7 +22,6 @@
 		return 0
 	else if(stat == CONSCIOUS)
 		return 0
-	create_attack_log("<font color='red'>Woken up at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Woken up", ATKLOG_ALL)
 	log_game("[key_name(src)] woke up at [atom_loc_line(get_turf(src))]")
 	stat = CONSCIOUS
@@ -47,7 +45,6 @@
 		return 0
 	if(!can_be_revived())
 		return 0
-	create_attack_log("<font color='red'>Came back to life at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Came back to life", ATKLOG_ALL)
 	log_game("[key_name(src)] came back to life at [atom_loc_line(get_turf(src))]")
 	stat = CONSCIOUS

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -4,7 +4,6 @@
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id
 	log_access_in(client)
-	create_attack_log("<font color='red'>Logged in at [atom_loc_line(get_turf(src))]</font>")
 	create_log(MISC_LOG, "Logged in")
 	if(GLOB.configuration.logging.access_logging)
 		for(var/mob/M in GLOB.player_list)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -3,7 +3,6 @@
 	unset_machine()
 	GLOB.player_list -= src
 	log_access_out(src)
-	create_attack_log("<font color='red'>Logged out at [atom_loc_line(get_turf(src))]</font>")
 	create_log(MISC_LOG, "Logged out")
 	// `holder` is nil'd out by now, so we check the `admin_datums` array directly
 	//Only report this stuff if we are currently playing.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1266,11 +1266,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/get_access()
 	return list() //must return list or IGNORE_ACCESS
 
-/mob/proc/create_attack_log(text, collapse = TRUE)
-	LAZYINITLIST(attack_log_old)
-	create_log_in_list(attack_log_old, text, collapse, last_log)
-	last_log = world.timeofday
-
 /mob/proc/create_debug_log(text, collapse = TRUE)
 	LAZYINITLIST(debug_log)
 	create_log_in_list(debug_log, text, collapse, world.timeofday)
@@ -1478,7 +1473,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		MA.plane = GAME_PLANE
 		pic.appearance = MA
 		flick_overlay(pic, list(client), 10)
-    
+
 
 GLOBAL_LIST_INIT(holy_areas, typecacheof(list(
 	/area/chapel

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -33,12 +33,10 @@
 	var/computer_id = null
 	var/lastattacker = null // real name of the person  doing the attacking
 	var/lastattackerckey = null // their ckey
-	var/list/attack_log_old = list( )
 	var/list/debug_log = null
 
 	var/last_known_ckey = null	// Used in logging
 
-	var/last_log = 0
 	var/obj/machinery/machine = null
 	var/other_mobs = null
 	var/memory = ""

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -50,7 +50,6 @@
 /obj/item/gun/magic/wand/proc/zap_self(mob/living/user)
 	user.visible_message("<span class='danger'>[user] zaps [user.p_them()]self with [src].</span>")
 	playsound(user, fire_sound, 50, 1)
-	user.create_attack_log("<b>[key_name(user)]</b> zapped [user.p_them()]self with a <b>[src]</b>")
 	add_attack_logs(null, user, "zapped [user.p_them()]self with a [src]", ATKLOG_ALL)
 
 /////////////////////////////////////

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -274,14 +274,12 @@
 			else
 				return
 
-		M.create_attack_log("<font color='orange'>[key_name(M)] became [new_mob.real_name].</font>")
 		add_attack_logs(null, M, "became [new_mob.real_name]", ATKLOG_ALL)
 
 		new_mob.a_intent = INTENT_HARM
 		if(M.mind)
 			M.mind.transfer_to(new_mob)
 		else
-			new_mob.attack_log_old = M.attack_log_old.Copy()
 			new_mob.key = M.key
 
 		to_chat(new_mob, "<B>Your form morphs into that of a [randomize].</B>")

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -204,7 +204,6 @@
 		return FALSE
 
 	user.visible_message("<span class='notice'>[user] wraps [target].</span>")
-	user.create_attack_log("<font color='blue'>Has used [name] on [target]</font>")
 	add_attack_logs(user, target, "used [name]", ATKLOG_ALL)
 
 	if(amount <= 0 && QDELETED(src)) //if we used our last wrapping paper, drop a cardboard tube

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -248,7 +248,6 @@
 		var/damage = rand(user.melee_damage_lower, user.melee_damage_upper)
 		deal_damage(damage)
 		visible_message("<span class='danger'>[user]</span> [user.attacktext] [src]!")
-		user.create_attack_log("<font color='red'>attacked [src.name]</font>")
 		add_attack_logs(user, src, "attacked")
 		return TRUE
 


### PR DESCRIPTION
## What Does This PR Do
Deletes the old attack log code which got replaced by the new system from #13115.
I've double-checked to see if all old logs were replaced by the new system calls and they were.

## Why It's Good For The Game
It seems no admins use it anymore, nor should they. Removing the code for this makes attack logging a bit more logical (no dupe log calls which looked weird) and will free up some memory per mob.

## Changelog
:cl:
del: Removes the old attack log code
/:cl: