### PR TITLE
Nerfs Shotguns

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -96123,11 +96123,8 @@
 	pixel_x = -24
 	},
 /obj/item/ammo_box/shotgun/rubbershot,
-/obj/item/ammo_box/shotgun/buck,
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/buck,
-/obj/item/storage/box/buck,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2427,15 +2427,7 @@
 /area/maintenance/auxsolarport)
 "agY" = (
 /obj/structure/rack,
-/obj/item/storage/box/buck{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/buck,
-/obj/item/storage/box/buck{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/item/storage/box/tranquilizer,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -4258,10 +4250,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/mob/living/simple_animal/hostile/retaliate/araneus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/retaliate/araneus,
 /turf/simulated/floor/carpet,
 /area/security/hos)
 "akC" = (
@@ -9591,10 +9583,10 @@
 	name = "Port Maintenance"
 	})
 "avY" = (
-/mob/living/simple_animal/mouse,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -17384,13 +17376,13 @@
 	})
 "aMc" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aMd" = (
@@ -19901,11 +19893,11 @@
 	},
 /area/security/brig)
 "aRQ" = (
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/binary/valve,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -49506,8 +49498,8 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "caZ" = (
-/mob/living/simple_animal/mouse,
 /obj/structure/disposalpipe/segment,
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cba" = (
@@ -62944,10 +62936,10 @@
 /area/toxins/storage)
 "cDO" = (
 /obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/cat/Runtime,
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
+/mob/living/simple_animal/pet/cat/Runtime,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -1927,21 +1927,27 @@
 	},
 /area/security/brig)
 "agR" = (
-/obj/structure/rack,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/storage/box/buck{
+/obj/structure/rack,
+/obj/item/storage/box/beanbag{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/box/buck,
-/obj/item/storage/box/buck{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/storage/box/beanbag,
+/obj/item/storage/box/beanbag{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/beanbag{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/beanbag,
+/obj/item/storage/box/beanbag,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2426,21 +2432,6 @@
 	dir = 1
 	},
 /obj/structure/rack,
-/obj/item/storage/box/beanbag{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/beanbag,
-/obj/item/storage/box/beanbag{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/beanbag{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/beanbag,
-/obj/item/storage/box/beanbag,
 /obj/item/storage/box/tranquilizer{
 	pixel_x = 3;
 	pixel_y = -3

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4013,9 +4013,9 @@
 /area/syndicate_mothership)
 "oB" = (
 /obj/structure/closet/secure_closet/guncabinet,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/beanbag,
+/obj/item/ammo_box/shotgun/beanbag,
+/obj/item/ammo_box/shotgun/beanbag,
 /obj/item/gun/projectile/shotgun/automatic/combat,
 /obj/item/gun/projectile/shotgun/automatic/combat,
 /obj/item/gun/projectile/shotgun/automatic/combat,

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -565,11 +565,11 @@
 	layer = 2.9
 	},
 /obj/structure/rack,
-/obj/item/gun/projectile/shotgun/riot/buckshot{
+/obj/item/gun/projectile/shotgun/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/projectile/shotgun/riot/buckshot,
+/obj/item/gun/projectile/shotgun/riot,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "Gx" = (
@@ -705,11 +705,11 @@
 	layer = 2.9
 	},
 /obj/structure/rack,
-/obj/item/gun/projectile/shotgun/riot/buckshot{
+/obj/item/gun/projectile/shotgun/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/projectile/shotgun/riot/buckshot,
+/obj/item/gun/projectile/shotgun/riot,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "Ns" = (
@@ -914,11 +914,11 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/gun/projectile/shotgun/riot/buckshot{
+/obj/item/gun/projectile/shotgun/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/projectile/shotgun/riot/buckshot,
+/obj/item/gun/projectile/shotgun/riot,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -405,28 +405,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	cost = 80
 	containername = "combat shotgun crate"
 
-/datum/supply_packs/security/armory/buckshotammo
-	name = "Buckshot Ammo Crate"
-	contains = list(/obj/item/ammo_box/shotgun/buck,
-					/obj/item/storage/box/buck,
-					/obj/item/storage/box/buck,
-					/obj/item/storage/box/buck,
-					/obj/item/storage/box/buck,
-					/obj/item/storage/box/buck)
-	cost = 45
-	containername = "buckshot ammo crate"
-
-/datum/supply_packs/security/armory/slugammo
-	name = "Slug Ammo Crate"
-	contains = list(/obj/item/ammo_box/shotgun,
-					/obj/item/storage/box/slug,
-					/obj/item/storage/box/slug,
-					/obj/item/storage/box/slug,
-					/obj/item/storage/box/slug,
-					/obj/item/storage/box/slug)
-	cost = 45
-	containername = "slug ammo crate"
-
 /datum/supply_packs/security/armory/expenergy
 	name = "Energy Guns Crate"
 	contains = list(/obj/item/gun/energy/gun,

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -110,7 +110,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/com
 	name = "combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
+	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/shot/dual
@@ -132,9 +132,6 @@
 
 /obj/item/ammo_box/magazine/internal/shot/riot/short
 	max_ammo = 3
-
-/obj/item/ammo_box/magazine/internal/shot/riot/buckshot
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 
 /obj/item/ammo_box/magazine/internal/grenadelauncher
 	name = "grenade launcher internal magazine"

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -204,10 +204,6 @@
 	..()
 	post_sawoff()
 
-/obj/item/gun/projectile/shotgun/riot/buckshot	//comes pre-loaded with buckshot rather than rubber
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot/buckshot
-
-
 ///////////////////////
 // BOLT ACTION RIFLE //
 ///////////////////////

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -703,22 +703,6 @@
 	build_path = /obj/item/weaponcrafting/receiver
 	category = list("hacked", "Security")
 
-/datum/design/shotgun_slug
-	name = "Shotgun Slug"
-	id = "shotgun_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
-
-/datum/design/buckshot_shell
-	name = "Buckshot shell"
-	id = "buckshot_shell"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
-
 /datum/design/shotgun_dart
 	name = "Shotgun Dart"
 	id = "shotgun_dart"


### PR DESCRIPTION
I've said this was coming for a very long time, now--probably over a year. This is ongoing with the combat overhaul.

Nerfs shotguns--the crew will no longer have access to the readily available buckshot or slugs for combat shotguns or riot shotguns.


Shotguns are currently the be all and end all of ranged combat---they're fast firing, they have printable ammunition, they do obscene amounts of damage at close range, and they are crippling at medium range---they cause bleeding, broken bones, and internal bleeding---to say they're unparalleled is an understatement. They've been nerfed multiple times, but this is the best direction to take them in. This keeps them still quite viable for taking down non-lethally, however.

The second issue is they violate the base level theme of SS13 that was established long ago---syndicate primarily uses ballistics and NT primarily uses energy weapons. Right now it makes way more sense to arm up with shotguns than it does anything else, bar a few examples.  If ballistics are to exist in NT territory, they should be rare and quirky (like the WT).

This also adds tranqs to Meta, as it didn't have them.

Expect further changes in the future (buffs and nerfs), but this is the most egregious of shotgun abuse at the moment.

:cl: Fox McCloud
del: removes buckshot and slugs from the crew. Autolathes, cargo, armories; they're all gone.
add: Adds tranq rounds to MetaStation
/:cl:
