### PR TITLE
Blood overlay fix for telescopic weapons

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -789,15 +789,15 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		var/index = blood_splatter_index()
 		var/icon/blood_splatter_icon = GLOB.blood_splatter_icons[index]
 		if(!blood_splatter_icon)
-			blood_splatter_icon = icon(initial(icon), initial(icon_state), , 1)		//we only want to apply blood-splatters to the initial icon_state for each object
-			blood_splatter_icon.Blend("#fff", ICON_ADD) 			//fills the icon_state with white (except where it's transparent)
+			blood_splatter_icon = icon(initial(icon), initial(icon_state), frame = 1)		//we only want to apply blood-splatters to the initial icon_state for each object
+			blood_splatter_icon.Blend("#ffffff", ICON_ADD) 			//fills the icon_state with white (except where it's transparent)
 			blood_splatter_icon.Blend(icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
 			blood_splatter_icon = fcopy_rsc(blood_splatter_icon)
 			GLOB.blood_splatter_icons[index] = blood_splatter_icon
 
 		blood_overlay = image(blood_splatter_icon)
 		blood_overlay.color = color
-		overlays += blood_overlay
+		add_overlay(blood_overlay)
 
 /atom/proc/clean_blood(radiation_clean = FALSE)
 	germ_level = 0
@@ -827,9 +827,9 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 /obj/item/clean_blood(radiation_clean = FALSE)
 	. = ..()
-	if(.)
-		if(blood_overlay)
-			overlays -= blood_overlay
+	if(. && blood_overlay)
+		cut_overlay(blood_overlay)
+		QDEL_NULL(blood_overlay)
 
 /obj/item/clothing/gloves/clean_blood(radiation_clean = FALSE)
 	. = ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -6,7 +6,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	move_resist = null // Set in the Initialise depending on the item size. Unless it's overriden by a specific item
 	var/discrete = 0 // used in item_attack.dm to make an item not show an attack message to viewers
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
-	var/blood_overlay_color = null
 	var/item_state = null
 	var/lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -189,9 +189,10 @@
 		H.update_inv_r_hand()
 	// Update blood splatter
 	if(blood_overlay)
+		var/blood_color = blood_overlay.color
 		cut_overlay(blood_overlay)
 		qdel(blood_overlay)
-		add_blood_overlay(blood_overlay_color)
+		add_blood_overlay(blood_color)
 	playsound(loc, extend_sound, 50, TRUE)
 	add_fingerprint(user)
 
@@ -210,5 +211,4 @@
 
 	blood_overlay = image(blood_splatter_icon)
 	blood_overlay.color = color
-	blood_overlay_color = color
 	add_overlay(blood_overlay)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -206,16 +206,28 @@
 		H.update_inv_l_hand()
 		H.update_inv_r_hand()
 	add_fingerprint(user)
-	if(!blood_DNA)
-		return
-	if(blood_overlay && (blood_DNA.len >= 1))	//updated blood overlay, if any
-		overlays.Cut()	//this might delete other item overlays as well but eeeeeh
+	if(blood_overlay)	//updated blood overlay, if any
+		var/blood_color = blood_overlay.color
+		cut_overlay(blood_overlay)
+		qdel(blood_overlay)
+		add_blood_overlay(blood_color)
 
-		var/icon/I = new /icon(icon, icon_state)
-		I.Blend(new /icon('icons/effects/blood.dmi', rgb(255,255,255)), ICON_ADD)
-		I.Blend(new /icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY)
-		blood_overlay = I
-		overlays += blood_overlay
+/obj/item/scythe/tele/blood_splatter_index()
+	return "\ref[icon]-[icon_state]"
+
+/obj/item/scythe/tele/add_blood_overlay(color)
+	var/index = blood_splatter_index()
+	var/icon/blood_splatter_icon = GLOB.blood_splatter_icons[index]
+	if(!blood_splatter_icon)
+		blood_splatter_icon = icon(icon, icon_state)
+		blood_splatter_icon.Blend("#ffffff", ICON_ADD)
+		blood_splatter_icon.Blend(icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY)
+		blood_splatter_icon = fcopy_rsc(blood_splatter_icon)
+		GLOB.blood_splatter_icons[index] = blood_splatter_icon
+
+	blood_overlay = image(blood_splatter_icon)
+	blood_overlay.color = color
+	add_overlay(blood_overlay)
 
 
 // *************************************


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes #16676 by converting the blood overlay system to use `SSoverlays` rather than directly adding and removing.
The issue seems to have been caused by the blood overlay being added by `add_overlay()`, but removed with `overlays -= blood_overlay` rather than the corresponding `cut_overlay()` proc.

Also fixes the blood overlay on telescopic scythes disappearing when the scythe gets extended or retracted.
I'm not very happy with the solution of copying the code from telescopic batons, but I couldn't find a better way to do it without a full refactor.

Also also removes the `blood_overlay_color` variable, because a mostly redundant variable only used in a single file really shouldn't be defined on `/obj/item`.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfix! (Consistent overlays are good.)

## Changelog
:cl:
fix: Fixed the blood overlay on telescopic batons being impossible to remove.
fix: Fixed the blood overlay on telescopic scythes disappearing when its mode gets switched.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
