### PR TITLE
MetaStation Fixes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51704,6 +51704,7 @@
 /area/atmos)
 "cfQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cfR" = (
@@ -53727,8 +53728,9 @@
 	},
 /area/atmos)
 "ckm" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/binary/valve/digital/open{
+	dir = 8;
+	name = "Mixed Air Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -82875,6 +82877,13 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
+"whC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "wma" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -126550,7 +126559,7 @@ cbg
 bGG
 bGG
 nzX
-bPw
+whC
 bIq
 ciE
 ckh

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -882,15 +882,11 @@
 	},
 /area/security/permabrig)
 "adz" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/obj/item/radio/electropack,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/chair/e_chair,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1100,6 +1096,10 @@
 	c_tag = "Prisoner Education Chamber";
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/sunglasses/blindfold,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "warndark"
@@ -1451,8 +1451,8 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/item/assembly/signaler{
-	pixel_x = -3;
-	pixel_y = 2
+	code = 6;
+	frequency = 1445
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -44364,7 +44364,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/table,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/storage/firstaid/machine,
+/obj/item/storage/firstaid/machine,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -58815,6 +58819,7 @@
 	maxcharge = 15000
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -63797,9 +63802,8 @@
 	name = "\improper Toxins Lab"
 	})
 "cFD" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 8;
-	req_access = "0"
+/obj/machinery/atmospherics/trinary/mixer{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -64428,6 +64432,7 @@
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing{
 	name = "\improper Toxins Lab"
@@ -64452,7 +64457,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing{
@@ -68120,8 +68124,11 @@
 	pixel_y = -4
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/obj/item/storage/firstaid/machine,
-/obj/item/storage/firstaid/machine,
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/hud/diagnostic,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68618,10 +68625,6 @@
 /obj/item/circular_saw,
 /obj/item/scalpel{
 	pixel_y = 12
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
 	},
 /obj/item/razor{
 	pixel_y = 5

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -78248,6 +78248,17 @@
 /area/construction/Storage{
 	name = "Storage Wing"
 	})
+"hDX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/binary/valve/digital{
+	color = "";
+	dir = 4;
+	name = "CO2 Outlet Valve"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "hEA" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -79782,6 +79793,17 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"moV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/binary/valve/digital{
+	color = "";
+	dir = 4;
+	name = "Plasma Outlet Valve"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "msg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -80151,6 +80173,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"nFC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/binary/valve/digital{
+	color = "";
+	dir = 4;
+	name = "N2O Outlet Valve"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "nHB" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -127790,15 +127823,15 @@ bIs
 bKg
 bMh
 bNe
-bPC
+nFC
 bRi
 bSU
 bPC
-bPC
+moV
 bRi
 bSU
 bRi
-bPC
+hDX
 bRi
 bSU
 ceK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

- Removes the bed and electropack from execution, and replaces with a proper electric chair as Space Law demands
- Removes the anesthetic cabinet from Robotics, but replaces it with a proper anesthetic set on a table
- Adds diagnostic huds to Robotics
- Adds a standard recharger to Research and Development
- Replaces the gas filter in Toxins Mixing with a gas mixer
- Adds digital valves to atmospherics CO2, Plasma, NO2 and mixed air pipes
- Adds gas meters to Nitrogen and Oxygen pipes

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Map fixes be fixey

## Changelog
:cl:
tweak: MetaStation execution now has an electric chair
tweak: MetaStation Robotics now has anesthetic outside of a cabinet
add: MetaStation Robotics now has diagnostic huds
tweak: Gives MetaStation Research and Development a recharger for map parity
fix: MetaStation Toxins Mixing can now actually mix gases
tweak: MetaStation Atmospherics now has digital pumps on the CO2, Plasma, and NO2 pipes, as well as on mixed air
tweak: MetaStation Atmospherics now has gas meters on the Nitrogen and Oxygen pipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
