### PR TITLE
Adds Revenants to the orbit menu antag list

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -121,6 +121,10 @@
 					var/list/antag_serialized = serialized.Copy()
 					antag_serialized["antag"] = "Terror Spider"
 					antagonists += list(antag_serialized)
+				else if(istype(M, /mob/living/simple_animal/revenant))
+					var/list/antag_serialized = serialized.Copy()
+					antag_serialized["antag"] = "Revenant"
+					antagonists += list(antag_serialized)
 		else
 			misc += list(serialized)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Gives Revenants their own category in the orbit menu 'Antagonists' section.
(#16520)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Revenants are already easily visible in the orbit menu (see the 'Alive' section below), so this just makes it a bit more convenient.
Arguably it's not actually needed at all thanks to the `[revenant]` in the name, but the same could be said for terror spiders, swarmers, etc. Revenants are also definitely antags, so it makes sense for them to be put into the 'Antagonists' section.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![TIO6qtrHsa](https://user-images.githubusercontent.com/57483089/133895136-114b931e-6d6e-4f6c-9d72-2d336bc517b5.png)

## Changelog
:cl:
add: Made Revenants always show in the 'Antagonists' orbit menu, similar to Terror Spiders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
