### PR TITLE
Allow the game to call votes whenever. Fixes the mapping vote not happening after a shuttle vote

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -209,7 +209,7 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, code_invoked = FALSE)
 	if(!mode)
-		if(started_time != null && !check_rights(R_ADMIN))
+		if(usr && started_time != null && !check_rights(R_ADMIN)) // Allow the game to call votes whenever. But check other callers
 			var/next_allowed_time = (started_time + GLOB.configuration.vote.vote_delay)
 			if(next_allowed_time > world.time)
 				return 0


### PR DESCRIPTION
## What Does This PR Do
Allows the game to call votes whenever. AKA when `usr` is null.

## Why It's Good For The Game
Allows the crew to vote if they want to leave and to vote what map they want to play next.

## Changelog
:cl:
fix: The game can now make votes whenever it wants. Fixes the mapping or any other vote not happening when another vote happened beforehand. Be it done triggered by admins or by the game itself
/:cl: