### PR TITLE
Metastation various fixes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -42897,6 +42897,10 @@
 /obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
+/obj/machinery/ticket_machine{
+	layer = 4;
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room{
 	name = "\improper Command Hallway"
@@ -42924,10 +42928,6 @@
 	},
 /obj/effect/decal/warning_stripes/arrow,
 /obj/effect/decal/warning_stripes/yellow/partial,
-/obj/machinery/ticket_machine{
-	layer = 4;
-	pixel_x = -32
-	},
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room{
 	name = "\improper Command Hallway"
@@ -44244,16 +44244,6 @@
 /area/security/vacantoffice)
 "bPS" = (
 /obj/effect/decal/warning_stripes/southeast,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -46735,8 +46725,8 @@
 "bVd" = (
 /obj/structure/table/wood,
 /obj/item/folder,
-/obj/item/stamp/centcom,
 /obj/item/pen/multi/fountain,
+/obj/item/stamp/rep,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "bVe" = (
@@ -47124,11 +47114,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -47313,11 +47298,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/teleporter{
@@ -47463,18 +47443,12 @@
 	name = "E.V.A. Storage"
 	})
 "bWB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
 "bWC" = (
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"
@@ -47509,7 +47483,6 @@
 	name = "\improper Teleporter Room"
 	})
 "bWF" = (
-/obj/structure/cable/yellow,
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -47607,11 +47580,6 @@
 /obj/item/clothing/mask/gas,
 /obj/structure/table,
 /obj/item/radio/off,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/teleporter{
@@ -51638,7 +51606,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
 "cfM" = (
@@ -52450,6 +52417,9 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -52467,6 +52437,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -52681,6 +52657,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53366,6 +53344,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -56119,6 +56099,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -56868,6 +56850,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -57813,13 +57797,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -60214,6 +60194,10 @@
 	name = "privacy shutters";
 	opacity = 0
 	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "cyt" = (
@@ -60523,6 +60507,16 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery 1 North"
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -60554,6 +60548,11 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -60720,6 +60719,11 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/accessory/stethoscope,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -60746,6 +60750,11 @@
 /obj/item/folder/white,
 /obj/item/stamp/cmo,
 /obj/item/clothing/glasses/hud/health,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -61593,12 +61602,27 @@
 	name = "Chief Medical Officer's Office";
 	req_access_txt = "40"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
 	},
 /area/medical/cmo)
 "cBs" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -61608,6 +61632,11 @@
 /obj/effect/landmark/start{
 	name = "Chief Medical Officer"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -61615,6 +61644,16 @@
 /area/medical/cmo)
 "cBu" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -67403,6 +67442,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -67417,6 +67466,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69323,6 +69377,7 @@
 	pixel_x = -24
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -74229,20 +74284,15 @@
 /turf/simulated/wall,
 /area/medical/surgeryobs)
 "dbv" = (
-/obj/structure/sign/biohazard{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreen"
+	icon_state = "white"
 	},
-/area/maintenance/aft)
+/area/medical/medbay2{
+	name = "Medbay Storage"
+	})
 "dbw" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -76905,6 +76955,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "ebA" = (
@@ -79330,6 +79381,15 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"lrA" = (
+/obj/structure/sign/biohazard{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/maintenance/aft)
 "lwN" = (
 /obj/effect/spawner/lootdrop{
 	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
@@ -80326,6 +80386,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"pcN" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "cmoprivacy";
+	name = "privacy shutters";
+	opacity = 0
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/plating,
+/area/medical/cmo)
 "pcW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80386,6 +80458,10 @@
 	opacity = 0
 	},
 /obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "pjn" = (
@@ -104258,7 +104334,7 @@ chy
 bZU
 cZv
 day
-cZv
+lrA
 bZU
 cQx
 bZU
@@ -104515,7 +104591,7 @@ cNZ
 cKV
 cZq
 dax
-dbv
+cZq
 deg
 cSl
 cRj
@@ -105012,7 +105088,7 @@ cxt
 csJ
 cys
 cMP
-cys
+pcN
 csJ
 csJ
 cFd
@@ -105255,7 +105331,7 @@ ccD
 cdT
 chU
 cjt
-cjt
+dbv
 cjt
 cjt
 cLT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Various fixes. All tested in game.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runetimes bad and consistency good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![medbay storage atmos clear](https://user-images.githubusercontent.com/62257265/133927568-6edd106b-4eaf-4f62-aabe-63c91e96de18.png)

![medbay storage atmos](https://user-images.githubusercontent.com/62257265/133927640-315295af-9789-4c5c-968c-b3ec28f40aa5.png)
Medbay storage room now has atmos.


![cmo wires](https://user-images.githubusercontent.com/62257265/133927580-35e15201-7167-4855-91e2-91759260c1d5.png)
CMO's office reinforced windows are now electrified.

![turbine double pipe](https://user-images.githubusercontent.com/62257265/133927599-0bfcb80f-4711-4c4e-ad6a-d471c7ccf501.png)
Removed a pipe under this airlock in incinerator that made runetimes.




![virobetter](https://user-images.githubusercontent.com/62257265/133927790-4f95da9f-f270-46bb-a935-0b3b718e8ea0.png)
This viro sign was on the floor but im not sure if its supposed to be there in the first place.


![surgery observation power](https://user-images.githubusercontent.com/62257265/133927624-9e238327-b901-4050-8974-c2f6c0c182eb.png)
Surgery observation room is now connected to the power grid.

**BEFORE**
![teleporter before](https://user-images.githubusercontent.com/62257265/133927722-3dffe139-5462-434f-b930-525edd8d4fb1.png)
**AFTER**
![remove useless wires in teleporter](https://user-images.githubusercontent.com/62257265/133927658-d469438a-7632-4baa-aba4-1b6d59bef64f.png)

Removing useless wires from the teleporter room.

![hop](https://user-images.githubusercontent.com/62257265/133927832-f823ebcd-4cde-4828-b843-7504693fc22d.png)
Moving HOP's ticket machine to the beginning of the line.





<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Connected medbay storage vent and scrubber to the station's supply and waste pipeline.
tweak: Moved misplaced viro sign.
tweak: Moved HOP's ticket machine from the end of the line to the beginning.
tweak: Windows in CMO's office are now electrified.
tweak: Replaces CC stamp with NTR stamp in NTR's office.
del: Removed cables with no purpose in teleporter room.
del: Removed a duplicate pipe in incinerator that made runetimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
