### PR TITLE
Makes admin verbs easier to see on the context menu

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -78,7 +78,7 @@
 
 /client/proc/debug_variables(datum/D in world)
 	set category = "Debug"
-	set name = "View Variables"
+	set name = "\[Admin\] View Variables"
 
 	var/static/cookieoffset = rand(1, 9999) //to force cookies to reset after the round.
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -72,7 +72,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 
 /datum/admins/proc/show_player_panel(mob/M in GLOB.mob_list)
 	set category = null
-	set name = "Show Player Panel"
+	set name = "\[Admin\] Show Player Panel"
 	set desc="Edit player (respawn, ban, heal, etc)"
 
 	if(!M)
@@ -766,7 +766,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	message_admins("[key_name_admin(usr)] checked the AI laws")
 
 /client/proc/update_mob_sprite(mob/living/carbon/human/H as mob)
-	set name = "Update Mob Sprite"
+	set name = "\[Admin\] Update Mob Sprite"
 	set desc = "Should fix any mob sprite update errors."
 	set category = null
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -611,7 +611,7 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 
 /client/proc/make_sound(obj/O in view()) // -- TLE
 	set category = "Event"
-	set name = "Make Sound"
+	set name = "\[Admin\] Make Sound"
 	set desc = "Display a message to everyone who can hear the target"
 
 	if(!check_rights(R_EVENT))
@@ -797,7 +797,7 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Manage Silicon Laws") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/change_human_appearance_admin(mob/living/carbon/human/H in GLOB.mob_list)
-	set name = "C.M.A. - Admin"
+	set name = "\[Admin\] C.M.A. - Admin"
 	set desc = "Allows you to change the mob appearance"
 	set category = null
 
@@ -823,7 +823,7 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "CMA - Admin") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/change_human_appearance_self(mob/living/carbon/human/H in GLOB.mob_list)
-	set name = "C.M.A. - Self"
+	set name = "\[Admin\] C.M.A. - Self"
 	set desc = "Allows the mob to change its appearance"
 	set category = null
 
@@ -963,7 +963,7 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 
 /client/proc/man_up(mob/T as mob in GLOB.player_list)
 	set category = null
-	set name = "Man Up"
+	set name = "\[Admin\] Man Up"
 	set desc = "Tells mob to man up and deal with it."
 
 	if(!check_rights(R_ADMIN))

--- a/code/modules/admin/machine_upgrade.dm
+++ b/code/modules/admin/machine_upgrade.dm
@@ -1,5 +1,5 @@
 /proc/machine_upgrade(obj/machinery/M in world)
-	set name = "Tweak Component Ratings"
+	set name = "\[Admin\] Tweak Component Ratings"
 	set category = null
 
 	if(!check_rights(R_DEBUG))

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -66,7 +66,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Jump To Area") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/jumptoturf(turf/T in world)
-	set name = "Jump to Turf"
+	set name = "\[Admin\] Jump to Turf"
 	set category = null
 
 	if(!check_rights(R_ADMIN))
@@ -135,7 +135,7 @@
 
 /client/proc/Getmob(mob/M in GLOB.mob_list)
 	set category = null
-	set name = "Get Mob"
+	set name = "\[Admin\] Get Mob"
 	set desc = "Mob to teleport"
 
 	if(!check_rights(R_ADMIN))
@@ -152,7 +152,7 @@
 
 /client/proc/Getkey()
 	set category = null
-	set name = "Get Key"
+	set name = "\[Admin\] Get Key"
 	set desc = "Key to teleport"
 
 	if(!check_rights(R_ADMIN))

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -1,7 +1,7 @@
 //allows right clicking mobs to send an admin PM to their client, forwards the selected mob's client to cmd_admin_pm
 /client/proc/cmd_admin_pm_context(mob/M as mob in GLOB.mob_list)
 	set category = null
-	set name = "Admin PM Mob"
+	set name = "\[Admin\] Admin PM Mob"
 	if(!check_rights(R_ADMIN|R_MENTOR))
 		return
 	if(!ismob(M) || !M.client)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -173,7 +173,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 /client/proc/callproc_datum(A as null|area|mob|obj|turf)
 	set category = null
-	set name = "Atom ProcCall"
+	set name = "\[Admin\] Atom ProcCall"
 
 	if(!check_rights(R_PROCCALL))
 		return
@@ -630,7 +630,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 /client/proc/cmd_admin_dress(mob/living/carbon/human/M in GLOB.human_list)
 	set category = "Event"
-	set name = "Select equipment"
+	set name = "\[Admin\] Select equipment"
 
 	if(!check_rights(R_EVENT))
 		return

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -9,7 +9,7 @@
 GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 
 /client/proc/freeze(atom/movable/M)
-	set name = "Freeze"
+	set name = "\[Admin\] Freeze"
 	set category = null
 
 	if(!check_rights(R_ADMIN))

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -1,5 +1,5 @@
 /proc/possess(obj/O as obj in world)
-	set name = "Possess Obj"
+	set name = "\[Admin\] Possess Obj"
 	set category = null
 
 	if(!check_rights(R_POSSESS))
@@ -34,7 +34,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Possess Object") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /proc/release(obj/O as obj in world)
-	set name = "Release Obj"
+	set name = "\[Admin\] Release Obj"
 	set category = null
 	//usr.loc = get_turf(usr)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1,6 +1,6 @@
 /client/proc/cmd_admin_drop_everything(mob/M as mob in GLOB.mob_list)
 	set category = null
-	set name = "Drop Everything"
+	set name = "\[Admin\] Drop Everything"
 
 	if(!check_rights(R_DEBUG|R_ADMIN))
 		return
@@ -46,7 +46,7 @@
 
 /client/proc/cmd_admin_subtle_message(mob/M as mob in GLOB.mob_list)
 	set category = "Event"
-	set name = "Subtle Message"
+	set name = "\[Admin\] Subtle Message"
 
 	if(!ismob(M))
 		return
@@ -124,7 +124,7 @@
 
 /client/proc/cmd_admin_direct_narrate(mob/M)	// Targetted narrate -- TLE
 	set category = null
-	set name = "Direct Narrate"
+	set name = "\[Admin\] Direct Narrate"
 
 	if(!check_rights(R_SERVER|R_EVENT))
 		return
@@ -151,7 +151,7 @@
 
 /client/proc/cmd_admin_headset_message(mob/M in GLOB.mob_list)
 	set category = "Event"
-	set name = "Headset Message"
+	set name = "\[Admin\] Headset Message"
 
 	admin_headset_message(M)
 
@@ -575,7 +575,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /client/proc/cmd_admin_rejuvenate(mob/living/M as mob in GLOB.mob_list)
 	set category = null
-	set name = "Rejuvenate"
+	set name = "\[Admin\] Rejuvenate"
 
 	if(!check_rights(R_REJUVINATE))
 		return
@@ -641,7 +641,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /client/proc/cmd_admin_delete(atom/A as obj|mob|turf in view())
 	set category = null
-	set name = "Delete"
+	set name = "\[Admin\] Delete"
 
 	if(!check_rights(R_ADMIN))
 		return
@@ -780,7 +780,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Gibself") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_check_contents(mob/living/M as mob in GLOB.mob_list)
-	set name = "Check Contents"
+	set name = "\[Admin\] Check Contents"
 	set category = null
 
 	if(!check_rights(R_ADMIN))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it easier to see at a glance what are admin verbs vs what are not in the right-click context menu.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You would not believe the amount of times admins misclick and heal/freeze/almost delete players. It's been one of my biggest gripes since becoming a TA. You can't even properly learn it in muscle memory because the window position shifts depending on what you are clicking.
This makes it significantly easier to see you are pushing a big uh-oh admin verb, thus making it harder to accidentally click on one.

The one downside to this is that a few verbs are also present in the event verb tab, meaning these now get shunted to the bottom of that list. Note that nothing has been deleted here.

In a ping to all online admins, 13 supported this change and 0 opposed it. While not _every_ active admin, this is a pretty strong indicator that this change is reasonably supported among those using these tools.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

### Current verb list: (As a TA, I don't have _all_ the verbs a GA has, hence the discrepancy.)

![2021-08-24 22_25_59-Greenshot](https://user-images.githubusercontent.com/12197162/130693037-3c8be2ce-b524-41f7-810e-b7630dcc8927.png)
![2021-08-24 22_26_26-Greenshot](https://user-images.githubusercontent.com/12197162/130693055-2670919e-16fc-49f6-b26b-de3412161e10.png)

### Proposed change:

![2021-08-24 22_28_29-Greenshot](https://user-images.githubusercontent.com/12197162/130693087-35845e1b-e773-4cf4-bc94-63b8934db796.png)
![2021-08-24 22_28_36-Greenshot](https://user-images.githubusercontent.com/12197162/130693090-db83635c-af36-4e35-8f14-8402619fe850.png)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Tweaked how admin verbs are displayed in the right-click context menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
