### PR TITLE
Vomiting causes nutrients to go down

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1182,6 +1182,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 			if(!no_text)
 				visible_message("<span class='warning'>[src] pukes all over [p_them()]self!</span>","<span class='warning'>You puke all over yourself!</span>")
 			location.add_vomit_floor(TRUE)
+	if (nutrition > 0)
+		adjust_nutrition(rand(-30, -15)) //❤ Monty unk
 
 /mob/proc/AddSpell(obj/effect/proc_holder/spell/S)
 	mob_spell_list += S

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1172,8 +1172,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/fakevomit(green = 0, no_text = 0) //for aesthetic vomits that need to be instant and do not stun. -Fox
 	if(stat==DEAD)
 		return
-	var/turf/location = loc
 	if (nutrition > 0)
+		var/turf/location = loc
 		if(istype(location, /turf/simulated))
 			if(green)
 				if(!no_text)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1173,17 +1173,20 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(stat==DEAD)
 		return
 	var/turf/location = loc
-	if(istype(location, /turf/simulated))
-		if(green)
-			if(!no_text)
-				visible_message("<span class='warning'>[src] vomits up some green goo!</span>","<span class='warning'>You vomit up some green goo!</span>")
-			location.add_vomit_floor(FALSE, TRUE)
-		else
-			if(!no_text)
-				visible_message("<span class='warning'>[src] pukes all over [p_them()]self!</span>","<span class='warning'>You puke all over yourself!</span>")
-			location.add_vomit_floor(TRUE)
 	if (nutrition > 0)
-		adjust_nutrition(rand(-30, -15))
+		if(istype(location, /turf/simulated))
+			if(green)
+				if(!no_text)
+					visible_message("<span class='warning'>[src] vomits up some green goo!</span>","<span class='warning'>You vomit up some green goo!</span>")
+				location.add_vomit_floor(FALSE, TRUE)
+			else
+				if(!no_text)
+					visible_message("<span class='warning'>[src] pukes all over [p_them()]self!</span>","<span class='warning'>You puke all over yourself!</span>")
+				location.add_vomit_floor(TRUE)
+			adjust_nutrition(rand(-30, -15))
+	else
+		if (!no_text)
+			visible_message("<span class='warning'>[src] dry heaves!","<span class='warning'>You attempt to puke but your stomach is empty!")
 
 /mob/proc/AddSpell(obj/effect/proc_holder/spell/S)
 	mob_spell_list += S

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1183,7 +1183,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 				visible_message("<span class='warning'>[src] pukes all over [p_them()]self!</span>","<span class='warning'>You puke all over yourself!</span>")
 			location.add_vomit_floor(TRUE)
 	if (nutrition > 0)
-		adjust_nutrition(rand(-30, -15)) //❤ Monty unk
+		adjust_nutrition(rand(-30, -15))
 
 /mob/proc/AddSpell(obj/effect/proc_holder/spell/S)
 	mob_spell_list += S


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Each time you vomit it will cause your nutrients to go down randomly between the values of -30 and -15
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this will hopefully prevent my puketopia and make toilet drinkers suffer a little more 🤯 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
This will hopefully not happen:
![image](https://user-images.githubusercontent.com/90203875/132235986-993964ea-f1fc-4eb5-b243-8718c3219bd0.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Made vomiting remove nutrients.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
