### PR TITLE
Fixes flying/jaunting/floating mobs breaking glass tables.

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -406,11 +406,12 @@
 	. = ..()
 	if(flags & NODECONSTRUCT)
 		return
-	if(isliving(AM))
-		var/mob/living/M = AM
-		if(M.incorporeal_move || M.flying || M.floating)
-			return
-	else
+	if(!isliving(AM))
+		return
+	var/mob/living/L = AM
+	if(L.incorporeal_move || L.flying || L.floating)
+		return
+
 		return
 	// Don't break if they're just flying past
 	if(AM.throwing)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -406,7 +406,11 @@
 	. = ..()
 	if(flags & NODECONSTRUCT)
 		return
-	if(!isliving(AM))
+	if(isliving(AM))
+		var/mob/living/M = AM
+		if(M.incorporeal_move || M.flying || M.floating)
+			return
+	else
 		return
 	// Don't break if they're just flying past
 	if(AM.throwing)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -412,7 +412,6 @@
 	if(L.incorporeal_move || L.flying || L.floating)
 		return
 
-		return
 	// Don't break if they're just flying past
 	if(AM.throwing)
 		addtimer(CALLBACK(src, .proc/throw_check, AM), 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR stops mobs with the `flying`, `floating`, or `incorporeal_move` vars from breaking glass tables when they cross them.
This includes things like scout holoparasites, jaunting slings, and anything else that doesn't actually sit on the floor.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Something that can phase through walls still breaks a glass table, this not only can unintentionally hurt the user, but it can also give them away to an unknowing crew.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed glass tables being broken by flying, floating or jaunting mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
