### PR TITLE
Allows status to output the round ID

### DIFF
--- a/code/modules/world_topic/status.dm
+++ b/code/modules/world_topic/status.dm
@@ -31,7 +31,7 @@
 	status_info["players"] = player_count
 	status_info["admins"] = admin_count
 	status_info["map_name"] = SSmapping.map_datum.fluff_name
-
+	status_info["round_id"] = GLOB.round_id
 	// Add more info if we are authed
 	if(key_valid)
 		if(SSticker && SSticker.mode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Allows world status to output round ID

## Why It's Good For The ~~Game~~ Discord
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

There are times where grabbing the round ID while not being on the server is useful, so allowing !status to do this can be beneficial.


No CL, does not affect players in game, only discord.
