### PR TITLE
Nerfs Earthsblood

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1205,26 +1205,48 @@
 	description = "Ichor from an extremely powerful plant. Great for restoring wounds, but it's a little heavy on the brain."
 	color = "#FFAF00"
 	overdose_threshold = 25
+	addiction_threshold = 50
+	addiction_chance = 5
 	harmless = FALSE
 	taste_description = "a gift from nature"
 
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-3 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustFireLoss(-3 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustOxyLoss(-15 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustToxLoss(-3 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustBrainLoss(2 * REAGENTS_EFFECT_MULTIPLIER, FALSE) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
-	update_flags |= M.adjustCloneLoss(-1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustStaminaLoss(-30 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	M.SetJitter(min(max(0, M.jitteriness + 3), 30))
+	if(current_cycle <= 25) //10u has to be processed before u get into THE FUN ZONE
+		update_flags |= M.adjustBruteLoss(-1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustFireLoss(-1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustOxyLoss(-0.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustToxLoss(-0.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustCloneLoss(-0.1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustStaminaLoss(-0.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustBrainLoss(1 * REAGENTS_EFFECT_MULTIPLIER, FALSE) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
+	else
+		update_flags |= M.adjustBruteLoss(-5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustFireLoss(-5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustOxyLoss(-3 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustToxLoss(-3 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustCloneLoss(-1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustStaminaLoss(-3 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		M.SetJitter(min(max(0, M.jitteriness + 3), 30))
+		update_flags |= M.adjustBrainLoss(2 * REAGENTS_EFFECT_MULTIPLIER, FALSE) //See above
 	update_flags |= M.SetDruggy(min(max(0, M.druggy + 10), 15), FALSE) //See above
 	return ..() | update_flags
 
+/datum/reagent/medicine/earthsblood/on_mob_add(mob/living/M)
+	..()
+	ADD_TRAIT(M, TRAIT_PACIFISM, type)
+
+/datum/reagent/medicine/earthsblood/on_mob_delete(mob/living/M)
+	REMOVE_TRAIT(M, TRAIT_PACIFISM, type)
+	..()
+
 /datum/reagent/medicine/earthsblood/overdose_process(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	M.SetHallucinate(min(max(0, M.hallucination + 10), 50))
-	update_flags |= M.adjustToxLoss(5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	M.SetHallucinate(min(max(0, M.hallucination + 5), 60))
+	if(current_cycle > 25)
+		update_flags |= M.adjustToxLoss(4 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		if(current_cycle > 100) //podpeople get out reeeeeeeeeeeeeeeeeeeee
+			update_flags |= M.adjustToxLoss(6 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return list(0, update_flags)
 
 /datum/reagent/medicine/corazone


### PR DESCRIPTION
Earthsblood is insanely strong, at the moment, with little downside to utilizing it---just take some mannitol and the only side effect is some pretty colors--it's a favorite of powergamers for extended combat engagements since it heals massive amounts of damage and even heals stamina.

This ports TG's nerfs to earthsblood to keep it a strong healing chem, but a useless combat chem.

- Heals less below 25 cycles, but heals more past this
  - It heals more brute and burn damage than it did, before, at > 25 cycles, but overall, it does less healing
  - Stamina healing is dramatically nerfed
-  It is now addictive, though it has a very high threshold of 50 units processed before it starts rolling for addiction
- It adds the pacifism trait as long as its in your blood stream

This means it has far less use in combat, and if you do use it, it's going to take a bit to kick in and has a fairly sizable chance to wind up causing you to be addicted---and, of course, the pacifism trait means you're not going to have much fun being able to beat the pulp out of everyone.

:cl: Fox McCloud
tweak: Dramatically overhauls how earthsblood works; don't expect to be able to utilize it nearly as effectively in combat
/:cl: