### PR TITLE
Removes Singularity Generator from DeltaStation

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -53751,7 +53751,7 @@
 /area/engine/engineering)
 "cog" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/the_singularitygen,
+/obj/machinery/the_singularitygen/tesla,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "coh" = (
@@ -53821,11 +53821,6 @@
 "coo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/engine/engine_smes)
-"cop" = (
-/obj/machinery/the_singularitygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/engine_smes)
 "coq" = (
@@ -55107,11 +55102,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"cqP" = (
-/obj/machinery/the_singularitygen/tesla,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/engine_smes)
 "cqQ" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
@@ -128267,8 +128257,8 @@ bXU
 bQr
 bQr
 clv
-cop
-cqP
+cnb
+cnb
 buB
 cso
 cuR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Removes the round start singularity generators on the DeltaStation, as it is currently causing major radiation issues, and moved the tesla ball generator to it's place from engineering's secure storage. Please note: this does not prevent them from ordering from supply, just removes the round start ones.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Radiation bugs be killer for the moment

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
del: Removes round start singularity generator from DeltaStation
tweak: Tesla ball generator now starts where the singularity generator was on DeltaStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
