### PR TITLE
Makes uncuttable chainlink fences deconstructable

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -95,7 +95,7 @@
 	if(!cuttable)
 		user.visible_message("<span class='warning'>[user] starts dismantling [src] with [W].</span>",\
 		"<span class='warning'>You start dismantling [src] with [W].</span>")
-		if(W.use_tool(src, user, FULL_CUT_TIME * W.toolspeed, volume = W.tool_volume))
+		if(W.use_tool(src, user, FULL_CUT_TIME, volume = W.tool_volume))
 			user.visible_message("<span class='notice'>[user] completely dismantles [src].</span>",\
 			"<span class='info'>You completely dismantle [src].</span>")
 			qdel(src)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -94,7 +94,7 @@
 			visible_message("<span class='notice'>\The [user] completely dismantles \the [src].</span>")
 			to_chat(user, "<span class='info'>You completely take apart \the [src].</span>")
 			qdel(src)
-			return
+		return
 	if(invulnerable)
 		to_chat(user, "<span class='warning'>This fence is too strong to cut through!</span>")
 		return

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -93,30 +93,30 @@
 		to_chat(user, "<span class='warning'>This fence is too strong to cut through!</span>")
 		return
 	if(!cuttable)
-		visible_message("<span class='danger'>[user] starts dismantling [src] with [W].</span>")
-		to_chat(user, "<span class='danger'>You start dismantling [src] with [W].</span>")
+		user.visible_message("<span class='warning'>[user] starts dismantling [src] with [W].</span>",\
+		"<span class='warning'>You start dismantling [src] with [W].</span>")
 		if(W.use_tool(src, user, FULL_CUT_TIME * W.toolspeed, volume = W.tool_volume))
-			visible_message("<span class='notice'>[user] completely dismantles [src].</span>")
-			to_chat(user, "<span class='info'>You completely dismantle [src].</span>")
+			user.visible_message("<span class='notice'>[user] completely dismantles [src].</span>",\
+			"<span class='info'>You completely dismantle [src].</span>")
 			qdel(src)
 		return
 	var/current_stage = hole_size
-	user.visible_message("<span class='danger'>\The [user] starts cutting through \the [src] with \the [W].</span>",\
-	"<span class='danger'>You start cutting through \the [src] with \the [W].</span>")
+	user.visible_message("<span class='warning'>[user] starts cutting through [src] with [W].</span>",\
+	"<span class='warning'>You start cutting through [src] with [W].</span>")
 	if(W.use_tool(src, user, CUT_TIME * W.toolspeed, volume = W.tool_volume))
 		if(current_stage == hole_size)
 			switch(hole_size)
 				if(NO_HOLE)
-					visible_message("<span class='notice'>\The [user] cuts into \the [src] some more.</span>")
-					to_chat(user, "<span class='info'>You could probably fit yourself through that hole now. Although climbing through would be much faster if you made it even bigger.</span>")
+					user.visible_message("<span class='notice'>[user] cuts into [src] some more.</span>",\
+					"<span class='info'>You could probably fit yourself through that hole now. Although climbing through would be much faster if you made it even bigger.</span>")
 					hole_size = MEDIUM_HOLE
 				if(MEDIUM_HOLE)
-					visible_message("<span class='notice'>\The [user] completely cuts through \the [src].</span>")
-					to_chat(user, "<span class='info'>The hole in \the [src] is now big enough to walk through.</span>")
+					user.visible_message("<span class='notice'>[user] completely cuts through [src].</span>",\
+					"<span class='info'>The hole in [src] is now big enough to walk through.</span>")
 					hole_size = LARGE_HOLE
 				if(LARGE_HOLE)
-					visible_message("<span class='notice'>\The [user] completely dismantles \the [src].</span>")
-					to_chat(user, "<span class='info'>You completely take apart \the [src].</span>")
+					user.visible_message("<span class='notice'>[user] completely dismantles [src].</span>",\
+					"<span class='info'>You completely take apart [src].</span>")
 					qdel(src)
 					return
 			update_cut_status()

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -89,14 +89,16 @@
 	. = TRUE
 	if(shock(user, 100))
 		return
-	if(!cuttable)
-		if(W.use_tool(src, user, FULL_CUT_TIME * W.toolspeed, volume = W.tool_volume))
-			visible_message("<span class='notice'>\The [user] completely dismantles \the [src].</span>")
-			to_chat(user, "<span class='info'>You completely take apart \the [src].</span>")
-			qdel(src)
-		return
 	if(invulnerable)
 		to_chat(user, "<span class='warning'>This fence is too strong to cut through!</span>")
+		return
+	if(!cuttable)
+		visible_message("<span class='danger'>[user] starts dismantling [src] with [W].</span>")
+		to_chat(user, "<span class='danger'>You start dismantling [src] with [W].</span>")
+		if(W.use_tool(src, user, FULL_CUT_TIME * W.toolspeed, volume = W.tool_volume))
+			visible_message("<span class='notice'>[user] completely dismantles [src].</span>")
+			to_chat(user, "<span class='info'>You completely dismantle [src].</span>")
+			qdel(src)
 		return
 	var/current_stage = hole_size
 	user.visible_message("<span class='danger'>\The [user] starts cutting through \the [src] with \the [W].</span>",\

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -3,6 +3,7 @@
 
 #define CUT_TIME 100
 #define CLIMB_TIME 150
+#define FULL_CUT_TIME 300
 
 #define NO_HOLE 0 //section is intact
 #define MEDIUM_HOLE 1 //medium hole in the section - can climb through
@@ -89,8 +90,11 @@
 	if(shock(user, 100))
 		return
 	if(!cuttable)
-		to_chat(user, "<span class='warning'>This section of the fence can't be cut!</span>")
-		return
+		if(W.use_tool(src, user, FULL_CUT_TIME * W.toolspeed, volume = W.tool_volume))
+			visible_message("<span class='notice'>\The [user] completely dismantles \the [src].</span>")
+			to_chat(user, "<span class='info'>You completely take apart \the [src].</span>")
+			qdel(src)
+			return
 	if(invulnerable)
 		to_chat(user, "<span class='warning'>This fence is too strong to cut through!</span>")
 		return
@@ -208,6 +212,7 @@
 
 #undef CUT_TIME
 #undef CLIMB_TIME
+#undef FULL_CUT_TIME
 
 #undef NO_HOLE
 #undef MEDIUM_HOLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes chainlink fences that don't support hole cutting (posts, ends, doors, corners) dismantleable.
This process takes the same time as cutting three holes in a regular fence, just in one step that deletes the fence.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, if you place a chainlink fence post, end, door, or corner you are screwed and have to bash it with an object until it breaks.
This is not ideal, as it makes fences stronger than walls in some ways.

With this change, even though you can't cut holes in them, you can spend the extra time to take them apart, as opposed to breaking it with a toolbox or whatever you have on hand.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Non-cuttable chainlink fences can now be taken apart with wire cutters after a delay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
