### PR TITLE
Deltastation - Fix cargo belts and doors

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -9014,7 +9014,7 @@
 /area/quartermaster/storage)
 "aBa" = (
 /obj/machinery/conveyor/south{
-	id = "QMLoad2"
+	id = "QMLoad"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -9786,7 +9786,7 @@
 /area/quartermaster/storage)
 "aCO" = (
 /obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
+	id = "QMLoad"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10325,7 +10325,7 @@
 /area/quartermaster/storage)
 "aDY" = (
 /obj/machinery/conveyor/southeast/ccw{
-	id = "QMLoad2"
+	id = "QMLoad"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -11171,7 +11171,8 @@
 	name = "Cargo Docking Hatch";
 	req_access_txt = "31"
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "aFO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11345,10 +11346,10 @@
 /area/hydroponics/abandoned_garden)
 "aGf" = (
 /obj/machinery/conveyor/east{
-	id = "QMLoad2"
+	id = "QMLoad"
 	},
 /obj/machinery/door/poddoor{
-	id_tag = "QMLoaddoor2";
+	id_tag = "QMLoaddoor";
 	name = "supply dock loading door"
 	},
 /turf/simulated/floor/plating,
@@ -11715,7 +11716,7 @@
 /area/quartermaster/sorting)
 "aGP" = (
 /obj/machinery/conveyor/east{
-	id = "QMLoad2"
+	id = "QMLoad"
 	},
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating,
@@ -12314,14 +12315,14 @@
 /area/quartermaster/storage)
 "aIf" = (
 /obj/machinery/door_control{
-	id = "QMLoaddoor2";
+	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = 24;
 	pixel_y = 8
 	},
 /obj/machinery/door_control{
-	id = "QMLoaddoor";
+	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = 24;
@@ -12354,23 +12355,23 @@
 /area/quartermaster/office)
 "aIi" = (
 /obj/machinery/conveyor/southwest/ccw{
-	id = "QMLoad"
+	id = "QMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "aIj" = (
 /obj/machinery/conveyor/west{
-	id = "QMLoad"
+	id = "QMLoad2"
 	},
 /obj/machinery/door/poddoor{
-	id_tag = "QMLoaddoor";
+	id_tag = "QMLoaddoor2";
 	name = "supply dock loading door"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "aIk" = (
 /obj/machinery/conveyor/west{
-	id = "QMLoad"
+	id = "QMLoad2"
 	},
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating,
@@ -13042,7 +13043,7 @@
 /area/engine/controlroom)
 "aJE" = (
 /obj/machinery/conveyor/south{
-	id = "QMLoad"
+	id = "QMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -14694,7 +14695,7 @@
 /area/crew_quarters/bar)
 "aNk" = (
 /obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad"
+	id = "QMLoad2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -16177,7 +16178,7 @@
 	dir = 4
 	},
 /obj/machinery/conveyor/southwest{
-	id = "QMLoad"
+	id = "QMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -17091,7 +17092,7 @@
 /area/security/execution)
 "aSw" = (
 /obj/machinery/conveyor/west{
-	id = "QMLoad"
+	id = "QMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -95548,7 +95549,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "gyY" = (
 /obj/structure/cable{
@@ -95897,7 +95898,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "hHM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the IDs for the cargo bay's belts, switches and hatches, as the maps use a shared shuttle. There were some complaints about atmos, and while I couldn't reproduce it, I updated the door layout to match Boxstation, which has some additional failsafes.

## Why It's Good For The Game
Crates don't get stuck unless their opposite belt is running. The place probably won't depressurize itself.

## Images of changes
https://user-images.githubusercontent.com/80771500/134205594-8e41cf98-ca1d-4e40-a265-e325ec0f4212.mp4

## Changelog
:cl:
tweak: Changed door setup to match boxstation
fix: Fixed the IDs for the belts, switches and hatches to match the shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
