### PR TITLE
Polishes knocking people off tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -91,8 +91,12 @@
 /obj/structure/table/attack_hand(mob/living/user)
 	..()
 	if(climber)
+		if(climber == user)
+			return
 		climber.Weaken(2)
-		climber.visible_message("<span class='warning'>[climber.name] has been knocked off the table", "You've been knocked off the table", "You hear [climber.name] get knocked off the table</span>")
+		climber.visible_message("<span class='warning'>[user] knocks [climber] off [src]!</span>", "<span class='userdanger'>[user] knocks you off [src]!</span>")
+		user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
+		playsound(src, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
 	else if(Adjacent(user) && user.pulling && user.pulling.pass_flags & PASSTABLE)
 		user.Move_Pulled(src)
 		if(user.pulling.loc == loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
- **Table climber can no longer knock themself off.**
- Rewrites the message, adds appropriate CSS classes.
- Adds attack animation (disarm).
- Add sounds (punch miss).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The message when getting knocked off isn't exactly clear and doesn't even tell you who did it.

## Changelog
:cl:
add: Add message, animation and sound when knocking people off tables
tweak: You can no longer knock yourself off a table you are climbing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
