### PR TITLE
Makes us use release dmdoc instead of our own snowflake version

### DIFF
--- a/.github/workflows/generate_autodoc.yml
+++ b/.github/workflows/generate_autodoc.yml
@@ -2,7 +2,8 @@ name: Generate Documentation
 
 on:
   schedule:
-  - cron: "0 0 * * *" # Every day at the very start of the day
+  - cron: "0 0 * * *" # Every day at the very start of the day. Except it happens an hour and a half later because actions backlog
+  workflow_dispatch:
 
 jobs:
   generate_docs:
@@ -14,10 +15,11 @@ jobs:
       with:
         fetch-depth: 1
         ref: master
-
+    - name: 'Install DMDOC'
+        run: bash tools/ci/install_dmdoc.sh
     - name: 'Generate Documentation'
       run: |
-        ./tools/github-actions/doc-generator
+        ~/dmdoc
         touch dmdoc/.nojekyll
       # Nojekyll is important to disable jeykll syntax, which can mess with files that start with underscores
 

--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -1,6 +1,6 @@
 # This file has all the information on what versions of libraries are thrown into the code
 # For dreamchecker
-export SPACEMANDMM_TAG=suite-1.7
+export SPACEMANDMM_TAG=suite-1.7.1
 # For TGUI
 export NODE_VERSION=12
 # Byond Major

--- a/code/world.dm
+++ b/code/world.dm
@@ -8,3 +8,4 @@
 	view = "15x15"
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	fps = 20 // If this isnt hard-defined, anything relying on this variable before world load will cry a lot
+	name = "Paradise Station 13"

--- a/tools/ci/install_dmdoc.sh
+++ b/tools/ci/install_dmdoc.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+source _build_dependencies.sh
+
+wget -O ~/dmdoc "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMANDMM_TAG/dmdoc"
+chmod +x ~/dmdoc
+~/dmdoc --version


### PR DESCRIPTION
## What Does This PR Do
Uses release dmdoc now because the font isn't times new roman, so its actually bearable.

## Why It's Good For The Repo
Dmdoc will now be:
- Up to date
- Able to parse more
- Darkmode compatible
- Less shit
- Not be a snowflake binary we have in the repo

## Images of changes
![image](https://user-images.githubusercontent.com/25063394/133156061-10ab1aa3-3134-455e-9be2-48bf2048ebc0.png)
Imagine this but paracode
