### PR TITLE
Fixes being able to make xray cameras, fixes invisible all cameras

### DIFF
--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -13,8 +13,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	anchored = FALSE
 	materials = list(MAT_METAL=400, MAT_GLASS=250)
-	//	Motion, EMP-Proof, X-Ray
-	var/list/obj/item/possible_upgrades = list(/obj/item/assembly/prox_sensor, /obj/item/stack/sheet/mineral/plasma, /obj/item/analyzer)
+	//	Motion, EMP-Proof
+	var/list/obj/item/possible_upgrades = list(/obj/item/assembly/prox_sensor, /obj/item/stack/sheet/mineral/plasma)
 	var/list/upgrades = list()
 	var/state = ASSEMBLY_UNBUILT
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -25,7 +25,7 @@
 
 // ALL UPGRADES
 /obj/machinery/camera/all
-	icon_state = "xraycamera" //mapping icon.
+	icon_state = "xraycam" //mapping icon.
 
 /obj/machinery/camera/all/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Prevents analysers from being able to be put in camera frames, which would allow crew to make xray cameras, which we removed in #14816. They can still be upgraded by procs / malf AI, or placed in mapping.

Fixed the all upgrade camera subtype being invisible.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Invisible cameras are bad, and we disabled building xray cameras for a reason, we should not still have a way to build them.

## Changelog
:cl:
fix: Fixed the all camera type being invisible.
fix: Fixed crew being able to construct xray cameras.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
