### PR TITLE
Removes wall jaunting as we know it

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -56,8 +56,7 @@
 	qdel(holder)
 	if(!QDELETED(target))
 		if(mobloc.density)
-			for(var/direction in GLOB.alldirs)
-				var/turf/T = get_step(mobloc, direction)
+			for(var/turf/T in orange(7))
 				if(T)
 					if(target.Move(T))
 						break

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -457,8 +457,7 @@
 		flick("mist_reappear", animation)
 		sleep(5)
 		if(!user.Move(mobloc))
-			for(var/direction in list(1,2,4,8,5,6,9,10))
-				var/turf/T = get_step(mobloc, direction)
+			for(var/turf/T in orange(7, mobloc))
 				if(T)
 					if(user.Move(T))
 						break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR expands the range of valid turfs scanned when jaunting into a wall from 1 to 7.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, when jaunting into a wall and/or dense turf, the game "scans" for a valid turf 1 tile away, if it cannot find this it just manifests you in the wall anyway.
This leads to AI kill cheesing by vampires, wizards and wraiths. As they are in a wall completely safe from retaliation.
With this PR, the range of "valid" turfs has been expanded to 7 from center, so the user will get popped out somewhere within that range if there is a valid turf.
If a user somehow manages to land in a space where there are no valid turfs in 7 tiles (see: deep in lavaland rock) then just manifest within the wall as usual.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked jaunt to not put you inside a wall if there is a valid spot to manifest within 7 tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
