### PR TITLE
Suit storage units drop their contents when destroyed

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -284,11 +284,6 @@
 
 /obj/machinery/suit_storage_unit/Destroy()
 	SStgui.close_uis(wires)
-	QDEL_NULL(suit)
-	QDEL_NULL(helmet)
-	QDEL_NULL(mask)
-	QDEL_NULL(boots)
-	QDEL_NULL(storage)
 	QDEL_NULL(wires)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This tweaks the suit storage units so they don't delete their contents when destroyed and drop them on the floor instead.

## Why It's Good For The Game
Technically fixes #16413. Seems it was originally as designed, but didn't match with other machinery or containers nor did it make sense.

## Images of changes
https://user-images.githubusercontent.com/80771500/133913205-225b19e9-3553-43b8-8508-84407a5e96a2.mp4

## Changelog
:cl:
tweak: Destroyed suit storage units drop their contents instead of actively deleting them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
