### PR TITLE
Display the type(s) of selected antags an antag might be in player panel

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -662,6 +662,74 @@ GLOBAL_VAR_INIT(nologevent, 0)
 
 	return 0
 
+/**
+  * A proc that return an array of capitalized strings containing name of the antag types they are
+  *
+  * you'll get something like
+  *
+  * Arguments:
+  * * M - the mob you're checking
+  * *
+  */
+/proc/get_antag_type_strings_list(mob/M as mob) // return an array of all the antag types they are with name
+	var/list/antag_list = new/list()
+
+	if(!SSticker || !SSticker.mode)
+		return 0
+	if(!istype(M))
+		return 0
+	if(M.mind in SSticker.mode.head_revolutionaries)
+		antag_list += "Head Rev"
+	if(M.mind in SSticker.mode.revolutionaries)
+		antag_list += "Revolutionary"
+	if(M.mind in SSticker.mode.cult)
+		antag_list += "Cultist"
+	if(M.mind in SSticker.mode.syndicates)
+		antag_list += "Nuclear Operative"
+	if(M.mind in SSticker.mode.wizards)
+		antag_list += "Wizard"
+	if(M.mind in SSticker.mode.changelings)
+		antag_list += "Changeling"
+	if(M.mind in SSticker.mode.abductors)
+		antag_list += "Abductor"
+	if(M.mind in SSticker.mode.vampires)
+		antag_list += "Vampire"
+	if(M.mind in SSticker.mode.vampire_enthralled)
+		antag_list += "Vampire Thrall"
+	if(M.mind in SSticker.mode.shadows)
+		antag_list += "Shadowling"
+	if(M.mind in SSticker.mode.shadowling_thralls)
+		antag_list += "Shadowling Thrall"
+	if(M.mind.has_antag_datum(/datum/antagonist/traitor))
+		antag_list += "Traitor"
+	if(M.mind.has_antag_datum(/datum/antagonist/mindslave))
+		antag_list += "Mindslave"
+	if(isrobot(M))
+		var/mob/living/silicon/robot/R = M
+		if(R.emagged)
+			antag_list += "Emagged Borg"
+	if(!length(antag_list) && M.mind.special_role) // Snowflake check. If none of the above but still special, then other antag. Technically not accurate.
+		antag_list += "Other Antag(s)"
+	return antag_list
+
+/**
+  * A proc that return a string containing all the singled out antags . Empty string if not antag
+  *
+  * Usually, you'd return a FALSE, but since this is consumed by javascript you're in
+  * for a world of hurt if you pass a byond FALSE which get converted into a fucking string anyway and pass for TRUE in check. Fuck.
+  * It always append "(May be other antag)"
+  * Arguments:
+  * * M - the mob you're checking
+  * *
+  */
+/proc/get_antag_type_truncated_plaintext_string(mob/M as mob)
+	var/list/antag_list = get_antag_type_strings_list(M)
+
+	if(length(antag_list))
+		return antag_list.Join(" &amp; ") + " " + "(May be other antag)"
+
+	return ""
+
 /datum/admins/proc/spawn_atom(object as text)
 	set category = "Debug"
 	set desc = "(atom path) Spawn an atom"

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -65,7 +65,7 @@
 
 				}
 
-				function expand(id,job,name,real_name,image,key,ip,antagonist,mobUID,client_ckey,eyeUID){
+				function expand(id,job,name,real_name,image,key,ip,antagonists,mobUID,client_ckey,eyeUID){
 
 					clearAll();
 
@@ -89,8 +89,8 @@
 					if(eyeUID)
 						body += "|<a href='?src=[UID()];adminplayerobservefollow="+eyeUID+"'>EYE</a>"
 					body += "<br>"
-					if(antagonist > 0)
-						body += "<font size='2'><a href='?src=[UID()];check_antagonist=1'><font color='red'><b>Antagonist</b></font></a></font>";
+					if(antagonists)
+						body += "<font size='2'><a href='?src=[UID()];check_antagonist=1'><font color='red'><b>"+antagonists+"</b></font></a></font>";
 
 					body += "</td></tr></table>";
 
@@ -227,7 +227,7 @@
 			var/color = "#e6e6e6"
 			if(i%2 == 0)
 				color = "#f2f2f2"
-			var/is_antagonist = is_special_character(M)
+			var/antagonist_string = get_antag_type_truncated_plaintext_string(M)
 
 			var/M_job = ""
 
@@ -305,7 +305,7 @@
 					<td align='center' bgcolor='[color]'>
 						<span id='notice_span[i]'></span>
 						<a id='link[i]'
-						onmouseover='expand("item[i]","[M_job]","[M_name]","[M_rname]","--unused--","[M_key]","[M.lastKnownIP]",[is_antagonist],"[M.UID()]","[client_ckey]","[M_eyeUID]")'
+						onmouseover='expand("item[i]","[M_job]","[M_name]","[M_rname]","--unused--","[M_key]","[M.lastKnownIP]","[antagonist_string]","[M.UID()]","[client_ckey]","[M_eyeUID]")'
 						>
 						<b id='search[i]'>[M_name] - [M_rname] - [M_key] ([M_job])</b>
 						</a>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Instead of displaying "Antagonist" if someone is an antagonist, it display the type of antags they are, though it only display the most common types there are, and other antags is lumped under the "Other Antag(s)" category, because of how special_role work under the hood. 

If they are an antag, "(May be other antag) is appended to the display **no matter what**, to prevent an admin from being confused if they turn out to be more than that antag. This preserve the correctness of "Antagonist" but add preciseness to the display. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Make it much easier for admins to see what kind of relevant antag a person is in the player panel. 

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->



Sane Case:
![dreamseeker_Y0ogwhEgtN](https://user-images.githubusercontent.com/40092670/133915644-bc496920-65df-4fc7-b37e-9737e5b564ae.png)

Event Antag:
![dreamseeker_lYjPPhSY51](https://user-images.githubusercontent.com/40092670/133915656-7be8fae7-968f-4fc3-b94e-52ba1bf63da3.png)

Insane Case just for Lulz:
![dreamseeker_gZ0U8zKodQ](https://user-images.githubusercontent.com/40092670/133915653-83ac1822-ef7a-4f09-937f-0682bb939876.png)


## Changelog
:cl:
add: Player Panel now display what type of antagonist an antag is, but limited to the most common antag types due to code limitation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
