### PR TITLE
Adds blobs to the AntagHUD orbit menu, Attempt 2

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -27,6 +27,7 @@
 	var/mob/living/simple_animal/mouse/blobinfected/B = new(vent.loc)
 	var/mob/M = pick(candidates)
 	B.key = M.key
+	B.mind.special_role = SPECIAL_ROLE_BLOB
 	SSticker.mode.update_blob_icons_added(B.mind)
 
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -31,10 +31,6 @@
 			update_static_data(owner, ui)
 			. = TRUE
 
-/datum/orbit_menu/ui_data(mob/user)
-	var/list/data = list()
-	return data
-
 /datum/orbit_menu/ui_static_data(mob/user)
 	var/list/data = list()
 
@@ -96,6 +92,7 @@
 					)
 					if(SSticker && SSticker.mode)
 						other_antags += list(
+							"Blob" = (mind.special_role == SPECIAL_ROLE_BLOB),
 							"Cultist" = (mind in SSticker.mode.cult),
 							"Wizard" = (mind in SSticker.mode.wizards),
 							"Wizard's Apprentice" = (mind in SSticker.mode.apprentices),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds blobs to the orbit menu if AntagHUD is enabled.
The original attempt of this in #16520 failed primarily because #16459 hadn't been merged when I was testing it, and I didn't think to manually enable AntagHUD and check the orbit menu with no antagonists.

To avoid that in this PR, I've tested and provided screenshots for the following:

AntagHUD **off** with no antagonists.
AntagHUD **off** with a blob.
AntagHUD **off** with a traitor.
AntagHUD **off** with a blob and a traitor.

AntagHUD **on** with no antagonists.
AntagHUD **on** with a blob.
AntagHUD **on** with a traitor.
AntagHUD **on** with a blob and a traitor.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
No more having to guess if it's an extended or blob round, and makes it easier for observers to track blob infected mice.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
<details>
<summary><b>AntagHUD off:</b></summary>

**No antagonists:**
![Antaghud off, no antags](https://user-images.githubusercontent.com/57483089/133885605-212b6fc9-e6d1-490b-be50-a9bd87bc8e9b.png)
**Blob antagonist:**
![Antaghud off, blob](https://user-images.githubusercontent.com/57483089/133885615-1995c498-db15-40ae-a4d0-49d437fe8e5f.png)
**Unrelated antagonist:**
![Antaghud off, unrelated antag](https://user-images.githubusercontent.com/57483089/133885806-c6dda5d5-768a-451d-824f-9177a1aefe42.png)
**Unrelated antagonist & Blob antagonist:**
![9PbTeUtdHe](https://user-images.githubusercontent.com/57483089/133886001-7ee752a1-148e-4bef-85be-3f29e1c34bf0.png)
</details>

<details>
<summary><b>AntagHUD on:</b></summary>

**No antagonists:**
![Antaghud on, no antags](https://user-images.githubusercontent.com/57483089/133885619-39dd6355-9c51-402a-9600-1e30b5208fe6.png)
**Blob antagonist:**
![Antaghud on, blob](https://user-images.githubusercontent.com/57483089/133885624-3b0cc5b6-d27e-4dba-bed5-09878039c81d.png)
**Unrelated antagonist:**
![Antaghud on, unrelated antag](https://user-images.githubusercontent.com/57483089/133885820-6d6f4799-f71d-4d9b-940f-870cdf4569d4.png)
**Unrelated antagonist & Blob antagonist:**
![8ZC4R9TAEA](https://user-images.githubusercontent.com/57483089/133886002-5d2d67c2-aae1-4bdb-8da2-9aa24a0242ca.png)
</details>

## Changelog
:cl:
add: Added Blob-infected players and mice to the 'Antagonist' orbit menu if AntagHUD is enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
