### PR TITLE
Makes revive, biodegrade, and freedom break grabs

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1524,7 +1524,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
-	desc = "An implant injected into the body and later activated manually to break out of any restraints. Can be activated up to 4 times."
+	desc = "An implant injected into the body and later activated manually to break out of any restraints or grabs. Can be activated up to 4 times."
 	reference = "FI"
 	item = /obj/item/implanter/freedom
 	cost = 5

--- a/code/game/gamemodes/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/changeling/powers/biodegrade.dm
@@ -9,7 +9,7 @@
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
 	var/used = FALSE // only one form of shackles removed per use
-	if(!user.restrained() && !user.legcuffed && !istype(user.loc, /obj/structure/closet) && !istype(user.loc, /obj/structure/spider/cocoon))
+	if(!user.restrained() && !user.legcuffed && !istype(user.loc, /obj/structure/closet) && !istype(user.loc, /obj/structure/spider/cocoon) && !user.grabbed_by)
 		to_chat(user, "<span class='warning'>We are already free!</span>")
 		return FALSE
 
@@ -57,7 +57,17 @@
 		to_chat(user, "<span class='warning'>We secrete acidic enzymes from our skin and begin melting our cocoon...</span>")
 		addtimer(CALLBACK(src, .proc/dissolve_cocoon, user, C), 2.5 SECONDS) //Very short because it's just webs
 		used = TRUE
-
+	for(var/obj/item/grab/G in user.grabbed_by)
+		var/mob/living/carbon/M = G.assailant
+		user.visible_message("<span class='warning'>[user] spits acid at [M]'s face and slips out of their grab!</span>")
+		M.Stun(1) //Drops the grab
+		M.apply_damage(5, BURN, "head", M.run_armor_check("head", "melee"))
+		user.SetStunned(0) //This only triggers if they are grabbed, to have them break out of the grab, without the large stun time. If you use biodegrade as an antistun without being grabbed, it will not work
+		user.SetWeakened(0)
+		user.lying = FALSE
+		user.update_canmove()
+		playsound(user.loc, 'sound/weapons/sear.ogg', 50, TRUE)
+		used = TRUE
 	if(used)
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return TRUE

--- a/code/game/gamemodes/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/changeling/powers/biodegrade.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/biodegrade
 	name = "Biodegrade"
 	desc = "Dissolves restraints or other objects preventing free movement. Costs 30 chemicals."
-	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets."
+	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets, and break you out of grabs."
 	button_icon_state = "biodegrade"
 	chemical_cost = 30 //High cost to prevent spam
 	dna_cost = 2
@@ -64,8 +64,6 @@
 		M.apply_damage(5, BURN, "head", M.run_armor_check("head", "melee"))
 		user.SetStunned(0) //This only triggers if they are grabbed, to have them break out of the grab, without the large stun time. If you use biodegrade as an antistun without being grabbed, it will not work
 		user.SetWeakened(0)
-		user.lying = FALSE
-		user.update_canmove()
 		playsound(user.loc, 'sound/weapons/sear.ogg', 50, TRUE)
 		used = TRUE
 	if(used)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -8,6 +8,12 @@
 //Revive from regenerative stasis
 /datum/action/changeling/revive/sting_action(mob/living/carbon/user)
 	REMOVE_TRAIT(user, TRAIT_FAKEDEATH, "changeling")
+	for(var/obj/item/grab/G in user.grabbed_by)
+		var/mob/living/carbon/M = G.assailant
+		user.visible_message("<span class='warning'>[user] suddenly hits [M] and slips out of their grab!</span>")
+		M.Stun(1) //Drops the grab
+		M.apply_damage(5, BRUTE, "head", M.run_armor_check("head", "melee"))
+		playsound(user.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)
 	user.revive()
 	user.updatehealth("revive sting")
 	user.update_blind_effects()

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -10,7 +10,7 @@
 	REMOVE_TRAIT(user, TRAIT_FAKEDEATH, "changeling")
 	for(var/obj/item/grab/G in user.grabbed_by)
 		var/mob/living/carbon/M = G.assailant
-		user.visible_message("<span class='warning'>[user] suddenly hits [M] and slips out of their grab!</span>")
+		user.visible_message("<span class='warning'>[user] suddenly hits [M] in the face and slips out of their grab!</span>")
 		M.Stun(1) //Drops the grab
 		M.apply_damage(5, BRUTE, "head", M.run_armor_check("head", "melee"))
 		playsound(user.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)

--- a/code/game/objects/items/weapons/implants/implant_freedom.dm
+++ b/code/game/objects/items/weapons/implants/implant_freedom.dm
@@ -21,8 +21,6 @@
 			M.apply_damage(2, BURN, "l_hand", M.run_armor_check("l_hand", "energy"))
 			C_imp_in.SetStunned(0) //This only triggers if they are grabbed, to have them break out of the grab, without the large stun time.
 			C_imp_in.SetWeakened(0)
-			C_imp_in.lying = FALSE
-			C_imp_in.update_canmove()
 			playsound(C_imp_in.loc, "sound/weapons/Egloves.ogg", 75, 1)
 	if(!uses)
 		qdel(src)

--- a/code/game/objects/items/weapons/implants/implant_freedom.dm
+++ b/code/game/objects/items/weapons/implants/implant_freedom.dm
@@ -13,6 +13,17 @@
 	if(iscarbon(imp_in))
 		var/mob/living/carbon/C_imp_in = imp_in
 		C_imp_in.uncuff()
+		for(var/obj/item/grab/G in C_imp_in.grabbed_by)
+			var/mob/living/carbon/M = G.assailant
+			C_imp_in.visible_message("<span class='warning'>[C_imp_in] suddenly shocks [M] from their wrists and slips out of their grab!</span>")
+			M.Stun(1) //Drops the grab
+			M.apply_damage(2, BURN, "r_hand", M.run_armor_check("r_hand", "energy"))
+			M.apply_damage(2, BURN, "l_hand", M.run_armor_check("l_hand", "energy"))
+			C_imp_in.SetStunned(0) //This only triggers if they are grabbed, to have them break out of the grab, without the large stun time.
+			C_imp_in.SetWeakened(0)
+			C_imp_in.lying = FALSE
+			C_imp_in.update_canmove()
+			playsound(C_imp_in.loc, "sound/weapons/Egloves.ogg", 75, 1)
 	if(!uses)
 		qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

This adds a check to revive, biodegrade, and freedom, that checks if the user is grabbed. If the user is grabbed, it will stun the grabber, do a bit of damage with a sound and message, allowing the user to get away

However, in the case of freedom and biodegrade, due to the stun time of the grab, under normal circumstances, the user would not be able to get away. Thus, if and only if the user is grabbed, these abilities will unstun the user, but not wake them up from sleep, or inject any chemicals. Otherwise, they do not work as antistun.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

As of late, many abilities have been getting negated by constant agressive grabs. Freedoms don't work if someone has a neck grab on you, you are still stunned and stuck in the grab, which would be useless. Same with changelings, of late if they have a chance to revive in combat, security will have neck grabbed them, preventing them from doing anything. As such, this pr will break grabs when the 3 abilities are used, allowing the user to get away.

**"Why not lower stun time of grabs?**

I could, but that would still not help these users, as they would still be stunned during these effects, and not have time to get away, even if the grab is broken. (baring revive.)

**"Why is this a problem? Can't security chain stun someone with a baton?**

Indeed, security can. However, batons have limited charge. Eventually, you run out of uses, it's not free. And baton chain stuning wont work on a changeling that revives currently, or anyone that has adrenals. In comparison, neck grabs, anyone can do, it lasts forever, and can not be broken out of, unless the user grabbing you stops. It is significantly better.


## Changelog
:cl:
tweak: Changeling revive, biodegrade, and freedom implants, can now break the user out of grabs when used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
