### PR TITLE
Fixes runtimes in spell can_cast() checks.

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -558,11 +558,13 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	if(((!user.mind) || !(src in user.mind.spell_list)) && !(src in user.mob_spell_list))
 		if(show_message)
 			to_chat(user, "<span class='warning'>You shouldn't have this spell! Something's wrong.</span>")
-		return 0
+		return FALSE
 
-	var/turf/T = get_turf(user)
-	if(is_admin_level(T.z) && !centcom_cancast) //Certain spells are not allowed on the centcom zlevel
-		return 0
+	if(!centcom_cancast) //Certain spells are not allowed on the centcom zlevel
+		var/turf/T = get_turf(user)
+		if(T)
+			if(is_admin_level(T.z))
+				return FALSE
 
 	if(!holy_area_cancast && user.holy_check())
 		return FALSE
@@ -573,21 +575,21 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 				if(charge_counter < charge_max)
 					if(show_message)
 						to_chat(user, still_recharging_msg)
-					return 0
+					return FALSE
 			if("charges")
 				if(!charge_counter)
 					if(show_message)
 						to_chat(user, "<span class='notice'>[name] has no charges left.</span>")
-					return 0
+					return FALSE
 	if(!ghost)
 		if(user.stat && !stat_allowed)
 			if(show_message)
 				to_chat(user, "<span class='notice'>You can't cast this spell while incapacitated.</span>")
-			return 0
+			return FALSE
 		if(ishuman(user) && (invocation_type == "whisper" || invocation_type == "shout") && user.is_muzzled())
 			if(show_message)
 				to_chat(user, "Mmmf mrrfff!")
-			return 0
+			return FALSE
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -562,9 +562,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 
 	if(!centcom_cancast) //Certain spells are not allowed on the centcom zlevel
 		var/turf/T = get_turf(user)
-		if(T)
-			if(is_admin_level(T.z))
-				return FALSE
+		if(T && is_admin_level(T.z))
+			return FALSE
 
 	if(!holy_area_cancast && user.holy_check())
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR changes how centcom_cancast checks are made for spells, to cut back on the number of runtimes caused by people in disposals having spells that check for turf z level.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fewer runtimes to filter through is good. There is no CL due to this being a backend change.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->