### PR TITLE
Added missing objs, storage shutters to cargo

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -8344,6 +8344,13 @@
 /area/quartermaster/sorting)
 "azF" = (
 /obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 24;
+	pixel_y = -3;
+	req_access_txt = "31"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "azG" = (
@@ -8351,6 +8358,13 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -24;
+	pixel_y = -3;
+	req_access_txt = "31"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -8952,6 +8966,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "qm_warehouse";
+	name = "Warehouse Shutters"
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "aAT" = (
@@ -9391,6 +9409,10 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
 	req_access_txt = "31"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "qm_warehouse";
+	name = "Warehouse Shutters"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
@@ -13539,6 +13561,8 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northeast,
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "aKw" = (
@@ -16822,7 +16846,13 @@
 "aRM" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
-/obj/item/destTagger,
+/obj/item/destTagger{
+	pixel_x = -4
+	},
+/obj/item/rcs{
+	pixel_x = 8;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -17627,6 +17657,11 @@
 /area/quartermaster/storage)
 "aTw" = (
 /obj/structure/table/reinforced,
+/obj/item/stamp/granted,
+/obj/item/stamp/granted{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -18423,10 +18458,10 @@
 	},
 /area/atmos)
 "aUR" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/photocopier,
+/obj/machinery/status_display/supply_display{
 	pixel_y = 32
 	},
-/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -98967,6 +99002,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permasolitary)
+"ssy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/space)
 "suy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -100207,6 +100250,18 @@
 	icon_state = "wood"
 	},
 /area/maintenance/gambling_den)
+"wPI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/telepad_cargo,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/quartermaster/office)
 "wRP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -141831,7 +141886,7 @@ aJf
 aKy
 aLZ
 aNo
-aNo
+wPI
 aQh
 aRO
 aJd
@@ -145689,7 +145744,7 @@ aQr
 aCN
 aKK
 azL
-aTw
+ssy
 aVa
 aWy
 aBS


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
On Delta station: Improves the cargo tech area by adding: rapid crate sender and receive pad, battery charger for M.U.L.Es, shutters to the secure storage, more accepted stamps
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds features already present on previous maps to Delta
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Cargo techs now have shutters on their storage
fix: Crate sender and crate pad added to cargo
fix: Added more stamps for cargo technicians
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
