### PR TITLE
Fixes some ghost poll chat messages being incorrect

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -237,7 +237,7 @@
 	blobber.AIStatus = AI_OFF
 	blobber.LoseTarget()
 	spawn()
-		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a blobbernaut?", ROLE_BLOB, TRUE, 10 SECONDS, source = blobber)
+		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a blobbernaut?", ROLE_BLOB, TRUE, 10 SECONDS, source = blobber, role_cleanname = "blobbernaut")
 		if(length(candidates) && !QDELETED(blobber))
 			var/mob/C = pick(candidates)
 			if(C)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -430,9 +430,9 @@
 	if(!chosen_ghost) // Failing that, we grab a ghost
 		var/list/consenting_candidates
 		if(purified)
-			consenting_candidates = SSghost_spawns.poll_candidates("Would you like to play as a Holy Shade?", ROLE_SENTIENT, FALSE, poll_time = 10 SECONDS, source = /mob/living/simple_animal/shade/holy)
+			consenting_candidates = SSghost_spawns.poll_candidates("Would you like to play as a Holy Shade?", ROLE_SENTIENT, FALSE, poll_time = 10 SECONDS, source = /mob/living/simple_animal/shade/holy, role_cleanname = "holy shade")
 		else
-			consenting_candidates = SSghost_spawns.poll_candidates("Would you like to play as a Shade?", ROLE_SENTIENT, FALSE, poll_time = 10 SECONDS, source = /mob/living/simple_animal/shade)
+			consenting_candidates = SSghost_spawns.poll_candidates("Would you like to play as a Shade?", ROLE_SENTIENT, FALSE, poll_time = 10 SECONDS, source = /mob/living/simple_animal/shade, role_cleanname = "shade")
 		if(length(consenting_candidates))
 			chosen_ghost = pick(consenting_candidates)
 	if(!M)

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -266,9 +266,11 @@
 
 	possessed = TRUE
 
-	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the spirit of [user.real_name]'s blade?", ROLE_PAI, FALSE, 10 SECONDS, source = src)
+	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the spirit of [user.real_name]'s blade?", ROLE_PAI, FALSE, 10 SECONDS, source = src, role_cleanname = "possessed blade")
 	var/mob/dead/observer/theghost = null
 
+	if(QDELETED(src))
+		return
 	if(length(candidates))
 		theghost = pick(candidates)
 		var/mob/living/simple_animal/shade/sword/S = new(src)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -138,7 +138,7 @@
 	if(confirm != "Yes")
 		return 0
 	var/image/I = new('icons/mob/simple_human.dmi', "wizard")
-	var/list/candidates = SSghost_spawns.poll_candidates("Do you wish to be considered for the position of a Wizard Foundation 'diplomat'?", "wizard", source = I)
+	var/list/candidates = SSghost_spawns.poll_candidates("Do you wish to be considered for the position of a Wizard Federation 'diplomat'?", "wizard", source = I)
 
 	log_admin("[key_name(owner)] tried making a Wizard with One-Click-Antag")
 	message_admins("[key_name_admin(owner)] tried making a Wizard with One-Click-Antag")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds the actual name of the ghost role to some ghost polls that were missing it. Specifically:
- `"pAI"` -> `"possessed blade"`
- `"sentient animal"` -> `"shade"` / `"holy shade"`
- `"blob"` -> `"blobbernaut"`

(Same idea as one of the fixes in #16520, but expanded upon a bit.)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's good to have more accurate descriptions of what the role is before you actually sign up for it. The ghost poll system mostly avoids any issues in that regard thanks to the popup alert, but it's still useful for the information in the chat message to be correct.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
### Before
**Possessed Blade:**
![Blade before](https://user-images.githubusercontent.com/57483089/133004019-981674fe-46b8-4d4c-8bc9-45bd3d130fb7.png)

**Shade:**
![Shade before](https://user-images.githubusercontent.com/57483089/133004020-5af7c2e1-f947-4690-aeee-80fb33f0c54e.png)

**Holy Shade:**
![Holy shade before](https://user-images.githubusercontent.com/57483089/133004022-55ed2d15-df96-4cc5-a3e9-fb53ca157ab9.png)

**Blobbernaut:**
![Blob before](https://user-images.githubusercontent.com/57483089/133004025-4fde82fd-ced4-450c-a9aa-204b98551f23.png)

### After
**Possessed Blade:**
![Blade after](https://user-images.githubusercontent.com/57483089/133004027-efa5e271-594a-4b0b-bfe6-557352660c2f.png)

**Shade:**
![Shade after](https://user-images.githubusercontent.com/57483089/133004029-135a9764-a07f-47c9-b473-643831fe9021.png)

**Holy Shade:**
![Holy shade after](https://user-images.githubusercontent.com/57483089/133004032-f36562ab-8e80-4139-b95a-a8d6b9dcd68d.png)

**Blobbernaut:**
![Blob after](https://user-images.githubusercontent.com/57483089/133004034-e677bb47-3963-48df-a6b3-b08e61461c6e.png)

## Changelog
:cl:
tweak: Added more information to the ghost spawn chat messages for Possessed Blades, Shades, Holy Shades, and Blobbernauts.
tweak: ("Do you want to play as a blob?" -> "Do you want to play as a blobbernaut?")
spellcheck: Changed 'Wizard Foundation' to 'Wizard Federation' in the admin one-click-antag poll.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
