### PR TITLE
Removes some macro abuse

### DIFF
--- a/code/modules/maze_generation/maze_generator.dm
+++ b/code/modules/maze_generation/maze_generator.dm
@@ -14,7 +14,7 @@
 do { \
 	var/timer = start_watch(); \
 	proc2run ;\
-	log_debug("\[MAZE] Operation '[opname]' on maze at [##x],[##y],[##z] took [stop_watch(timer)]s"); \
+	log_debug("\[MAZE] Operation '[opname]' on maze at [x],[y],[z] took [stop_watch(timer)]s"); \
 } while (FALSE)
 
 


### PR DESCRIPTION
## What Does This PR Do
2 things

1. Scares the powergamers with this title
2. Fixes mazegenerator macros which could make the compiler act weirdly at times

```dm
// Nice way to format logs
#define LOG_MAZE_PROGRESS(proc2run, opname) \
do { \
    var/timer = start_watch(); \
    proc2run ;\
    log_debug("\[MAZE] Operation '[opname]' on maze at [##x],[##y],[##z] took [stop_watch(timer)]s"); \
} while (FALSE)
```

The `##x` syntax is used for preprocessor args, but in this instance its referencing the atom itself, so the `##x` isnt needed, only `x` is, but it still passed anyway. DM MAGIC!

## Why It's Good For The Game
Compiler stability good.

## Changelog
N/A