### PR TITLE
Removes Catwalks from SM Pipes and other injectors around DeltaStation and MetaStation Engineering

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -8562,7 +8562,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "aAf" = (
@@ -8588,7 +8588,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "aAj" = (
@@ -9438,7 +9438,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "aBW" = (
@@ -10124,7 +10124,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "aDD" = (
@@ -10333,14 +10333,14 @@
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /turf/space,
 /area/engine/controlroom)
 "aEa" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "aEb" = (
@@ -13014,7 +13014,7 @@
 /area/security/permabrig)
 "aJy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "aJz" = (
@@ -123074,7 +123074,7 @@ aaa
 aaa
 aaa
 aaa
-acF
+vXX
 aHa
 aIu
 aJN
@@ -123841,7 +123841,7 @@ aAi
 ayG
 azR
 ayG
-aAi
+azR
 ayG
 azR
 aIT
@@ -124097,7 +124097,7 @@ aaa
 aAi
 aAi
 aAi
-aAi
+abj
 aAi
 aAi
 aAi
@@ -124355,7 +124355,7 @@ aAi
 ayG
 ayG
 ayG
-aAi
+azR
 ayG
 ayG
 aIT

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -8451,12 +8451,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
-"azR" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/space,
-/area/space/nearstation)
 "azS" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/warning_stripes/northwestcorner,
@@ -12747,13 +12741,6 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
-"aIT" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/space,
-/area/space/nearstation)
 "aIU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -123074,7 +123061,7 @@ aaa
 aaa
 aaa
 aaa
-vXX
+abj
 aHa
 aIu
 aJN
@@ -123838,13 +123825,13 @@ rvc
 dij
 abj
 aAi
-ayG
-azR
-ayG
-azR
-ayG
-azR
-aIT
+aAi
+aAi
+aAi
+aAi
+aAi
+aAi
+aAe
 aEa
 aGZ
 aIx
@@ -124097,7 +124084,7 @@ aaa
 aAi
 aAi
 aAi
-abj
+aAi
 aAi
 aAi
 aAi
@@ -124352,13 +124339,13 @@ rvc
 dij
 abj
 aAi
+aAi
+aAi
+aAi
+aAi
+aAi
 ayG
-ayG
-ayG
-azR
-ayG
-ayG
-aIT
+aAe
 aEa
 aHa
 aIz

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -23902,10 +23902,10 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "baG" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "baH" = (
@@ -27090,11 +27090,6 @@
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
 	})
-"bhA" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "bhB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77859,14 +77854,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/construction)
-"gyy" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "gyR" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -79468,10 +79455,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "lmi" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
 	},
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "lpc" = (
@@ -81033,14 +81020,6 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"qtt" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "qwd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -81640,14 +81619,6 @@
 	dir = 9
 	},
 /obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
-"rYO" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "rZk" = (
@@ -82519,15 +82490,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"vfv" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "vge" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -82551,14 +82513,6 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"vmT" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "vmY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -83294,14 +83248,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"xLf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "xOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -127251,11 +127197,11 @@ gpj
 aJt
 kBa
 gdM
-gyy
-xLf
-qtt
-vmT
-qtt
+rYj
+tgE
+kKa
+bfz
+kKa
 anq
 dfj
 dfu
@@ -127512,7 +127458,7 @@ abq
 bfz
 wxE
 wxE
-gyy
+rYj
 anq
 pRy
 aoN
@@ -127748,7 +127694,7 @@ bal
 axh
 axh
 abq
-aef
+abq
 tZI
 aJJ
 aPy
@@ -127769,7 +127715,7 @@ kKa
 tgE
 wxE
 wxE
-qtt
+kKa
 anq
 dfk
 aoN
@@ -128005,8 +127951,8 @@ asJ
 axh
 axh
 abq
-aef
-aef
+abq
+abq
 aCg
 rRM
 ogE
@@ -128026,7 +127972,7 @@ aKT
 bfz
 wxE
 wxE
-gyy
+rYj
 anq
 dfk
 aoN
@@ -128279,11 +128225,11 @@ aOd
 gZY
 hgN
 aCg
-rYO
-xLf
-vfv
-vfv
-qtt
+aKT
+tgE
+wxE
+wxE
+kKa
 anq
 dfl
 dfl
@@ -128536,11 +128482,11 @@ oWm
 ssZ
 qxn
 aCg
-rYO
-vmT
-vfv
-vfv
-gyy
+aKT
+bfz
+wxE
+wxE
+rYj
 anq
 abq
 abq
@@ -128797,7 +128743,7 @@ aKT
 tgE
 wxE
 wxE
-qtt
+kKa
 aaa
 aaa
 aaa
@@ -129054,7 +129000,7 @@ aKT
 bfz
 wxE
 wxE
-gyy
+rYj
 aaa
 aaa
 aaa
@@ -129311,7 +129257,7 @@ aKT
 tgE
 wxE
 wxE
-qtt
+kKa
 aaa
 aaa
 aaa
@@ -129561,14 +129507,14 @@ abq
 aaa
 aaa
 abq
-aef
+abq
 lmi
 baG
-rYO
-bhA
-xLf
-gyy
-rYO
+aKT
+abq
+tgE
+rYj
+aKT
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> Was requested to remove the catwalks from the SM cooling loops on DeltaStation and MetaStation due to how they process atmospherics. Also removes catwalks from injector ports on MetaStation. All removed catwalks were replaced with lattice.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Atmospherics simulator should process atmospherics properly, in ways we desire.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Replaces catwalks with lattice from DeltaStation SM cooling loop
tweak: Replaces catwalks with lattice from MetaStation SM cooling loop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
