### PR TITLE
Deploying shelter capsules no longer crashes the MC

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -247,6 +247,7 @@ to destroy them and players will be able to make replacements.
 		"NanoMed" =								/obj/machinery/vending/wallmed,
 		"Emergency NanoMed" =					/obj/machinery/vending/wallmed,
 		"NanoMed Plus" =						/obj/machinery/vending/medical,
+		"survival pod medical supply" =			/obj/machinery/vending/medical,
 		"SyndiMed Plus" = 						/obj/machinery/vending/medical/syndicate_access,
 		"Vendomat" =							/obj/machinery/vending/assist,
 		"YouTool" =								/obj/machinery/vending/tool,


### PR DESCRIPTION
*sigh*

## What Does This PR Do
Fixes another bug introduced in #16520 

Deploying mining capsules no longer crashes the MC

## Why It's Good For The Game
*sigh*

## Changelog
:cl: AffectedArc07
fix: Deploying shelter capsules no longer crashes the MC
/:cl:

