### PR TITLE
Moves existing_station_areas to SSmapping, to prevent midround lag

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -10,6 +10,8 @@ SUBSYSTEM_DEF(mapping)
 	var/list/teleportlocs
 	/// List of all areas that can be accessed via IC and OOC means
 	var/list/ghostteleportlocs
+	///List of areas that exist on the station this shift
+	var/list/existing_station_areas
 
 // This has to be here because world/New() uses [station_name()], which looks this datum up
 /datum/controller/subsystem/mapping/PreInit()
@@ -88,6 +90,13 @@ SUBSYSTEM_DEF(mapping)
 			ghostteleportlocs[AR.name] = AR
 
 	ghostteleportlocs = sortAssoc(ghostteleportlocs)
+
+	// Now we make a list of areas that exist on the station. Good for if you don't want to select areas that exist for one station but not others. Directly references
+	existing_station_areas = list()
+	for(var/area/AR in world)
+		var/turf/picked = safepick(get_area_turfs(AR.type))
+		if(picked && is_station_level(picked.z))
+			existing_station_areas += AR
 
 	// World name
 	if(GLOB.configuration.general.server_name)

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -5,13 +5,6 @@
 
 /datum/event/anomaly/proc/findEventArea()
 	var/static/list/allowed_areas
-	var/static/list/existing_areas
-	if(!existing_areas)
-		existing_areas = list()
-		for(var/area/AR in world)
-			var/turf/picked = safepick(get_area_turfs(AR.type))
-			if(picked && is_station_level(picked.z))
-				existing_areas += AR
 	if(!allowed_areas)
 		//Places that shouldn't explode
 		var/list/safe_area_types = typecacheof(list(
@@ -36,7 +29,7 @@
 		))
 
 		allowed_areas = typecacheof(GLOB.the_station_areas) - safe_area_types + unsafe_area_subtypes
-	var/list/possible_areas = typecache_filter_list(existing_areas, allowed_areas)
+	var/list/possible_areas = typecache_filter_list(SSmapping.existing_station_areas, allowed_areas)
 	if(length(possible_areas))
 		return pick(possible_areas)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Moves the check for the existing station areas, from the first time an anomaly spawns per shift, to SSmapping. Thus, it is done and lags roundstart, rather than during a round in progress

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Time slowing when anomalies are spawned is bad. Sorry about that.

## Changelog
:cl:
fix: Fixes lag when anomalies are spawned from events for the first time in a shift.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
