### PR TITLE
Cults now require a sacrifice before they can make mirror shields

### DIFF
--- a/code/game/gamemodes/cult/cult_datums.dm
+++ b/code/game/gamemodes/cult/cult_datums.dm
@@ -73,6 +73,9 @@
 	var/airlock_unruned_icon_file = 'icons/obj/doors/airlocks/cult/unruned/cult.dmi'
 	var/airlock_unruned_overlays_file = 'icons/obj/doors/airlocks/cult/unruned/cult-overlays.dmi'
 
+	/// Are cultist mirror shields active yet?
+	var/mirror_shields_active = FALSE
+
 
 /datum/cult_info/fire
 	name = "Cult of Kha'Rin"

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -444,6 +444,11 @@
   * The illusion has a 60% chance to be hostile and attack non-cultists, and a 40% chance to just run away from the user.
   */
 /obj/item/shield/mirror/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	// Incase they get one by some magic
+	if(!SSticker.cultdat.mirror_shields_active)
+		to_chat(owner, "<span class='warning'>This shield is powerless! You must perform the required sacrifice to empower it!</span>")
+		return
+
 	if(iscultist(owner) && !owner.holy_check()) // Cultist holding the shield
 
 		// Hit by a projectile

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -86,14 +86,24 @@
 		to_chat(user, "<span class='cultitalic'>The magic in [src] is weak, it will be ready to use again in [get_ETA()].</span>")
 		return
 
-	var/choice = show_radial_menu(user, src, choosable_items, require_near = TRUE)
-	var/picked_type = choosable_items[choice]
+
+	var/list/pickable_items = get_choosable_items()
+	var/choice = show_radial_menu(user, src, pickable_items, require_near = TRUE)
+	var/picked_type = pickable_items[choice]
 	if(!QDELETED(src) && picked_type && Adjacent(user) && !user.incapacitated() && cooldowntime <= world.time)
 		cooldowntime = world.time + creation_delay
 		var/obj/O = new picked_type
 		if(istype(O, /obj/structure) || !user.put_in_hands(O))
 			O.forceMove(get_turf(src))
 		to_chat(user, replacetext("[creation_message]", "%ITEM%", "[O.name]"))
+
+/**
+  * Returns the items the cult can craft from this forge.
+  *
+  * Override on children for logic regarding game state.
+  */
+/obj/structure/cult/functional/proc/get_choosable_items()
+	return choosable_items.Copy() // Copied incase its modified on children
 
 /**
   * Returns the cooldown time in minutes and seconds
@@ -159,8 +169,15 @@
 	selection_prompt = "You study the schematics etched on the forge..."
 	selection_title = "Forge"
 	creation_message = "<span class='cultitalic'>You work the forge as dark knowledge guides your hands, creating a %ITEM%!</span>"
-	choosable_items = list("Shielded Robe" = /obj/item/clothing/suit/hooded/cultrobes/cult_shield, "Flagellant's Robe" = /obj/item/clothing/suit/hooded/cultrobes/flagellant_robe,
-							"Mirror Shield" = /obj/item/shield/mirror)
+	choosable_items = list("Shielded Robe" = /obj/item/clothing/suit/hooded/cultrobes/cult_shield, "Flagellant's Robe" = /obj/item/clothing/suit/hooded/cultrobes/flagellant_robe)
+
+/obj/structure/cult/functional/forge/get_choosable_items()
+	. = ..()
+	if(SSticker.cultdat.mirror_shields_active)
+		// Both lines here are needed. If you do it without, youll get issues.
+		. += "Mirror Shield"
+		.["Mirror Shield"] = /obj/item/shield/mirror
+
 
 /obj/structure/cult/functional/forge/Initialize(mapload)
 	. = ..()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -384,6 +384,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 	for(var/M in invokers)
 		if(sacrifice_fulfilled)
 			to_chat(M, "<span class='cultlarge'>\"Yes! This is the one I desire! You have done well.\"</span>")
+			if(!SSticker.cultdat.mirror_shields_active) // Only show once
+				to_chat(M, "<span class='cultitalic'>You are now able to construct mirror shields inside the daemon forge.</span>")
+				SSticker.cultdat.mirror_shields_active = TRUE
 		else
 			if(ishuman(offering) && offering.mind.offstation_role && offering.mind.special_role != SPECIAL_ROLE_ERT) //If you try it on a ghost role, you get nothing
 				to_chat(M, "<span class='cultlarge'>\"This soul is of no use to either of us.\"</span>")


### PR DESCRIPTION
## What Does This PR Do
Cultists must complete their first sacrifice objective before mirror shields can be constructed inside the daemon forge.

## Why It's Good For The Game
This item is fucking garbage and needs some sort of gatekeeping, and people agree this is fine.

## Changelog
:cl: AffectedArc07
tweak: Cultists must complete their first sacrifice objective before they can produce mirror shields
/:cl:
