### PR TITLE
Allows rotating booze and soda dispensers with alt click

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -319,6 +319,21 @@
 		return
 	ui_interact(user)
 
+/obj/machinery/chem_dispenser/AltClick(mob/user)
+	if(!is_drink)
+		return
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!Adjacent(user))
+		return
+	if(anchored)
+		to_chat(user, "<span class='warning'>[src] is anchored to the floor!</span>")
+		return
+	pixel_x = 0
+	pixel_y = 0
+	setDir(turn(dir, 90))
+
 /obj/machinery/chem_dispenser/soda
 	icon_state = "soda_dispenser"
 	name = "soda fountain"

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -320,12 +320,10 @@
 	ui_interact(user)
 
 /obj/machinery/chem_dispenser/AltClick(mob/user)
-	if(!is_drink)
+	if(!is_drink || !Adjacent(user))
 		return
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!Adjacent(user))
 		return
 	if(anchored)
 		to_chat(user, "<span class='warning'>[src] is anchored to the floor!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR lets you rotate unanchored drink dispenser machinery with alt-click.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was not an issue before the new sprites as there was only one dir.
You currently have to do a funny dance to spin it that requires space you might not have, this is more intuitive and simple.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Alt-clicking unanchored drinks dispensers now rotates them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
