### PR TITLE
Grinder - Use items for full container, not all

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -17,75 +17,76 @@
 	//IMPORTANT NOTE! A negative number is a multiplier, a positive number is a flat amount to add. 0 means equal to the amount of the original reagent
 	var/list/blend_items = list (
 
-			//Sheets
-			/obj/item/stack/sheet/mineral/plasma = list("plasma_dust" = 20),
-			/obj/item/stack/sheet/metal = list("iron" = 20),
-			/obj/item/stack/rods = list("iron" = 10),
-			/obj/item/stack/sheet/plasteel = list("iron" = 20, "plasma_dust" = 20),
-			/obj/item/stack/sheet/wood = list("carbon" = 20),
-			/obj/item/stack/sheet/glass = list("silicon" = 20),
-			/obj/item/stack/sheet/rglass = list("silicon" = 20, "iron" = 20),
-			/obj/item/stack/sheet/mineral/uranium = list("uranium" = 20),
-			/obj/item/stack/sheet/mineral/bananium = list("banana" = 20),
-			/obj/item/stack/sheet/mineral/tranquillite = list("nothing" = 20),
-			/obj/item/stack/sheet/mineral/silver = list("silver" = 20),
-			/obj/item/stack/sheet/mineral/gold = list("gold" = 20),
-			/obj/item/grown/nettle/basic = list("wasabi" = 0),
-			/obj/item/grown/nettle/death = list("facid" = 0, "sacid" = 0),
-			/obj/item/grown/novaflower = list("capsaicin" = 0, "condensedcapsaicin" = 0),
+		//Sheets
+		/obj/item/stack/sheet/mineral/plasma = list("plasma_dust" = 20),
+		/obj/item/stack/sheet/metal = list("iron" = 20),
+		/obj/item/stack/rods = list("iron" = 10),
+		/obj/item/stack/sheet/plasteel = list("iron" = 20, "plasma_dust" = 20),
+		/obj/item/stack/sheet/wood = list("carbon" = 20),
+		/obj/item/stack/sheet/glass = list("silicon" = 20),
+		/obj/item/stack/sheet/rglass = list("silicon" = 20, "iron" = 20),
+		/obj/item/stack/sheet/mineral/uranium = list("uranium" = 20),
+		/obj/item/stack/sheet/mineral/bananium = list("banana" = 20),
+		/obj/item/stack/sheet/mineral/tranquillite = list("nothing" = 20),
+		/obj/item/stack/sheet/mineral/silver = list("silver" = 20),
+		/obj/item/stack/sheet/mineral/gold = list("gold" = 20),
 
-			//Blender Stuff
-			/obj/item/reagent_containers/food/snacks/grown/tomato = list("ketchup" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/wheat = list("flour" = -5),
-			/obj/item/reagent_containers/food/snacks/grown/oat = list("flour" = -5),
-			/obj/item/reagent_containers/food/snacks/grown/cherries = list("cherryjelly" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/bluecherries = list("bluecherryjelly" = 0),
-			/obj/item/reagent_containers/food/snacks/egg = list("egg" = -5),
-			/obj/item/reagent_containers/food/snacks/grown/rice = list("rice" = -5),
+		/obj/item/grown/nettle/basic = list("wasabi" = 0),
+		/obj/item/grown/nettle/death = list("facid" = 0, "sacid" = 0),
+		/obj/item/grown/novaflower = list("capsaicin" = 0, "condensedcapsaicin" = 0),
 
-			//Grinder stuff, but only if dry
-			/obj/item/reagent_containers/food/snacks/grown/coffee/robusta = list("coffeepowder" = 0, "morphine" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/coffee = list("coffeepowder" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/tea/astra = list("teapowder" = 0, "salglu_solution" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/tea = list("teapowder" = 0),
+		//Blender Stuff
+		/obj/item/reagent_containers/food/snacks/grown/tomato = list("ketchup" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/wheat = list("flour" = -5),
+		/obj/item/reagent_containers/food/snacks/grown/oat = list("flour" = -5),
+		/obj/item/reagent_containers/food/snacks/grown/cherries = list("cherryjelly" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/bluecherries = list("bluecherryjelly" = 0),
+		/obj/item/reagent_containers/food/snacks/egg = list("egg" = -5),
+		/obj/item/reagent_containers/food/snacks/grown/rice = list("rice" = -5),
 
+		//Grinder stuff, but only if dry
+		/obj/item/reagent_containers/food/snacks/grown/coffee/robusta = list("coffeepowder" = 0, "morphine" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/coffee = list("coffeepowder" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/tea/astra = list("teapowder" = 0, "salglu_solution" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/tea = list("teapowder" = 0),
 
-			//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
-			/obj/item/slime_extract = list(),
-			/obj/item/reagent_containers/food = list(),
-			/obj/item/reagent_containers/honeycomb = list()
+		//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
+		/obj/item/slime_extract = list(),
+		/obj/item/reagent_containers/food = list(),
+		/obj/item/reagent_containers/honeycomb = list()
 	)
 
 	var/list/juice_items = list (
 
-			//Juicer Stuff
-			/obj/item/reagent_containers/food/snacks/grown/soybeans = list("soymilk" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/corn = list("corn_starch" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/tomato = list("tomatojuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/carrot = list("carrotjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/berries = list("berryjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/banana = list("banana" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/potato = list("potato" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/citrus/lemon = list("lemonjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/citrus/orange = list("orangejuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/citrus/lime = list("limejuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/watermelon = list("watermelonjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/watermelonslice = list("watermelonjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/berries/poison = list("poisonberryjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/pumpkin = list("pumpkinjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/blumpkin = list("blumpkinjuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/apple = list("applejuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/grapes = list("grapejuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/grapes/green = list("grapejuice" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/pineapple = list("pineapplejuice" = 0)
+		//Juicer Stuff
+		/obj/item/reagent_containers/food/snacks/grown/soybeans = list("soymilk" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/corn = list("corn_starch" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/tomato = list("tomatojuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/carrot = list("carrotjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/berries = list("berryjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/banana = list("banana" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/potato = list("potato" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/citrus/lemon = list("lemonjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/citrus/orange = list("orangejuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/citrus/lime = list("limejuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/watermelon = list("watermelonjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/watermelonslice = list("watermelonjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/berries/poison = list("poisonberryjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/pumpkin = list("pumpkinjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/blumpkin = list("blumpkinjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/apple = list("applejuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/grapes = list("grapejuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/grapes/green = list("grapejuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/pineapple = list("pineapplejuice" = 0)
 	)
 
 	var/list/dried_items = list(
-			//Grinder stuff, but only if dry,
-			/obj/item/reagent_containers/food/snacks/grown/coffee/robusta = list("coffeepowder" = 0, "morphine" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/coffee = list("coffeepowder" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/tea/astra = list("teapowder" = 0, "salglu_solution" = 0),
-			/obj/item/reagent_containers/food/snacks/grown/tea = list("teapowder" = 0)
+
+		//Grinder stuff, but only if dry,
+		/obj/item/reagent_containers/food/snacks/grown/coffee/robusta = list("coffeepowder" = 0, "morphine" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/coffee = list("coffeepowder" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/tea/astra = list("teapowder" = 0, "salglu_solution" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/tea = list("teapowder" = 0)
 	)
 
 	var/list/holdingitems = list()
@@ -231,59 +232,59 @@
 
 
 /obj/machinery/reagentgrinder/attack_ai(mob/user)
-		return FALSE
+	return FALSE
 
 /obj/machinery/reagentgrinder/attack_hand(mob/user)
-		user.set_machine(src)
-		interact(user)
+	user.set_machine(src)
+	interact(user)
 
 /obj/machinery/reagentgrinder/interact(mob/user) // The microwave Menu
-		var/is_chamber_empty = 0
-		var/is_beaker_ready = 0
-		var/processing_chamber = ""
-		var/beaker_contents = ""
-		var/dat = ""
+	var/is_chamber_empty = 0
+	var/is_beaker_ready = 0
+	var/processing_chamber = ""
+	var/beaker_contents = ""
+	var/dat = ""
 
-		if(!operating)
-				for (var/obj/item/O in holdingitems)
-						processing_chamber += "\A [html_encode(O.name)]<BR>"
+	if(!operating)
+		for (var/obj/item/O in holdingitems)
+			processing_chamber += "\A [html_encode(O.name)]<BR>"
 
-				if (!processing_chamber)
-						is_chamber_empty = 1
-						processing_chamber = "Nothing."
-				if (!beaker)
-						beaker_contents = "<B>No beaker attached.</B><br>"
-				else
-						is_beaker_ready = 1
-						beaker_contents = "<B>The beaker contains:</B><br>"
-						var/anything = 0
-						for(var/datum/reagent/R in beaker.reagents.reagent_list)
-								anything = 1
-								beaker_contents += "[R.volume] - [R.name]<br>"
-						if(!anything)
-								beaker_contents += "Nothing<br>"
-
-
-				dat = {"
-		<b>Processing chamber contains:</b><br>
-		[processing_chamber]<br>
-		[beaker_contents]<hr>
-		"}
-				if (is_beaker_ready && !is_chamber_empty && !(stat & (NOPOWER|BROKEN)))
-						dat += "<A href='?src=[src.UID()];action=grind'>Grind the reagents</a><BR>"
-						dat += "<A href='?src=[src.UID()];action=juice'>Juice the reagents</a><BR><BR>"
-				if(holdingitems && holdingitems.len > 0)
-						dat += "<A href='?src=[src.UID()];action=eject'>Eject the reagents</a><BR>"
-				if (beaker)
-						dat += "<A href='?src=[src.UID()];action=detach'>Detach the beaker</a><BR>"
+		if (!processing_chamber)
+			is_chamber_empty = 1
+			processing_chamber = "Nothing."
+		if (!beaker)
+			beaker_contents = "<B>No beaker attached.</B><br>"
 		else
-				dat += "Please wait..."
+			is_beaker_ready = 1
+			beaker_contents = "<B>The beaker contains:</B><br>"
+			var/anything = 0
+			for(var/datum/reagent/R in beaker.reagents.reagent_list)
+				anything = 1
+				beaker_contents += "[R.volume] - [R.name]<br>"
+			if(!anything)
+				beaker_contents += "Nothing<br>"
 
-		var/datum/browser/popup = new(user, "reagentgrinder", "All-In-One Grinder")
-		popup.set_content(dat)
-		popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
-		popup.open(1)
-		return
+
+		dat = {"
+	<b>Processing chamber contains:</b><br>
+	[processing_chamber]<br>
+	[beaker_contents]<hr>
+	"}
+		if (is_beaker_ready && !is_chamber_empty && !(stat & (NOPOWER|BROKEN)))
+			dat += "<A href='?src=[src.UID()];action=grind'>Grind the reagents</a><BR>"
+			dat += "<A href='?src=[src.UID()];action=juice'>Juice the reagents</a><BR><BR>"
+		if(holdingitems && holdingitems.len > 0)
+			dat += "<A href='?src=[src.UID()];action=eject'>Eject the reagents</a><BR>"
+		if (beaker)
+			dat += "<A href='?src=[src.UID()];action=detach'>Detach the beaker</a><BR>"
+	else
+		dat += "Please wait..."
+
+	var/datum/browser/popup = new(user, "reagentgrinder", "All-In-One Grinder")
+	popup.set_content(dat)
+	popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
+	popup.open(1)
+	return
 
 /obj/machinery/reagentgrinder/Topic(href, href_list)
 	if(..())
@@ -303,213 +304,218 @@
 			detach()
 
 /obj/machinery/reagentgrinder/proc/detach()
-
-		if (usr.stat != 0)
-				return
-		if (!beaker)
-				return
-		beaker.loc = src.loc
-		beaker = null
-		update_icon()
-		updateUsrDialog()
+	if (usr.stat != 0)
+		return
+	if (!beaker)
+		return
+	beaker.loc = src.loc
+	beaker = null
+	update_icon()
+	updateUsrDialog()
 
 /obj/machinery/reagentgrinder/proc/eject()
+	if (usr.stat != 0)
+		return
+	if (holdingitems && holdingitems.len == 0)
+		return
 
-		if (usr.stat != 0)
-				return
-		if (holdingitems && holdingitems.len == 0)
-				return
-
-		for(var/obj/item/O in holdingitems)
-				O.loc = src.loc
-				holdingitems -= O
-		holdingitems = list()
-		updateUsrDialog()
+	for(var/obj/item/O in holdingitems)
+		O.loc = src.loc
+		holdingitems -= O
+	holdingitems = list()
+	updateUsrDialog()
 
 /obj/machinery/reagentgrinder/proc/is_allowed(obj/item/reagent_containers/O)
-		for (var/i in blend_items)
-				if(istype(O, i))
-						return TRUE
-		return FALSE
+	for (var/i in blend_items)
+		if(istype(O, i))
+			return TRUE
+	return FALSE
 
 /obj/machinery/reagentgrinder/proc/get_allowed_by_id(obj/item/O)
-		for (var/i in blend_items)
-				if (istype(O, i))
-						return blend_items[i]
+	for (var/i in blend_items)
+		if (istype(O, i))
+			return blend_items[i]
 
 /obj/machinery/reagentgrinder/proc/get_allowed_snack_by_id(obj/item/reagent_containers/food/snacks/O)
-		for(var/i in blend_items)
-				if(istype(O, i))
-						return blend_items[i]
+	for(var/i in blend_items)
+		if(istype(O, i))
+			return blend_items[i]
 
 /obj/machinery/reagentgrinder/proc/get_allowed_juice_by_id(obj/item/reagent_containers/food/snacks/O)
-		for(var/i in juice_items)
-				if(istype(O, i))
-						return juice_items[i]
+	for(var/i in juice_items)
+		if(istype(O, i))
+			return juice_items[i]
 
 /obj/machinery/reagentgrinder/proc/get_grownweapon_amount(obj/item/grown/O)
-		if (!istype(O) || !O.seed)
-				return 5
-		else if (O.seed.potency == -1)
-				return 5
-		else
-				return round(O.seed.potency)
+	if (!istype(O) || !O.seed)
+		return 5
+	else if (O.seed.potency == -1)
+		return 5
+	else
+		return round(O.seed.potency)
 
 /obj/machinery/reagentgrinder/proc/get_juice_amount(obj/item/reagent_containers/food/snacks/grown/O)
-		if (!istype(O) || !O.seed)
-				return 5
-		else if (O.seed.potency == -1)
-				return 5
-		else
-				return round(5*sqrt(O.seed.potency))
+	if (!istype(O) || !O.seed)
+		return 5
+	else if (O.seed.potency == -1)
+		return 5
+	else
+		return round(5*sqrt(O.seed.potency))
 
 /obj/machinery/reagentgrinder/proc/remove_object(obj/item/O)
-		holdingitems -= O
-		qdel(O)
+	holdingitems -= O
+	qdel(O)
 
 /obj/machinery/reagentgrinder/proc/juice()
-		power_change()
-		if(stat & (NOPOWER|BROKEN))
-				return
-		if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
-				return
-		playsound(src.loc, 'sound/machines/juicer.ogg', 20, 1)
-		var/offset = prob(50) ? -2 : 2
-		animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 250) //start shaking
-		operating = 1
+	power_change()
+	if(stat & (NOPOWER|BROKEN))
+		return
+	if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
+		return
+	playsound(src.loc, 'sound/machines/juicer.ogg', 20, 1)
+	var/offset = prob(50) ? -2 : 2
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 250) //start shaking
+	operating = 1
+	updateUsrDialog()
+	spawn(50)
+		pixel_x = initial(pixel_x) //return to its spot after shaking
+		operating = 0
 		updateUsrDialog()
-		spawn(50)
-				pixel_x = initial(pixel_x) //return to its spot after shaking
-				operating = 0
-				updateUsrDialog()
 
-		//Snacks
-		for (var/obj/item/reagent_containers/food/snacks/O in holdingitems)
-				if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-						break
+	//Snacks
+	for (var/obj/item/reagent_containers/food/snacks/O in holdingitems)
+		if (beaker.reagents.holder_full())
+			break
 
-				var/allowed = get_allowed_juice_by_id(O)
-				if(isnull(allowed))
-						break
+		var/allowed = get_allowed_juice_by_id(O)
+		if(isnull(allowed))
+			break
 
-				for (var/r_id in allowed)
+		for (var/r_id in allowed)
 
-						var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-						var/amount = get_juice_amount(O)
+			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+			var/amount = get_juice_amount(O)
 
-						beaker.reagents.add_reagent(r_id, min(amount*efficiency, space))
+			beaker.reagents.add_reagent(r_id, min(amount*efficiency, space))
 
-						if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-								break
+			if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+				break
 
-				remove_object(O)
+		remove_object(O)
 
 /obj/machinery/reagentgrinder/proc/grind()
 
-		power_change()
-		if(stat & (NOPOWER|BROKEN))
-				return
-		if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
-				return
-		playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)
-		var/offset = prob(50) ? -2 : 2
-		animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 250) //start shaking
-		operating = 1
+	power_change()
+	if(stat & (NOPOWER|BROKEN))
+		return
+	if (!beaker || (beaker && beaker.reagents.holder_full()))
+		return
+	playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)
+	var/offset = prob(50) ? -2 : 2
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 250) //start shaking
+	operating = 1
+	updateUsrDialog()
+	spawn(60)
+		pixel_x = initial(pixel_x) //return to its spot after shaking
+		operating = 0
 		updateUsrDialog()
-		spawn(60)
-				pixel_x = initial(pixel_x) //return to its spot after shaking
-				operating = 0
-				updateUsrDialog()
 
-		//Snacks and Plants
-		for (var/obj/item/reagent_containers/food/snacks/O in holdingitems)
-				if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-						break
+	//Snacks and Plants
+	for (var/obj/item/reagent_containers/food/snacks/O in holdingitems)
+		if (beaker.reagents.holder_full())
+			break
 
-				var/allowed = get_allowed_snack_by_id(O)
-				if(isnull(allowed))
-						break
+		var/allowed = get_allowed_snack_by_id(O)
+		if(isnull(allowed))
+			break
 
-				for (var/r_id in allowed)
+		for (var/r_id in allowed)
 
-						var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-						var/amount = allowed[r_id]
-						if(amount <= 0)
-								if(amount == 0)
-										if (O.reagents != null && O.reagents.has_reagent("nutriment"))
-												beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("nutriment")*efficiency, space))
-												O.reagents.remove_reagent("nutriment", min(O.reagents.get_reagent_amount("nutriment"), space))
-										if (O.reagents != null && O.reagents.has_reagent("plantmatter"))
-												beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("plantmatter")*efficiency, space))
-												O.reagents.remove_reagent("plantmatter", min(O.reagents.get_reagent_amount("plantmatter"), space))
-								else
-										if (O.reagents != null && O.reagents.has_reagent("nutriment"))
-												beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("nutriment")*abs(amount)*efficiency), space))
-												O.reagents.remove_reagent("nutriment", min(O.reagents.get_reagent_amount("nutriment"), space))
-										if (O.reagents != null && O.reagents.has_reagent("plantmatter"))
-												beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("plantmatter")*abs(amount)*efficiency), space))
-												O.reagents.remove_reagent("plantmatter", min(O.reagents.get_reagent_amount("plantmatter"), space))
+			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+			var/amount = allowed[r_id]
+			if(amount <= 0)
+				if(amount == 0)
+					if (O.reagents != null && O.reagents.has_reagent("nutriment"))
+						beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("nutriment")*efficiency, space))
+						O.reagents.remove_reagent("nutriment", min(O.reagents.get_reagent_amount("nutriment"), space))
+					if (O.reagents != null && O.reagents.has_reagent("plantmatter"))
+						beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("plantmatter")*efficiency, space))
+						O.reagents.remove_reagent("plantmatter", min(O.reagents.get_reagent_amount("plantmatter"), space))
+				else
+					if (O.reagents != null && O.reagents.has_reagent("nutriment"))
+						beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("nutriment")*abs(amount)*efficiency), space))
+						O.reagents.remove_reagent("nutriment", min(O.reagents.get_reagent_amount("nutriment"), space))
+					if (O.reagents != null && O.reagents.has_reagent("plantmatter"))
+						beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("plantmatter")*abs(amount)*efficiency), space))
+						O.reagents.remove_reagent("plantmatter", min(O.reagents.get_reagent_amount("plantmatter"), space))
 
 
-						else
-								O.reagents.trans_id_to(beaker, r_id, min(amount, space))
+			else
+				O.reagents.trans_id_to(beaker, r_id, min(amount, space))
 
-						if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-								break
+			if (beaker.reagents.holder_full())
+				break
 
-				if(O.reagents.reagent_list.len == 0)
-						remove_object(O)
+		if(O.reagents.reagent_list.len == 0)
+			remove_object(O)
 
-		//Sheets
-		for (var/obj/item/stack/sheet/O in holdingitems)
-				var/allowed = get_allowed_by_id(O)
-				if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-						break
-				for(var/i = 1; i <= round(O.amount, 1); i++)
-						for (var/r_id in allowed)
-								var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-								var/amount = allowed[r_id]
-								beaker.reagents.add_reagent(r_id,min(amount*efficiency, space))
-								if (space < amount)
-										break
-						if (i == round(O.amount, 1))
-								remove_object(O)
-								break
-		//Plants
-		for (var/obj/item/grown/O in holdingitems)
-				if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-						break
-				var/allowed = get_allowed_by_id(O)
-				for (var/r_id in allowed)
-						var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-						var/amount = allowed[r_id]
-						if (amount == 0)
-								if (O.reagents != null && O.reagents.has_reagent(r_id))
-										beaker.reagents.add_reagent(r_id,min(O.reagents.get_reagent_amount(r_id)*efficiency, space))
-						else
-								beaker.reagents.add_reagent(r_id,min(amount*efficiency, space))
+	//Sheets and rods(!)
+	for (var/obj/item/stack/O in holdingitems)
+		if (beaker.reagents.holder_full())
+			break
 
-						if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-								break
+		var/allowed = get_allowed_by_id(O)
+		if(isnull(allowed))
+			break
+
+		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+		while(O.amount) //Work untill hold something
+			if(O.amount < 1)
 				remove_object(O)
+				break
+			if (!space) //if no free space - exit
+				break
+			O.amount -= 1 //remove one from stack
+			for (var/r_id in allowed)
+				var/spaceused = min(allowed[r_id]*efficiency, space)
+				space -= spaceused
+				beaker.reagents.add_reagent(r_id,spaceused)
 
-		//Slime Extractis
-		for (var/obj/item/slime_extract/O in holdingitems)
-				if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-						break
-				var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-				if (O.reagents != null)
-						var/amount = O.reagents.total_volume
-						O.reagents.trans_to(beaker, min(amount, space))
-				if (O.Uses > 0)
-						beaker.reagents.add_reagent("slimejelly",min(20*efficiency, space))
-				remove_object(O)
+	//Plants
+	for (var/obj/item/grown/O in holdingitems)
+		if (beaker.reagents.holder_full())
+			break
+		var/allowed = get_allowed_by_id(O)
+		for (var/r_id in allowed)
+			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+			var/amount = allowed[r_id]
+			if (amount == 0)
+				if (O.reagents != null && O.reagents.has_reagent(r_id))
+					beaker.reagents.add_reagent(r_id,min(O.reagents.get_reagent_amount(r_id)*efficiency, space))
+			else
+				beaker.reagents.add_reagent(r_id,min(amount*efficiency, space))
 
-		//Everything else - Transfers reagents from it into beaker
-		for (var/obj/item/reagent_containers/O in holdingitems)
-				if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-						break
-				var/amount = O.reagents.total_volume
-				O.reagents.trans_to(beaker, amount)
-				if(!O.reagents.total_volume)
-						remove_object(O)
+			if (beaker.reagents.holder_full())
+				break
+		remove_object(O)
+
+	//Slime Extractis
+	for (var/obj/item/slime_extract/O in holdingitems)
+		if (beaker.reagents.holder_full())
+			break
+		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+		if (O.reagents != null)
+			var/amount = O.reagents.total_volume
+			O.reagents.trans_to(beaker, min(amount, space))
+		if (O.Uses > 0)
+			beaker.reagents.add_reagent("slimejelly",min(20*efficiency, space))
+		remove_object(O)
+
+	//Everything else - Transfers reagents from it into beaker
+	for (var/obj/item/reagent_containers/O in holdingitems)
+		if (beaker.reagents.holder_full())
+			break
+		var/amount = O.reagents.total_volume
+		O.reagents.trans_to(beaker, amount)
+		if(!O.reagents.total_volume)
+			remove_object(O)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -470,9 +470,6 @@
 
 		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 		while(O.amount) //Grind until there's no more reagents
-			if(O.amount < 1)
-				remove_object(O)
-				break
 			if(!space) //if no free space - exit
 				break
 			O.amount -= 1 //remove one from stack
@@ -480,6 +477,9 @@
 				var/spaceused = min(allowed[r_id] * efficiency, space)
 				space -= spaceused
 				beaker.reagents.add_reagent(r_id, spaceused)
+			if(O.amount < 1) //if leftover small - destroy
+				remove_object(O)
+				break
 
 	//Plants
 	for (var/obj/item/grown/O in holdingitems)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -249,10 +249,10 @@
 		for (var/obj/item/O in holdingitems)
 			processing_chamber += "\A [html_encode(O.name)]<BR>"
 
-		if (!processing_chamber)
+		if(!processing_chamber)
 			is_chamber_empty = 1
 			processing_chamber = "Nothing."
-		if (!beaker)
+		if(!beaker)
 			beaker_contents = "<B>No beaker attached.</B><br>"
 		else
 			is_beaker_ready = 1
@@ -270,12 +270,12 @@
 	[processing_chamber]<br>
 	[beaker_contents]<hr>
 	"}
-		if (is_beaker_ready && !is_chamber_empty && !(stat & (NOPOWER|BROKEN)))
+		if(is_beaker_ready && !is_chamber_empty && !(stat & (NOPOWER|BROKEN)))
 			dat += "<A href='?src=[src.UID()];action=grind'>Grind the reagents</a><BR>"
 			dat += "<A href='?src=[src.UID()];action=juice'>Juice the reagents</a><BR><BR>"
 		if(holdingitems && holdingitems.len > 0)
 			dat += "<A href='?src=[src.UID()];action=eject'>Eject the reagents</a><BR>"
-		if (beaker)
+		if(beaker)
 			dat += "<A href='?src=[src.UID()];action=detach'>Detach the beaker</a><BR>"
 	else
 		dat += "Please wait..."
@@ -294,19 +294,19 @@
 		updateUsrDialog()
 		return
 	switch(href_list["action"])
-		if ("grind")
+		if("grind")
 			grind()
 		if("juice")
 			juice()
 		if("eject")
 			eject()
-		if ("detach")
+		if("detach")
 			detach()
 
 /obj/machinery/reagentgrinder/proc/detach()
-	if (usr.stat != 0)
+	if(usr.stat != 0)
 		return
-	if (!beaker)
+	if(!beaker)
 		return
 	beaker.loc = src.loc
 	beaker = null
@@ -314,9 +314,9 @@
 	updateUsrDialog()
 
 /obj/machinery/reagentgrinder/proc/eject()
-	if (usr.stat != 0)
+	if(usr.stat != 0)
 		return
-	if (holdingitems && holdingitems.len == 0)
+	if(holdingitems && holdingitems.len == 0)
 		return
 
 	for(var/obj/item/O in holdingitems)
@@ -333,7 +333,7 @@
 
 /obj/machinery/reagentgrinder/proc/get_allowed_by_id(obj/item/O)
 	for (var/i in blend_items)
-		if (istype(O, i))
+		if(istype(O, i))
 			return blend_items[i]
 
 /obj/machinery/reagentgrinder/proc/get_allowed_snack_by_id(obj/item/reagent_containers/food/snacks/O)
@@ -347,17 +347,17 @@
 			return juice_items[i]
 
 /obj/machinery/reagentgrinder/proc/get_grownweapon_amount(obj/item/grown/O)
-	if (!istype(O) || !O.seed)
+	if(!istype(O) || !O.seed)
 		return 5
-	else if (O.seed.potency == -1)
+	else if(O.seed.potency == -1)
 		return 5
 	else
 		return round(O.seed.potency)
 
 /obj/machinery/reagentgrinder/proc/get_juice_amount(obj/item/reagent_containers/food/snacks/grown/O)
-	if (!istype(O) || !O.seed)
+	if(!istype(O) || !O.seed)
 		return 5
-	else if (O.seed.potency == -1)
+	else if(O.seed.potency == -1)
 		return 5
 	else
 		return round(5*sqrt(O.seed.potency))
@@ -370,7 +370,7 @@
 	power_change()
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
+	if(!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
 		return
 	playsound(src.loc, 'sound/machines/juicer.ogg', 20, 1)
 	var/offset = prob(50) ? -2 : 2
@@ -384,7 +384,7 @@
 
 	//Snacks
 	for (var/obj/item/reagent_containers/food/snacks/O in holdingitems)
-		if (beaker.reagents.holder_full())
+		if(beaker.reagents.holder_full())
 			break
 
 		var/allowed = get_allowed_juice_by_id(O)
@@ -396,9 +396,9 @@
 			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 			var/amount = get_juice_amount(O)
 
-			beaker.reagents.add_reagent(r_id, min(amount*efficiency, space))
+			beaker.reagents.add_reagent(r_id, min(amount * efficiency, space))
 
-			if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+			if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 				break
 
 		remove_object(O)
@@ -408,7 +408,7 @@
 	power_change()
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if (!beaker || (beaker && beaker.reagents.holder_full()))
+	if(!beaker || (beaker && beaker.reagents.holder_full()))
 		return
 	playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)
 	var/offset = prob(50) ? -2 : 2
@@ -422,7 +422,7 @@
 
 	//Snacks and Plants
 	for (var/obj/item/reagent_containers/food/snacks/O in holdingitems)
-		if (beaker.reagents.holder_full())
+		if(beaker.reagents.holder_full())
 			break
 
 		var/allowed = get_allowed_snack_by_id(O)
@@ -435,25 +435,25 @@
 			var/amount = allowed[r_id]
 			if(amount <= 0)
 				if(amount == 0)
-					if (O.reagents != null && O.reagents.has_reagent("nutriment"))
-						beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("nutriment")*efficiency, space))
+					if(O.reagents != null && O.reagents.has_reagent("nutriment"))
+						beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("nutriment") * efficiency, space))
 						O.reagents.remove_reagent("nutriment", min(O.reagents.get_reagent_amount("nutriment"), space))
-					if (O.reagents != null && O.reagents.has_reagent("plantmatter"))
-						beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("plantmatter")*efficiency, space))
+					if(O.reagents != null && O.reagents.has_reagent("plantmatter"))
+						beaker.reagents.add_reagent(r_id, min(O.reagents.get_reagent_amount("plantmatter") * efficiency, space))
 						O.reagents.remove_reagent("plantmatter", min(O.reagents.get_reagent_amount("plantmatter"), space))
 				else
-					if (O.reagents != null && O.reagents.has_reagent("nutriment"))
-						beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("nutriment")*abs(amount)*efficiency), space))
+					if(O.reagents != null && O.reagents.has_reagent("nutriment"))
+						beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("nutriment") * abs(amount) * efficiency), space))
 						O.reagents.remove_reagent("nutriment", min(O.reagents.get_reagent_amount("nutriment"), space))
-					if (O.reagents != null && O.reagents.has_reagent("plantmatter"))
-						beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("plantmatter")*abs(amount)*efficiency), space))
+					if(O.reagents != null && O.reagents.has_reagent("plantmatter"))
+						beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("plantmatter") * abs(amount) * efficiency), space))
 						O.reagents.remove_reagent("plantmatter", min(O.reagents.get_reagent_amount("plantmatter"), space))
 
 
 			else
 				O.reagents.trans_id_to(beaker, r_id, min(amount, space))
 
-			if (beaker.reagents.holder_full())
+			if(beaker.reagents.holder_full())
 				break
 
 		if(O.reagents.reagent_list.len == 0)
@@ -461,7 +461,7 @@
 
 	//Sheets and rods(!)
 	for (var/obj/item/stack/O in holdingitems)
-		if (beaker.reagents.holder_full())
+		if(beaker.reagents.holder_full())
 			break
 
 		var/allowed = get_allowed_by_id(O)
@@ -469,51 +469,51 @@
 			break
 
 		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-		while(O.amount) //Work untill hold something
+		while(O.amount) //Grind until there's no more reagents
 			if(O.amount < 1)
 				remove_object(O)
 				break
-			if (!space) //if no free space - exit
+			if(!space) //if no free space - exit
 				break
 			O.amount -= 1 //remove one from stack
 			for (var/r_id in allowed)
-				var/spaceused = min(allowed[r_id]*efficiency, space)
+				var/spaceused = min(allowed[r_id] * efficiency, space)
 				space -= spaceused
-				beaker.reagents.add_reagent(r_id,spaceused)
+				beaker.reagents.add_reagent(r_id, spaceused)
 
 	//Plants
 	for (var/obj/item/grown/O in holdingitems)
-		if (beaker.reagents.holder_full())
+		if(beaker.reagents.holder_full())
 			break
 		var/allowed = get_allowed_by_id(O)
 		for (var/r_id in allowed)
 			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 			var/amount = allowed[r_id]
-			if (amount == 0)
-				if (O.reagents != null && O.reagents.has_reagent(r_id))
-					beaker.reagents.add_reagent(r_id,min(O.reagents.get_reagent_amount(r_id)*efficiency, space))
+			if(amount == 0)
+				if(O.reagents != null && O.reagents.has_reagent(r_id))
+					beaker.reagents.add_reagent(r_id,min(O.reagents.get_reagent_amount(r_id) * efficiency, space))
 			else
-				beaker.reagents.add_reagent(r_id,min(amount*efficiency, space))
+				beaker.reagents.add_reagent(r_id,min(amount * efficiency, space))
 
-			if (beaker.reagents.holder_full())
+			if(beaker.reagents.holder_full())
 				break
 		remove_object(O)
 
 	//Slime Extractis
 	for (var/obj/item/slime_extract/O in holdingitems)
-		if (beaker.reagents.holder_full())
+		if(beaker.reagents.holder_full())
 			break
 		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-		if (O.reagents != null)
+		if(O.reagents != null)
 			var/amount = O.reagents.total_volume
 			O.reagents.trans_to(beaker, min(amount, space))
-		if (O.Uses > 0)
-			beaker.reagents.add_reagent("slimejelly",min(20*efficiency, space))
+		if(O.Uses > 0)
+			beaker.reagents.add_reagent("slimejelly",min(20 * efficiency, space))
 		remove_object(O)
 
 	//Everything else - Transfers reagents from it into beaker
 	for (var/obj/item/reagent_containers/O in holdingitems)
-		if (beaker.reagents.holder_full())
+		if(beaker.reagents.holder_full())
 			break
 		var/amount = O.reagents.total_volume
 		O.reagents.trans_to(beaker, amount)


### PR DESCRIPTION
## What Does This PR Do
- Now can grind rods
- Don't use all grinding stack items. EX: you place 50 stack plasma. Grind only 5 of them for 100 Plasma dust
*changed code from //Sheets and rods(!)

## Why It's Good For The Game
- Grinder machine works as it shoud be

## Changelog
:cl:
tweak: All-In-One Grinder can grind rods
tweak: All-In-One Grinder don't grind the entire stack and instead grind items until it is full.
/:cl:


