### PR TITLE
changes size of koi migration

### DIFF
--- a/code/modules/events/koi_mirgration.dm
+++ b/code/modules/events/koi_mirgration.dm
@@ -5,4 +5,4 @@
 
 
 /datum/event/carp_migration/koi/start()
-	spawn_fish(GLOB.landmarks_list.len)
+	spawn_fish(rand(4, 6)) 			//12 to 30 koi, in small groups

--- a/code/modules/events/koi_mirgration.dm
+++ b/code/modules/events/koi_mirgration.dm
@@ -5,4 +5,4 @@
 
 
 /datum/event/carp_migration/koi/start()
-	spawn_fish(rand(4, 6)) 			//12 to 30 koi, in small groups
+	spawn_fish(rand(4, 6)) //12 to 30 koi, in small groups


### PR DESCRIPTION
Changes the size of the koi mirgration event to be smaller, reason being it was functioning off the size of a major carp migration (IE: ALOT OF KOI) and that many koi kinda can kill the MC processing. so the size is 12 to 30 in small groups.

Had considered nerfing carp major but major events run late into the round.

:cl: Fethas
tweak: Tweaked size of koi spawn to the same as carp level moderate.
/:cl:


