### PR TITLE
uplink update

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
-/proc/get_uplink_items(job = null)
+/proc/get_uplink_items(obj/item/uplink/U)
 	var/list/uplink_items = list()
 	var/list/sales_items = list()
 	var/newreference = 1
@@ -12,9 +12,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			var/datum/uplink_item/I = new path
 			if(!I.item)
 				continue
-			if(I.gamemodes.len && SSticker && !(SSticker.mode.type in I.gamemodes))
+			if(I.uplinktypes.len && SSticker && !(U.uplink_type in I.uplinktypes))
 				continue
-			if(I.excludefrom.len && SSticker && (SSticker.mode.type in I.excludefrom))
+			if(I.excludefrom.len && SSticker && (U.uplink_type in I.excludefrom))
 				continue
 			if(I.last)
 				last += I
@@ -71,8 +71,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/cost = 0
 	var/last = 0 // Appear last
 	var/abstract = 0
-	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
-	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
+	var/list/uplinktypes = list() // Empty list means it is in all the uplinktypes. Otherwise place the uplinktype name here.
+	var/list/excludefrom = list() //Empty list does nothing. Place the name of uplinktype you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
 	var/list/job = null
 	var/surplus = 100 //Chance of being included in the surplus crate (when pick() selects it)
 	var/cant_discount = FALSE
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/uplink/U)
 
-	if(hijack_only && !(usr.mind.special_role == SPECIAL_ROLE_NUKEOPS))//nukies get items that regular traitors only get with hijack. If a hijack-only item is not for nukies, then exclude it via the gamemode list.
+	if(hijack_only && !(usr.mind.special_role == SPECIAL_ROLE_NUKEOPS))//nukies get items that regular traitors only get with hijack. If a hijack-only item is not for nukies, then exclude it via the uplinktype list.
 		if(!(locate(/datum/objective/hijack) in usr.mind.objectives))
 			to_chat(usr, "<span class='warning'>The Syndicate will only issue this extremely dangerous item to agents assigned the Hijack objective.</span>")
 			return
@@ -162,7 +162,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/jobspecific
 	category = "Job Specific Tools"
 	cant_discount = TRUE
-	excludefrom = list(/datum/game_mode/nuclear) // Stops the job specific category appearing for nukies
+	excludefrom = list("nuclear", "sst") // Stops the job specific category appearing for nukies
 
 //Clown
 /datum/uplink_item/jobspecific/clowngrenade
@@ -438,7 +438,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "PP"
 	item = /obj/item/pen/poison
 	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian")
 
 
@@ -468,7 +468,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun that fires .45 rounds with a 20-round magazine and is compatible with suppressors."
 	item = /obj/item/gun/projectile/automatic/c20r
 	cost = 14
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 40
 
 /datum/uplink_item/dangerous/carbine
@@ -477,7 +477,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "AR"
 	item = /obj/item/gun/projectile/automatic/m90
 	cost = 18
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 50
 
 /datum/uplink_item/dangerous/machinegun
@@ -486,7 +486,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "LMG"
 	item = /obj/item/gun/projectile/automatic/l6_saw
 	cost = 40
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 /datum/uplink_item/dangerous/rapid
@@ -503,7 +503,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	cost = 16
 	surplus = 25
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/dangerous/sniper_compact //For when you really really hate that one guy.
 	name = "Compact Sniper Rifle"
@@ -513,7 +513,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 16
 	surplus = 0
 	cant_discount = TRUE
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/dangerous/crossbow
 	name = "Energy Crossbow"
@@ -521,7 +521,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "EC"
 	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
 	cost = 12
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 	surplus = 50
 
 /datum/uplink_item/dangerous/flamethrower
@@ -530,7 +530,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FT"
 	item = /obj/item/flamethrower/full/tank
 	cost = 8
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 40
 
 /datum/uplink_item/dangerous/sword
@@ -569,7 +569,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/support
 	category = "Support and Mechanized Exosuits"
 	surplus = 0
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/support/gygax
 	name = "Gygax Exosuit"
@@ -630,7 +630,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FSMG"
 	item = /obj/item/gun/projectile/automatic/c20r/toy
 	cost = 5
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 /datum/uplink_item/dangerous/foammachinegun
@@ -639,7 +639,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FLMG"
 	item = /obj/item/gun/projectile/automatic/l6_saw/toy
 	cost = 10
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 /datum/uplink_item/dangerous/guardian
@@ -648,7 +648,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an organic host as a home base and source of fuel. \
 			The holoparasites are unable to incoporate themselves to changeling and vampire agents."
 	item = /obj/item/storage/box/syndie_kit/guardian
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 	cost = 12
 	refund_path = /obj/item/guardiancreator/tech/choose
 	refundable = TRUE
@@ -694,7 +694,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12BSG"
 	item = /obj/item/ammo_box/magazine/m12g
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/bullbuck
 	name = "Bulldog - 12g Buckshot Magazine"
@@ -702,7 +702,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12BS"
 	item = /obj/item/ammo_box/magazine/m12g/buckshot
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/bullstun
 	name = "Bulldog - 12g Stun Slug Magazine"
@@ -710,7 +710,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12SS"
 	item = /obj/item/ammo_box/magazine/m12g/stun
 	cost = 3
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/bulldragon
 	name = "Bulldog - 12g Dragon's Breath Magazine"
@@ -718,7 +718,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12DB"
 	item = /obj/item/ammo_box/magazine/m12g/dragon
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/bulldog_ammobag
 	name = "Bulldog - 12g Ammo Duffel Bag"
@@ -726,7 +726,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12ADB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgun
 	cost = 12 // normally 18
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/bulldog_XLmagsbag
 	name = "Bulldog - 12g XL Magazine Duffel Bag"
@@ -734,7 +734,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12XLDB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
 	cost = 12 // normally 18
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/smg
 	name = "C-20r - .45 Magazine"
@@ -742,7 +742,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "45"
 	item = /obj/item/ammo_box/magazine/smgm45
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/smg_ammobag
 	name = "C-20r - .45 Ammo Duffel Bag"
@@ -750,7 +750,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "45ADB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/smg
 	cost = 14 // normally 20
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/carbine
 	name = "Carbine - 5.56 Toploader Magazine"
@@ -758,7 +758,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "556"
 	item = /obj/item/ammo_box/magazine/m556
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/a40mm
 	name = "Carbine - 40mm Grenade Ammo Box"
@@ -766,7 +766,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "40MM"
 	item = /obj/item/ammo_box/a40mm
 	cost = 4
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/machinegun
 	name = "L6 SAW - 5.56x45mm Box Magazine"
@@ -774,12 +774,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "762"
 	item = /obj/item/ammo_box/magazine/mm556x45
 	cost = 12
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 /datum/uplink_item/ammo/sniper
 	cost = 4
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/sniper/basic
 	name = "Sniper - .50 Magazine"
@@ -815,7 +815,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BTS"
 	item = /obj/item/storage/box/syndie_kit/bioterror
 	cost = 5
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/ammo/toydarts
 	name = "Box of Riot Darts"
@@ -823,7 +823,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FOAM"
 	item = /obj/item/ammo_box/foambox/riot
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 /datum/uplink_item/ammo/revolver
@@ -854,7 +854,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SCS"
 	item = /obj/item/sleeping_carp_scroll
 	cost = 13
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 	refundable = TRUE
 	cant_discount = TRUE
 
@@ -896,7 +896,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SP"
 	item = /obj/item/pen/sleepy
 	cost = 8
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_weapons/foampistol
 	name = "Toy Gun (with Stun Darts)"
@@ -928,7 +928,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/dart_gun
 	cost = 4
 	surplus = 50
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_weapons/RSG
 	name = "Rapid Syringe Gun"
@@ -936,7 +936,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "RSG"
 	item = /obj/item/gun/syringe/rapidsyringe
 	cost = 4
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_weapons/silencer
 	name = "Universal Suppressor"
@@ -959,7 +959,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CGP"
 	item = /obj/item/clothing/gloves/color/black/krav_maga/combat
 	cost = 5
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 // GRENADES AND EXPLOSIVES
 
@@ -987,7 +987,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/backpack/duffel/syndie/c4
 	cost = 8 //20% discount!
 	cant_discount = TRUE
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/explosives/breaching_charge
 	name = "Composition X-4"
@@ -995,7 +995,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "X4"
 	item = /obj/item/grenade/plastic/x4
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/explosives/x4bag
 	name = "Bag of X-4 explosives"
@@ -1006,7 +1006,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/backpack/duffel/syndie/x4
 	cost = 4
 	cant_discount = TRUE
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
@@ -1057,7 +1057,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/belt/grenade/full
 	cost = 30
 	surplus = 0
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/explosives/manhacks
 	name = "Viscerator Delivery Grenade"
@@ -1065,7 +1065,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "VDG"
 	item = /obj/item/grenade/spawnergrenade/manhacks
 	cost = 6
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 35
 
 /datum/uplink_item/explosives/atmosn2ogrenades
@@ -1135,7 +1135,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SBM"
 	item = /obj/item/storage/belt/military/traitor
 	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_tools/frame
 	name = "F.R.A.M.E. PDA Cartridge"
@@ -1161,13 +1161,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CHAM"
 	item = /obj/item/storage/box/syndie_kit/chameleon
 	cost = 4
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_tools/chameleon/nuke
 	reference = "NCHAM"
 	cost = 6
 	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_tools/syndigaloshes
 	name = "No-Slip Chameleon Shoes"
@@ -1176,13 +1176,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "NSSS"
 	item = /obj/item/clothing/shoes/chameleon/noslip
 	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	reference = "NNSSS"
 	cost = 4
 	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_tools/chameleon_proj
 	name = "Chameleon-Projector"
@@ -1229,14 +1229,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "NOCS"
 	item = /obj/item/clothing/shoes/chameleon/noslip
 	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	reference = "NOCSN"
 	item = /obj/item/clothing/shoes/chameleon/noslip
 	cost = 4
 	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/stealthy_tools/cutouts
 	name = "Adaptive Cardboard Cutouts"
@@ -1260,7 +1260,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "HBIK"
 	item = /obj/item/storage/backpack/clown/syndie
 	cost = 6
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 // DEVICE AND TOOLS
@@ -1320,7 +1320,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "DRL"
 	item = /obj/item/thermal_drill
 	cost = 3
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/device_tools/diamond_drill
 	name = "Diamond Tipped Thermal Safe Drill"
@@ -1328,7 +1328,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "DDRL"
 	item = /obj/item/thermal_drill/diamond_drill
 	cost = 1
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/device_tools/medkit
 	name = "Syndicate Combat Medic Kit"
@@ -1337,7 +1337,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SCMK"
 	item = /obj/item/storage/firstaid/tactical
 	cost = 7
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/device_tools/vtec
 	name = "Syndicate Cyborg Upgrade Module (VTEC)"
@@ -1345,7 +1345,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "VTEC"
 	item = /obj/item/borg/upgrade/vtec
 	cost = 6
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
@@ -1371,7 +1371,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BRHS"
 	item = /obj/item/storage/box/syndie_kit/hardsuit
 	cost = 6
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/suits/hardsuit/elite
 	name = "Elite Syndicate Hardsuit"
@@ -1380,7 +1380,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 8
 	reference = "ESHS"
 	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/suits/hardsuit/shielded
 	name = "Shielded Hardsuit"
@@ -1389,7 +1389,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 30
 	reference = "SHS"
 	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/device_tools/binary
 	name = "Binary Translator Key"
@@ -1421,7 +1421,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BRMB"
 	item = /obj/item/clothing/shoes/magboots/syndie
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
@@ -1450,7 +1450,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SD"
 	item = /obj/item/syndicatedetonator
 	cost = 3
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/device_tools/advpinpointer
 	name = "Advanced Pinpointer"
@@ -1479,7 +1479,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/circuitboard/teleporter
 	reference = "TP"
 	cost = 20
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 /datum/uplink_item/device_tools/assault_pod
@@ -1488,7 +1488,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/assault_pod
 	reference = "APT"
 	cost = 25
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 0
 
 /datum/uplink_item/device_tools/shield
@@ -1497,7 +1497,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/shield/energy
 	reference = "ESD"
 	cost = 16
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 	surplus = 20
 
 /datum/uplink_item/device_tools/medgun
@@ -1506,7 +1506,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/medbeam
 	reference = "MBG"
 	cost = 15
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 
 // IMPLANTS
@@ -1558,13 +1558,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "MBI"
 	item = /obj/item/implanter/explosive
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 // Cybernetics
 /datum/uplink_item/cyber_implants
 	category = "Cybernetic Implants"
 	surplus = 0
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/cyber_implants/thermals
 	name = "Thermal Vision Implant"
@@ -1614,7 +1614,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SPC"
 	item = /obj/item/toy/cards/deck/syndicate
 	cost = 1
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 	surplus = 40
 
 /datum/uplink_item/badass/syndiecash
@@ -1631,7 +1631,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "PBAG"
 	item = /obj/item/storage/bag/plasticbag
 	cost = 1
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/badass/balloon
 	name = "For showing that you are The Boss"
@@ -1647,7 +1647,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "HAB"
 	item = /obj/item/implanter/explosive_macro
 	cost = 20
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC
 	category = "Bundles and Telecrystals"
@@ -1661,7 +1661,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BULB"
 	item = /obj/item/storage/backpack/duffel/syndie/bulldogbundle
 	cost = 9 // normally 12
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC/c20r
 	name = "C-20r Bundle"
@@ -1669,7 +1669,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "C20B"
 	item = /obj/item/storage/backpack/duffel/syndie/c20rbundle
 	cost = 18 // normally 21
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC/cyber_implants
 	name = "Cybernetic Implants Bundle"
@@ -1677,7 +1677,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CIB"
 	item = /obj/item/storage/box/cyber_implants
 	cost = 40
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC/medical
 	name = "Medical Bundle"
@@ -1686,7 +1686,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "MEDB"
 	item = /obj/item/storage/backpack/duffel/syndie/med/medicalbundle
 	cost = 20 // normally 24
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC/sniper
 	name = "Sniper bundle"
@@ -1696,7 +1696,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SNPB"
 	item = /obj/item/storage/briefcase/sniperbundle
 	cost = 18 // normally 23
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC/contractor
 	name = "Syndicate Contractor Kit"
@@ -1704,7 +1704,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SCOK"
 	cost = 20
 	item = /obj/item/storage/box/syndie_kit/contractor
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC/contractor/spawn_item(turf/loc, obj/item/uplink/U)
 	var/datum/mind/mind = usr.mind
@@ -1736,7 +1736,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SYB"
 	item = /obj/item/storage/box/syndicate
 	cost = 20
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 
 /datum/uplink_item/bundles_TC/surplus_crate
 	name = "Syndicate Surplus Crate"
@@ -1744,7 +1744,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SYSC"
 	cost = 20
 	item = /obj/item/storage/box/syndicate
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear", "sst")
 	var/crate_value = 50
 
 /datum/uplink_item/bundles_TC/surplus_crate/super
@@ -1812,4 +1812,4 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "RTCB"
 	item = /obj/item/stack/telecrystal/fifty
 	cost = 50
-	gamemodes = list(/datum/game_mode/nuclear)
+	uplinktypes = list("nuclear", "sst")

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -29,10 +29,13 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 /obj/item/uplink/ui_host()
 	return loc
 
+/obj/item/uplink/proc/update_uplink_items()
+	uplink_items = get_uplink_items(src)
+
 /obj/item/uplink/New()
 	..()
 	uses = SSticker.mode.uplink_uses
-	uplink_items = get_uplink_items()
+	uplink_items = get_uplink_items(src)
 
 	GLOB.world_uplinks += src
 
@@ -255,6 +258,7 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 	..()
 	if(hidden_uplink)
 		hidden_uplink.uplink_type = "nuclear"
+		hidden_uplink.update_uplink_items()
 	GLOB.nuclear_uplink_list += src
 
 /obj/item/radio/uplink/nuclear/Destroy()
@@ -265,6 +269,7 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 	..()
 	if(hidden_uplink)
 		hidden_uplink.uplink_type = "sst"
+		hidden_uplink.update_uplink_items()
 
 /obj/item/multitool/uplink/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR is separating traitor and nuclear and sst uplinks from others. Now you can get nuclear uplink with nuclear items without gamemode. This doesnt change default uplinks with default gamemodes, you will not get nuclear items as traitor or something else. PR allows admins(if they want) for example to spawn nuclear squad with uplinks after two hours of boring traitor round.
You still need to set uplink uses(TC) after spawn by changing Uses value in Hidden uplink using VV
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR doesnt change default game, but adds an opportunity to get any uplink shop in any gamemode
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: uplink names now match their store
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
