### PR TITLE
Fixes all players being marked as blobs

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -92,7 +92,7 @@
 					)
 					if(SSticker && SSticker.mode)
 						other_antags += list(
-							"Blob" = (mind.special_role = SPECIAL_ROLE_BLOB),
+							"Blob" = (mind.special_role == SPECIAL_ROLE_BLOB),
 							"Cultist" = (mind in SSticker.mode.cult),
 							"Wizard" = (mind in SSticker.mode.wizards),
 							"Wizard's Apprentice" = (mind in SSticker.mode.apprentices),


### PR DESCRIPTION
## What Does This PR Do
Fixes a bug introduced in #16520 that caused all players to be marked as blob.

Test your fucking code in the future.

## Why It's Good For The Game
All players shouldnt be marked as blob

## Changelog
:cl: AffectedArc07
fix: All players no longer show up as blob in ghost orbit
/:cl:
