### PR TITLE
Attack logs on SSD targets now only get the FEW loglevel if there is a user doing it

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -272,15 +272,19 @@
 	update_all_mob_security_hud()
 	return 1
 
-/*
-Proc for attack log creation, because really why not
-1 argument is the actor
-2 argument is the target of action
-3 is the full description of the action
-4 is whether or not to message admins
-This is always put in the attack log.
-*/
-
+/**
+ * Creates attack (old and new) logs for the user and defense logs for the target.
+ * Will message admins depending on the custom_level, user and target.
+ *
+ * custom_level will determine the log level set. Unless the target is SSD and there is a user doing it
+ * If custom_level is not set then the log level will be determined using the user and the target.
+ *
+ * * Arguments:
+ * * user - The thing doing it. Can be null
+ * * target - The target of the attack
+ * * what_done - What has happened
+ * * custom_level - The log level override
+ */
 /proc/add_attack_logs(atom/user, target, what_done, custom_level)
 	if(islist(target)) // Multi-victim adding
 		var/list/targets = target

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -323,7 +323,7 @@ This is always put in the attack log.
 				loglevel = ATKLOG_ALMOSTALL
 	else
 		loglevel = ATKLOG_ALL // Hitting an object. Not a mob
-	if(isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE. Overrides custom level
+	if(user && isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE. Overrides custom level
 		loglevel = ATKLOG_FEW
 
 

--- a/code/game/machinery/wishgranter.dm
+++ b/code/game/machinery/wishgranter.dm
@@ -42,11 +42,11 @@
 		user.mind.add_antag_datum(/datum/antagonist/wishgranter)
 
 		to_chat(user, "You have a very bad feeling about this.")
-		
+
 /obj/machinery/wish_granter/super
 	name = "super wish granter"
 	var/list/types = list()
-	
+
 /obj/machinery/wish_granter/super/attack_hand(mob/living/carbon/user)
 	. = ..()
 
@@ -60,9 +60,9 @@
 	if(is_special_character(user) || jobban_isbanned(user, ROLE_TRAITOR) || jobban_isbanned(user, ROLE_SYNDICATE))
 		to_chat(user, "<span class='warning'>Something instinctual makes you pull away.</span>")
 		return TRUE
-	
+
 	to_chat(user, "<span class='notice'>Your touch makes the Wish Granter stir. Are you really sure you want to do this?</span>")
-	
+
 	for(var/supname in GLOB.all_superheroes)
 		types += supname
 
@@ -85,6 +85,6 @@
 
 	playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1)
 	visible_message("<span class='notice'>The wishgranter fades into mist..</span>")
-	add_attack_logs(null, user, "Became [GLOB.all_superheroes[wish]]")
+	add_attack_logs(user, user, "Became [GLOB.all_superheroes[wish]]")
 	notify_ghosts("[GLOB.all_superheroes[wish]] has appeared in [get_area(user)].", source = user)
 	qdel(src)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -165,7 +165,7 @@
 		if(istype(firer, /mob))
 			add_attack_logs(firer, M, "Mecha-shot with <b>[src]</b>")
 		else
-			add_attack_logs(null, M, "Mecha-shot with <b>[src]</b>")
+			add_attack_logs(src, M, "Mecha-shot with <b>[src]</b> (no firer)")
 	if(life <= 0)
 		qdel(src)
 	return

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -51,7 +51,7 @@
 	user.visible_message("<span class='danger'>[user] zaps [user.p_them()]self with [src].</span>")
 	playsound(user, fire_sound, 50, 1)
 	user.create_attack_log("<b>[key_name(user)]</b> zapped [user.p_them()]self with a <b>[src]</b>")
-	add_attack_logs(null, user, "zapped [user.p_them()]self with a [src]", ATKLOG_ALL)
+	add_attack_logs(user, user, "zapped [user.p_them()]self with a [src]", ATKLOG_ALL)
 
 /////////////////////////////////////
 //WAND OF DEATH

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -275,7 +275,7 @@
 				return
 
 		M.create_attack_log("<font color='orange'>[key_name(M)] became [new_mob.real_name].</font>")
-		add_attack_logs(null, M, "became [new_mob.real_name]", ATKLOG_ALL)
+		add_attack_logs(M, M, "became [new_mob.real_name]", ATKLOG_ALL)
 
 		new_mob.a_intent = INTENT_HARM
 		if(M.mind)


### PR DESCRIPTION
## What Does This PR Do
As the title says. This prevents things like the mass hallucination event from spamming logs while it is not needed.
Changes some instances where there is no user to have an actual user set since that made more sense.

Only instances where null is the user:
![image](https://user-images.githubusercontent.com/15887760/132399646-b00f2bac-fd45-493a-874e-770f86bb0c60.png)
Where the bomb one is when a holoparasite booby trap expires and it is send to the stored_object. Which wouldn't create a message ever

## Why It's Good For The Game
Less log spam for things that don't need it

## Changelog
:cl:
tweak: Attack logs made on SSD targets now won't get forced to the FEW log level if there is no user doing the attack
/:cl: