### PR TITLE
Adds a limit of 5 crates per round to null crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -55,6 +55,10 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	var/list/announce_beacons = list() // Particular beacons that we'll notify the relevant department when we reach
 	var/special = FALSE //Event/Station Goals/Admin enabled packs
 	var/special_enabled = FALSE
+	/// The number of times one can order a cargo crate, before it becomes restricted. -1 for infinite
+	var/order_limit = -1
+	/// Number of times a crate has been ordered in a shift
+	var/times_ordered = 0
 	/// List of names for being done in TGUI
 	var/list/ui_manifest = list()
 
@@ -200,6 +204,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	containertype = /obj/structure/closet/crate
 	containername = "crate"
 	hidden = 1
+	order_limit = 5
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Security ////////////////////////////////////////

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -521,17 +521,20 @@
 				visible_message("<b>[src]</b>'s monitor flashes, \"[world.time - reqtime] seconds remaining until another requisition form may be printed.\"")
 				return
 
+			var/datum/supply_packs/P = locateUID(params["crate"])
+			if(!istype(P))
+				return
+
+			if(P.times_ordered >= P.order_limit && P.order_limit != -1) //If the crate has reached the limit, do not allow it to be ordered.
+				to_chat(usr, "<span class='warning'>[P.name] is out of stock, and can no longer be ordered.</span>")
+				return
+
 			var/amount = 1
 			if(params["multiple"] == "1") // 1 is a string here. DO NOT MAKE THIS A BOOLEAN YOU DORK
 				var/num_input = input(usr, "Amount", "How many crates? (20 Max)") as null|num
 				if(!num_input || (!is_public && !is_authorized(usr)) || ..()) // Make sure they dont walk away
 					return
 				amount = clamp(round(num_input), 1, 20)
-
-
-			var/datum/supply_packs/P = locateUID(params["crate"])
-			if(!istype(P))
-				return
 
 			var/timeout = world.time + 600 // If you dont type the reason within a minute, theres bigger problems here
 			var/reason = input(usr, "Reason", "Why do you require this item?","") as null|text
@@ -573,10 +576,13 @@
 				if(SO.ordernum == ordernum)
 					O = SO
 					P = O.object
-					if(SSshuttle.points >= P.cost)
+					if(P.times_ordered >= P.order_limit && P.order_limit != -1) //If this order would put it over the limit, deny it
+						to_chat(usr, "<span class='warning'>[P.name] is out of stock, and can no longer be ordered.</span>")
+					else if(SSshuttle.points >= P.cost)
 						SSshuttle.requestlist.Cut(i,i+1)
 						SSshuttle.points -= P.cost
 						SSshuttle.shoppinglist += O
+						P.times_ordered += 1
 						investigate_log("[key_name(usr)] has authorized an order for [P.name]. Remaining points: [SSshuttle.points].", "cargo")
 					else
 						to_chat(usr, "<span class='warning'>There are insufficient supply points for this request.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds an times_ordered variable and order_limit variable to supply crates. Times ordered is increased each time a specific crate is ordered. order_limit is the number of times a crate can be ordered (and approved) before the supply of the crate runs out. All crates but one have a limit of -1, meaning they can be ordered endlessly. These variables can be changed by admins through var edit, allowing crates to be restricted or limited for an event.

Adds a order limit of 5 to null crates, allowing at most 5 to be ordered during a shift.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Null crates are strong. With purely just points from rnd, you can order 10-12 crates. Add in say, 200 plasma, and that is another 7 crates. It is quite easy to get an insane amount of items, and even TC, from these crates. All you have to do is order them, and hope no one notices for 2 minutes, and you are home free. As such, this PR limits them to 5 at most.

**"Why not just increase the price?"**

I could increase the base price, however eventually we are moving to tech webs, which will reduce the points cargo gets. While this could lower the amount of crates order, plasma still exists. I also don't want to prevent crates from being ordered at all, if mining is poor. As such, as there is no clear good number to increase it to, I thought a limit is better.

**"Why not make the price scale as more crates are ordered?"**

I considered this as well. Another potential alternative, make the crate scale up in price by a number each time one is ordered.

However, not sure how well that would work with multiple crates being ordered at once, and might confuse people when they order 3 crates for 100, but when they go to approve, they pay 450 total, or something.  As such, a flat limit seemed better.


**"Why not nerf what is in the crates?"**

Theoretically, crates could be changed to use 10 TC worth of random items. However, not sure if that is better or not, to be honest. It feels like you would get the same things over and over again, or get something like a trick revolver, 2 flags, and a cham toolbelt, or something. As such, I chose to keep the crates functioning as they currently do, while adding the limit.

## Changelog
:cl:
add: Supply packs can now have a limit of how many times it can be ordered in a round.
add: Null crates can now only be ordered 5 times in a round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
