### PR TITLE
Removes Null Entry/Surplus Crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -55,10 +55,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	var/list/announce_beacons = list() // Particular beacons that we'll notify the relevant department when we reach
 	var/special = FALSE //Event/Station Goals/Admin enabled packs
 	var/special_enabled = FALSE
-	/// The number of times one can order a cargo crate, before it becomes restricted. -1 for infinite
-	var/order_limit = -1
-	/// Number of times a crate has been ordered in a shift
-	var/times_ordered = 0
 	/// List of names for being done in TGUI
 	var/list/ui_manifest = list()
 
@@ -196,15 +192,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	containertype = /obj/structure/closet/crate
 	containername = "special ops crate"
 	hidden = 1
-
-/datum/supply_packs/emergency/syndicate
-	name = "ERROR_NULL_ENTRY"
-	contains = list(/obj/item/storage/box/syndicate)
-	cost = 140
-	containertype = /obj/structure/closet/crate
-	containername = "crate"
-	hidden = 1
-	order_limit = 5
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Security ////////////////////////////////////////

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -521,20 +521,16 @@
 				visible_message("<b>[src]</b>'s monitor flashes, \"[world.time - reqtime] seconds remaining until another requisition form may be printed.\"")
 				return
 
-			var/datum/supply_packs/P = locateUID(params["crate"])
-			if(!istype(P))
-				return
-
-			if(P.times_ordered >= P.order_limit && P.order_limit != -1) //If the crate has reached the limit, do not allow it to be ordered.
-				to_chat(usr, "<span class='warning'>[P.name] is out of stock, and can no longer be ordered.</span>")
-				return
-
 			var/amount = 1
 			if(params["multiple"] == "1") // 1 is a string here. DO NOT MAKE THIS A BOOLEAN YOU DORK
 				var/num_input = input(usr, "Amount", "How many crates? (20 Max)") as null|num
 				if(!num_input || (!is_public && !is_authorized(usr)) || ..()) // Make sure they dont walk away
 					return
 				amount = clamp(round(num_input), 1, 20)
+
+			var/datum/supply_packs/P = locateUID(params["crate"])
+			if(!istype(P))
+				return
 
 			var/timeout = world.time + 600 // If you dont type the reason within a minute, theres bigger problems here
 			var/reason = input(usr, "Reason", "Why do you require this item?","") as null|text
@@ -576,13 +572,10 @@
 				if(SO.ordernum == ordernum)
 					O = SO
 					P = O.object
-					if(P.times_ordered >= P.order_limit && P.order_limit != -1) //If this order would put it over the limit, deny it
-						to_chat(usr, "<span class='warning'>[P.name] is out of stock, and can no longer be ordered.</span>")
-					else if(SSshuttle.points >= P.cost)
+					if(SSshuttle.points >= P.cost)
 						SSshuttle.requestlist.Cut(i,i+1)
 						SSshuttle.points -= P.cost
 						SSshuttle.shoppinglist += O
-						P.times_ordered += 1
 						investigate_log("[key_name(usr)] has authorized an order for [P.name]. Remaining points: [SSshuttle.points].", "cargo")
 					else
 						to_chat(usr, "<span class='warning'>There are insufficient supply points for this request.</span>")


### PR DESCRIPTION
Surplus/null entry crates probably shouldn't exist---traitors get a limited amount of telecrystals for a reason---just because you emag a console doesn't mean you should automatically more---sure, they're expensive, but the impact these can have is truly astounding---worse yet, if some big conflict comes up and someone gets ahold of an emag, as the crew---wellll, it's off to the races. I'm anti-hug box, but even I have limits.

These are definitely fun and I'll be sad to see them go, but they have a ridiculous impact on the round and shouldn't even be available in limited quantity, in my opinion---and if we ever move in the direction of mixed/dynamic game modes---it's going to get really crazy what these can do.

:cl: Fox McCloud
del: Removes null/surplus syndicate crates
/:cl: