### PR TITLE
Butterflies created from severe anxiety decompose

### DIFF
--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -36,6 +36,15 @@
 			if(prob(2))
 				affected_mob.visible_message("<span class='danger'>[affected_mob] coughs up butterflies!</span>", \
 													"<span class='userdanger'>You cough up butterflies!</span>")
-				new /mob/living/simple_animal/butterfly(affected_mob.loc)
-				new /mob/living/simple_animal/butterfly(affected_mob.loc)
+				for(var/i in 1 to 2)
+					var/mob/living/simple_animal/butterfly/B = new(affected_mob.loc)
+					addtimer(CALLBACK(B, /mob/living/simple_animal/butterfly/.proc/decompose), rand(5, 25) SECONDS)
 	return
+
+/**
+ * Made so severe anxiety does not overload the SSmob while keeping it's effect
+ */
+/mob/living/simple_animal/butterfly/proc/decompose()
+	visible_message("<span class='notice'>[src] decomposes due to being outside of its original habitat for too long!</span>", \
+					"<span class='userdanger'>You decompose for being too long out of your habitat!</span>")
+	melt()

--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -44,6 +44,6 @@
  * Made so severe anxiety does not overload the SSmob while keeping it's effect
  */
 /mob/living/simple_animal/butterfly/proc/decompose()
-	visible_message("<span class='notice'>[src] decomposes due to being outside of its original habitat for too long!</span>", \
+	visible_message("<span class='notice'>[src] decomposes due to being outside of its original habitat for too long!</span>",
 					"<span class='userdanger'>You decompose for being too long out of your habitat!</span>")
 	melt()

--- a/code/datums/diseases/anxiety.dm
+++ b/code/datums/diseases/anxiety.dm
@@ -39,7 +39,6 @@
 				for(var/i in 1 to 2)
 					var/mob/living/simple_animal/butterfly/B = new(affected_mob.loc)
 					addtimer(CALLBACK(B, /mob/living/simple_animal/butterfly/.proc/decompose), rand(5, 25) SECONDS)
-	return
 
 /**
  * Made so severe anxiety does not overload the SSmob while keeping it's effect


### PR DESCRIPTION
## What Does This PR Do
Makes butterflies from severe anxiety decompose after 5 to 25 seconds

## Why It's Good For The Game
Will cut down on the SSmob abuse when severe anxiety is not cured instantly on highpop rounds while keeping the effect of the virus mostly intact.

## Changelog
:cl:
tweak: Makes butterflies spawned from severe anxiety decompose after 5 to 25 seconds
/:cl: