### PR TITLE
More delta changes

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -33018,7 +33018,6 @@
 /area/bridge)
 "bxv" = (
 /obj/machinery/computer/atmos_alert,
-/obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellow"
@@ -49523,8 +49522,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
-	name = "Security-Storage Backroom";
-	req_access = null;
+	name = "Evidence Storage";
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
@@ -73400,7 +73398,9 @@
 	},
 /area/medical/medbay)
 "deh" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
 	},
@@ -80508,6 +80508,10 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -80521,7 +80525,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -96336,6 +96343,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
+"jdF" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluecorner"
+	},
+/area/medical/medbay)
 "jgO" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Brig";
@@ -99070,8 +99086,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/security{
-	name = "Security-Storage Backroom";
-	req_access = null;
+	name = "Evidence Storage";
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
@@ -150133,7 +150148,7 @@ cZW
 cUr
 cKV
 dqW
-cSF
+cPJ
 cJg
 dhe
 dye
@@ -150390,7 +150405,7 @@ cZX
 cWd
 dbn
 dcz
-cSF
+jdF
 cKY
 dhf
 diO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes duplicate atmos alert console on bridge
Renames "Security-Storage Backroom" airlocks in brig to "Evidence Storage" like on cyberiad
Adds 2 public-accessible disposal bins in medbay
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Second atmos console was not intended
Naming evidence storage what it is + consistency 
One public bin for an area this big isn't good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![bin1](https://user-images.githubusercontent.com/62257265/134678867-8303268b-9c63-474a-8ee7-fb15bb392ea6.png)
![bin2](https://user-images.githubusercontent.com/62257265/134678872-7a78f2e1-69f2-43c3-bc77-1b782eb0a87b.png)
![image](https://user-images.githubusercontent.com/62257265/134680350-53a641f3-e20d-4cb9-87c6-13437ff0b4f2.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->


## Changelog
:cl:
del: Delta: removed duplicate atmos console on bridge
tweak: Delta: added two disposal bins to medbay
tweak: Delta: renamed "Security-Storage Backroom" to "Evidence Storage"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
