### PR TITLE
 Fixes the Claw Game arcade machine being impossible to deconstruct.

### DIFF
--- a/code/modules/arcade/arcade_base.dm
+++ b/code/modules/arcade/arcade_base.dm
@@ -83,7 +83,7 @@
 	return TRUE
 
 /obj/machinery/arcade/crowbar_act(mob/living/user, obj/item/I)
-	if(!component_parts)
+	if(!component_parts || !panel_open)
 		return FALSE
 	default_deconstruction_crowbar(user, I)
 	return TRUE

--- a/code/modules/arcade/arcade_base.dm
+++ b/code/modules/arcade/arcade_base.dm
@@ -59,12 +59,8 @@
 			to_chat(user, "Someone else is already playing this machine, please wait your turn!")
 		return
 
-/obj/machinery/arcade/attackby(obj/item/O as obj, mob/user as mob, params)
-	if(istype(O, /obj/item/screwdriver) && anchored)
-		playsound(src.loc, O.usesound, 50, 1)
-		panel_open = !panel_open
-		to_chat(user, "You [panel_open ? "open" : "close"] the maintenance panel.")
-		update_icon()
+/obj/machinery/arcade/attackby(obj/item/O, mob/user, params)
+	if(exchange_parts(user, O))
 		return
 	if(!freeplay)
 		if(istype(O, /obj/item/card/id))
@@ -76,11 +72,21 @@
 			var/obj/item/stack/spacecash/C = O
 			if(pay_with_cash(C, user))
 				tokens += 1
-		return
-	if(panel_open && component_parts && istype(O, /obj/item/crowbar))
-		default_deconstruction_crowbar(user, O)
-		return
+			return
 	return ..()
+
+/obj/machinery/arcade/screwdriver_act(mob/living/user, obj/item/I)
+	if(!anchored)
+		return FALSE
+	default_deconstruction_screwdriver(user, icon_state, icon_state, I)
+	update_icon()
+	return TRUE
+
+/obj/machinery/arcade/crowbar_act(mob/living/user, obj/item/I)
+	if(!component_parts)
+		return FALSE
+	default_deconstruction_crowbar(user, I)
+	return TRUE
 
 /obj/machinery/arcade/update_icon()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As per title. Issue is that the `if(!freeplay)` check is true for the on-station claw games, so the code for crowbar deconstruction was unreachable.

Also allows the Claw Game to be upgraded by the standard Rapid Parts Exchange Device. It is currently only possible to use the bluespace RPED to upgrade the claw game.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
tweak: Allows the Claw Game to be upgrade by the standard Rapid Parts Exchange Device
fix: Fixes the Claw Game arcade machine being impossible to deconstruct.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
