### PR TITLE
Note deletion confirmation

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -982,7 +982,9 @@
 
 	else if(href_list["removenote"])
 		var/note_id = href_list["removenote"]
-		remove_note(note_id)
+		if(note_id)
+			if((alert("Do you really want to delete this note?","Note deletion confirmation", "Yes", "No") == "Yes") && note_id)
+				remove_note(note_id)
 
 	else if(href_list["editnote"])
 		var/note_id = href_list["editnote"]

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -982,7 +982,7 @@
 
 	else if(href_list["removenote"])
 		var/note_id = href_list["removenote"]
-		if(alert("Do you really want to delete this note?","Note deletion confirmation", "Yes", "No") == "Yes")
+		if(alert("Do you really want to delete this note?", "Note deletion confirmation", "Yes", "No") == "Yes")
 			remove_note(note_id)
 
 	else if(href_list["editnote"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -982,9 +982,8 @@
 
 	else if(href_list["removenote"])
 		var/note_id = href_list["removenote"]
-		if(note_id)
-			if((alert("Do you really want to delete this note?","Note deletion confirmation", "Yes", "No") == "Yes") && note_id)
-				remove_note(note_id)
+		if((alert("Do you really want to delete this note?","Note deletion confirmation", "Yes", "No") == "Yes"))
+			remove_note(note_id)
 
 	else if(href_list["editnote"])
 		var/note_id = href_list["editnote"]

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -982,7 +982,7 @@
 
 	else if(href_list["removenote"])
 		var/note_id = href_list["removenote"]
-		if((alert("Do you really want to delete this note?","Note deletion confirmation", "Yes", "No") == "Yes"))
+		if(alert("Do you really want to delete this note?","Note deletion confirmation", "Yes", "No") == "Yes")
 			remove_note(note_id)
 
 	else if(href_list["editnote"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR prompts admins to confirm they really do want to delete a note completely.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Deleting notes outright is not something done lightly, the fact that you can misclick and do it without confirmation is... troublesome. This adds some sort of safety net to doing so.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![2021-09-10 23_08_17-Note deletion confirmation](https://user-images.githubusercontent.com/12197162/132922869-f18b721f-104c-4cf7-8177-e20e0c1df254.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Admins now have to confirm they want to delete a note.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
