### PR TITLE
Fixes the night shift config setting not disabling night shifts when set to `false`

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -287,7 +287,7 @@ SUBSYSTEM_DEF(ticker)
 	else
 		log_debug("Playercount: [playercount] versus trigger: [highpop_trigger] - keeping standard job config")
 
-	SSnightshift.check_nightshift()
+	SSnightshift.check_nightshift(TRUE)
 
 	#ifdef UNIT_TESTS
 	RunUnitTests()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
(Couldn't come up with a shorter title)
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes the `enable_night_shifts` config setting not disabling night shift mode when set to `false`.
The actual setting itself works as it should, and sets the Night Shift subsystem's `can_fire` to `FALSE`, but that variable isn't currently checked in `/datum/controller/subsystem/ticker/proc/setup()`, so night shifts will still happen either way when the game starts.
https://github.com/ParadiseSS13/Paradise/blob/0ce6bba543b0dc8c776f8a39913424ace071a644/config/example/config.toml#L361-L362
https://github.com/ParadiseSS13/Paradise/blob/0ce6bba543b0dc8c776f8a39913424ace071a644/code/controllers/subsystem/nightshift.dm#L16-L18
https://github.com/ParadiseSS13/Paradise/blob/0ce6bba543b0dc8c776f8a39913424ace071a644/code/controllers/subsystem/ticker.dm#L290
https://github.com/ParadiseSS13/Paradise/blob/0ce6bba543b0dc8c776f8a39913424ace071a644/code/controllers/subsystem/nightshift.dm#L31-L33

(Originally fixed in #16520, but reverted due to various other issues caused by that PR.)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Disabling night shift mode in the config file should disable it ingame too.

## Changelog
:cl:
fix: Fixed disabling night shift mode in the config not working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
