### PR TITLE
Nerfs (S)laughter demons

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -26,8 +26,8 @@
 	maxbodytemp = INFINITY
 	faction = list("slaughter")
 	attacktext = "wildly tears into"
-	maxHealth = 200
-	health = 200
+	maxHealth = 130
+	health = 130
 	environment_smash = 1
 	//universal_understand = 1
 	obj_damage = 50
@@ -302,10 +302,10 @@
 	emote_hear = list("gaffaws", "laughs")
 	response_help  = "hugs"
 	attacktext = "wildly tickles"
-	maxHealth = 175
-	health = 175
-	melee_damage_lower = 25
-	melee_damage_upper = 25
+	maxHealth = 125
+	health = 125
+	melee_damage_lower = 20
+	melee_damage_upper = 20
 	playstyle_string = "<B>You are the Laughter Demon, an adorable creature from another existence. You have a single desire: to hug and tickle.  \
 						You may use the blood crawl icon when on blood pools to travel through them, appearing and dissapearing from the station at will. \
 						Pulling a dead or critical mob while you enter a pool will pull them in with you, allowing you to hug them. \

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -26,8 +26,8 @@
 	maxbodytemp = INFINITY
 	faction = list("slaughter")
 	attacktext = "wildly tears into"
-	maxHealth = 130
-	health = 130
+	maxHealth = 200
+	health = 200
 	environment_smash = 1
 	//universal_understand = 1
 	obj_damage = 50
@@ -114,6 +114,12 @@
 	. = ..()
 	speed = 0
 	boost = world.time + 60
+
+// Midround slaughter demon, less tanky
+
+/mob/living/simple_animal/slaughter/lesser
+	maxHealth = 130
+	health = 130
 
 // Cult slaughter demon
 /mob/living/simple_animal/slaughter/cult //Summoned as part of the cult objective "Bring the Slaughter"
@@ -302,10 +308,10 @@
 	emote_hear = list("gaffaws", "laughs")
 	response_help  = "hugs"
 	attacktext = "wildly tickles"
-	maxHealth = 125
-	health = 125
-	melee_damage_lower = 20
-	melee_damage_upper = 20
+	maxHealth = 175
+	health = 175
+	melee_damage_lower = 25
+	melee_damage_upper = 25
 	playstyle_string = "<B>You are the Laughter Demon, an adorable creature from another existence. You have a single desire: to hug and tickle.  \
 						You may use the blood crawl icon when on blood pools to travel through them, appearing and dissapearing from the station at will. \
 						Pulling a dead or critical mob while you enter a pool will pull them in with you, allowing you to hug them. \

--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -36,7 +36,7 @@
 		kill()
 		return
 	var/obj/effect/dummy/slaughter/holder = new /obj/effect/dummy/slaughter(pick(spawn_locs))
-	var/mob/living/simple_animal/slaughter/S = new /mob/living/simple_animal/slaughter/(holder)
+	var/mob/living/simple_animal/slaughter/lesser/S = new /mob/living/simple_animal/slaughter/lesser/(holder)
 	S.holder = holder
 	player_mind.transfer_to(S)
 	player_mind.assigned_role = "Slaughter Demon"

--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -1,5 +1,6 @@
 /datum/event/spawn_slaughter
 	var/key_of_slaughter
+	var/demon = /mob/living/simple_animal/slaughter/lesser
 
 /datum/event/spawn_slaughter/proc/get_slaughter()
 	var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a slaughter demon?", ROLE_DEMON, TRUE, source = /mob/living/simple_animal/slaughter)
@@ -36,7 +37,7 @@
 		kill()
 		return
 	var/obj/effect/dummy/slaughter/holder = new /obj/effect/dummy/slaughter(pick(spawn_locs))
-	var/mob/living/simple_animal/slaughter/lesser/S = new /mob/living/simple_animal/slaughter/lesser/(holder)
+	var/mob/living/simple_animal/slaughter/S = new demon(holder)
 	S.holder = holder
 	player_mind.transfer_to(S)
 	player_mind.assigned_role = "Slaughter Demon"
@@ -46,3 +47,6 @@
 
 /datum/event/spawn_slaughter/start()
 	INVOKE_ASYNC(src, .proc/get_slaughter)
+
+/datum/event/spawn_slaughter/greater
+	demon = /mob/living/simple_animal/slaughter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds a new subtype of slaughter demons used for midrounds, with a max HP of 130, compared to the usual 200.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Demons are strong. With a competent demon, it is extremely hard to kill without extreme preventative cleaning to prevent it from attacking, voice cleaner grenades to instantly clean all blood so it can't escape, or shotguns with slugs to melt it before it can react to leave. Otherwise, due it's large amount of HP, full heal on kill, and high mobility with blood crawl, it almost never gets killed. 

A nerf is needed, to keep them from steamrolling the station each time one shows up.

Thus, this PR lowers the HP, to allow crew to have an easier time killing it, without having to worry anymore about demons getting 2-3 shot by a shotgun. Now, it takes 7 lasers / wt550 shots, instead of 10, making it easier to kill a demon if it has not ate in a while. I did not however want to lower laughter demons health too much below what slaughter demons have, thus I lowered laughter demon damage from 25 to 20, so they now deal 2/3rds the amount of damage slaughters do.

For those wondering why I did not lower the damage to 20 like TG did and not leave health, it would be because demons on TG have wound modifiers after multiple hits, which is not applicable here, and because a slaughter demon taking 10 hits to get someone to -100 with no armor didn't quite feel the best, especially when dealing with things like janiborgs or crew with welders.

## Changelog
:cl:
tweak: Midround slaughter demon health lowered to 130 from 200
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
