### PR TITLE
Adds Epinephrine to the Gutlunch Mob

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
@@ -1,7 +1,7 @@
 //Gutlunches, passive mods that devour blood and gibs
 /mob/living/simple_animal/hostile/asteroid/gutlunch
 	name = "gutlunch"
-	desc = "A scavenger that eats raw meat, often found alongside ash walkers. Produces a thick, nutritious milk."
+	desc = "A scavenger that eats raw meat, often found alongside ash walkers. Produces a thick, medicinally nutritious milk."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "gutlunch"
 	icon_living = "gutlunch"
@@ -104,7 +104,9 @@
 	if(prob(60))
 		reagents.add_reagent("cream", rand(2, 5))
 	if(prob(45))
-		reagents.add_reagent("salglu_solution", rand(2,5))
+		reagents.add_reagent("salglu_solution", rand(2, 5))
+	if(prob(30))
+		reagents.add_reagent("epinephrine", rand(2, 5))
 
 
 //Male gutlunch. They're smaller and more colorful!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Attempts to Fix #16360.   Adds the reagent Epinephrine to the Gutlunch Mob's udder, so that Ash Walkers are able to avoid getting screwed over permanently from just being near Critical for a short time.  

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Currently, when an Ash Walker gets near Critical they begin to go through Cardiac Failure into Cardiac Arrest with no way of breaking out of Failure, even if they manage to heal back up to full from Critical - once it starts it doesn't stop.  Essentially, Cardiac Failure for Ash Walkers is a game ender and ruins much of their ability to play, the Trait_NOBREATH prevents oxyloss so they never accumulate the necessary oxy damage to die while in Cardiac Arrest.  

Once they enter Cardiac Arrest they just remain stunlocked on the ground for eternity auto screaming until they're finished off by external means, forcing them to eat the 5 minute respawn time and wasting resources which they don't have very much of, or suiciding.   Letting them milk Epinephrine from Gutlunch Mobs will allow them to counter this impending Cardiac Arrest Purgatory, if they're able to get it them quick enough.  That said, if they do enter full Cardiac Arrest then they're still screwed without a Defib--this at least gives them the ability to try to prevent themselves from entering Cardiac Arrest Purgatory.  

This PR also gives the Gutlunch Mob itself a much better use, it becomes more important to Ash Walkers - love your Gutlunch Ash Walkers.

## Changelog
:cl: Exavere
add: Adds Epinephrine to Gutlunches.
fix: Part of a Fix related to #16360.  
tweak: Tweaks the reagents of the Gutlunch Mob.  
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
