### PR TITLE
Fix - Lighting matches on shoes display the right message, and block spamming burnt matches on shoes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -458,10 +458,12 @@ BLIND     // can't see anything
 /obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/match) && src.loc == user)
 		var/obj/item/match/M = I
-		if(M.matchignite()) // Match isn't lit, but isn't burnt.
+		if(!M.lit && !M.burnt) // Match isn't lit, but isn't burnt.
 			user.visible_message("<span class='warning'>[user] strikes a [M] on the bottom of [src], lighting it.</span>","<span class='warning'>You strike [M] on the bottom of [src] to light it.</span>")
+			M.matchignite()
 			playsound(user.loc, 'sound/goonstation/misc/matchstick_light.ogg', 50, 1)
-		else
+			return
+		if(M.lit && !M.burnt)
 			user.visible_message("<span class='warning'>[user] crushes [M] into the bottom of [src], extinguishing it.</span>","<span class='warning'>You crush [M] into the bottom of [src], extinguishing it.</span>")
 			M.dropped()
 		return


### PR DESCRIPTION
## What Does This PR Do
Puts the action of lighting a match on shoes after the message is displayed for it, and adds a check if it's already burnt out as it lacks any.

## Why It's Good For The Game
Fixes #16259, and also prevents repeatedly crushing matches already burnt out.
![Burnt](https://user-images.githubusercontent.com/80771500/134409295-60879a37-d6f8-4a00-9060-3bdacec27d1c.PNG)

## Images of changes
![Match](https://user-images.githubusercontent.com/80771500/134406381-332b4906-9e64-437d-b668-8650998a395d.PNG)

## Changelog
:cl:
fix: Fixed lighting matches on shoes and prevent spamming
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
