### PR TITLE
Removes Separated Chemicals

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -85,7 +85,7 @@
 	lifespan = 30
 	endurance = 25
 	mutatelist = list()
-	genes = list(/datum/plant_gene/trait/glow/berry , /datum/plant_gene/trait/noreact, /datum/plant_gene/trait/repeated_harvest)
+	genes = list(/datum/plant_gene/trait/glow/berry, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("uranium" = 0.25, "iodine" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 20
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -327,21 +327,6 @@
 		new /obj/effect/decal/cleanable/molten_object(T)
 		qdel(G)
 
-
-/datum/plant_gene/trait/noreact
-	// Makes plant reagents not react until squashed.
-	name = "Separated Chemicals"
-
-/datum/plant_gene/trait/noreact/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
-	..()
-	G.reagents.set_reacting(FALSE)
-
-/datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
-	if(G && G.reagents)
-		G.reagents.set_reacting(TRUE)
-		G.reagents.handle_reactions()
-
-
 /datum/plant_gene/trait/maxchem
 	// 2x to max reagents volume.
 	name = "Densified Chemicals"


### PR DESCRIPTION
Botany, in its current form, needs...work.

That said, some of the most egregious botany abuse revolves around the separated chemicals trait, which allows for instant shock plants, explosions, and the like--among other nonsense.

Given the nature of botany and its infinite reproducibility, this just isn't healthy for the game.

:cl: Fox McCloud
tweak: removes separated chemicals trait from botany
/:cl: