### PR TITLE
Tweak to revolution conversions

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -82,3 +82,6 @@
 #define STATUS_EFFECT_CRUSHERDAMAGETRACKING /datum/status_effect/crusher_damage //tracks total kinetic crusher damage on a target
 
 #define STATUS_EFFECT_SYPHONMARK /datum/status_effect/syphon_mark //tracks kills for the KA death syphon module
+
+///Enforces timer between flash conversions for head revolutionaries
+#define STATUS_EFFECT_CONVERSION_COOLDOWN /datum/status_effect/conversion_cooldown

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -45,7 +45,7 @@
 	var/list/targets = list()
 
 	///Tracks if this mind has been a rev or not
-	var/has_been_rev = 0
+	var/has_been_rev = FALSE
 	///Tracks if headrevs are on a conversion cooldown or not
 	var/conversion_on_cooldown = FALSE
 	///How long the cooldown timer is for conversion

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -44,12 +44,7 @@
 	var/list/datum/objective/special_verbs = list()
 	var/list/targets = list()
 
-	///Tracks if this mind has been a rev or not
-	var/has_been_rev = 0
-	///Tracks if headrevs are on a conversion cooldown or not
-	var/conversion_on_cooldown = FALSE
-	///How long the cooldown timer is for conversion
-	var/conversion_cooldown_time = 20 SECONDS
+	var/has_been_rev = 0//Tracks if this mind has been a rev or not
 
 	var/miming = 0 // Mime's vow of silence
 	var/list/antag_datums
@@ -1509,13 +1504,6 @@
 	var/obj/item/uplink/hidden/H = find_syndicate_uplink()
 	if(H)
 		qdel(H)
-
-/datum/mind/proc/begin_conversion_cooldown()
-	conversion_on_cooldown = TRUE
-	addtimer(CALLBACK(src, .proc/end_conversion_cooldown), conversion_cooldown_time, TIMER_OVERRIDE)
-
-/datum/mind/proc/end_conversion_cooldown()
-	conversion_on_cooldown = FALSE
 
 /datum/mind/proc/make_Traitor()
 	if(!has_antag_datum(/datum/antagonist/traitor))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -45,7 +45,7 @@
 	var/list/targets = list()
 
 	///Tracks if this mind has been a rev or not
-	var/has_been_rev = FALSE
+	var/has_been_rev = 0
 	///Tracks if headrevs are on a conversion cooldown or not
 	var/conversion_on_cooldown = FALSE
 	///How long the cooldown timer is for conversion

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -44,7 +44,12 @@
 	var/list/datum/objective/special_verbs = list()
 	var/list/targets = list()
 
-	var/has_been_rev = 0//Tracks if this mind has been a rev or not
+	///Tracks if this mind has been a rev or not
+	var/has_been_rev = 0
+	///Tracks if headrevs are on a conversion cooldown or not
+	var/conversion_on_cooldown = FALSE
+	///How long the cooldown timer is for conversion
+	var/conversion_cooldown_time = 20 SECONDS
 
 	var/miming = 0 // Mime's vow of silence
 	var/list/antag_datums
@@ -1504,6 +1509,13 @@
 	var/obj/item/uplink/hidden/H = find_syndicate_uplink()
 	if(H)
 		qdel(H)
+
+/datum/mind/proc/begin_conversion_cooldown()
+	conversion_on_cooldown = TRUE
+	addtimer(CALLBACK(src, .proc/end_conversion_cooldown), conversion_cooldown_time, TIMER_OVERRIDE)
+
+/datum/mind/proc/end_conversion_cooldown()
+	conversion_on_cooldown = FALSE
 
 /datum/mind/proc/make_Traitor()
 	if(!has_antag_datum(/datum/antagonist/traitor))

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -45,3 +45,11 @@
 
 /datum/status_effect/high_five/on_remove()
 	owner.visible_message("[owner] was left hanging....")
+
+/datum/status_effect/conversion_cooldown
+	id = "conversion_cooldown"
+	duration = 20 SECONDS
+	alert_type = null
+
+/datum/status_effect/conversion_cooldown/on_remove()
+	to_chat(owner, "You feel ready to recruit someone to the cause!")

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -146,7 +146,7 @@
 		return
 	if(!user.mind || !(user.mind in SSticker.mode.head_revolutionaries))
 		return
-	if(user.has_status_effect(/datum/status_effect/conversion_cooldown))
+	if(user.has_status_effect(STATUS_EFFECT_CONVERSION_COOLDOWN))
 		to_chat(user, "<span class='warning'>You must wait a little longer before recruiting another to your cause!</span>")
 		return
 	if(!M.client)
@@ -160,7 +160,7 @@
 		if(user.mind in SSticker.mode.head_revolutionaries)
 			if(SSticker.mode.add_revolutionary(M.mind))
 				times_used -- //Flashes less likely to burn out for headrevs when used for conversion
-				user.apply_status_effect(/datum/status_effect/conversion_cooldown)
+				user.apply_status_effect(STATUS_EFFECT_CONVERSION_COOLDOWN)
 				return
 	to_chat(user, "<span class='warning'>This mind seems resistant to [src]!</span>")
 

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -91,7 +91,7 @@
 		if(targeted)
 			if(M.flash_eyes(1, 1))
 				M.AdjustConfused(power)
-				terrible_conversion_proc(M, user)
+				rev_conversion_proc(M, user)
 				M.Stun(1)
 				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
 				to_chat(user, "<span class='danger'>You blind [M] with the flash!</span>")
@@ -141,32 +141,29 @@
 	..()
 
 
-/obj/item/flash/proc/terrible_conversion_proc(mob/M, mob/living/user)
-	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
-		if(user.mind && (user.mind in SSticker.mode.head_revolutionaries))
-			if(user.has_status_effect(/datum/status_effect/conversion_cooldown))
-				to_chat(user, "<span class='warning'>You must wait a little longer before recruiting another to your cause!</span>")
+/obj/item/flash/proc/rev_conversion_proc(mob/M, mob/living/user)
+	if(!ishuman(M) || !ishuman(user) || M.stat == DEAD)
+		return
+	if(!user.mind || !(user.mind in SSticker.mode.head_revolutionaries))
+		return
+	if(user.has_status_effect(/datum/status_effect/conversion_cooldown))
+		to_chat(user, "<span class='warning'>You must wait a little longer before recruiting another to your cause!</span>")
+		return
+	if(!M.client)
+		to_chat(user, "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>")
+		return
+	if(M.stat != CONSCIOUS)
+		to_chat(user, "<span class='warning'>They must be conscious before you can convert [M.p_them()]!</span>")
+		return
+	M.mind_initialize() //give them a mind datum if they don't have one.
+	if(!ismindshielded(M))
+		if(user.mind in SSticker.mode.head_revolutionaries)
+			if(SSticker.mode.add_revolutionary(M.mind))
+				times_used -- //Flashes less likely to burn out for headrevs when used for conversion
+				user.apply_status_effect(/datum/status_effect/conversion_cooldown)
 				return
-			if(M.client)
-				if(M.stat == CONSCIOUS)
-					M.mind_initialize() //give them a mind datum if they don't have one.
-					var/resisted
-					if(!ismindshielded(M))
-						if(user.mind in SSticker.mode.head_revolutionaries)
-							if(SSticker.mode.add_revolutionary(M.mind))
-								times_used -- //Flashes less likely to burn out for headrevs when used for conversion
-								user.apply_status_effect(/datum/status_effect/conversion_cooldown)
-							else
-								resisted = 1
-					else
-						resisted = 1
+	to_chat(user, "<span class='warning'>This mind seems resistant to [src]!</span>")
 
-					if(resisted)
-						to_chat(user, "<span class='warning'>This mind seems resistant to [src]!</span>")
-				else
-					to_chat(user, "<span class='warning'>They must be conscious before you can convert [M.p_them()]!</span>")
-			else
-				to_chat(user, "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>")
 
 
 /obj/item/flash/cyborg

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -144,9 +144,6 @@
 /obj/item/flash/proc/terrible_conversion_proc(mob/M, mob/user)
 	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
 		if(user.mind && (user.mind in SSticker.mode.head_revolutionaries))
-			if(user.mind.conversion_on_cooldown)
-				to_chat(user, "<span class='warning'>You must wait a little longer before recruiting another to your cause!</span>")
-				return
 			if(M.client)
 				if(M.stat == CONSCIOUS)
 					M.mind_initialize() //give them a mind datum if they don't have one.
@@ -155,7 +152,6 @@
 						if(user.mind in SSticker.mode.head_revolutionaries)
 							if(SSticker.mode.add_revolutionary(M.mind))
 								times_used -- //Flashes less likely to burn out for headrevs when used for conversion
-								user.mind.begin_conversion_cooldown()
 							else
 								resisted = 1
 					else

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -144,6 +144,9 @@
 /obj/item/flash/proc/terrible_conversion_proc(mob/M, mob/user)
 	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
 		if(user.mind && (user.mind in SSticker.mode.head_revolutionaries))
+			if(user.mind.conversion_on_cooldown)
+				to_chat(user, "<span class='warning'>You must wait a little longer before recruiting another to your cause!</span>")
+				return
 			if(M.client)
 				if(M.stat == CONSCIOUS)
 					M.mind_initialize() //give them a mind datum if they don't have one.
@@ -152,6 +155,7 @@
 						if(user.mind in SSticker.mode.head_revolutionaries)
 							if(SSticker.mode.add_revolutionary(M.mind))
 								times_used -- //Flashes less likely to burn out for headrevs when used for conversion
+								user.mind.begin_conversion_cooldown()
 							else
 								resisted = 1
 					else

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -141,9 +141,12 @@
 	..()
 
 
-/obj/item/flash/proc/terrible_conversion_proc(mob/M, mob/user)
+/obj/item/flash/proc/terrible_conversion_proc(mob/M, mob/living/user)
 	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
 		if(user.mind && (user.mind in SSticker.mode.head_revolutionaries))
+			if(user.has_status_effect(/datum/status_effect/conversion_cooldown))
+				to_chat(user, "<span class='warning'>You must wait a little longer before recruiting another to your cause!</span>")
+				return
 			if(M.client)
 				if(M.stat == CONSCIOUS)
 					M.mind_initialize() //give them a mind datum if they don't have one.
@@ -152,6 +155,7 @@
 						if(user.mind in SSticker.mode.head_revolutionaries)
 							if(SSticker.mode.add_revolutionary(M.mind))
 								times_used -- //Flashes less likely to burn out for headrevs when used for conversion
+								user.apply_status_effect(/datum/status_effect/conversion_cooldown)
 							else
 								resisted = 1
 					else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is a small PR that adds a 20-second cooldown to flash conversions by head revs.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While it's rarely forced and is not in rotation, when rev _is_ played the lack of any cooldown on conversions just leads to flash spam and an overwhelming rev force within minutes. This PR means it takes a little while to build up rev forces, and admins can tweak the cooldown var per head rev on demand.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked head revs so they can only convert every 20 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
