### PR TITLE
Applies more fixes to DeltaStation

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -42060,18 +42060,16 @@
 /area/security/detectives_office)
 "bPp" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
+/obj/item/flashlight/lamp,
+/obj/item/reagent_containers/food/drinks/flask/detflask,
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
 "bPq" = (
-/obj/structure/table/wood,
-/obj/item/storage/secure/safe{
-	pixel_x = 32
+/obj/machinery/computer/security/wooden_tv{
+	network = list("SS13","Research Outpost","Mining Outpost")
 	},
-/obj/item/flashlight/lamp,
-/obj/item/reagent_containers/food/drinks/flask/detflask,
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
@@ -89270,14 +89268,13 @@
 	},
 /area/medical/virology)
 "dMA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/storage/secure/safe{
+	pixel_x = 32
 	},
-/obj/machinery/computer/rdconsole/robotics,
-/obj/structure/window/reinforced/polarized,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "dMB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89878,8 +89875,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/machinery/computer/rdconsole/robotics,
 /obj/structure/window/reinforced/polarized,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -90158,20 +90154,15 @@
 	},
 /area/hallway/secondary/exit)
 "dOD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/maintenance/starboardsolar)
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/structure/window/reinforced/polarized,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "dOE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -90187,19 +90178,20 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "dOF" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
 	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/medical/virology)
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/maintenance/starboardsolar)
 "dOG" = (
 /obj/machinery/light{
 	dir = 8
@@ -91015,8 +91007,8 @@
 "dQv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -91139,14 +91131,18 @@
 	},
 /area/medical/virology)
 "dQH" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreen"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
+/turf/simulated/floor/plating,
 /area/medical/virology)
 "dQI" = (
 /obj/effect/decal/warning_stripes/north,
@@ -91402,14 +91398,14 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/portsolar)
 "dRf" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreen"
+	},
 /area/medical/virology)
 "dRg" = (
 /obj/structure/cable{
@@ -95771,8 +95767,8 @@
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
@@ -97473,6 +97469,16 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
+"nGA" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "nGL" = (
 /obj/machinery/bodyscanner{
 	dir = 4
@@ -138619,7 +138625,7 @@ dqm
 dsL
 dvl
 dui
-dMA
+dOc
 dvp
 dam
 dFw
@@ -138876,7 +138882,7 @@ dsH
 due
 dvm
 dws
-dOc
+dOD
 dav
 dav
 dyR
@@ -147116,7 +147122,7 @@ dLd
 dLY
 dIW
 abj
-dOF
+dQv
 dIc
 dFG
 dFI
@@ -147379,7 +147385,7 @@ dLR
 dMw
 dNj
 dRg
-dRf
+hMu
 abj
 aaa
 aaa
@@ -147887,13 +147893,13 @@ dHa
 dFG
 dFG
 aaa
-dQv
+dQH
 dNW
 deV
 dMy
 dNl
 dRi
-hMu
+nGA
 aaa
 aaa
 aaa
@@ -148403,7 +148409,7 @@ abj
 abj
 dFG
 dNY
-dQH
+dRf
 dMz
 dNn
 dWT
@@ -149096,7 +149102,7 @@ aaa
 aaa
 bFS
 bHP
-dDN
+dMA
 bLu
 bNu
 bPq
@@ -159695,7 +159701,7 @@ aaa
 dij
 aaa
 dak
-dOD
+dOF
 dbc
 aaa
 dak
@@ -159703,7 +159709,7 @@ daT
 dbc
 aaa
 dak
-dOD
+dOF
 dbc
 aaa
 dij
@@ -159956,7 +159962,7 @@ aaa
 aaa
 aaa
 dak
-dOD
+dOF
 dbc
 aaa
 aaa

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -622,7 +622,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "afm" = (
 /obj/structure/cable{
@@ -650,7 +650,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "afn" = (
 /obj/structure/cable{
@@ -664,7 +664,7 @@
 	name = "Engineering External Access";
 	req_access_txt = "10;13"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "afw" = (
 /obj/docking_port/stationary{
@@ -13078,7 +13078,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "aJL" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -13105,7 +13105,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "aJM" = (
 /obj/structure/cable{
@@ -13431,7 +13431,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "aKp" = (
 /obj/structure/table/wood,
@@ -26332,7 +26332,7 @@
 /area/security/hos)
 "bkp" = (
 /obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine/longrange{
+/obj/machinery/photocopier/faxmachine{
 	department = "Head of Security's Office"
 	},
 /turf/simulated/floor/plasteel{
@@ -32943,7 +32943,6 @@
 	},
 /area/bridge)
 "bxv" = (
-/obj/machinery/computer/atmos_alert,
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -46759,7 +46758,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
 /area/magistrateoffice)
 "bYQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -73646,7 +73647,12 @@
 	},
 /area/library/abandoned)
 "deV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen"
 	},
@@ -86213,6 +86219,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
+/obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/button/windowtint{
 	id = 1;
 	pixel_x = 24
@@ -88343,33 +88350,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "dKz" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
 	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/medical/virology)
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/maintenance/auxsolarstarboard)
 "dKA" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/medical/virology)
+/obj/item/stack/cable_coil/random,
+/turf/space,
+/area/space)
 "dKB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -88985,11 +88983,21 @@
 	},
 /area/medical/virology)
 "dLR" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
+/obj/structure/table/glass,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = -32
+	},
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen"
+	dir = 1;
+	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
 "dLT" = (
@@ -89174,12 +89182,37 @@
 	icon_state = "4-8";
 	tag = ""
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/machinery/smartfridge/secure/chemistry/virology/preloaded,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/medical/virology)
+"dMx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"dMx" = (
+"dMy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -89206,26 +89239,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"dMy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/virology)
 "dMz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89241,12 +89254,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -89259,22 +89266,10 @@
 	},
 /area/medical/virology)
 "dMA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreencorner"
-	},
-/area/medical/virology)
+/obj/structure/lattice,
+/obj/item/stack/cable_coil/random,
+/turf/space,
+/area/space/nearstation)
 "dMB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89361,19 +89356,17 @@
 	},
 /area/medical/virology)
 "dMG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /obj/structure/table/glass,
-/obj/item/folder/white,
-/obj/item/pen/red,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/machinery/requests_console{
-	department = "Virology";
-	departmentType = 3;
-	name = "Virology Requests Console";
-	pixel_y = 30
-	},
-/obj/effect/decal/warning_stripes/south,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreencorner"
@@ -89537,20 +89530,45 @@
 	},
 /area/hallway/secondary/exit)
 "dNi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/pen/red,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
 	},
-/obj/machinery/computer/pandemic,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/requests_console{
+	department = "Virology";
+	departmentType = 3;
+	name = "Virology Requests Console";
+	pixel_y = 30
+	},
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
 "dNj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/dropper,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreencorner"
+	},
+/area/medical/virology)
+"dNk" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -89562,7 +89580,7 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"dNk" = (
+"dNl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -89575,7 +89593,7 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"dNl" = (
+"dNm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -89584,19 +89602,7 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"dNm" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/medical/virology)
 "dNn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreen"
@@ -89806,6 +89812,20 @@
 /turf/space,
 /area/space)
 "dNW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/computer/pandemic,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitegreencorner"
+	},
+/area/medical/virology)
+"dNX" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -89813,7 +89833,7 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"dNX" = (
+"dNY" = (
 /obj/machinery/light{
 	dir = 1;
 	on = 1
@@ -89834,19 +89854,6 @@
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
-"dNY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitegreencorner"
-	},
-/area/medical/virology)
 "dNZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -89862,21 +89869,18 @@
 "dOc" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
+	d2 = 8;
+	icon_state = "1-8";
 	tag = ""
 	},
-/obj/structure/table/glass,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = -32
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/reagentgrinder,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreencorner"
-	},
-/area/medical/virology)
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/maintenance/starboardsolar)
 "dOd" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90157,6 +90161,20 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
+"dOE" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4";
@@ -90164,23 +90182,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"dOE" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/medical/virology)
 "dOF" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
 /obj/structure/cable{
-	d1 = 1;
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
@@ -90998,26 +91010,11 @@
 /area/medical/surgery2)
 "dQv" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/machinery/smartfridge/secure/chemistry/virology/preloaded,
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
@@ -91134,24 +91131,14 @@
 	},
 /area/medical/virology)
 "dQH" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreencorner"
-	},
+/turf/simulated/floor/plating,
 /area/medical/virology)
 "dQI" = (
 /obj/effect/decal/warning_stripes/north,
@@ -91218,7 +91205,7 @@
 	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "dQM" = (
 /obj/structure/cable{
@@ -91407,6 +91394,16 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/portsolar)
 "dRf" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
+"dRg" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -91422,7 +91419,7 @@
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
-"dRg" = (
+"dRh" = (
 /obj/structure/table/glass,
 /obj/structure/sign/deathsposal{
 	pixel_y = -32
@@ -91434,7 +91431,7 @@
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
-"dRh" = (
+"dRi" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -91449,13 +91446,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitegreencorner"
-	},
-/area/medical/virology)
-"dRi" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "dRj" = (
@@ -92359,11 +92349,7 @@
 	},
 /area/chapel/office)
 "dTu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen"
 	},
@@ -92378,20 +92364,14 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreen"
+	icon_state = "white"
 	},
 /area/medical/virology)
 "dTw" = (
@@ -93532,22 +93512,15 @@
 /area/hallway/primary/central)
 "dWS" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/machinery/light,
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitegreencorner"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "dWT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/machinery/light,
+/obj/machinery/status_display{
+	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -95581,11 +95554,8 @@
 	},
 /area/security/seceqstorage)
 "hbU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen"
@@ -95787,16 +95757,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery1)
-"hMu" = (
-/obj/machinery/power/solar{
-	name = "Aft Starboard Solar Panel"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/space,
-/area/maintenance/starboardsolar)
 "hOL" = (
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -97494,13 +97454,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
-"nGA" = (
-/obj/machinery/power/solar{
-	name = "Aft Starboard Solar Panel"
-	},
-/obj/structure/cable,
-/turf/space,
-/area/maintenance/starboardsolar)
 "nGL" = (
 /obj/machinery/bodyscanner{
 	dir = 4
@@ -121329,7 +121282,7 @@ abj
 ash
 atL
 atY
-abj
+dMA
 dij
 abj
 abj
@@ -128916,7 +128869,7 @@ aaa
 aaa
 abj
 aaa
-aaa
+dKA
 dTV
 dYP
 dVn
@@ -145952,7 +145905,7 @@ dij
 abj
 dij
 dij
-aaa
+dKA
 aaa
 abj
 aaa
@@ -146887,13 +146840,13 @@ dFG
 dFG
 dFG
 aaa
-dKz
-dIc
-dFG
-dFI
-dFG
-dFH
-dOD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -147144,12 +147097,12 @@ dLd
 dLY
 dIW
 abj
-dFJ
-dMA
-dOc
-dQv
-dQH
-dRf
+dOD
+dIc
+dFG
+dFI
+dFG
+dFH
 dOE
 abj
 aaa
@@ -147401,13 +147354,13 @@ dLQ
 dMa
 dFG
 aaa
-dFG
+dFJ
 dMG
 dLR
 dMw
 dNj
 dRg
-dFG
+dQH
 abj
 aaa
 aaa
@@ -147658,13 +147611,13 @@ dLU
 dMv
 dIX
 abj
-dKA
+dFG
 dNi
 hbU
 dMx
 dNk
 dRh
-dOF
+dFG
 aaa
 aaa
 aaa
@@ -147915,13 +147868,13 @@ dHa
 dFG
 dFG
 aaa
-dKB
+dOF
 dNW
 deV
 dMy
 dNl
 dRi
-dKB
+dRf
 aaa
 aaa
 aaa
@@ -148172,13 +148125,13 @@ dHb
 dFG
 aaa
 aaa
-dFG
+dKB
 dNX
 dTu
 dTv
 dNm
 dWS
-dFG
+dKB
 abj
 aaa
 aaa
@@ -148429,13 +148382,13 @@ dHc
 dIc
 abj
 abj
-dFH
+dFG
 dNY
-hbU
+dQv
 dMz
 dNn
 dWT
-dIc
+dFG
 aaa
 aaa
 aaa
@@ -149548,7 +149501,7 @@ aaa
 dij
 aaa
 kYo
-acj
+dKz
 aco
 aaa
 kYo
@@ -149556,7 +149509,7 @@ acj
 aco
 aaa
 kYo
-acj
+dKz
 aco
 aaa
 abj
@@ -149809,13 +149762,13 @@ abj
 aaa
 aaa
 kYo
-acj
+dKz
 aco
 aaa
 aaa
 abj
 aaa
-aaa
+dKA
 dij
 aaa
 aaa
@@ -156385,9 +156338,9 @@ aaa
 abj
 aaa
 aaa
-hMu
-daC
-nGA
+dak
+daz
+dbc
 aaa
 aaa
 abj
@@ -156647,7 +156600,7 @@ daC
 dbc
 aaa
 dak
-daC
+daz
 dbc
 aaa
 abj
@@ -158445,7 +158398,7 @@ abj
 cTN
 abj
 abj
-abj
+dMA
 daG
 abj
 aaa
@@ -159723,7 +159676,7 @@ aaa
 dij
 aaa
 dak
-daT
+dOc
 dbc
 aaa
 dak
@@ -159731,7 +159684,7 @@ daT
 dbc
 aaa
 dak
-daT
+dOc
 dbc
 aaa
 dij
@@ -159984,7 +159937,7 @@ aaa
 aaa
 aaa
 dak
-daT
+dOc
 dbc
 aaa
 aaa

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -26652,25 +26652,26 @@
 	},
 /area/security/permabrig)
 "blf" = (
+/obj/structure/foodcart,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "blg" = (
-/obj/structure/foodcart,
+/obj/machinery/light,
+/obj/machinery/vending/dinnerware,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "blh" = (
-/obj/machinery/light,
-/obj/machinery/vending/dinnerware,
+/obj/machinery/icemachine,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bli" = (
@@ -26686,11 +26687,6 @@
 	},
 /area/crew_quarters/kitchen)
 "blj" = (
-/obj/machinery/icemachine,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/kitchen)
-"blk" = (
 /obj/structure/rack,
 /obj/item/storage/box/donkpockets,
 /obj/item/storage/box/donkpockets,
@@ -26698,12 +26694,16 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
-"bll" = (
+"blk" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/reagentgrinder,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/kitchen)
+"bll" = (
+/obj/machinery/kitchen_machine/candy_maker,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "blm" = (
@@ -81424,19 +81424,28 @@
 /obj/effect/landmark/start{
 	name = "Roboticist"
 	},
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "dvp" = (
-/obj/structure/window/reinforced/polarized,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/computer/rdconsole/robotics,
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced/polarized{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/assembly/robotics)
 "dvq" = (
-/obj/structure/window/reinforced/polarized,
-/obj/effect/decal/warning_stripes/southeast,
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/plasteel,
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/assembly/robotics)
 "dvr" = (
 /obj/structure/chair/office/light{
@@ -83213,7 +83222,7 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "dyO" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "dyP" = (
@@ -83240,12 +83249,20 @@
 	},
 /area/assembly/robotics)
 "dyT" = (
-/obj/structure/window/reinforced/polarized,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
-/turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/maintenance/auxsolarstarboard)
 "dyU" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -84633,9 +84650,6 @@
 /obj/item/bonegel,
 /obj/item/FixOVein,
 /obj/item/surgicaldrill,
-/obj/structure/mirror{
-	pixel_x = 32
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -88350,24 +88364,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "dKz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/maintenance/auxsolarstarboard)
-"dKA" = (
 /obj/item/stack/cable_coil/random,
 /turf/space,
 /area/space)
+"dKA" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil/random,
+/turf/space,
+/area/space/nearstation)
 "dKB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -89266,10 +89270,14 @@
 	},
 /area/medical/virology)
 "dMA" = (
-/obj/structure/lattice,
-/obj/item/stack/cable_coil/random,
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/computer/rdconsole/robotics,
+/obj/structure/window/reinforced/polarized,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "dMB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89867,20 +89875,15 @@
 	},
 /area/medical/surgery)
 "dOc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/maintenance/starboardsolar)
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/structure/window/reinforced/polarized,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "dOd" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90155,19 +90158,20 @@
 	},
 /area/hallway/secondary/exit)
 "dOD" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
 	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/medical/virology)
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/maintenance/starboardsolar)
 "dOE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -90185,8 +90189,8 @@
 "dOF" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -91009,14 +91013,18 @@
 	},
 /area/medical/surgery2)
 "dQv" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreen"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
+/turf/simulated/floor/plating,
 /area/medical/virology)
 "dQw" = (
 /obj/structure/disposalpipe/segment{
@@ -91131,14 +91139,14 @@
 	},
 /area/medical/virology)
 "dQH" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreen"
+	},
 /area/medical/virology)
 "dQI" = (
 /obj/effect/decal/warning_stripes/north,
@@ -91398,8 +91406,8 @@
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
@@ -93777,8 +93785,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/warning_stripes/southeast,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/window/reinforced/polarized,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "dXs" = (
@@ -95757,6 +95766,16 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery1)
+"hMu" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "hOL" = (
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -121282,7 +121301,7 @@ abj
 ash
 atL
 atY
-dMA
+dKA
 dij
 abj
 abj
@@ -128869,7 +128888,7 @@ aaa
 aaa
 abj
 aaa
-dKA
+dKz
 dTV
 dYP
 dVn
@@ -138600,7 +138619,7 @@ dqm
 dsL
 dvl
 dui
-dvn
+dMA
 dvp
 dam
 dFw
@@ -138857,8 +138876,8 @@ dsH
 due
 dvm
 dws
-dvn
-dyT
+dOc
+dav
 dav
 dyR
 dzY
@@ -145905,7 +145924,7 @@ dij
 abj
 dij
 dij
-dKA
+dKz
 aaa
 abj
 aaa
@@ -147097,7 +147116,7 @@ dLd
 dLY
 dIW
 abj
-dOD
+dOF
 dIc
 dFG
 dFI
@@ -147360,7 +147379,7 @@ dLR
 dMw
 dNj
 dRg
-dQH
+dRf
 abj
 aaa
 aaa
@@ -147868,13 +147887,13 @@ dHa
 dFG
 dFG
 aaa
-dOF
+dQv
 dNW
 deV
 dMy
 dNl
 dRi
-dRf
+hMu
 aaa
 aaa
 aaa
@@ -148384,7 +148403,7 @@ abj
 abj
 dFG
 dNY
-dQv
+dQH
 dMz
 dNn
 dWT
@@ -149501,7 +149520,7 @@ aaa
 dij
 aaa
 kYo
-dKz
+dyT
 aco
 aaa
 kYo
@@ -149509,7 +149528,7 @@ acj
 aco
 aaa
 kYo
-dKz
+dyT
 aco
 aaa
 abj
@@ -149762,13 +149781,13 @@ abj
 aaa
 aaa
 kYo
-dKz
+dyT
 aco
 aaa
 aaa
 abj
 aaa
-dKA
+dKz
 dij
 aaa
 aaa
@@ -158398,7 +158417,7 @@ abj
 cTN
 abj
 abj
-dMA
+dKA
 daG
 abj
 aaa
@@ -159676,7 +159695,7 @@ aaa
 dij
 aaa
 dak
-dOc
+dOD
 dbc
 aaa
 dak
@@ -159684,7 +159703,7 @@ daT
 dbc
 aaa
 dak
-dOc
+dOD
 dbc
 aaa
 dij
@@ -159937,7 +159956,7 @@ aaa
 aaa
 aaa
 dak
-dOc
+dOD
 dbc
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

- Shrinks Virology by a tile to allow pods onto certain escape shuttles
- Adds a missing floor tile underneath the Magistrate's Office Airlock
- Head of Security now has a regular fax machine
- Bridge has half the amount of atmospheric alert consoles
- Aft Starboard solar array has been completely installed now
- Some engineers left random cable coils hanging around after installing the solar arrays
- Removes floor tiles from solar array airlocks to make wiring easy, considering that they lead immediately to an area without floor tiles
- Robotics now has a bottle of space cleaner
- Robotics now also has a sink to wash their hands, at the adjustment of extending their surgical area by one tile
- Kitchen now has a candy maker
- Detective's Office now doesn't have a camera console that blocks stuff from access (fixes #16736 )
     - This also fixes the camera console to use the right network

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Map fixes!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Minor fixes, recommend opening in a map editor if you wish to view

## Changelog
:cl:
tweak: DeltaStation Virology downsized by a tile
fix: Fixed DeltaStation Aft Starboard solar array to have fully functioning tiles
add: Spare cable coils hanging around DeltaStation solar arrays
tweak: DeltaStation solar array airlocks don't have floor tiles now
tweak: DeltaStation Robotics now has space cleaner and a sink
fix: DeltaStation Bridge now only has one atmospheric alert console
tweak: Fixed the flooring on the DeltaStation Magistrate's Office
fix: DeltaStation HoS fax is no longer long range
tweak: DeltaStation Kitchen now has a candy maker
tweak: DeltaStation Detective's Office doesn't block off their flask with a camera console now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
