### PR TITLE
Makes AIs and borgs able to use Shift+Middle+Click to toggle door timings.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -67,6 +67,9 @@
 	if(modifiers["shift"] && modifiers["alt"])
 		AltShiftClickOn(A)
 		return
+	if(modifiers["shift"] && modifiers["middle"])
+		ShiftMiddleClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		if(controlled_mech) //Are we piloting a mech? Placed here so the modifiers are not overridden.
@@ -128,6 +131,8 @@
 	A.AICtrlShiftClick(src)
 /mob/living/silicon/ai/AltShiftClickOn(atom/A)
 	A.AIAltShiftClick(src)
+/mob/living/silicon/ai/ShiftMiddleClickOn(atom/A)
+	A.AIShiftMiddleClick(src)
 /mob/living/silicon/ai/ShiftClickOn(atom/A)
 	A.AIShiftClick(src)
 /mob/living/silicon/ai/CtrlClickOn(atom/A)
@@ -148,10 +153,19 @@
 /atom/proc/AIAltShiftClick()
 	return
 
+/atom/proc/AIShiftMiddleClick()
+	return
+
 /atom/proc/AIShiftClick(mob/living/user) // borgs use this too
 	if(user.client)
 		user.examinate(src)
 	return
+
+/atom/proc/AIShiftMiddleClickOn(mob/living/user)
+	return
+
+/obj/machinery/door/airlock/AIShiftMiddleClickOn(mob/living/user)
+	toggle_speed()
 
 /atom/proc/AICtrlClick(mob/living/silicon/user)
 	return
@@ -215,3 +229,8 @@
 	if(!ai_control_check(user))
 		return
 	toggle_light(user)
+
+/obj/machinery/door/airlock/AIShiftMiddleClick(mob/user)  // Toggles door timings.
+	if(!ai_control_check(user))
+		return
+	toggle_speed(user)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -161,12 +161,6 @@
 		user.examinate(src)
 	return
 
-/atom/proc/AIShiftMiddleClickOn(mob/living/user)
-	return
-
-/obj/machinery/door/airlock/AIShiftMiddleClickOn(mob/living/user)
-	toggle_speed()
-
 /atom/proc/AICtrlClick(mob/living/silicon/user)
 	return
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -363,6 +363,12 @@
 	A.AltShiftClick(src)
 	return
 
+/mob/proc/ShiftMiddleClickOn(atom/A)
+	return
+
+/atom/proc/CtrlShiftMiddleClick(mob/user)
+	return
+
 /atom/proc/AltShiftClick(mob/user)
 	return
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -366,12 +366,8 @@
 /mob/proc/ShiftMiddleClickOn(atom/A)
 	return
 
-/atom/proc/CtrlShiftMiddleClick(mob/user)
-	return
-
 /atom/proc/AltShiftClick(mob/user)
 	return
-
 
 /*
 	Misc helpers

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -30,6 +30,9 @@
 	if(modifiers["middle"] && modifiers["ctrl"])
 		CtrlMiddleClickOn(A)
 		return
+	if(modifiers["shift"] && modifiers["middle"])
+		ShiftMiddleClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return
@@ -126,7 +129,8 @@
 	A.BorgCtrlShiftClick(src)
 /mob/living/silicon/robot/AltShiftClickOn(atom/A)
 	A.BorgAltShiftClick(src)
-
+/mob/living/silicon/robot/ShiftMiddleClickOn(atom/A)
+	A.BorgShiftMiddleClick(src)
 
 /atom/proc/BorgShiftClick(mob/user)
 	if(user.client && user.client.eye == user)
@@ -148,6 +152,8 @@
 /atom/proc/BorgAltShiftClick()
 	return
 
+/atom/proc/BorgShiftMiddleClick()
+	return
 
 // AIRLOCKS
 
@@ -163,6 +169,8 @@
 /obj/machinery/door/airlock/BorgAltShiftClick(mob/living/silicon/robot/user)  // Enables emergency override on doors! Forwards to AI code.
 	AIAltShiftClick(user)
 
+/obj/machinery/door/airlock/BorgShiftMiddleClick(mob/living/silicon/robot/user)  //Toggles door timing. Forwards to AI code.
+	AIShiftMiddleClick(user)
 
 // APC
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -817,9 +817,9 @@ About the new airlock wires panel:
 			if(wires.is_cut(WIRE_SPEED))
 				to_chat(usr, "<span class='warning'>The timing wire is cut - Cannot alter timing.</span>")
 			else if(normalspeed)
-				normalspeed = 0
+				normalspeed = FALSE
 			else
-				normalspeed = 1
+				normalspeed = TRUE
 		if("open-close")
 			open_close(usr)
 		else
@@ -863,6 +863,17 @@ About the new airlock wires panel:
 	else
 		to_chat(user, "<span class='notice'>Emergency access has been disabled.</span>")
 	update_icon()
+
+/obj/machinery/door/airlock/proc/toggle_speed(mob/user)
+	normalspeed = !normalspeed
+	if(wires.is_cut(WIRE_SPEED))
+		to_chat(user, "<span class='warning'>The timing wire is cut - Cannot alter timing.</span>")
+	else if(normalspeed)
+		normalspeed = TRUE
+		to_chat(user, "<span class='notice'>The door is now in normal mode.</span>")
+	else if(!normalspeed)
+		normalspeed = FALSE
+		to_chat(user, "<span class='notice'>The door is now in fast mode.</span>")
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
 	add_fingerprint(user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -814,12 +814,7 @@ About the new airlock wires panel:
 				safe = 1
 				to_chat(usr, "<span class='notice'>The door safeties have been enabled.</span>")
 		if("speed-toggle")
-			if(wires.is_cut(WIRE_SPEED))
-				to_chat(usr, "<span class='warning'>The timing wire is cut - Cannot alter timing.</span>")
-			else if(normalspeed)
-				normalspeed = FALSE
-			else
-				normalspeed = TRUE
+			toggle_speed(usr)
 		if("open-close")
 			open_close(usr)
 		else
@@ -865,15 +860,15 @@ About the new airlock wires panel:
 	update_icon()
 
 /obj/machinery/door/airlock/proc/toggle_speed(mob/user)
-	normalspeed = !normalspeed
 	if(wires.is_cut(WIRE_SPEED))
-		to_chat(user, "<span class='warning'>The timing wire is cut - Cannot alter timing.</span>")
-	else if(normalspeed)
-		normalspeed = TRUE
-		to_chat(user, "<span class='notice'>The door is now in normal mode.</span>")
-	else if(!normalspeed)
-		normalspeed = FALSE
-		to_chat(user, "<span class='notice'>The door is now in fast mode.</span>")
+		to_chat(user, "<span class='warning'>The timing wire has been cut - Cannot alter timing.</span>")
+		return
+	normalspeed = !normalspeed
+
+	if(normalspeed)
+		to_chat(user, "<span class='notice'>The door is now in <b>normal</b> mode.</span>")
+	else
+		to_chat(user, "<span class='notice'>The door is now in <b>fast</b> mode.</span>")
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes AIs and borgs able to use Shift+Middle+Click to toggle door timings.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Changes Cyborg.dm, AI.dm, click.dm and airlock.dm, Basically copied the Emergency access code with a few tweaks, I think some stuff in here could be changed from 1 and 0, to TRUE and FALSE but I will leave that to another PR.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
AI's being pesterd by heads to change door timings should be less annoying, There seems to be a want for a door timing shortcut but last time it was implemented people did not like it because it replaced an old shortcut, This pr adds a new shortcut without replacing any old ones. This was also was discussed on the forums, which made me want to try and code it.
>Implementation #11863 
>removal #12207
>reimplementation with tweaks #16598 

https://www.paradisestation.org/forum/topic/21363-make-synthetic-middle-mouse-click-change-timers-on-doors-rather-than-toggle-bolt-lights/

## Note
this is my second PR, thanks to bubblegum for helping me figure out some stuff, if theres any changes you think would make the code better please tell me.

A.I.

https://user-images.githubusercontent.com/70362590/130872034-a779158c-7220-4beb-a124-e89c1c10b179.mp4

Cyborgs

https://user-images.githubusercontent.com/70362590/130872334-4556cb62-8e92-416b-af09-16c3c977bdd8.mp4

## Changelog
:cl:
tweak: Synthetics can now use Shift+Middle+Click to toggle door timings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
