### PR TITLE
Removes service borgs being able to print credits

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -21,7 +21,6 @@ RSF
 	..()
 	desc = "A RSF. It currently holds [matter]/30 fabrication-units."
 	// configured_items[ID_NUMBER] = list("Human-readable name", price in energy, /type/path)
-	configured_items[++configured_items.len] = list("Dosh", 50, /obj/item/stack/spacecash/c10)
 	configured_items[++configured_items.len] = list("Drinking Glass", 50, /obj/item/reagent_containers/food/drinks/drinkingglass)
 	configured_items[++configured_items.len] = list("Paper", 50, /obj/item/paper)
 	configured_items[++configured_items.len] = list("Pen", 50, /obj/item/pen)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes the ability for the rapid service fabricator used by service borgs to print credits.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Our economy is currently unbalanced and pretty pointless. It has still has a little roleplay value. This roleplay value gets shattered whenever I see borgs printing dosh everywhere for free, ruining what little immersion credits bring to the station.

Being able to print credits provide no roleplay value for service borgs other than ancient killing floor memes, and it diminishes the roleplay value of credits as a whole (as little as it is), so we'd be better off without that ability.

## Changelog
:cl:
del: Service borgs can no longer print credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
