### PR TITLE
Moves mutes to a GLOB

### DIFF
--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -66,10 +66,10 @@
 		return
 
 	if(src.client)
-		if(client.prefs.muted & MUTE_IC)
+		if(check_mute(client.ckey, MUTE_IC))
 			to_chat(src, "You cannot send IC messages (muted).")
 			return
-		if(src.client.handle_spam_prevention(message,MUTE_IC))
+		if(src.client.handle_spam_prevention(message, MUTE_IC))
 			return
 
 	if(stat)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -4,10 +4,10 @@
 
 /mob/living/captive_brain/say(message)
 	if(client)
-		if(client.prefs.muted & MUTE_IC)
+		if(check_mute(client.ckey, MUTE_IC))
 			to_chat(src, "<span class='warning'>You cannot speak in IC (muted).</span>")
 			return
-		if(client.handle_spam_prevention(message,MUTE_IC))
+		if(client.handle_spam_prevention(message, MUTE_IC))
 			return
 
 	if(istype(loc,/mob/living/simple_animal/borer))

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -13,7 +13,7 @@
 	var/list/insultmsg = list("FUCK EVERYONE!", "I'M A TATER!", "ALL SECURITY TO SHOOT ME ON SIGHT!", "I HAVE A BOMB!", "CAPTAIN IS A COMDOM!", "FOR THE SYNDICATE!")
 
 /obj/item/megaphone/attack_self(mob/living/user as mob)
-	if(user.client && (user.client.prefs.muted & MUTE_IC))
+	if(check_mute(user.ckey, MUTE_IC))
 		to_chat(src, "<span class='warning'>You cannot speak in IC (muted).</span>")
 		return
 	if(!ishuman(user))

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -25,7 +25,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 		if(!GLOB.dooc_enabled && (mob.stat == DEAD))
 			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
 			return
-		if(prefs.muted & MUTE_OOC)
+		if(check_mute(ckey, MUTE_OOC))
 			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return
 
@@ -181,7 +181,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 		if(!GLOB.dooc_enabled && (mob.stat == DEAD))
 			to_chat(usr, "<span class='danger'>LOOC for dead mobs has been turned off.</span>")
 			return
-		if(prefs.muted & MUTE_OOC)
+		if(check_mute(ckey, MUTE_OOC))
 			to_chat(src, "<span class='danger'>You cannot use LOOC (muted).</span>")
 			return
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -140,14 +140,13 @@ GLOBAL_VAR_INIT(nologevent, 0)
 		body += "\ <A href='?_src_=holder;sendbacktolobby=[M.UID()]'>Send back to Lobby</A> | "
 		body += "\ <A href='?_src_=holder;eraseflavortext=[M.UID()]'>Erase Flavor Text</A> | "
 		body += "\ <A href='?_src_=holder;userandomname=[M.UID()]'>Use Random Name</A> | "
-		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
-			\[<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"#6685f5"]'>IC</font></a> |
-			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_OOC]'><font color='[(muted & MUTE_OOC)?"red":"#6685f5"]'>OOC</font></a> |
-			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_PRAY]'><font color='[(muted & MUTE_PRAY)?"red":"#6685f5"]'>PRAY</font></a> |
-			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_ADMINHELP]'><font color='[(muted & MUTE_ADMINHELP)?"red":"#6685f5"]'>ADMINHELP</font></a> |
-			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_DEADCHAT]'><font color='[(muted & MUTE_DEADCHAT)?"red":"#6685f5"]'>DEADCHAT</font></a>\]
-			(<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_ALL]'><font color='[(muted & MUTE_ALL)?"red":"#6685f5"]'>toggle all</font></a>)
+			\[<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_IC]'><font color='[check_mute(M.client.ckey, MUTE_IC) ? "red" : "#6685f5"]'>IC</font></a> |
+			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_OOC]'><font color='[check_mute(M.client.ckey, MUTE_OOC) ? "red" : "#6685f5"]'>OOC</font></a> |
+			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_PRAY]'><font color='[check_mute(M.client.ckey, MUTE_PRAY) ? "red" : "#6685f5"]'>PRAY</font></a> |
+			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_ADMINHELP]'><font color='[check_mute(M.client.ckey, MUTE_ADMINHELP) ? "red" : "#6685f5"]'>ADMINHELP</font></a> |
+			<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_DEADCHAT]'><font color='[check_mute(M.client.ckey, MUTE_DEADCHAT) ?" red" : "#6685f5"]'>DEADCHAT</font></a>]
+			(<A href='?_src_=holder;mute=[M.UID()];mute_type=[MUTE_ALL]'><font color='[check_mute(M.client.ckey, MUTE_ALL) ? "red" : "#6685f5"]'>toggle all</font></a>)
 		"}
 
 	var/jumptoeye = ""

--- a/code/modules/admin/mute.dm
+++ b/code/modules/admin/mute.dm
@@ -1,0 +1,32 @@
+/// Associative list of people who are muted via admin mutes
+GLOBAL_LIST_EMPTY(admin_mutes_assoc)
+
+/proc/check_mute(ckey, muteflag)
+	if(isnull(GLOB.admin_mutes_assoc[ckey]))
+		return FALSE
+
+	if(GLOB.admin_mutes_assoc[ckey] & muteflag)
+		return TRUE
+	return FALSE
+
+/proc/toggle_mute(ckey, muteflag)
+	if(isnull(GLOB.admin_mutes_assoc[ckey]))
+		GLOB.admin_mutes_assoc[ckey] = 0
+
+	if(GLOB.admin_mutes_assoc[ckey] & muteflag)
+		GLOB.admin_mutes_assoc[ckey] &= ~muteflag
+	else
+		GLOB.admin_mutes_assoc[ckey] |= muteflag
+
+/proc/force_add_mute(ckey, muteflag)
+	if(isnull(GLOB.admin_mutes_assoc[ckey]))
+		GLOB.admin_mutes_assoc[ckey] = 0
+
+	GLOB.admin_mutes_assoc[ckey] |= muteflag
+
+/proc/force_remove_mute(ckey, muteflag)
+	if(isnull(GLOB.admin_mutes_assoc[ckey]))
+		GLOB.admin_mutes_assoc[ckey] = 0
+
+	GLOB.admin_mutes_assoc[ckey] &= ~muteflag
+

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_INIT(adminhelp_ignored_words, list("unknown", "the", "a", "an", "of"
 	set name = "Adminhelp"
 
 	//handle muting and automuting
-	if(prefs.muted & MUTE_ADMINHELP)
+	if(check_mute(ckey, MUTE_ADMINHELP))
 		to_chat(src, "<font color='red'>Error: Admin-PM: You cannot send adminhelps (Muted).</font>")
 		return
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -58,7 +58,7 @@
 //takes input from cmd_admin_pm_context, cmd_admin_pm_panel or /client/Topic and sends them a PM.
 //Fetching a message if needed. src is the sender and C is the target client
 /client/proc/cmd_admin_pm(whom, msg, type = "PM")
-	if(prefs.muted & MUTE_ADMINHELP)
+	if(check_mute(ckey, MUTE_ADMINHELP))
 		to_chat(src, "<span class='danger'>Error: Private-Message: You are unable to use PM-s (muted).</span>")
 		return
 
@@ -212,7 +212,7 @@
 		return
 
 /client/proc/cmd_admin_discord_pm()
-	if(prefs.muted & MUTE_ADMINHELP)
+	if(check_mute(ckey, MUTE_ADMINHELP))
 		to_chat(src, "<span class='danger'>Error: Private-Message: You are unable to use PMs (muted).</span>")
 		return
 

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -9,7 +9,7 @@
 	if(!src.mob)
 		return
 
-	if(prefs.muted & MUTE_DEADCHAT)
+	if(check_mute(ckey, MUTE_DEADCHAT))
 		to_chat(src, "<span class='warning'>You cannot send DSAY messages (muted).</span>")
 		return
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -7,7 +7,7 @@
 		return
 
 	if(usr.client)
-		if(usr.client.prefs.muted & MUTE_PRAY)
+		if(check_mute(client.ckey, MUTE_PRAY))
 			to_chat(usr, "<span class='warning'>You cannot pray (muted).</span>")
 			return
 		if(client.handle_spam_prevention(msg, MUTE_PRAY, OOC_COOLDOWN))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -230,19 +230,19 @@
 
 	if(automute)
 		muteunmute = "auto-muted"
-		M.client.prefs.muted |= mute_type
+		force_add_mute(M.client.ckey, mute_type)
 		log_admin("SPAM AUTOMUTE: [muteunmute] [key_name(M)] from [mute_string]")
 		message_admins("SPAM AUTOMUTE: [muteunmute] [key_name_admin(M)] from [mute_string].", 1)
 		to_chat(M, "You have been [muteunmute] from [mute_string] by the SPAM AUTOMUTE system. Contact an admin.")
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Automute") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		return
 
-	if(M.client.prefs.muted & mute_type)
-		muteunmute = "unmuted"
-		M.client.prefs.muted &= ~mute_type
-	else
+	toggle_mute(M.client.ckey, mute_type)
+
+	if(check_mute(M.client.ckey, mute_type))
 		muteunmute = "muted"
-		M.client.prefs.muted |= mute_type
+	else
+		muteunmute = "unmuted"
 
 	log_admin("[key_name(usr)] has [muteunmute] [key_name(M)] from [mute_string]")
 	message_admins("[key_name_admin(usr)] has [muteunmute] [key_name_admin(M)] from [mute_string].", 1)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -113,7 +113,7 @@
 		if(!holder && received_discord_pm < world.time - 6000) // Worse they can do is spam discord for 10 minutes
 			to_chat(usr, "<span class='warning'>You are no longer able to use this, it's been more then 10 minutes since an admin on Discord has responded to you</span>")
 			return
-		if(prefs.muted & MUTE_ADMINHELP)
+		if(check_mute(ckey, MUTE_ADMINHELP))
 			to_chat(usr, "<span class='warning'>You cannot use this as your client has been muted from sending messages to the admins on Discord</span>")
 			return
 		cmd_admin_discord_pm()

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -71,7 +71,6 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	var/max_gear_slots = 0
 
 	//non-preference stuff
-	var/muted = 0
 	var/last_ip
 	var/last_id
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -19,7 +19,7 @@
 	log_ghostemote(message, src)
 
 	if(src.client)
-		if(src.client.prefs.muted & MUTE_DEADCHAT)
+		if(check_mute(client.ckey, MUTE_DEADCHAT))
 			to_chat(src, "<span class='warning'>You cannot emote in deadchat (muted).</span>")
 			return
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -112,7 +112,7 @@
 				O.show_message(message, m_type)
 
 /mob/proc/emote_dead(message)
-	if(client.prefs.muted & MUTE_DEADCHAT)
+	if(check_mute(client.ckey, MUTE_DEADCHAT))
 		to_chat(src, "<span class='warning'>You cannot send deadchat emotes (muted).</span>")
 		return
 

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -14,10 +14,10 @@
 			if(silent)
 				return
 			if(src.client)
-				if(client.prefs.muted & MUTE_IC)
+				if(check_mute(client.ckey, MUTE_IC))
 					to_chat(src, "<span class='warning'>You cannot send IC messages (muted).</span>")
 					return
-				if(src.client.handle_spam_prevention(message,MUTE_IC))
+				if(src.client.handle_spam_prevention(message, MUTE_IC))
 					return
 			if(stat)
 				return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 
 /mob/living/say(message, verb = "says", sanitize = TRUE, ignore_speech_problems = FALSE, ignore_atmospherics = FALSE, ignore_languages = FALSE)
 	if(client)
-		if(client.prefs.muted & MUTE_IC)
+		if(check_mute(client.ckey, MUTE_IC))
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
 			return
 
@@ -297,7 +297,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 
 /mob/living/emote(act, type, message, force) //emote code is terrible, this is so that anything that isn't already snowflaked to shit can call the parent and handle emoting sanely
 	if(client)
-		if(client.prefs.muted & MUTE_IC)
+		if(check_mute(client.ckey, MUTE_IC))
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
 			return
 
@@ -352,7 +352,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 
 /mob/living/proc/whisper_say(list/message_pieces, verb = "whispers")
 	if(client)
-		if(client.prefs.muted & MUTE_IC)
+		if(check_mute(client.ckey, MUTE_IC))
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
 			return
 

--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -19,10 +19,10 @@
 			if(silent)
 				return
 			if(src.client)
-				if(client.prefs.muted & MUTE_IC)
+				if(check_mute(client.ckey, MUTE_IC))
 					to_chat(src, "<span class='warning'>You cannot send IC messages (muted).</span>")
 					return
-				if(src.client.handle_spam_prevention(message,MUTE_IC))
+				if(src.client.handle_spam_prevention(message, MUTE_IC))
 					return
 				if(stat)
 					return

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -51,7 +51,7 @@
 				to_chat(src, "<span class='danger'>Deadchat is globally muted.</span>")
 				return
 
-		if(client.prefs.muted & MUTE_DEADCHAT)
+		if(check_mute(client.ckey, MUTE_DEADCHAT))
 			to_chat(src, "<span class='warning'>You cannot talk in deadchat (muted).</span>")
 			return
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -1176,6 +1176,7 @@
 #include "code\modules\admin\holder2.dm"
 #include "code\modules\admin\IsBanned.dm"
 #include "code\modules\admin\machine_upgrade.dm"
+#include "code\modules\admin\mute.dm"
 #include "code\modules\admin\NewBan.dm"
 #include "code\modules\admin\outfits.dm"
 #include "code\modules\admin\player_panel.dm"


### PR DESCRIPTION
## What Does This PR Do
Puts mutes on a `GLOB` assoc list instead of on the prefs datum.

## Why It's Good For The Game
This is the sole reason (that I am aware of) that prefs datums have to be cached instead of remaking them on each login, which is a necessity for when I finish the multi instance patch to avoid data inconsistencies.

## Changelog
N/A