### PR TITLE
Spin Emote Changes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -449,7 +449,7 @@
 			if(!incapacitated(ignore_lying = TRUE))
 				if(prob(5))
 					spin(32, 1)
-					to_chat(usr, "You spin too much!")
+					to_chat(src, "<span class='warning'>You spin too much!</span>")
 					Dizzy(12)
 					Confused(12)
 				else

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -446,7 +446,7 @@
 								SpinAnimation(5,1)
 
 		if("spin", "spins")
-			if(!restrained())
+			if(!incapacitated(ignore_lying = TRUE))
 				if(prob(5))
 					spin(32, 1)
 					to_chat(usr, "You spin too much!")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -446,15 +446,14 @@
 								SpinAnimation(5,1)
 
 		if("spin", "spins")
-			if(!restrained() && !lying)
+			if(!restrained())
 				if(prob(5))
-					spin(30, 1)
-					message = "<B>[src]</B> spins too much!"
+					spin(32, 1)
+					to_chat(usr, "You spin too much!")
 					Dizzy(12)
 					Confused(12)
 				else
 					spin(20, 1)
-					message = "<B>[src]</B> spins!"
 
 		if("aflap", "aflaps")
 			if(!restrained())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1351,17 +1351,23 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	return FALSE		//overridden in living.dm
 
 /mob/proc/spin(spintime, speed)
-	set waitfor = 0
+	set waitfor = FALSE
 	if(!spintime || !speed || spintime > 100)
 		CRASH("Aborted attempted call of /mob/proc/spin with invalid args ([spintime],[speed]) which could have frozen the server.")
-	var/end_time = world.time + spintime
-	var/spin_dir = prob(50)
-	while(world.time <= end_time)
+	var/D = dir
+	while(spintime >= speed)
 		sleep(speed)
-		if(spin_dir)
-			dir = turn(dir, 90)
-		else
-			dir = turn(dir, -90)
+		switch(D)
+			if(NORTH)
+				D = EAST
+			if(SOUTH)
+				D = WEST
+			if(EAST)
+				D = SOUTH
+			if(WEST)
+				D = NORTH
+		setDir(D)
+		spintime -= speed
 
 /mob/proc/is_literate()
 	return FALSE
@@ -1479,7 +1485,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		MA.plane = GAME_PLANE
 		pic.appearance = MA
 		flick_overlay(pic, list(client), 10)
-    
+
 
 GLOBAL_LIST_INIT(holy_areas, typecacheof(list(
 	/area/chapel

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1354,19 +1354,17 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	set waitfor = FALSE
 	if(!spintime || !speed || spintime > 100)
 		CRASH("Aborted attempted call of /mob/proc/spin with invalid args ([spintime],[speed]) which could have frozen the server.")
-	var/D = dir
 	while(spintime >= speed)
 		sleep(speed)
-		switch(D)
+		switch(dir)
 			if(NORTH)
-				D = EAST
+				setDir(EAST)
 			if(SOUTH)
-				D = WEST
+				setDir(WEST)
 			if(EAST)
-				D = SOUTH
+				setDir(SOUTH)
 			if(WEST)
-				D = NORTH
-		setDir(D)
+				setDir(NORTH)
 		spintime -= speed
 
 /mob/proc/is_literate()


### PR DESCRIPTION
Just some tweaks to the spin emote.

This emote largely replaces the functionality lost of the ssinput system, which prevents you from rapidly spinning with the control key depressed in combination with the direction keys.

As such, I don't think it's appropriate for it to display a message, especially when it's pretty clear what you're doing (flipping is a bit more up for debate without the explicit text). This also makes it a bit less annoying if a bunch of people all start spinning at once while standing in a common location while people are trying to talk.

Also restores old functionality of the `spin` proc. The refactor wasn't worth breaking animations of existing things that used `spin`, not to mention the old way allowed for a lot more fine tuned precision for the total number of spins.

This fixes you spinning and winding up in a direction other than the one you started in.

This also makes it so you can spin while lying down---but not if stunned or weakened.

:cl: Fox McCloud
fix: Fixes spinning not resulting in you being in the same direction you started in
fix: Fixes dog tail chasing and other spin animations.
add: can spin while lying down
del: removes the spin message displayed to those around you
/:cl: