### PR TITLE
Remove ways to dupe materials. Also Alien Alloy fix

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1352,14 +1352,14 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 
 /datum/supply_packs/materials/plasteel20
 	name = "20 Plasteel Sheets Crate"
-	contains = list(/obj/item/stack/sheet/plasteel)
+	contains = list(/obj/item/stack/sheet/plasteel/lowplasma)
 	amount = 20
 	cost = 30
 	containername = "plasteel sheets crate"
 
 /datum/supply_packs/materials/plasteel50
 	name = "50 Plasteel Sheets Crate"
-	contains = list(/obj/item/stack/sheet/plasteel)
+	contains = list(/obj/item/stack/sheet/plasteel/lowplasma)
 	amount = 50
 	cost = 50
 	containername = "plasteel sheets crate"

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -738,6 +738,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon_closed = "abductor"
 	icon_opened = "abductoropen"
 	material_drop = /obj/item/stack/sheet/mineral/abductor
+	material_drop_amount = 1
 
 /obj/structure/door_assembly/door_assembly_abductor
 	name = "alien airlock assembly"

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -30,7 +30,6 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 100)
 	resistance_flags = ACID_PROOF
-	origin_tech = "materials=1"
 	created_window = /obj/structure/window/basic
 	full_window = /obj/structure/window/full/basic
 	merge_type = /obj/item/stack/sheet/glass

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -128,7 +128,6 @@ GLOBAL_LIST_INIT(snow_recipes, list(
 	singular_name = "sandstone brick"
 	icon_state = "sheet-sandstone"
 	throw_range = 5
-	origin_tech = "materials=1"
 	sheettype = "sandstone"
 	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
 
@@ -181,7 +180,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	origin_tech = "materials=6"
 	sheettype = "diamond"
 	merge_type = /obj/item/stack/sheet/mineral/diamond
-	materials = list(MAT_DIAMOND=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_DIAMOND = MINERAL_MATERIAL_AMOUNT)
 	point_value = 25
 
 /obj/item/stack/sheet/mineral/diamond/New()
@@ -255,7 +254,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	origin_tech = "materials=4"
 	sheettype = "gold"
 	merge_type = /obj/item/stack/sheet/mineral/gold
-	materials = list(MAT_GOLD=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_GOLD = MINERAL_MATERIAL_AMOUNT)
 	point_value = 20
 
 /obj/item/stack/sheet/mineral/gold/New()
@@ -269,7 +268,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	origin_tech = "materials=4"
 	sheettype = "silver"
 	merge_type = /obj/item/stack/sheet/mineral/silver
-	materials = list(MAT_SILVER=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_SILVER = MINERAL_MATERIAL_AMOUNT)
 	point_value = 20
 
 /obj/item/stack/sheet/mineral/silver/New()
@@ -283,7 +282,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	origin_tech = "materials=4"
 	sheettype = "bananium"
 	merge_type = /obj/item/stack/sheet/mineral/bananium
-	materials = list(MAT_BANANIUM=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_BANANIUM = MINERAL_MATERIAL_AMOUNT)
 	point_value = 50
 
 /obj/item/stack/sheet/mineral/bananium/fifty
@@ -300,7 +299,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	origin_tech = "materials=4"
 	sheettype = "tranquillite"
 	merge_type = /obj/item/stack/sheet/mineral/tranquillite
-	materials = list(MAT_TRANQUILLITE=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_TRANQUILLITE = MINERAL_MATERIAL_AMOUNT)
 	wall_allowed = FALSE	//no tranquilite walls in code
 	point_value = 50
 
@@ -321,12 +320,11 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	singular_name = "titanium sheet"
 	force = 5
 	throwforce = 5
-	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	throw_range = 3
 	sheettype = "titanium"
 	merge_type = /obj/item/stack/sheet/mineral/titanium
-	materials = list(MAT_TITANIUM=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_TITANIUM = MINERAL_MATERIAL_AMOUNT)
 	point_value = 20
 
 GLOBAL_LIST_INIT(titanium_recipes, list(
@@ -352,12 +350,11 @@ GLOBAL_LIST_INIT(titanium_recipes, list(
 	singular_name = "plastitanium sheet"
 	force = 5
 	throwforce = 5
-	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	throw_range = 3
 	sheettype = "plastitanium"
 	merge_type = /obj/item/stack/sheet/mineral/plastitanium
-	materials = list(MAT_TITANIUM=2000, MAT_PLASMA=2000)
+	materials = list(MAT_TITANIUM = MINERAL_MATERIAL_AMOUNT, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT)
 	point_value = 45
 
 GLOBAL_LIST_INIT(plastitanium_recipes, list(
@@ -372,7 +369,7 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list(
 	name = "enriched uranium"
 	icon_state = "sheet-enruranium"
 	origin_tech = "materials=6"
-	materials = list(MAT_URANIUM=3000)
+	materials = list(MAT_URANIUM = 3000)
 
 //Alien Alloy
 /obj/item/stack/sheet/mineral/abductor
@@ -382,9 +379,9 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list(
 	singular_name = "alien alloy sheet"
 	force = 5
 	throwforce = 5
-	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	origin_tech = "materials=6;abductor=1"
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT)
 	sheettype = "abductor"
 
 /obj/item/stack/sheet/mineral/abductor/fifty

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -111,11 +111,10 @@ GLOBAL_LIST_INIT(metal_recipes, list(
 	desc = "Sheets made out of metal."
 	singular_name = "metal sheet"
 	icon_state = "sheet-metal"
-	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT)
 	throwforce = 10.0
 	flags = CONDUCT
 	resistance_flags = FIRE_PROOF
-	origin_tech = "materials=1"
 	merge_type = /obj/item/stack/sheet/metal
 	point_value = 2
 
@@ -161,7 +160,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list(
 	desc = "This sheet is an alloy of iron and plasma."
 	icon_state = "sheet-plasteel"
 	item_state = "sheet-metal"
-	materials = list(MAT_METAL=2000, MAT_PLASMA=2000)
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 80)
 	resistance_flags = FIRE_PROOF
 	throwforce = 10.0
@@ -174,9 +173,9 @@ GLOBAL_LIST_INIT(plasteel_recipes, list(
 	recipes = GLOB.plasteel_recipes
 	return ..()
 
-/obj/item/stack/sheet/wood/cyborg
-	energy_type = /datum/robot_energy_storage/wood
-	is_cyborg = TRUE
+/obj/item/stack/sheet/plasteel/lowplasma
+	desc = "This sheet is an alloy of iron and plasma. There are an special barcode 'Low Plasma Level'"
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT, MAT_PLASMA = 200)
 
 /*
  * Wood
@@ -226,6 +225,10 @@ GLOBAL_LIST_INIT(wood_recipes, list(
 /obj/item/stack/sheet/wood/New(loc, amount=null)
 	recipes = GLOB.wood_recipes
 	return ..()
+
+/obj/item/stack/sheet/wood/cyborg
+	energy_type = /datum/robot_energy_storage/wood
+	is_cyborg = TRUE
 
 /*
  * Cloth
@@ -359,7 +362,6 @@ GLOBAL_LIST_INIT(cardboard_recipes, list (
 	desc = "Large sheets of card, like boxes folded flat."
 	singular_name = "cardboard sheet"
 	icon_state = "sheet-card"
-	origin_tech = "materials=1"
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/cardboard
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -12,7 +12,6 @@
 	throw_range = 20
 	max_amount = 60
 	flags = CONDUCT
-	origin_tech = "materials=1"
 	var/turf_type = null
 	var/mineralType = null
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -81,7 +81,6 @@
 /obj/item/stack/ore/iron
 	name = "iron ore"
 	icon_state = "Iron ore"
-	origin_tech = "materials=1"
 	singular_name = "iron ore chunk"
 	points = 1
 	refined_type = /obj/item/stack/sheet/metal
@@ -90,7 +89,6 @@
 /obj/item/stack/ore/glass
 	name = "sand pile"
 	icon_state = "Glass ore"
-	origin_tech = "materials=1"
 	singular_name = "sand pile"
 	points = 1
 	refined_type = /obj/item/stack/sheet/glass


### PR DESCRIPTION
## What Does This PR Do
- Abductor closet cost only 1 Alien Alloy but if you disassemble it - you'll get 2. Fixed.
- 50 Plasteel from cargo cost 50. If you melt them and pick raw - you will get 50 plasma. If you send it back - you'll get 250 cargo points. Infinity dupe? Fixed.
- /obj/item/stack already have origin_tech = "materials=1" so children don't need it ?
- You can create alien alloy for 4000 metal and plasma but can't smelting back? Now it's 2000/2000

## Why It's Good For The Game
Remove ways to dupe something

## Images of changes
![image](https://user-images.githubusercontent.com/11385249/134704840-668f748c-1753-4327-ad21-0540b3a79ddd.png)


## Changelog
:cl:
add: New plasteel with low plasma
tweak: Plasteel from cargo with low plasma
fix: Abductor closet drop only 1 Alien Alloy
fix: Now alien alloy cost something
/:cl:

PS. You can build same objects from lowplasma plasteel. And if you disassemble - you will get raw plasteel. Can solve it even with new obj var.