### PR TITLE
Makes the game panel window title more descriptive

### DIFF
--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -1,9 +1,11 @@
 GLOBAL_VAR(create_mob_html)
+
 /datum/admins/proc/create_mob(mob/user)
 	if(!GLOB.create_mob_html)
 		var/mobjs = null
 		mobjs = jointext(typesof(/mob), ";")
 		GLOB.create_mob_html = file2text('html/create_object.html')
+		GLOB.create_mob_html = replacetext(GLOB.create_mob_html, "$ATOM$", "Mob")
 		GLOB.create_mob_html = replacetext(GLOB.create_mob_html, "null /* object types */", "\"[mobjs]\"")
 
 	user << browse(replacetext(GLOB.create_mob_html, "/* ref src */", UID()), "window=create_mob;size=425x475")

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_INIT(create_object_forms, list(/obj, /obj/structure, /obj/machinery,
 		var/objectjs = null
 		objectjs = jointext(typesof(/obj), ";")
 		GLOB.create_object_html = file2text('html/create_object.html')
+		GLOB.create_object_html = replacetext(GLOB.create_object_html, "$ATOM$", "Object")
 		GLOB.create_object_html = replacetext(GLOB.create_object_html, "null /* object types */", "\"[objectjs]\"")
 
 	user << browse(replacetext(GLOB.create_object_html, "/* ref src */", UID()), "window=create_object;size=425x475")
@@ -17,6 +18,7 @@ GLOBAL_LIST_INIT(create_object_forms, list(/obj, /obj/structure, /obj/machinery,
 	if(!html_form)
 		var/objectjs = jointext(typesof(path), ";")
 		html_form = file2text('html/create_object.html')
+		html_form = replacetext(html_form, "$ATOM$", "Object")
 		html_form = replacetext(html_form, "null /* object types */", "\"[objectjs]\"")
 		GLOB.create_object_forms[path] = html_form
 

--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -1,9 +1,11 @@
 GLOBAL_VAR(create_turf_html)
+
 /datum/admins/proc/create_turf(mob/user)
 	if(!GLOB.create_turf_html)
 		var/turfjs = null
 		turfjs = jointext(typesof(/turf), ";")
 		GLOB.create_turf_html = file2text('html/create_object.html')
+		GLOB.create_turf_html = replacetext(GLOB.create_turf_html, "$ATOM$", "Turf")
 		GLOB.create_turf_html = replacetext(GLOB.create_turf_html, "null /* object types */", "\"[turfjs]\"")
 
 	user << browse(replacetext(GLOB.create_turf_html, "/* ref src */", UID()), "window=create_turf;size=425x475")

--- a/html/create_object.html
+++ b/html/create_object.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-  <title>Create Object</title>
+  <title>Create $ATOM$</title>
   <style type="text/css">
     body
     {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Makes the window title of the 'Game Panel' spawn menu change based on the atom type being spawned.
So `Create Mob` or `Create Turf`, rather than just `Create Object` for everything.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Very very minor QOL improvement, since personally I've lost a surprising amount of time in the past after forgetting what window I was in, or pressing 'Create Turf' rather than 'Create Mob' by accident and not realising.

To be honest there's a good chance that I'm the only one who's ever even noticed this, but it's been bugging me very slightly for a few months now so I figured there's no harm in just making a PR to change it.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
<details>
<summary><b>Before:</b></summary>

**Object:**
![obj before](https://user-images.githubusercontent.com/57483089/133695001-d101470a-6f67-4170-bc78-b5bc9170cff0.png)
**Mob:**
![mob before](https://user-images.githubusercontent.com/57483089/133695015-631e961f-a22e-4067-b516-aaf730ffed50.png)
**Turf:**
![turf before](https://user-images.githubusercontent.com/57483089/133695514-f0ffcd20-372a-4cd5-9c14-c38f2701a502.png)

</details>

<details>
<summary><b>After:</b></summary>

**Object:**
![obj after](https://user-images.githubusercontent.com/57483089/133695076-96d13222-411b-4998-9456-c43626235582.png)
**Mob:**
![mob after](https://user-images.githubusercontent.com/57483089/133695080-e7c79557-af6d-4725-af50-f194ed764ea7.png)
**Turf:**
![turf after](https://user-images.githubusercontent.com/57483089/133695519-446ced86-4377-4fe7-8f60-2129a93832ca.png)

</details>

## Changelog
:cl:
tweak: Tweaked the title of the admin 'Game Panel' window to better show what atom type is being spawned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
