### PR TITLE
Fix - Wheelchair users can go into the gateway

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -76,7 +76,7 @@
 	if(!has_buckled_mobs())
 		return
 	var/mob/living/buckled_mob = buckled_mobs[1]
-	if(istype(A, /obj/machinery/door))
+	if(istype(A, /obj/machinery/door) || istype(A, /obj/machinery/gateway))
 		A.Bumped(buckled_mob)
 
 	if(propelled)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the bumped check so wheelchair users can go in the gateway without slamming into a wall.

## Why It's Good For The Game
Fixes #16611

## Images of changes
https://user-images.githubusercontent.com/80771500/134789023-a9170743-0d50-4492-99c1-01649f3432d2.mp4

## Changelog
:cl:
fix: Mobs buckled to wheelchairs can use the gateway
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
