### PR TITLE
Spirit Realm nullspace fix

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -948,11 +948,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	V.Grant(ghost)
 	//GM.Grant(ghost)
 	while(!QDELETED(user))
-		if(!(user in T))
-			user.visible_message("<span class='warning'>A spectral tendril wraps around [user] and pulls [user.p_them()] back to the rune!</span>")
-			Beam(user, icon_state = "drainbeam", time = 2)
-			user.forceMove(get_turf(src)) //NO ESCAPE :^)
-		if(user.key)
+		if(user.key || QDELETED(src))
 			user.visible_message("<span class='warning'>[user] slowly relaxes, the glow around [user.p_them()] dimming.</span>",
 								"<span class='danger'>You are re-united with your physical form. [src] releases its hold over you.</span>")
 			user.Weaken(3)
@@ -960,12 +956,16 @@ structure_check() searches for nearby cultist structures required for the invoca
 		if(user.health <= 10)
 			to_chat(ghost, "<span class='cultitalic'>Your body can no longer sustain the connection!</span>")
 			break
+		if(!(user in T))
+			user.visible_message("<span class='warning'>A spectral tendril wraps around [user] and pulls [user.p_them()] back to the rune!</span>")
+			Beam(user, icon_state = "drainbeam", time = 2)
+			user.forceMove(get_turf(src)) //NO ESCAPE :^)
 		sleep(5)
-	CM.Remove(ghost)
-	V.Remove(ghost)
-	//GM.Remove(ghost)
+	if(user.grab_ghost())
+		CM.Remove(ghost)
+		V.Remove(ghost)
+		//GM.Remove(ghost)
 	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, RUNE_COLOR_DARKRED)
-	user.grab_ghost()
 	user = null
 	rune_in_use = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Makes cult 'Spirit Realm' runes pull the user back to their body if the rune gets deleted, and also re-orders the `while()` loop a bit.
This stops the player being `forceMove()`'d into nullspace along with the qdeleted rune, and instead just breaks the loop.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The cultist being either deleted or stuck as a ghost because their body was dragged into hell and eaten is, while pretty thematic, not intended behaviour.

## Changelog
:cl:
fix: Fixed deleting the cult 'Spirit Realm' rune also sometimes deleting the player.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
