### PR TITLE
Adds NO_BLOOD check to coughing up blood from damaged lungs.

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -76,7 +76,7 @@
 			owner.emote("cough")		//respitory tract infection
 
 	if(is_bruised())
-		if(prob(2) && !(owner && (NO_BLOOD in owner.dna.species.species_traits)))
+		if(prob(2) && !(NO_BLOOD in owner.dna.species.species_traits))
 			owner.custom_emote(1, "coughs up blood!")
 			owner.bleed(1)
 		if(prob(4))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -76,7 +76,7 @@
 			owner.emote("cough")		//respitory tract infection
 
 	if(is_bruised())
-		if(prob(2))
+		if(prob(2) && !(owner && (NO_BLOOD in owner.dna.species.species_traits)))
 			owner.custom_emote(1, "coughs up blood!")
 			owner.bleed(1)
 		if(prob(4))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds a NO_BLOOD check for when coughing up blood from damaged lungs.  

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Species with NO_BLOOD should not emote coughing up blood.  Coughing up blood from lungs does not stun the owner so this has no real change other than Plasmaman will no longer emote coughing up blood. 

## Changelog
:cl:
tweak: Species with no blood no longer emotes coughing up blood when lungs are damaged.  
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
