### PR TITLE
Adds warning messages to admins for missing nukes

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -1,3 +1,6 @@
+#define NUKE_INTACT 0
+#define NUKE_CORE_MISSING 1
+#define NUKE_MISSING 2
 /*
  * GAMEMODES (by Rastaf0)
  *
@@ -434,6 +437,15 @@
 			nukecode = bomb.r_code
 	return nukecode
 
+/proc/get_nuke_status()
+	var/nuke_status = NUKE_MISSING
+	for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
+		if(bomb && is_station_level(bomb.z))
+			nuke_status = NUKE_CORE_MISSING
+			if(bomb.core)
+				nuke_status = NUKE_INTACT
+	return nuke_status
+
 /datum/game_mode/proc/replace_jobbanned_player(mob/living/M, role_type)
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as a [role_type]?", role_type, FALSE, 10 SECONDS)
 	var/mob/dead/observer/theghost = null
@@ -534,3 +546,7 @@
 	var/datum/atom_hud/antag/antaghud = GLOB.huds[ANTAG_HUD_EVENTMISC]
 	antaghud.leave_hud(mob_mind.current)
 	set_antag_hud(mob_mind.current, null)
+
+#undef NUKE_INTACT
+#undef NUKE_CORE_MISSING
+#undef NUKE_MISSING

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -440,7 +440,7 @@
 /proc/get_nuke_status()
 	var/nuke_status = NUKE_MISSING
 	for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
-		if(bomb && is_station_level(bomb.z))
+		if(is_station_level(bomb.z))
 			nuke_status = NUKE_CORE_MISSING
 			if(bomb.core)
 				nuke_status = NUKE_INTACT

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -83,11 +83,11 @@
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
 			if(nuke_status == NUKE_MISSING)
-				to_chat(X, "<span class='userdanger'>Nuclear device is not on station!</span>")
+				to_chat(X, "<span class='userdanger'>The nuclear device is not on station!</span>")
 			else
 				to_chat(X, "<b>The nuke code is [nuke_code].</b>")
 				if(nuke_status == NUKE_CORE_MISSING)
-					to_chat(X, "<span class='userdanger'>Nuclear device does not have a core, and will not arm!</span>")
+					to_chat(X, "<span class='userdanger'>The nuclear device does not have a core, and will not arm!</span>")
 			if(X.prefs.sound & SOUND_ADMINHELP)
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -83,11 +83,11 @@
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
 			if(nuke_status == NUKE_MISSING)
-				to_chat(X, "<b><span class='userdanger'>Nuclear device is not on station!</b></span>")
+				to_chat(X, "<span class='userdanger'>Nuclear device is not on station!</span>")
 			else
-				to_chat(X, "<span class='adminnotice'><b>The nuke code is [nuke_code].</b></span>")
+				to_chat(X, "<b>The nuke code is [nuke_code].</b>")
 				if(nuke_status == NUKE_CORE_MISSING)
-					to_chat(X, "<b><span class='userdanger'>Nuclear device does not have a core, and will not arm!</b></span>")
+					to_chat(X, "<span class='userdanger'>Nuclear device does not have a core, and will not arm!</span>")
 			if(X.prefs.sound & SOUND_ADMINHELP)
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -1,3 +1,7 @@
+#define NUKE_INTACT 0
+#define NUKE_CORE_MISSING 1
+#define NUKE_MISSING 2
+
 /mob/living/verb/pray(msg as text)
 	set category = "IC"
 	set name = "Pray"
@@ -72,11 +76,21 @@
 
 /proc/Nuke_request(text , mob/Sender)
 	var/nuke_code = get_nuke_code()
+	var/nuke_status = get_nuke_status()
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "<span class='adminnotice'><b><font color=orange>NUKE CODE REQUEST: </font>[key_name(Sender)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) ([ADMIN_CENTCOM_REPLY(Sender,"RPLY")]):</b> [msg]</span>"
 	for(var/client/X in GLOB.admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
-			to_chat(X, "<span class='adminnotice'><b>The nuke code is [nuke_code].</b></span>")
+			if(nuke_status == NUKE_MISSING)
+				to_chat(X, "<b><span class='userdanger'>Nuclear device is not on station!</b></span>")
+			else
+				to_chat(X, "<span class='adminnotice'><b>The nuke code is [nuke_code].</b></span>")
+				if(nuke_status == NUKE_CORE_MISSING)
+					to_chat(X, "<b><span class='userdanger'>Nuclear device does not have a core, and will not arm!</b></span>")
 			if(X.prefs.sound & SOUND_ADMINHELP)
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
+
+#undef NUKE_INTACT
+#undef NUKE_CORE_MISSING
+#undef NUKE_MISSING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

This PR adds a new proc to gamemode, similar to the proc above that returns the code of a nuclear device on station. This proc returns either that no nuclear device is on station, that the nuclear device has no core and will not arm, or that the nuclear device is perfectly fine.

This is outputted to admins when nuke codes are requested, so one can quickly know if the nuclear device is even accessible to crew, or if it has its core removed, meaning some other method of ending the round may be needed.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

As above, so below. Notifying admins when the nuke codes are requested, that the nuke is missing / will not be operational is good, so other plans can be prepared for ending the round, be it a deathsquad, an extra nuke, or the round end button.

## Changelog
:cl:
add: Nuke code requests now notify admins if the nuclear device is operational / on station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
