### PR TITLE
Limit designs for RnD console

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -276,6 +276,9 @@
 	board_name = "RD Console - Public"
 	build_path = /obj/machinery/computer/rdconsole/public
 
+/obj/item/circuitboard/rdconsole/syndicate
+	board_name = "RD Console - syndicate"
+	build_path = /obj/machinery/computer/rdconsole/syndicate
 
 /obj/item/circuitboard/mecha_control
 	board_name = "Exosuit Control Console"
@@ -411,6 +414,9 @@
 
 /obj/item/circuitboard/rdconsole/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/card/id) || istype(I, /obj/item/pda))
+		if(build_path == /obj/machinery/computer/rdconsole/syndicate) //You can't change Syndicate console type. Steal normal from station
+			to_chat(user, "<span class='warning'>Access Denied</span>")
+			return
 		if(allowed(user))
 			user.visible_message("<span class='notice'>[user] waves [user.p_their()] ID past [src]'s access protocol scanner.</span>", "<span class='notice'>You swipe your ID past [src]'s access protocol scanner.</span>")
 			var/console_choice = input(user, "What do you want to configure the access to?", "Access Modification", "R&D Core") as null|anything in access_types

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -45,3 +45,5 @@ other types of metals and chemistry for reagents).
 	var/list/reagents_list = list()			//List of reagents. Format: "id" = amount.
 	var/maxstack = 1
 	var/lathe_time_factor = 1			//How many times faster than normal is this to build on the protolathe
+	var/list/consolelimit = list()		//Remove design from consoles with listed ID
+

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -70,6 +70,7 @@
 	materials = list(MAT_METAL = 2000, MAT_GLASS = 1750, MAT_SILVER = 500)
 	build_path = /obj/item/telepad_beacon
 	category = list("Bluespace")
+	consolelimit = list(6)
 
 /datum/design/beacon
 	name = "Tracking Beacon"
@@ -80,6 +81,7 @@
 	materials = list(MAT_METAL = 150, MAT_GLASS = 100)
 	build_path = /obj/item/radio/beacon
 	category = list("Bluespace")
+	consolelimit = list(6)
 
 /datum/design/brpd
 	name = "Bluespace Rapid Pipe Dispenser (BRPD)"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -11,6 +11,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/aicore
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/aifixer
 	name = "Console Board (AI Integrity Restorer)"
@@ -21,6 +22,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/aifixer
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/aiupload
 	name = "Console Board (AI Upload)"
@@ -31,6 +33,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/aiupload
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/atmosalerts
 	name = "Console Board (Atmospheric Alerts)"
@@ -61,6 +64,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/camera
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/clonecontrol
 	name = "Console Board (Cloning Machine Console)"
@@ -81,6 +85,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/communications
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/crewconsole
 	name = "Console Board (Crew Monitoring Computer)"
@@ -91,6 +96,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/crew
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/borgupload
 	name = "Console Board (Cyborg Upload)"
@@ -101,6 +107,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/borgupload
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/scan_console
 	name = "Console Board (DNA Machine)"
@@ -121,6 +128,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/drone_control
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/mechacontrol
 	name = "Console Board (Exosuit Control Console)"
@@ -131,6 +139,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha_control
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/idcardconsole
 	name = "Console Board (ID Computer)"
@@ -141,6 +150,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/card
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/mechapower
 	name = "Console Board (Mech Bay Power Control Console)"
@@ -151,6 +161,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mech_bay_power_console
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/med_data
 	name = "Console Board (Medical Records)"
@@ -161,6 +172,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/med_data
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/message_monitor
 	name = "Console Board (Messaging Monitor Console)"
@@ -231,6 +243,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/rdconsole
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/rdservercontrol
 	name = "Console Board (R&D Server Control Console)"
@@ -241,6 +254,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/rdservercontrol
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/robocontrol
 	name = "Console Board (Robotics Control Console)"
@@ -251,6 +265,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/robotics
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/secdata
 	name = "Console Board (Security Records Console)"
@@ -261,6 +276,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/secure_data
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/solarcontrol
 	name = "Console Board (Solar Control)"
@@ -321,6 +337,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/teleporter
 	category = list("Computer Boards")
+	consolelimit = list(6)
 
 /datum/design/GAC
 	name = "Console Board (General Air Control)"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -91,6 +91,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/teleporter_hub
 	category = list ("Teleportation Machinery")
+	consolelimit = list(6)
 
 /datum/design/teleport_station
 	name = "Machine Board (Teleportation Station)"
@@ -101,6 +102,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/teleporter_station
 	category = list ("Teleportation Machinery")
+	consolelimit = list(6)
 
 /datum/design/teleport_perma
 	name = "Machine Board (Permanent Teleporter)"
@@ -111,6 +113,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/teleporter_perma
 	category = list ("Teleportation Machinery")
+	consolelimit = list(6)
 
 /datum/design/bodyscanner
 	name = "Machine Board (Body Scanner)"
@@ -321,6 +324,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/rdserver
 	category = list("Research Machinery")
+	consolelimit = list(6)
 
 /datum/design/gibber
 	name = "Machine Design (Gibber Board)"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -225,7 +225,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 /obj/machinery/computer/rdconsole/emag_act(user as mob)
 	if(id == 6) //Syndicate protect from emag
-		to_chat(user, "<span class='notice'>You can't Emag this consile</span>")
+		to_chat(user, "<span class='notice'>You can't Emag this console</span>")
 	else if(!emagged)
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
 		req_access = list()

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -62,6 +62,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 /obj/machinery/computer/rdconsole
 	name = "\improper R&D console"
+	desc = "A console used to interface with R&D tools."
 	icon_screen = "rdcomp"
 	icon_keyboard = "rd_key"
 	light_color = LIGHT_COLOR_FADEDPURPLE
@@ -223,7 +224,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	return
 
 /obj/machinery/computer/rdconsole/emag_act(user as mob)
-	if(!emagged)
+	if(id == 6) //Syndicate protect from emag
+		to_chat(user, "<span class='notice'>You can't Emag this consile</span>")
+	else if(!emagged)
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
 		req_access = list()
 		emagged = TRUE
@@ -739,6 +742,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	if(submenu == SUBMENU_LATHE_CATEGORY)
 		for(var/datum/design/D in matching_designs)
+			if((id in D.consolelimit) || (D.id == "id")) //if forbidden for this console or 'NULL' design NAME
+				continue
 			var/list/design_list = list()
 			designs_list[++designs_list.len] = design_list
 			var/list/design_materials_list = list()
@@ -939,35 +944,36 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 /obj/machinery/computer/rdconsole/core
 	name = "core R&D console"
-	desc = "A console used to interface with R&D tools."
 	id = 1
 
 /obj/machinery/computer/rdconsole/robotics
 	name = "robotics R&D console"
-	desc = "A console used to interface with R&D tools."
 	id = 2
 	req_access = list(ACCESS_ROBOTICS)
 	circuit = /obj/item/circuitboard/rdconsole/robotics
 
 /obj/machinery/computer/rdconsole/experiment
 	name = "\improper E.X.P.E.R.I-MENTOR R&D console"
-	desc = "A console used to interface with R&D tools."
 	id = 3
 	circuit = /obj/item/circuitboard/rdconsole/experiment
 
 /obj/machinery/computer/rdconsole/mechanics
 	name = "mechanics R&D console"
-	desc = "A console used to interface with R&D tools."
 	id = 4
 	req_access = list(ACCESS_MECHANIC)
 	circuit = /obj/item/circuitboard/rdconsole/mechanics
 
 /obj/machinery/computer/rdconsole/public
 	name = "public R&D console"
-	desc = "A console used to interface with R&D tools."
 	id = 5
 	req_access = list()
 	circuit = /obj/item/circuitboard/rdconsole/public
+
+/obj/machinery/computer/rdconsole/syndicate
+	name = "syndicate R&D console"
+	id = 6
+	req_access = list(ACCESS_SYNDICATE)
+	circuit = /obj/item/circuitboard/rdconsole/syndicate
 
 #undef TECH_UPDATE_DELAY
 #undef DESIGN_UPDATE_DELAY

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -236,7 +236,7 @@
 		if(href_list["access"])
 			screen = 1
 			for(var/obj/machinery/computer/rdconsole/C in GLOB.machines)
-				if(C.sync)
+				if(C.sync && !(C.id in list(6))) //ignore all forbidden consoles(6-syndicate)
 					consoles += C
 		else if(href_list["data"])
 			screen = 2


### PR DESCRIPTION
## What Does This PR Do

- Now you can limit designs for RnD console. Remove all weapons, AI laws from public console? Sure!
- New RnD console type for Syndicate Researcher. Removed all teleportation designs. Can't sync or emag.
- Removed default design from printing list.

## Why It's Good For The Game

1.  Now you can't build public RnD. People will print some bad stuff. Like AI upload. Or weapon(yea, emag+locked weapon = free weapon) 
2. Syndicate Researcher base starts without upgrades. You can't even extract Production Speed 8. Now after some research - you can upgrade all machines.
 Also restricted all teleportation designs for print.
3. Removed default design from print list.

## Images of changes
![image](https://user-images.githubusercontent.com/11385249/133077507-0ae93358-af6d-47dc-a329-39ac834d3c3f.png)


## Changelog
:cl:
add: Restrictions for RnD consoles
fix: Removed default design from print list
wip: 1st part RnD work for Syndicate Researcher base
/:cl:

