### PR TITLE
Fixes gibber deconstruction

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -24,6 +24,21 @@
 	idle_power_usage = 2
 	active_power_usage = 500
 
+/obj/machinery/gibber/Initialize(mapload)
+	. = ..()
+	add_overlay("grjam")
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/gibber(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	RefreshParts()
+
+/obj/machinery/gibber/Destroy()
+	for(var/atom/movable/A in contents)
+		A.forceMove(get_turf(src))
+	occupant = null
+	return ..()
+
 /obj/machinery/gibber/suicide_act(mob/user)
 	if(occupant || locked)
 		return FALSE
@@ -35,21 +50,6 @@
 	feedinTopanim()
 	addtimer(CALLBACK(src, .proc/startgibbing, user), 33)
 	return OBLITERATION
-
-/obj/machinery/gibber/Destroy()
-	if(contents.len)
-		for(var/atom/movable/A in contents)
-			A.loc = get_turf(src)
-	if(occupant)
-		occupant = null
-	return ..()
-
-/obj/machinery/gibber/RefreshParts() //If you want to make the machine upgradable, this is where you would change any vars basd on its stock parts.
-	return
-
-/obj/machinery/gibber/New()
-	..()
-	overlays += image('icons/obj/kitchen.dmi', "grjam")
 
 /obj/machinery/gibber/update_icon()
 	overlays.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes gibbers vanishing completely when deconstructed.
This was due to it having no `component_parts` set, and therefore no machine frame in `deconstruct()` either.
https://github.com/ParadiseSS13/Paradise/blob/660d8586773112390adbaf63975f632eeabe2c51/code/game/machinery/machinery.dm#L406-L414

(Originally fixed in #16520, but reverted due to various other issues caused by that PR.)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Since gibbers can be constructed, they should be able to be *de*constructed too.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/57483089/132941726-891f1453-132c-4c1e-b245-36c47db19969.mp4

https://user-images.githubusercontent.com/57483089/132941727-f958f948-3f7d-494b-9ad8-1f28b7b1ba4d.mp4

## Changelog
:cl:
fix: Fixed gibbers vanishing after being deconstructed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
