### PR TITLE
Makes anomalies able to spawn in more areas

### DIFF
--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -5,11 +5,13 @@
 
 /datum/event/anomaly/proc/findEventArea()
 	var/static/list/allowed_areas
-	var/static/list/existing_areas = list()
-	for(var/area/AR in world)
-		var/turf/picked = safepick(get_area_turfs(AR.type))
-		if(picked && is_station_level(picked.z))
-			existing_areas += AR
+	var/static/list/existing_areas
+	if(!existing_areas)
+		existing_areas = list()
+		for(var/area/AR in world)
+			var/turf/picked = safepick(get_area_turfs(AR.type))
+			if(picked && is_station_level(picked.z))
+				existing_areas += AR
 	if(!allowed_areas)
 		//Places that shouldn't explode
 		var/list/safe_area_types = typecacheof(list(

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -5,6 +5,11 @@
 
 /datum/event/anomaly/proc/findEventArea()
 	var/static/list/allowed_areas
+	var/static/list/existing_areas = list()
+	for(var/area/AR in world)
+		var/turf/picked = safepick(get_area_turfs(AR.type))
+		if(picked && is_station_level(picked.z))
+			existing_areas += AR
 	if(!allowed_areas)
 		//Places that shouldn't explode
 		var/list/safe_area_types = typecacheof(list(
@@ -20,10 +25,16 @@
 		)
 
 		//Subtypes from the above that actually should explode.
-		var/list/unsafe_area_subtypes = typecacheof(list(/area/engine/break_room))
+		var/list/unsafe_area_subtypes = typecacheof(list(
+		/area/engine/break_room,
+		/area/engine/equipmentstorage,
+		/area/engine/chiefs_office,
+		/area/engine/controlroom,
+		/area/engine/mechanic_workshop
+		))
 
-		allowed_areas = make_associative(GLOB.the_station_areas) - safe_area_types + unsafe_area_subtypes
-	var/list/possible_areas = typecache_filter_list(GLOB.all_areas, allowed_areas)
+		allowed_areas = typecacheof(GLOB.the_station_areas) - safe_area_types + unsafe_area_subtypes
+	var/list/possible_areas = typecache_filter_list(existing_areas, allowed_areas)
 	if(length(possible_areas))
 		return pick(possible_areas)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds a check in anomalies that let them know what areas exist on a station, to be possible areas to select, rather than only selecting from a smaller list of 17 areas.

Adds more engineering subtypes that would be fine with blowing up.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Anomalies spawning in more areas then currently is good. If you have been playing the game for a while, you will notice that anomalies only ever seem to spawn in a few areas, over and over again. Be it clown / mime office, hydroponics, eva equipment, escape, janitors office, or the atmos air tanks, the areas seem to repeat a bunch.

This PR makes anomalies able to spawn anywhere that is not a restricted area on station. Security? Medical? Vacant office? The HOP office? All now possible locations. Anomalies will still not spawn near the supermatter, in maints, in solars, or in turret protected areas, like the AI sat.

## Changelog
:cl:
tweak: Anomalies can now spawn in a greater amount of areas than before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
