### PR TITLE
Fix - Removes twohanded wielding when equipping the item to a different slot

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -93,13 +93,11 @@
 	return TRUE
 
 /obj/item/twohanded/mob_can_equip(mob/M, slot) //Unwields twohanded items if they're equipped on the back
-	if(!slot_flags)
-		return FALSE
 	if(wielded && slot_flags)
 		var/obj/item/twohanded/O = M.get_inactive_hand()
 		if(istype(O))
 			O.unwield(M)
-	return TRUE
+	return slot_flags
 
 /obj/item/twohanded/dropped(mob/user)
 	..()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -92,6 +92,15 @@
 	user.put_in_inactive_hand(O)
 	return TRUE
 
+/obj/item/twohanded/mob_can_equip(mob/M, slot) //Unwields twohanded items if they're equipped on the back
+	if(!slot_flags)
+		return FALSE
+	if(wielded && slot_flags)
+		var/obj/item/twohanded/O = M.get_inactive_hand()
+		if(istype(O))
+			O.unwield(M)
+	return TRUE
+
 /obj/item/twohanded/dropped(mob/user)
 	..()
 	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -97,7 +97,7 @@
 		var/obj/item/twohanded/O = M.get_inactive_hand()
 		if(istype(O))
 			O.unwield(M)
-	return slot_flags
+	return ..()
 
 /obj/item/twohanded/dropped(mob/user)
 	..()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -92,11 +92,9 @@
 	user.put_in_inactive_hand(O)
 	return TRUE
 
-/obj/item/twohanded/mob_can_equip(mob/M, slot) //Unwields twohanded items if they're equipped on the back
-	if(wielded && slot_flags)
-		var/obj/item/twohanded/O = M.get_inactive_hand()
-		if(istype(O))
-			O.unwield(M)
+/obj/item/twohanded/mob_can_equip(mob/M, slot) //Unwields twohanded items when they're attempted to be equipped to another slot
+	if(wielded)
+		unwield(M)
 	return ..()
 
 /obj/item/twohanded/dropped(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check for wielded items that can be also equipped onto the back or stuffed in a pocket, and frees ups the hands if that passes.

## Why It's Good For The Game
Fixes #15482

## Images of changes
https://user-images.githubusercontent.com/80771500/133180177-ee9b5284-c5ce-469c-8f7f-5b2950edb022.mp4

## Changelog
:cl:
fix: Putting a twohanded weapon on your back or pockets while holding with two hands will free your hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
