### PR TITLE
Fix - Ordinal railings block properly, rotations are done in 45°

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -75,19 +75,8 @@
 	if(mover.throwing)
 		return TRUE
 	mover_dir = get_dir(loc, target)
-	switch(dir)
-		if(5)
-			if(mover_dir == 1 || mover_dir == 4)
-				return FALSE
-		if(6)
-			if(mover_dir == 2 || mover_dir == 4)
-				return FALSE
-		if(9)
-			if(mover_dir == 1 || mover_dir == 8)
-				return FALSE
-		if(10)
-			if(mover_dir == 2 || mover_dir == 8)
-				return FALSE
+	if(ordinal_direction_check())
+		return FALSE
 	if(mover_dir != dir)
 		return density
 	return FALSE
@@ -110,20 +99,26 @@
 	mover_dir = get_dir(O.loc, target)
 	if(mover_dir == dir)
 		return FALSE
+	if(ordinal_direction_check())
+		return FALSE
+	return TRUE
+
+// Checks if the direction the mob is trying to move towards would be blocked by a corner railing
+/obj/structure/railing/proc/ordinal_direction_check()
 	switch(dir)
 		if(5)
 			if(mover_dir == 1 || mover_dir == 4)
-				return FALSE
+				return TRUE
 		if(6)
 			if(mover_dir == 2 || mover_dir == 4)
-				return FALSE
+				return TRUE
 		if(9)
 			if(mover_dir == 1 || mover_dir == 8)
-				return FALSE
+				return TRUE
 		if(10)
 			if(mover_dir == 2 || mover_dir == 8)
-				return FALSE
-	return TRUE
+				return TRUE
+	return FALSE
 
 /obj/structure/railing/do_climb(mob/living/user)
 	var/initial_mob_loc = get_turf(user)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -75,6 +75,7 @@
 	if(mover.throwing)
 		return TRUE
 	mover_dir = get_dir(loc, target)
+	//Due to how the other check is done, it would always return density for ordinal directions no matter what
 	if(ordinal_direction_check())
 		return FALSE
 	if(mover_dir != dir)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -9,6 +9,7 @@
 	climbable = TRUE
 	layer = ABOVE_MOB_LAYER
 	var/currently_climbed = FALSE
+	var/mover_dir = null
 
 /obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
 	icon_state = "railing_corner"
@@ -73,7 +74,21 @@
 			return TRUE
 	if(mover.throwing)
 		return TRUE
-	if(get_dir(loc, target) != dir)
+	mover_dir = get_dir(loc, target)
+	switch(dir)
+		if(5)
+			if(mover_dir == 1 || mover_dir == 4)
+				return FALSE
+		if(6)
+			if(mover_dir == 2 || mover_dir == 4)
+				return FALSE
+		if(9)
+			if(mover_dir == 1 || mover_dir == 8)
+				return FALSE
+		if(10)
+			if(mover_dir == 2 || mover_dir == 8)
+				return FALSE
+	if(mover_dir != dir)
 		return density
 	return FALSE
 
@@ -92,8 +107,22 @@
 		return TRUE
 	if(currently_climbed)
 		return TRUE
-	if(get_dir(O.loc, target) == dir)
+	mover_dir = get_dir(O.loc, target)
+	if(mover_dir == dir)
 		return FALSE
+	switch(dir)
+		if(5)
+			if(mover_dir == 1 || mover_dir == 4)
+				return FALSE
+		if(6)
+			if(mover_dir == 2 || mover_dir == 4)
+				return FALSE
+		if(9)
+			if(mover_dir == 1 || mover_dir == 8)
+				return FALSE
+		if(10)
+			if(mover_dir == 2 || mover_dir == 8)
+				return FALSE
 	return TRUE
 
 /obj/structure/railing/do_climb(mob/living/user)
@@ -112,7 +141,7 @@
 		to_chat(user, "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>")
 		return FALSE
 
-	var/target_dir = turn(dir, -90)
+	var/target_dir = turn(dir, -45)
 
 	if(!valid_window_location(loc, target_dir)) //Expanded to include rails, as well!
 		to_chat(user, "<span class='warning'>[src] cannot be rotated in that direction!</span>")
@@ -133,4 +162,4 @@
 	if(!Adjacent(user))
 		return
 	if(can_be_rotated(user))
-		setDir(turn(dir, 90))
+		setDir(turn(dir, 45))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Railings in ordinal directions block properly from either sides, and rotating unanchored railings will do so in 45° steps instead of 90°.

## Why It's Good For The Game
Fixes #16713. Railings can be quickly adjusted by rotating them instead of requiring a deconstruct to switch between cardinal and ordinal should the wrong direction be constructed.

## Images of changes
https://user-images.githubusercontent.com/80771500/134714525-43736d3f-14e0-49b5-8127-7d14ff565c8f.mp4

https://user-images.githubusercontent.com/80771500/134714544-ea098f1e-ca72-4341-9268-c0773d1da399.mp4

## Changelog
:cl:
tweak: Railing rotations (alt-click) are done in 45 degree steps
fix: Ordinal direction railings block properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
