### PR TITLE
Constructable electrochromic windows

### DIFF
--- a/code/game/objects/effects/spawners/windowspawner.dm
+++ b/code/game/objects/effects/spawners/windowspawner.dm
@@ -59,6 +59,12 @@
 	window_to_spawn_regular = /obj/structure/window/reinforced/tinted
 	window_to_spawn_full = /obj/structure/window/full/reinforced/tinted
 
+/obj/effect/spawner/window/reinforced/polarized
+	name = "electrochromic reinforced window spawner"
+	icon_state = "pwindow_spawner"
+	window_to_spawn_regular = /obj/structure/window/reinforced/polarized
+	window_to_spawn_full = /obj/structure/window/full/reinforced/polarized
+
 /obj/effect/spawner/window/shuttle
 	name = "shuttle window spawner"
 	icon_state = "swindow_spawner"

--- a/code/game/objects/items/mountable_frames/buttons_switches.dm
+++ b/code/game/objects/items/mountable_frames/buttons_switches.dm
@@ -21,3 +21,11 @@
 /obj/item/mounted/frame/light_switch/do_build(turf/on_wall, mob/user)
 	new /obj/machinery/light_switch(get_turf(user), get_dir(user, on_wall))
 	qdel(src)
+
+/obj/item/mounted/frame/light_switch/windowtint
+	name = "window tint control button frame"
+	desc = "Used for repairing or building window tint control buttons"
+
+/obj/item/mounted/frame/light_switch/windowtint/do_build(turf/on_wall, mob/user)
+	new /obj/machinery/button/windowtint(get_turf(user), get_dir(user, on_wall))
+	qdel(src)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -89,7 +89,10 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	new/datum/stack_recipe/window("windoor frame", /obj/structure/windoor_assembly, 5, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	null, \
 	new/datum/stack_recipe/window("directional reinforced window", /obj/structure/window/reinforced, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe/window("fulltile reinforced window", /obj/structure/window/full/reinforced, 2, time = 0, on_floor = TRUE, window_checks = TRUE) \
+	new/datum/stack_recipe/window("fulltile reinforced window", /obj/structure/window/full/reinforced, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
+	null, \
+	new/datum/stack_recipe/window("directional electrochromic window", /obj/structure/window/reinforced/polarized, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
+	new/datum/stack_recipe/window("fulltile electrochromic window", /obj/structure/window/full/reinforced/polarized, 4, time = 0, on_floor = TRUE, window_checks = TRUE) \
 ))
 
 /obj/item/stack/sheet/rglass

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -83,6 +83,7 @@ GLOBAL_LIST_INIT(metal_recipes, list(
 	null,
 	new /datum/stack_recipe("mass driver button frame", /obj/item/mounted/frame/driver_button, 1, time = 50, one_per_turf = 0, on_floor = 1),
 	new /datum/stack_recipe("light switch frame", /obj/item/mounted/frame/light_switch, 1, time = 50, one_per_turf = 0, on_floor = 1),
+	new /datum/stack_recipe("window tint control button frame", /obj/item/mounted/frame/light_switch/windowtint, 1, time = 50, one_per_turf = 0, on_floor = 1),
 	null,
 	new /datum/stack_recipe("grenade casing", /obj/item/grenade/chem_grenade),
 	new /datum/stack_recipe("light fixture frame", /obj/item/mounted/frame/light_fixture, 2),

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -514,11 +514,34 @@
 	var/id = 0
 	var/active = 0
 
+/obj/machinery/button/windowtint/New(turf/loc, w_dir=null)
+	..()
+	switch(w_dir)
+		if(NORTH)
+			pixel_y = 25
+		if(SOUTH)
+			pixel_y = -25
+		if(EAST)
+			pixel_x = 25
+		if(WEST)
+			pixel_x = -25
+
 /obj/machinery/button/windowtint/attack_hand(mob/user)
 	if(..())
-		return 1
+		return TRUE
 
 	toggle_tint()
+
+/obj/machinery/button/windowtint/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/wrench))
+		playsound(get_turf(src), W.usesound, 50, 1)
+		if(do_after(user, 30 * W.toolspeed, target = src))
+			to_chat(user, "<span class='notice'>You detach \the [src] from the wall.</span>")
+			new/obj/item/mounted/frame/light_switch/windowtint(get_turf(src))
+			qdel(src)
+		return TRUE
+
+	return ..()
 
 /obj/machinery/button/windowtint/proc/toggle_tint()
 	use_power(5)
@@ -527,6 +550,12 @@
 	update_icon()
 
 	for(var/obj/structure/window/reinforced/polarized/W in range(src,range))
+		if(W.id == src.id || !W.id)
+			spawn(0)
+				W.toggle()
+				return
+
+	for(var/obj/structure/window/full/reinforced/polarized/W in range(src,range))
 		if(W.id == src.id || !W.id)
 			spawn(0)
 				W.toggle()
@@ -589,7 +618,7 @@
 	icon_state = "window"
 	max_integrity = 50
 	smooth = SMOOTH_TRUE
-	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
+	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/polarized, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
 
 /obj/structure/window/full/plasmabasic
 	name = "plasma window"
@@ -602,7 +631,7 @@
 	heat_resistance = 32000
 	max_integrity = 300
 	smooth = SMOOTH_TRUE
-	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
+	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/polarized, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
 	explosion_block = 1
 	armor = list("melee" = 75, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 45, "bio" = 100, "rad" = 100, "fire" = 99, "acid" = 100)
 	rad_insulation = RAD_NO_INSULATION
@@ -616,7 +645,7 @@
 	shardtype = /obj/item/shard/plasma
 	glass_type = /obj/item/stack/sheet/plasmarglass
 	smooth = SMOOTH_TRUE
-	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
+	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/polarized, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
 	reinf = TRUE
 	max_integrity = 1000
 	explosion_block = 2
@@ -632,7 +661,7 @@
 	icon = 'icons/obj/smooth_structures/reinforced_window.dmi'
 	icon_state = "r_window"
 	smooth = SMOOTH_TRUE
-	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
+	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/polarized, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced, /turf/simulated/wall/indestructible/fakeglass)
 	max_integrity = 100
 	reinf = TRUE
 	heat_resistance = 1600
@@ -640,6 +669,19 @@
 	rad_insulation = RAD_HEAVY_INSULATION
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/rglass
+
+/obj/structure/window/full/reinforced/polarized
+	name = "electrochromic window"
+	desc = "Adjusts its tint with voltage. Might take a few good hits to shatter it."
+	var/id
+
+/obj/structure/window/full/reinforced/polarized/proc/toggle()
+	if(opacity)
+		animate(src, color="#FFFFFF", time=5)
+		set_opacity(0)
+	else
+		animate(src, color="#222222", time=5)
+		set_opacity(1)
 
 /obj/structure/window/full/reinforced/tinted
 	name = "tinted window"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -27,6 +27,8 @@
 	var/real_explosion_block	//ignore this, just use explosion_block
 	var/breaksound = "shatter"
 	var/hitsound = 'sound/effects/Glasshit.ogg'
+	/// Used to restore colours from polarised glass
+	var/old_color
 
 /obj/structure/window/examine(mob/user)
 	. = ..()
@@ -71,9 +73,12 @@
 
 /obj/structure/window/proc/toggle_polarization()
 	if(opacity)
-		animate(src, color = "#FFFFFF", time = 0.5 SECONDS)
+		if(!old_color)
+			old_color = "#FFFFFF"
+		animate(src, color = old_color, time = 0.5 SECONDS)
 		set_opacity(FALSE)
 	else
+		old_color = color
 		animate(src, color = "#222222", time = 0.5 SECONDS)
 		set_opacity(TRUE)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -71,11 +71,11 @@
 
 /obj/structure/window/proc/toggle_polarization()
 	if(opacity)
-		animate(src, color="#FFFFFF", time=5)
-		set_opacity(0)
+		animate(src, color = "#FFFFFF", time = 0.5 SECONDS)
+		set_opacity(FALSE)
 	else
-		animate(src, color="#222222", time=5)
-		set_opacity(1)
+		animate(src, color = "#222222", time = 0.5 SECONDS)
+		set_opacity(TRUE)
 
 /obj/structure/window/narsie_act()
 	color = NARSIE_WINDOW_COLOUR
@@ -514,7 +514,7 @@
 	var/id = 0
 	var/active = 0
 
-/obj/machinery/button/windowtint/Initialize(mapload, w_dir=null)
+/obj/machinery/button/windowtint/Initialize(mapload, w_dir = null)
 	. = ..()
 	switch(w_dir)
 		if(NORTH)
@@ -537,7 +537,6 @@
 	if(!I.tool_use_check(user, 0))
 		return
 	user.visible_message("<span class='notice'>[user] starts unwrenching [src] from the wall...</span>", "<span class='notice'>You are unwrenching [src] from the wall...</span>", "<span class='warning'>You hear ratcheting.</span>")
-	. = TRUE
 	if(!I.use_tool(src, user, 50, volume = I.tool_volume))
 		return
 	WRENCH_UNANCHOR_WALL_MESSAGE
@@ -554,7 +553,7 @@
 		if(W.id == src.id || !W.id)
 			W.toggle_polarization()
 
-	for(var/obj/structure/window/full/reinforced/polarized/W in range(src,range))
+	for(var/obj/structure/window/full/reinforced/polarized/W in range(src, range))
 		if(W.id == src.id || !W.id)
 			W.toggle_polarization()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -551,15 +551,11 @@
 
 	for(var/obj/structure/window/reinforced/polarized/W in range(src,range))
 		if(W.id == src.id || !W.id)
-			spawn(0)
-				W.toggle()
-				return
+			W.toggle()
 
 	for(var/obj/structure/window/full/reinforced/polarized/W in range(src,range))
 		if(W.id == src.id || !W.id)
-			spawn(0)
-				W.toggle()
-				return
+			W.toggle()
 
 /obj/machinery/button/windowtint/power_change()
 	..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -545,7 +545,7 @@
 	if(!I.use_tool(src, user, 50, volume = I.tool_volume))
 		return
 	WRENCH_UNANCHOR_WALL_MESSAGE
-	new/obj/item/mounted/frame/light_switch/windowtint(get_turf(src))
+	new /obj/item/mounted/frame/light_switch/windowtint(get_turf(src))
 	qdel(src)
 
 /obj/machinery/button/windowtint/proc/toggle_tint()
@@ -559,7 +559,7 @@
 			W.toggle_polarization()
 
 	for(var/obj/structure/window/full/reinforced/polarized/W in range(src, range))
-		if(W.id == src.id || !W.id)
+		if(W.id == id || !W.id)
 			W.toggle_polarization()
 
 /obj/machinery/button/windowtint/power_change()
@@ -675,6 +675,7 @@
 	name = "electrochromic window"
 	desc = "Adjusts its tint with voltage. Might take a few good hits to shatter it."
 	var/id
+	
 /obj/structure/window/full/reinforced/tinted
 	name = "tinted window"
 	desc = "It looks rather strong and opaque. Might take a few good hits to shatter it."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes directional and fulltile electrochromic windows constructible with rglass. You can also (obviously) build the control button with metal.
This also makes the fulltile electrochromic windows their own object, not just a dir on the directional ones.
Electrochromic fulltile windows now smooth correctly with other glass.
Mapping spawner for this glass+grille added.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fancy windows are cool, the lack of buildability was a giant pain in the ass. This makes it easier for both players _and_ mappers to include these.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![2021-08-28 15_05_56-Paradise Station 13](https://user-images.githubusercontent.com/12197162/131220911-84bb6a86-5d20-49ad-957c-e74362cb1232.png)
![2021-08-28 15_06_15-](https://user-images.githubusercontent.com/12197162/131220913-be2e84bd-5af6-4e3e-90c3-4c71a76e27c2.png)
![2021-08-28 15_07_42-Paradise Station 13](https://user-images.githubusercontent.com/12197162/131220914-02dadf6e-6944-438e-87da-a80ec55fb84f.png)
![2021-08-28 15_07_49-Paradise Station 13](https://user-images.githubusercontent.com/12197162/131220915-0721bd78-b2ef-4141-9001-b137546a4eaf.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Added fulltile electrochromic windows
add: Added the ability to build electrochromic windows with rglass, and the control button with metal.
add: Added mapping spawners for fulltile electrochromic windows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
