### PR TITLE
Fix - Wheelchair deconstruction gives 15 metal sheets

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -4,6 +4,7 @@
 	item_chair = null
 	anchored = FALSE
 	movable = TRUE
+	buildstackamount = 15
 
 	var/move_delay = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives wheelchairs a build stack value of 15 instead of inheriting the parent's 1.

## Why It's Good For The Game
Fixes #16695 

## Images of changes
![WheelChairMetal](https://user-images.githubusercontent.com/80771500/132995136-352b5e7b-c1d5-45d2-8628-2eb1d5f17f41.PNG)

## Changelog
:cl:
fix: Gave wheelchairs a metal stack value of 15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
