### PR TITLE
Fixes vendor item sprite previews showing multiple icon states

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -122,7 +122,7 @@
 	for(var/datum/data/vending_product/R in (product_records + coin_records + hidden_records))
 		var/obj/item/I = R.product_path
 		var/pp = replacetext(replacetext("[R.product_path]", "/obj/item/", ""), "/", "-")
-		imagelist[pp] = "[icon2base64(icon(initial(I.icon), initial(I.icon_state)))]"
+		imagelist[pp] = "[icon2base64(icon(initial(I.icon), initial(I.icon_state), SOUTH, 1))]"
 	if(LAZYLEN(slogan_list))
 		// So not all machines speak at the exact same time.
 		// The first time this machine says something will be at slogantime + this random value,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title and pictures below.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Images of changes
Examples of what this would fix:

Before:
![SXl8Aku0qz](https://user-images.githubusercontent.com/42044220/134791735-5a6e205e-47d5-425a-9f43-477cda155577.png)
![ss5QXl81sP](https://user-images.githubusercontent.com/42044220/134791739-cefc9ad6-5056-41cd-9790-bc31d81f7d81.png)

After:
![8kvN8sUTdJ](https://user-images.githubusercontent.com/42044220/134791779-a4f93af2-a22a-4daa-a303-781c2b1c3645.png)
![RDlgoejeFk](https://user-images.githubusercontent.com/42044220/134791812-c4ebcce9-7ba5-4af1-ab0b-28c1a4311750.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Vendor item sprite previews now only show 1 icon state
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
