### PR TITLE
Adds Sugar to Gimlet Drink Recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/drinks.dm
+++ b/code/modules/reagents/chemistry/recipes/drinks.dm
@@ -915,8 +915,8 @@
 	name = "Gimlet"
 	id = "gimlet"
 	result = "gimlet"
-	required_reagents = list("gin" = 1, "limejuice" = 1)
-	result_amount = 2
+	required_reagents = list("gin" = 1, "limejuice" = 1, "sugar" = 1)
+	result_amount = 3
 	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'
 
 /datum/chemical_reaction/sidecar


### PR DESCRIPTION
## What Does This PR Do
Adds requirement of 1u of sugar for gimlet drink recipe + makes produced amount 3u
Fixes #16634 

## Why It's Good For The Game
Drink recipe conflicts are bad, also gimlet uses sweetened lime juice/syrup anyway so this is more accurate.

This has been tested on my own personal server.
## Changelog
:cl:
tweak: Adds sugar to gimlet recipe and bumps its result amount to 3u
fix: Fixes Gimlet and Pan-Galactic Gargle Blaster recipe conflict
/:cl:

