### PR TITLE
Remaps MetaStation Escape

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26238,6 +26238,29 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"bfL" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "bfM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29826,6 +29849,14 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
+	})
+"bmY" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "bmZ" = (
 /obj/structure/window/reinforced{
@@ -38886,6 +38917,27 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"bEz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "bEA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45028,6 +45080,9 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"bRz" = (
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "bRA" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -47346,6 +47401,17 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
+	})
+"bWg" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "bWh" = (
 /obj/machinery/alarm{
@@ -70796,7 +70862,10 @@
 	name = "\improper Departure Lounge"
 	})
 "cTQ" = (
-/turf/space,
+/obj/structure/flora/ausbushes,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/bush,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71924,28 +71993,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"cWw" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "cWz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
@@ -72387,6 +72434,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"cXy" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cXz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -73970,12 +74025,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
-"daY" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dbb" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76357,20 +76406,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"dlS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dmU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76386,12 +76421,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/security/main)
-"dnw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "dom" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -76432,6 +76461,27 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"dre" = (
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"drK" = (
+/obj/machinery/door_control{
+	desc = "A remote control-switch for the pod doors.";
+	id = "escapepodbay";
+	name = "Pod Door Control";
+	pixel_y = 24;
+	req_access_txt = "13"
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "dtM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76454,38 +76504,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
-"dyk" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Starboard";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dyI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dAs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -76504,6 +76522,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"dCE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Port";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dCV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76668,6 +76710,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"dWv" = (
+/obj/machinery/sparker{
+	id = "Xenobio";
+	pixel_x = -25
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dWX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76726,6 +76777,15 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
+"ebu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ebA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76801,6 +76861,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"efS" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -76899,24 +76970,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"eGd" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
+"eFv" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eGG" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -76940,19 +77011,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
-"eIT" = (
-/obj/machinery/camera{
-	c_tag = "Escape - Aft";
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "eKV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77010,19 +77068,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"eQA" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "eRU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -77066,12 +77111,43 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"eVu" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+"eVm" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"eYc" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eYE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77089,23 +77165,40 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"fbp" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
+"faR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
 	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"feV" = (
+/mob/living/simple_animal/slime,
 /turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ffa" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -77202,23 +77295,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"fpm" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio7";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"fpy" = (
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "fsY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -77236,26 +77312,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"fte" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fts" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77268,15 +77324,6 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
-"fun" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "fvO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77301,10 +77348,6 @@
 	icon_state = "dark"
 	},
 /area/engine/break_room)
-"fxX" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine/vacuum,
-/area/escapepodbay)
 "fyS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -77313,6 +77356,12 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
+"fzU" = (
+/obj/structure/closet,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -77370,16 +77419,26 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"fGR" = (
-/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id_tag = "escapepodbay";
-	req_one_access_txt = "13"
+"fHu" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/spacepoddoor{
-	luminosity = 3
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fHC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -77387,6 +77446,10 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"fLW" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "fOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -77394,6 +77457,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"fOJ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "fPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77401,22 +77472,43 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"fTC" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/stock_parts/cell,
-/obj/item/flashlight,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Escape Podbay APC";
-	pixel_y = 25
+"fPf" = (
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Podbay"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
+"fPx" = (
+/obj/item/radio/intercom{
+	pixel_y = -25
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"fRU" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fUI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77437,6 +77529,48 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"fXa" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"fXx" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "fZa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -77496,28 +77630,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"gcT" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gda" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77636,6 +77748,13 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"gmB" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/chem_dispenser/beer,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "gnJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77679,26 +77798,42 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"grA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gtu" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
-"gvA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+"gvW" = (
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gwJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/construction)
-"gxd" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "gyy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -77722,29 +77857,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"gCK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77756,38 +77868,12 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"gDI" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gEi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
-"gFU" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"gHn" = (
-/obj/structure/spacepoddoor{
-	luminosity = 3
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "gIN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -77801,6 +77887,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
+"gJB" = (
+/obj/item/radio/beacon,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -77824,13 +77916,30 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"gNb" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+"gMU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "gOD" = (
 /obj/structure/cable/yellow{
@@ -77851,15 +77960,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
-"gOU" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "gQu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77870,23 +77970,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
-"gRa" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gRw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
@@ -77910,24 +77993,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"gVT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gYM" = (
 /obj/machinery/light{
 	dir = 8
@@ -77950,6 +78015,42 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
+"hbz" = (
+/obj/effect/decal/remains/xeno,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"hcg" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/stock_parts/cell,
+/obj/item/flashlight,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Escape Podbay APC";
+	pixel_y = 25
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"hcN" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hdL" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -77974,15 +78075,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"hfi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hgN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -78053,6 +78145,10 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"hkq" = (
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "hlZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78079,6 +78175,14 @@
 	},
 /area/maintenance/abandonedbar{
 	name = "New Bar"
+	})
+"hmE" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "hmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -78116,38 +78220,6 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"hoM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"hqf" = (
-/obj/item/radio/intercom{
-	pixel_y = -25
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hqN" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -78160,6 +78232,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"hrQ" = (
+/obj/machinery/shieldwallgen{
+	req_access = list(55)
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "huo" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -78167,17 +78248,17 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"huC" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
-"huP" = (
-/obj/effect/spawner/window/reinforced,
+"hwc" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/escapepodbay)
-"hvd" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -78208,6 +78289,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"hyk" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hAg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78223,27 +78312,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"hAw" = (
-/obj/machinery/door/window/southleft{
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hBM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -78318,62 +78386,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
-"hFo" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"hFX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"hHd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"hHz" = (
-/obj/structure/table,
-/obj/item/mounted/frame/light_fixture,
-/obj/item/mounted/frame/light_fixture,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "hHE" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -78404,17 +78416,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
-"hJV" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hKu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -78508,15 +78509,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"hXj" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+"hYo" = (
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78570,6 +78568,36 @@
 	},
 /turf/space,
 /area/space)
+"ick" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"icB" = (
+/obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "idx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78594,23 +78622,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"ifN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"igR" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge Podbay"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "ihM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78671,6 +78682,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"ikv" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio7";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "ikO" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -78741,10 +78766,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"ioO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+"ipa" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
@@ -78779,6 +78817,15 @@
 	},
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
+	})
+"iyi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "iyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78843,13 +78890,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"iIw" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "iMC" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/light{
@@ -78858,12 +78898,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
-	})
-"iNp" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "iNu" = (
 /turf/simulated/floor/plasteel{
@@ -78882,24 +78916,6 @@
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
-"iQe" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "iRu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78943,17 +78959,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
-"iTt" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "iTR" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -78965,6 +78970,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
+"iVE" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "iWv" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -78972,13 +78984,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"iXH" = (
-/obj/structure/table/wood,
-/obj/item/candle,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "iXL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79057,21 +79062,10 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"jkg" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+"jie" = (
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/escapepodbay)
 "jlB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79087,6 +79081,15 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"jpl" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "jrE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79102,6 +79105,23 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
+"jBx" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "jCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79199,24 +79219,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"jPA" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "jQZ" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -79249,6 +79251,24 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"kei" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kez" = (
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -79281,50 +79301,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"kid" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #6";
-	req_access_txt = "55"
+"kkJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"kik" = (
-/obj/machinery/constructable_frame/machine_frame,
-/obj/item/circuitboard/vendor,
-/obj/item/vending_refill/boozeomat,
-/obj/item/vending_refill/boozeomat,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
-"kkh" = (
-/obj/machinery/constructable_frame/machine_frame,
-/obj/item/circuitboard/chem_dispenser/beer,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
-"kma" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -79345,19 +79326,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"koX" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Test Chamber Monitor";
-	network = list("Xeno");
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kry" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -79396,6 +79364,19 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"ksT" = (
+/obj/machinery/camera{
+	c_tag = "Escape - Aft";
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kto" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -79420,11 +79401,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"kun" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
+"kvw" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine/vacuum,
+/area/escapepodbay)
+"kvC" = (
+/obj/machinery/door/window/southleft{
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "kvG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -79475,6 +79475,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"kzG" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kzH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -79533,25 +79553,6 @@
 	icon_state = "brown"
 	},
 /area/storage/primary)
-"kFl" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kGw" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
@@ -79594,6 +79595,20 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/sleep)
+"kLo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "kLs" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	layer = 2
@@ -79602,6 +79617,17 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"kNg" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kNr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -79637,6 +79663,16 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
+"kQL" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kRX" = (
 /obj/structure/window/plasmareinforced{
 	dir = 1
@@ -79691,27 +79727,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"kWA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kXs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -79737,28 +79752,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
-"kZJ" = (
-/obj/structure/chair,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"lan" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table/wood/poker,
-/obj/item/deck/cards,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "law" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79766,18 +79759,33 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
+"lca" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lcc" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"lcy" = (
-/obj/structure/table,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "lcL" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -79785,6 +79793,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"lcW" = (
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "len" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -79807,6 +79821,15 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"lgg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lgr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -79836,14 +79859,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"lgK" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lid" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -79864,6 +79879,12 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"lno" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "lpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79890,40 +79911,6 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
-"ltd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"lwd" = (
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"lwz" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "lwN" = (
 /obj/effect/spawner/lootdrop{
 	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
@@ -79934,22 +79921,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
-	})
-"lys" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "lBy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -79973,16 +79944,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"lCY" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
-/obj/item/radio/electropack,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lDa" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79994,14 +79955,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
 "lDx" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
+	})
+"lEJ" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "lFH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -80033,23 +79999,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"lGm" = (
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lGr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -80069,21 +80018,30 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
-"lID" = (
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+"lIb" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lIR" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/hydroponics)
-"lJn" = (
-/obj/item/radio/beacon,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lJX" = (
 /obj/structure/window/plasmareinforced,
 /obj/machinery/power/rad_collector{
@@ -80095,26 +80053,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"lMb" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Central";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lOU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/west,
@@ -80125,6 +80063,21 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
+	})
+"lRu" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80138,16 +80091,13 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"lTk" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"lTf" = (
+/obj/structure/table,
+/obj/item/mounted/frame/light_fixture,
+/obj/item/mounted/frame/light_fixture,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "lUc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80162,13 +80112,20 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
-"lVh" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+"lVa" = (
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -80181,9 +80138,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"lZa" = (
-/turf/simulated/wall,
-/area/escapepodbay)
+"lZH" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "mcP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -80267,21 +80229,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"mjY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mmk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80340,42 +80287,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"mtf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"mvP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "myY" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -80421,12 +80332,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"mBH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "mDj" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -80442,6 +80347,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"mEh" = (
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"mEU" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "mFx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80466,26 +80380,49 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"mJS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "mKy" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
+	})
+"mLY" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
+"mNi" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 18;
+	id = "skipjack_se";
+	name = "southeast of SS13";
+	width = 19
+	},
+/turf/space,
+/area/space)
+"mNS" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "mOc" = (
 /obj/structure/cable/yellow{
@@ -80509,17 +80446,13 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
-"mQJ" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light,
+"mRF" = (
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
+	icon_state = "white"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "mRP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -80568,12 +80501,38 @@
 "mXy" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
-"mYN" = (
-/obj/machinery/constructable_frame/machine_frame,
-/obj/item/circuitboard/chem_dispenser/soda,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
+"mXN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"mYM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "mZH" = (
 /obj/structure/chair{
@@ -80593,15 +80552,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"naO" = (
-/obj/machinery/shieldwallgen{
-	req_access = list(55)
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "naY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80633,6 +80583,19 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/wall,
 /area/construction)
+"ncJ" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nej" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -80685,27 +80648,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
-"nkh" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+"nmp" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"nko" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -80736,6 +80699,22 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"nuh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nuB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80753,6 +80732,15 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"nwy" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/vendor,
+/obj/item/vending_refill/boozeomat,
+/obj/item/vending_refill/boozeomat,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "nxh" = (
 /obj/structure/chair{
 	dir = 1
@@ -80785,6 +80773,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"nAe" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nEQ" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -80818,6 +80822,15 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"nGF" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "nHB" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -80839,11 +80852,30 @@
 	},
 /turf/space,
 /area/space)
+"nJq" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nKy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/ntrep)
+"nKR" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nLH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80860,24 +80892,6 @@
 "nMC" = (
 /turf/simulated/wall/r_wall,
 /area/storage/secure)
-"nON" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door_control{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nPe" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
@@ -80897,14 +80911,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"nUc" = (
-/obj/structure/grille,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
-	},
-/turf/space,
-/area/escapepodbay)
 "nUW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80937,14 +80943,6 @@
 /area/crew_quarters/locker/locker_toilet{
 	name = "\improper Restrooms"
 	})
-"nWf" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "nXf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/bluegrid,
@@ -80958,6 +80956,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"obj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"obv" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "odF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80980,6 +81003,17 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
+"ofp" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Test Chamber";
+	dir = 1;
+	network = list("SS13","RD")
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ofz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80989,28 +81023,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"ogD" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ogE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -81026,6 +81038,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"oia" = (
+/obj/structure/chair,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "oiv" = (
 /turf/simulated/floor/wood,
 /area/hallway/secondary/exit{
@@ -81039,9 +81063,38 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"omx" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+"oko" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"onh" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -81089,6 +81142,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"oDo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "oJQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81103,19 +81162,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"oJZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "oOs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/yellow,
@@ -81141,6 +81187,18 @@
 	},
 /area/medical/medbay2{
 	name = "Medbay Storage"
+	})
+"oSv" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "oTM" = (
 /obj/structure/sign/fire,
@@ -81191,6 +81249,29 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"oXp" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"oYR" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "pad" = (
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/carpet,
@@ -81231,22 +81312,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"pdX" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+"pdz" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio8";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/table/wood/poker,
+/obj/item/deck/cards,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "pef" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -81299,6 +81373,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
+"phU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pjn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -81328,13 +81411,24 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"pkG" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+"pkI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -81373,14 +81467,6 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
-"ppg" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "ppw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -81393,30 +81479,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
-"ppR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Port";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -81455,30 +81517,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"pvb" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pvu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81496,29 +81534,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"pzk" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pzX" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81560,30 +81575,20 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"pDo" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #4";
-	req_access_txt = "55"
+"pGh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"pEt" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/escapepodbay)
 "pHQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -81707,27 +81712,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"pSQ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pTP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81792,6 +81776,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/toxins/explab)
+"qaQ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qbl" = (
 /obj/effect/spawner/airlock,
 /turf/simulated/wall,
@@ -81816,6 +81818,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/construction)
+"qdh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "qee" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81849,15 +81857,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
-"qgY" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qhx" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
@@ -81898,14 +81897,31 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"qpd" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"qps" = (
+/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
+	id_tag = "escapepodbay";
+	req_one_access_txt = "13"
+	},
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "qpO" = (
 /turf/simulated/wall,
 /area/engine/equipmentstorage)
-"qtg" = (
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"qqd" = (
+/obj/structure/table,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "qts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81926,15 +81942,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"quX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qwd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -81967,6 +81974,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"qzA" = (
+/obj/structure/grille,
+/turf/space,
+/area/escapepodbay)
 "qAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81991,17 +82002,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"qEb" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qFg" = (
 /obj/machinery/space_heater,
 /obj/machinery/power/apc{
@@ -82012,25 +82012,6 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"qFG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "qHi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -82064,6 +82045,25 @@
 	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/starboard)
+"qIO" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"qLi" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qME" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82079,6 +82079,23 @@
 	icon_state = "red"
 	},
 /area/security/main)
+"qPm" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio8";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qQy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82104,14 +82121,16 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"qSv" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #3";
-	req_access_txt = "55"
+"qTa" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82146,6 +82165,17 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"qYP" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "raV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82154,6 +82184,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"rbr" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/space,
+/area/escapepodbay)
 "rdz" = (
 /obj/item/twohanded/required/kirbyplants{
 	level = 4.1
@@ -82178,41 +82216,20 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"rhb" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+"rgu" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"riH" = (
-/obj/machinery/door_control{
-	desc = "A remote control-switch for the pod doors.";
-	id = "escapepodbay";
-	name = "Pod Door Control";
-	pixel_y = 24;
-	req_access_txt = "13"
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "riM" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"riV" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "rjj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -82240,19 +82257,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rkl" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"rli" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "rlJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/light,
@@ -82280,6 +82284,10 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"rnz" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "rpg" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -82289,6 +82297,12 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"rpo" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "rqY" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -82321,20 +82335,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"rvj" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio8";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "rvu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82355,6 +82355,16 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"rwo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/item/cigbutt,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rxV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 5
@@ -82388,8 +82398,19 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rAb" = (
-/obj/effect/decal/warning_stripes/north,
+"rDc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -82448,6 +82469,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
+"rEp" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "rEw" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82629,6 +82658,9 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"rYt" = (
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "rYO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -82683,17 +82715,18 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"siV" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+"sdC" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
+	icon_state = "white"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "sjx" = (
 /obj/structure/chair{
@@ -82722,24 +82755,6 @@
 	icon_state = "dark"
 	},
 /area/space/nearstation)
-"smM" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "soT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -82776,13 +82791,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/library)
-"spH" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"sqJ" = (
+/obj/structure/table/wood/poker,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "srJ" = (
 /obj/structure/cable/yellow{
@@ -82802,35 +82815,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"stE" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"svx" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 18;
-	id = "skipjack_se";
-	name = "southeast of SS13";
-	width = 19
-	},
-/turf/space,
-/area/space)
 "svF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82858,19 +82842,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"swF" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "sxA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -82884,9 +82855,16 @@
 "sBY" = (
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"sEG" = (
-/obj/structure/closet,
-/turf/simulated/floor/plating,
+"sCk" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82906,6 +82884,29 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
+"sHM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sJe" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -82920,6 +82921,14 @@
 	},
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
+	})
+"sKo" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "sLs" = (
 /obj/structure/cable/yellow{
@@ -82948,22 +82957,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"sMx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "sOB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -82971,6 +82964,19 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"sOG" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Test Chamber Monitor";
+	network = list("Xeno");
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sOJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -82984,6 +82990,28 @@
 	density = 0;
 	icon_state = "open";
 	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"sQo" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
 	name = "containment blast door";
 	opacity = 0
 	},
@@ -83014,14 +83042,21 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"sZK" = (
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Maximum Security Test Chamber";
+"tam" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -24;
+	pixel_y = 24;
 	req_access_txt = "55"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83057,6 +83092,9 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"teU" = (
+/turf/simulated/wall,
+/area/escapepodbay)
 "teW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83093,6 +83131,48 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
+"tja" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"tjg" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/ignition_switch{
+	id = "Xenobio";
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/machinery/door_control{
+	id = "Xenolab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = -2;
+	req_access_txt = "55"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tjR" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83108,31 +83188,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
-"tmV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tpg" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
@@ -83147,14 +83202,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"tsf" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "tvk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -83228,16 +83275,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"tAY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "tBw" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83246,14 +83283,6 @@
 	icon_state = "vault"
 	},
 /area/security/main)
-"tBT" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "tCC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83285,11 +83314,40 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"tLJ" = (
-/turf/simulated/floor/plating,
+"tHN" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"tId" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"tKX" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -83315,19 +83373,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"tQR" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
-"tRr" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tSj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -83386,12 +83431,6 @@
 	icon_state = "redfull"
 	},
 /area/security/permabrig)
-"tZr" = (
-/mob/living/simple_animal/slime,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tZI" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1441;
@@ -83412,15 +83451,15 @@
 /area/security/checkpoint2{
 	name = "Customs"
 	})
-"uaB" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "uaQ" = (
 /turf/simulated/wall,
 /area/engine/mechanic_workshop)
+"ubk" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "udB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -83459,18 +83498,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"ujJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
-"ukt" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "umD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -83492,6 +83519,50 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
+"ung" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Starboard";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"unj" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio6";
+	name = "Containment Blast Doors";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -83505,21 +83576,23 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"uuf" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+"uqY" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Central";
+	dir = 8;
+	network = list("SS13","RD")
 	},
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83552,32 +83625,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
+"uyB" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uzt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
 	},
 /area/hydroponics)
-"uzx" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uAA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -83604,17 +83663,6 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
-"uEq" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uEN" = (
 /obj/effect/landmark/start{
 	name = "Roboticist"
@@ -83671,21 +83719,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
-"uOq" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uOL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -83723,6 +83756,12 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"uTM" = (
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "uTZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -83744,28 +83783,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"uVb" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uWq" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -83782,6 +83799,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
+"uYQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "vaE" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -83840,24 +83871,6 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"vmK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vmT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -83878,19 +83891,26 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
-"vnn" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+"vpD" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
-"vnM" = (
-/obj/machinery/light,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
 /turf/simulated/floor/engine,
-/area/escapepodbay)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -83915,30 +83935,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"vtM" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vtP" = (
 /obj/machinery/conveyor/west{
 	id = "garbage"
@@ -83980,24 +83976,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"vAJ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vBv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -84130,6 +84108,23 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
+"vQm" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/escapepodbay)
+"vRD" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vRY" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow{
@@ -84145,26 +84140,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"vRZ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vSx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84221,6 +84196,15 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
+"whx" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "whC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -84233,17 +84217,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
-"wpx" = (
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/table,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+"wnH" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
+	})
+"wqq" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/chem_dispenser/soda,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "wri" = (
 /obj/structure/window/reinforced,
@@ -84271,6 +84258,35 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"wsJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"wtk" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/item/radio/electropack,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wtP" = (
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
@@ -84329,30 +84345,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
-"wvW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair,
-/obj/item/cigbutt,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"wxB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "wxE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -84368,6 +84360,26 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
+"wyO" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -84440,6 +84452,15 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"wFR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wFW" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -84455,34 +84476,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"wHN" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/ignition_switch{
-	id = "Xenobio";
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/machinery/door_control{
-	id = "Xenolab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = -2;
-	req_access_txt = "55"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wHZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -84506,10 +84499,28 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"wOx" = (
-/obj/structure/grille,
-/turf/space,
-/area/escapepodbay)
+"wNm" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wRy" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84544,23 +84555,6 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"wTk" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wUE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84593,6 +84587,30 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
+"xbP" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84621,27 +84639,14 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"xiV" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #5";
-	req_access_txt = "55"
+"xhT" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -84666,14 +84671,6 @@
 	icon_state = "caution"
 	},
 /area/atmos)
-"xqw" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "xqz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
@@ -84689,26 +84686,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
-"xsV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xtA" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -84740,6 +84717,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"xvP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xxA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -84749,27 +84744,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
-"xyL" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio6";
-	name = "Containment Blast Doors";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xDw" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/meter,
@@ -84792,6 +84766,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"xFy" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -84823,6 +84810,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"xJo" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xJB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -84844,20 +84844,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"xNr" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "xOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84866,17 +84852,6 @@
 	icon_state = "stage_stairs"
 	},
 /area/security/podbay)
-"xPv" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Test Chamber";
-	dir = 1;
-	network = list("SS13","RD")
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xSh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84896,6 +84871,34 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"xWE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"xXc" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xXW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -106810,12 +106813,12 @@ aaa
 aaa
 aaa
 aaa
-wOx
+qzA
 aaa
 aaa
 aaa
 aaa
-wOx
+qzA
 aaa
 aaa
 aaa
@@ -107067,12 +107070,12 @@ aaa
 aaa
 aaa
 aaa
-nUc
+rbr
 aaa
 aaa
 aaa
 aaa
-nUc
+rbr
 aaa
 aaa
 aaa
@@ -107324,12 +107327,12 @@ dbW
 dbW
 dbW
 dbV
-lZa
-fxX
-fxX
-fxX
-fxX
-lZa
+teU
+kvw
+kvw
+kvw
+kvw
+teU
 aaa
 aaa
 aaa
@@ -107578,15 +107581,15 @@ dbV
 dcw
 ddU
 deT
-mYN
-kkh
-kik
-lZa
-gHn
-gHn
-gHn
-fGR
-lZa
+wqq
+gmB
+nwy
+teU
+uTM
+uTM
+uTM
+qps
+teU
 aaa
 aaa
 aaa
@@ -107838,12 +107841,12 @@ dfD
 dcx
 dcx
 dcx
-lZa
-fpy
-fpy
-fpy
-fpy
-lZa
+teU
+rYt
+rYt
+rYt
+rYt
+teU
 aaa
 aaa
 aaa
@@ -108092,15 +108095,15 @@ dbW
 dcx
 ddW
 dfH
-hHz
-lcy
-lcy
-lZa
-fpy
-fpy
-fpy
-fpy
-lZa
+lTf
+qqd
+qqd
+teU
+rYt
+rYt
+rYt
+rYt
+teU
 aaa
 aaa
 aaa
@@ -108352,12 +108355,12 @@ dfW
 ddX
 ddX
 ddX
-lZa
-riH
-fpy
-fpy
-fpy
-lZa
+teU
+drK
+rYt
+rYt
+rYt
+teU
 aaa
 aaa
 aaa
@@ -108608,13 +108611,13 @@ dej
 dgB
 dcx
 dcx
-gNb
-lZa
-igR
-fpy
-fpy
-vnM
-lZa
+lZH
+teU
+fPf
+rYt
+rYt
+hkq
+teU
 aaa
 aaa
 aaa
@@ -108864,14 +108867,14 @@ dcx
 dcx
 dgW
 dcx
-kun
+sqJ
 dcx
-lZa
-gxd
-gxd
-gxd
-xqw
-lZa
+teU
+jie
+jie
+jie
+mLY
+teU
 aaa
 aaa
 aaa
@@ -109120,15 +109123,15 @@ dbW
 dcz
 deo
 dhF
-dnw
-lan
+oDo
+pdz
 dcx
-lZa
-hXj
-mBH
-lID
-eVu
-lZa
+teU
+jpl
+qdh
+bRz
+lcW
+teU
 aaa
 aaa
 aaa
@@ -109378,14 +109381,14 @@ dcx
 dcx
 ged
 dcx
-kun
-vnn
-lZa
-fTC
-mvP
-gvA
-rli
-lZa
+sqJ
+lEJ
+teU
+hcg
+pGh
+rpo
+mEU
+teU
 aaa
 aaa
 aaa
@@ -109637,12 +109640,12 @@ ged
 dcx
 dcx
 dcx
-lZa
-huC
-wxB
-lID
-xNr
-lZa
+teU
+rnz
+kLo
+bRz
+tja
+teU
 aaa
 aaa
 aaa
@@ -109891,15 +109894,15 @@ dbV
 dbV
 dbW
 hlZ
-tAY
+icB
 dbW
 dbV
-lZa
-huP
-eGd
-iIw
-huP
-lZa
+teU
+vQm
+fXx
+qpd
+vQm
+teU
 aaa
 aaa
 aaa
@@ -110150,12 +110153,12 @@ des
 jhQ
 cWi
 cWi
-siV
-mJS
+oSv
+uYQ
 cWi
-qFG
+faR
 cWi
-fun
+nGF
 cTX
 aaa
 aaa
@@ -110410,7 +110413,7 @@ cLS
 cOZ
 cRt
 cVc
-mtf
+xWE
 cWb
 bPk
 cTX
@@ -110662,14 +110665,14 @@ cZU
 gTp
 cWb
 mGK
-tBT
-kZJ
+rEp
+oia
 cUu
 mGK
-tsf
-kZJ
+sKo
+oia
 cWb
-pEt
+oYR
 cVk
 aaa
 aaa
@@ -110919,14 +110922,14 @@ cZL
 gTp
 cWb
 mGK
-lwz
-kZJ
+fOJ
+oia
 dap
 mGK
-ppg
-kZJ
+cXy
+oia
 cWb
-pEt
+oYR
 cVk
 aaa
 aaa
@@ -111176,14 +111179,14 @@ cTW
 cNz
 cWb
 mGK
-ppg
-kZJ
+cXy
+oia
 cWb
 mGK
-lwz
-kZJ
+fOJ
+oia
 cWb
-mQJ
+oXp
 cVk
 aaa
 aaa
@@ -111433,14 +111436,14 @@ dbZ
 cUz
 cWb
 nxh
-tsf
-kZJ
+sKo
+oia
 cWb
 mGK
-tBT
-kZJ
+rEp
+oia
 cWb
-pEt
+oYR
 cVk
 aaa
 aaa
@@ -111697,7 +111700,7 @@ cTs
 cTW
 cNz
 cWb
-rkl
+tId
 cVk
 aaa
 aaa
@@ -111954,7 +111957,7 @@ cWb
 cWb
 cWb
 cTr
-gOU
+whx
 cVk
 aaa
 aaa
@@ -112210,7 +112213,7 @@ dat
 cYV
 cYV
 cYV
-eIT
+ksT
 cVk
 cVk
 aaa
@@ -112718,12 +112721,12 @@ cWo
 dcD
 cTX
 pad
-iXH
-nWf
+iVE
+bmY
 cTX
-tLJ
+mEh
 cTX
-uaB
+lno
 cVk
 aaa
 aaa
@@ -120436,8 +120439,8 @@ cVG
 cVG
 cVG
 rpg
-lwd
-lwd
+gvW
+gvW
 cVG
 cVG
 cVG
@@ -120685,18 +120688,18 @@ dci
 dcH
 ddw
 rpg
-lwd
-tZr
+gvW
+feV
 ddw
 rpg
-lwd
-tZr
+gvW
+feV
 ddw
 rDg
-lwd
-lwd
+gvW
+gvW
 cVG
-sEG
+fzU
 cVG
 cVG
 cVG
@@ -120942,25 +120945,25 @@ dcj
 dcN
 ddw
 rDg
-lwd
-lwd
+gvW
+gvW
 ddw
 rDg
-lwd
-lwd
+gvW
+gvW
 ddw
 rDg
-lwd
-lwd
+gvW
+gvW
 cVG
-dyI
-omx
-omx
-omx
-omx
-omx
-omx
-quX
+lgg
+ubk
+ubk
+ubk
+ubk
+ubk
+ubk
+phU
 cVG
 aaa
 aaa
@@ -121199,25 +121202,25 @@ dcj
 dcX
 ddw
 rDg
-lwd
-lwd
+gvW
+gvW
 ddw
 rDg
-lwd
-lwd
+gvW
+gvW
 ddw
-hFo
-xiV
-uuf
+kzG
+nmp
+oko
 cVG
-gDI
-cVG
-cVG
+hwc
 cVG
 cVG
 cVG
 cVG
-ifN
+cVG
+cVG
+kkJ
 cVG
 abq
 aaa
@@ -121456,25 +121459,25 @@ dck
 ddv
 ddw
 sOJ
-pvb
-stE
+xbP
+lIb
 ddw
-fbp
-vtM
-jPA
+vpD
+fXa
+eFv
 ddw
 ueD
-lTk
-vAJ
-ppR
-lGm
-naO
+bWg
+mNS
+dCE
+lVa
+hrQ
 cVG
-lwd
-qgY
-tRr
+gvW
+dWv
+hbz
 cVG
-ifN
+kkJ
 cVG
 abq
 aaa
@@ -121713,25 +121716,25 @@ dcl
 ddJ
 cpf
 ueD
-hJV
-kWA
-lVh
+qYP
+grA
+kQL
 ueD
-qSv
-ltd
-lVh
-nON
+efS
+bEz
+kQL
+tam
 dcj
-xsV
-sMx
-koX
-wTk
-lDx
-lwd
-lwd
-lwd
+fHu
+nuh
+sOG
+jBx
+rgu
+gvW
+gvW
+gvW
 cVG
-ifN
+kkJ
 cVG
 aaa
 aaa
@@ -121969,26 +121972,26 @@ dbM
 dcl
 ddK
 dez
-rAb
+nKR
 dcj
-eQA
-dlS
-riV
+sCk
+obj
+mRF
 dcj
-eQA
-pkG
-riV
+sCk
+sdC
+mRF
 dcj
-fte
-hoM
-wHN
-pzk
-gFU
-gFU
-lgK
-lwd
+wyO
+pkI
+tjg
+bfL
+lDx
+lDx
+hyk
+gvW
 cVG
-wvW
+rwo
 cZN
 aaa
 aaa
@@ -122226,29 +122229,29 @@ dbR
 dcq
 ddL
 deB
-lys
-mjY
-tmV
-hFX
-mjY
-kma
-tmV
-mjY
-mjY
-kFl
-gCK
-vmK
-sZK
-hAw
-lwd
-lwd
-lwd
-xPv
+nAe
+lRu
+gMU
+wsJ
+lRu
+xvP
+gMU
+lRu
+lRu
+rDc
+sHM
+mXN
+dre
+kvC
+gvW
+gvW
+gvW
+ofp
 cVG
-hfi
-hvd
-ujJ
-tQR
+iyi
+qIO
+fLW
+tKX
 aaa
 aaa
 aaa
@@ -122483,24 +122486,24 @@ dbS
 dcs
 ddM
 deQ
-rAb
+nKR
 dcj
-oJZ
-lMb
-ukt
+qTa
+uqY
+wnH
 dcj
-oJZ
-spH
-ukt
+qTa
+hmE
+wnH
 dcj
-uOq
-qEb
-nkh
-cWw
-qtg
-lwd
-lJn
-lwd
+mYM
+xhT
+qLi
+wNm
+hYo
+gvW
+gJB
+gvW
 cVG
 cVJ
 cZN
@@ -122740,24 +122743,24 @@ cZj
 dcs
 ddN
 cpf
-rvj
-swF
-gVT
-lVh
-fpm
-pDo
-gVT
-lVh
-rAb
+hcN
+xJo
+tHN
+kQL
+ikv
+ncJ
+tHN
+kQL
+nKR
 dcj
-uzx
-rhb
-wpx
-gRa
-lDx
-lwd
-lwd
-hqf
+ick
+xFy
+ffa
+onh
+rgu
+gvW
+gvW
+fPx
 cVG
 cVJ
 cVG
@@ -122997,24 +123000,24 @@ dbT
 dct
 ddO
 ddw
-pdX
+qPm
 ddD
 cYA
 ddw
 dca
-gcT
-pSQ
+eYc
+lca
 ddw
-xyL
-kid
-iQe
-dyk
-nko
-naO
+unj
+vRD
+qaQ
+ung
+obv
+hrQ
 cVG
-lCY
-jkg
-ogD
+wtk
+eVm
+ipa
 cVG
 cVJ
 cVG
@@ -123254,19 +123257,19 @@ cZW
 dcj
 ddP
 ddw
-lwd
-lwd
+gvW
+gvW
 rDg
 ddw
-lwd
-lwd
+gvW
+gvW
 rDg
 ddw
-vRZ
-uVb
-smM
+fRU
+sQo
+kei
 cVG
-iTt
+kNg
 cVG
 cVG
 cVG
@@ -123511,17 +123514,17 @@ dcv
 dcj
 ddR
 ddw
-lwd
-lwd
+gvW
+gvW
 rDg
 ddw
-lwd
-lwd
+gvW
+gvW
 rDg
 ddw
-ioO
-iNp
-hHd
+ebu
+xXc
+wFR
 cVG
 cVJ
 cVJ
@@ -123768,19 +123771,19 @@ dbU
 dcu
 ddS
 ddw
-lwd
-lwd
-uEq
+gvW
+gvW
+nJq
 ddw
-tZr
-lwd
-uEq
+feV
+gvW
+nJq
 ddw
-lwd
-lwd
+gvW
+gvW
 rDg
 cVG
-daY
+uyB
 cVG
 cVG
 cVG
@@ -124033,9 +124036,9 @@ cVG
 cVG
 cVG
 cVG
-lwd
-lwd
-uEq
+gvW
+gvW
+nJq
 cVG
 cVG
 cVG
@@ -130719,7 +130722,7 @@ aaa
 aaa
 aaa
 aaa
-svx
+mNi
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2604,24 +2604,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
-"ahy" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ahz" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -47428,26 +47410,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep)
-"bWq" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "bWs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -70195,14 +70157,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
-"cSw" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "cSx" = (
 /obj/structure/table,
 /obj/item/mmi,
@@ -71970,6 +71924,28 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"cWw" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cWz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
@@ -73994,6 +73970,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
+"daY" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dbb" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -74690,10 +74672,7 @@
 	name = "\improper Secure Lab"
 	})
 "dcw" = (
-/obj/item/mounted/frame/light_fixture{
-	dir = 8;
-	pixel_x = -16
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -74704,9 +74683,6 @@
 	name = "New Bar"
 	})
 "dcy" = (
-/obj/item/mounted/frame/apc_frame{
-	pixel_y = 28
-	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -74722,14 +74698,6 @@
 	name = "New Bar"
 	})
 "dcA" = (
-/obj/item/mounted/frame/firealarm{
-	pixel_y = 27
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
-"dcB" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25
@@ -74738,7 +74706,7 @@
 /area/maintenance/abandonedbar{
 	name = "New Bar"
 	})
-"dcC" = (
+"dcB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheesiehonkers,
 /obj/item/reagent_containers/food/drinks/cans/cola,
@@ -74753,7 +74721,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcD" = (
+"dcC" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "emergency_home";
 	locked = 1;
@@ -74763,7 +74731,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcE" = (
+"dcD" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -74771,7 +74739,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcH" = (
+"dcE" = (
 /obj/docking_port/stationary{
 	dir = 4;
 	dwidth = 11;
@@ -74782,6 +74750,14 @@
 	},
 /turf/space,
 /area/space)
+"dcH" = (
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dcK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -74790,8 +74766,8 @@
 /turf/simulated/floor/plasteel,
 /area/medical/cryo)
 "dcN" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
@@ -74810,7 +74786,13 @@
 /turf/space,
 /area/space)
 "dcX" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/disposal,
+/obj/structure/sign/deathsposal{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -74832,15 +74814,27 @@
 	name = "\improper Secure Lab"
 	})
 "ddv" = (
-/obj/machinery/disposal,
-/obj/structure/sign/deathsposal{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74877,32 +74871,6 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_y = 4
-	},
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 8
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/glass,
 /obj/item/slime_scanner,
 /obj/item/slime_scanner,
 /obj/effect/decal/warning_stripes/southeastcorner,
@@ -74912,7 +74880,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddL" = (
+"ddK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -74923,7 +74891,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddM" = (
+"ddL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -74942,7 +74910,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddN" = (
+"ddM" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -74950,7 +74918,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddO" = (
+"ddN" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
@@ -74961,12 +74929,20 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddP" = (
+"ddO" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddP" = (
+/obj/machinery/monkey_recycler,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74984,14 +74960,6 @@
 /turf/space,
 /area/space)
 "ddR" = (
-/obj/machinery/monkey_recycler,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddS" = (
 /obj/machinery/processor{
 	desc = "A machine used to process slimes and retrieve their extract.";
 	name = "Slime Processor"
@@ -75006,7 +74974,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddU" = (
+"ddS" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
@@ -75016,14 +74984,21 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddW" = (
+"ddU" = (
 /obj/structure/reagent_dispensers/beerkeg/nuke,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
 	})
-"ddX" = (
+"ddW" = (
 /obj/structure/table,
+/obj/item/mounted/frame/apc_frame,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
+"ddX" = (
+/obj/structure/chair/stool/bar,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -75077,7 +75052,11 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dej" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -75107,11 +75086,7 @@
 	},
 /area/chapel/main)
 "deo" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -75143,12 +75118,6 @@
 /turf/simulated/floor/plating,
 /area/medical/psych)
 "des" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
-"det" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -75160,7 +75129,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dez" = (
+"det" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
@@ -75179,9 +75148,26 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"deB" = (
+"dez" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"deB" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -75312,16 +75298,11 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "deQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -75350,16 +75331,13 @@
 	},
 /area/security/main)
 "deT" = (
-/obj/machinery/light{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/machinery/disposal,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "deU" = (
 /obj/machinery/power/apc{
@@ -75607,10 +75585,9 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dfD" = (
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/disposal,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -75631,6 +75608,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/mounted/frame/firealarm,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -75755,7 +75734,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table,
+/obj/structure/chair/stool/bar,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -75980,10 +75959,14 @@
 	name = "Arrivals"
 	})
 "dgB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar,
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
@@ -76082,9 +76065,9 @@
 /area/engine/mechanic_workshop)
 "dgW" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76293,6 +76276,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -76363,24 +76352,25 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/exam_room)
-"djK" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Test Chamber Monitor";
-	network = list("Xeno");
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "djL" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"dlS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dmU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76396,21 +76386,11 @@
 	icon_state = "showroomfloor"
 	},
 /area/security/main)
-"dol" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"dnw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dom" = (
 /obj/effect/decal/warning_stripes/north,
@@ -76452,36 +76432,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"dsN" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dsY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "dtM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76490,14 +76440,6 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"dvM" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "dwC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76512,9 +76454,32 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
-"dyw" = (
+"dyk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Starboard";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dyI" = (
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -76539,16 +76504,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"dBK" = (
-/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id_tag = "escapepodbay";
-	req_one_access_txt = "13"
-	},
-/obj/structure/spacepoddoor{
-	luminosity = 3
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "dCV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76614,26 +76569,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dHb" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dHr" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76683,19 +76618,6 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"dNi" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dOQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76879,19 +76801,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"egX" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -76933,13 +76842,6 @@
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
 /area/security/permabrig)
-"emp" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
 "eoq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76970,24 +76872,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"etk" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "evR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
-"ewu" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "eEV" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -77009,6 +76899,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"eGd" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "eGG" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -77032,16 +76940,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
-"eJd" = (
-/obj/machinery/door_control{
-	desc = "A remote control-switch for the pod doors.";
-	id = "escapepodbay";
-	name = "Pod Door Control";
-	pixel_y = 24;
-	req_access_txt = "13"
+"eIT" = (
+/obj/machinery/camera{
+	c_tag = "Escape - Aft";
+	dir = 1
 	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "eKV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77082,17 +76993,6 @@
 	icon_state = "grimy"
 	},
 /area/hallway/primary/port)
-"eQb" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "eQf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77110,6 +77010,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"eQA" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eRU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -77153,21 +77066,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"eXj" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+"eVu" = (
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "eYE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77185,23 +77089,19 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"eZh" = (
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ffs" = (
+"fbp" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
-	id_tag = "xenobio3";
+	id_tag = "xenobio2";
 	name = "containment blast door";
 	opacity = 0
 	},
@@ -77246,24 +77146,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"fhT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fhW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -77320,6 +77202,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"fpm" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio7";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"fpy" = (
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "fsY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -77337,6 +77236,26 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"fte" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fts" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77349,6 +77268,15 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
+"fun" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "fvO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77373,6 +77301,10 @@
 	icon_state = "dark"
 	},
 /area/engine/break_room)
+"fxX" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine/vacuum,
+/area/escapepodbay)
 "fyS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -77438,6 +77370,16 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"fGR" = (
+/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
+	id_tag = "escapepodbay";
+	req_one_access_txt = "13"
+	},
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "fHC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -77459,13 +77401,22 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"fUd" = (
-/obj/machinery/constructable_frame/machine_frame,
-/obj/item/circuitboard/chem_dispenser/beer,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
+"fTC" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/stock_parts/cell,
+/obj/item/flashlight,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Escape Podbay APC";
+	pixel_y = 25
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "fUI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77486,28 +77437,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"fYn" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fZa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -77567,6 +77496,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"gcT" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gda" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77607,10 +77558,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77618,15 +77569,6 @@
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar{
 	name = "New Bar"
-	})
-"gez" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "gfB" = (
 /obj/structure/window/plasmareinforced,
@@ -77737,39 +77679,25 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"gsP" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"gtd" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
 "gtu" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
+"gvA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "gwJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/construction)
-"gyw" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
+"gxd" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
 /area/escapepodbay)
 "gyy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -77794,14 +77722,26 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"gBT" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #3";
-	req_access_txt = "55"
+"gCK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -77816,12 +77756,38 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"gDI" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gEi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
+"gFU" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"gHn" = (
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "gIN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -77858,6 +77824,14 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"gNb" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "gOD" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -77877,6 +77851,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
+"gOU" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "gQu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77887,6 +77870,23 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
+"gRa" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gRw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
@@ -77910,6 +77910,24 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"gVT" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gYM" = (
 /obj/machinery/light{
 	dir = 8
@@ -77932,30 +77950,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
-"hax" = (
-/obj/item/radio/intercom{
-	pixel_y = -25
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"haZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hdL" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -77963,17 +77957,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"hdY" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 18;
-	id = "skipjack_se";
-	name = "southeast of SS13";
-	width = 19
-	},
-/turf/space,
-/area/space)
 "het" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -77991,6 +77974,15 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"hfi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hgN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -78016,28 +78008,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"hhi" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hht" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78049,10 +78019,6 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"hhy" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine/vacuum,
-/area/escapepodbay)
 "hio" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78088,21 +78054,29 @@
 	name = "Port Maintenance"
 	})
 "hlZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/maintenance/abandonedbar{
 	name = "New Bar"
 	})
@@ -78142,18 +78116,33 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"hqs" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+"hoM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio8";
-	name = "containment blast door";
-	opacity = 0
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"hqf" = (
+/obj/item/radio/intercom{
+	pixel_y = -25
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
@@ -78178,6 +78167,20 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"huC" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"huP" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/escapepodbay)
+"hvd" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hwe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78205,18 +78208,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"hzZ" = (
-/obj/structure/chair,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "hAg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78232,6 +78223,27 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"hAw" = (
+/obj/machinery/door/window/southleft{
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hBM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -78274,24 +78286,6 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"hEc" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hEA" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -78324,6 +78318,62 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
+"hFo" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"hFX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"hHd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"hHz" = (
+/obj/structure/table,
+/obj/item/mounted/frame/light_fixture,
+/obj/item/mounted/frame/light_fixture,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "hHE" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -78354,21 +78404,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
+"hJV" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hKu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"hLm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hLt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78456,6 +78508,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"hXj" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "hYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78480,12 +78541,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
-"ias" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "ibi" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow{
@@ -78539,36 +78594,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"ieT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+"ifN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ihe" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+"igR" = (
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Podbay"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "ihM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78641,15 +78683,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"ilY" = (
-/obj/machinery/shieldwallgen{
-	req_access = list(55)
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "imC" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78664,29 +78697,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"imP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Starboard";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "imQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -78731,14 +78741,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"irT" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+"ioO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "isf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -78824,20 +78834,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
-"iHM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "iIk" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -78847,6 +78843,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"iIw" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "iMC" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/light{
@@ -78856,22 +78859,8 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"iNt" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
+"iNp" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -78893,6 +78882,24 @@
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
+"iQe" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "iRu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78936,6 +78943,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
+"iTt" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "iTR" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -78947,12 +78965,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
-"iVr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "iWv" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -78960,23 +78972,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"iWF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"iXH" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "iXL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79041,25 +79042,35 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "neutral"
 	},
-/area/maintenance/abandonedbar{
-	name = "New Bar"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"jkg" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "jlB" = (
 /obj/structure/cable/yellow{
@@ -79076,16 +79087,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
-"jqq" = (
-/obj/machinery/door/firedoor,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "jrE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79138,17 +79139,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"jGF" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Test Chamber";
-	dir = 1;
-	network = list("SS13","RD")
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "jGU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79156,31 +79146,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"jHM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"jIN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "jKJ" = (
 /obj/structure/chair{
 	dir = 1
@@ -79234,6 +79199,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"jPA" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "jQZ" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -79246,19 +79229,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"jSw" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"jTR" = (
-/obj/structure/table/wood,
-/obj/item/candle,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "jUV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79271,15 +79241,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"jWA" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "jZd" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_y = -32
@@ -79320,55 +79281,47 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"khx" = (
-/obj/machinery/light{
-	dir = 8
+"kid" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"kjB" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"kks" = (
+"kik" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/vendor,
+/obj/item/vending_refill/boozeomat,
+/obj/item/vending_refill/boozeomat,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
+"kkh" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/chem_dispenser/beer,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
+"kma" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/effect/landmark{
+	name = "lightsout"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -79392,26 +79345,15 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"kqU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+"koX" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Test Chamber Monitor";
+	network = list("Xeno");
+	pixel_y = 2
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Port";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -79478,6 +79420,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"kun" = (
+/obj/structure/table/wood/poker,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "kvG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -79487,12 +79435,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/hor)
-"kwg" = (
-/obj/structure/spacepoddoor{
-	luminosity = 3
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "kwD" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79533,17 +79475,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"kxJ" = (
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kzH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -79602,18 +79533,19 @@
 	icon_state = "brown"
 	},
 /area/storage/primary)
-"kFj" = (
-/obj/machinery/light{
-	dir = 1
+"kFl" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door_control{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "55"
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -79670,46 +79602,31 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"kMl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+"kNr" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/railing/corner{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"kNr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -79774,6 +79691,27 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"kWA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kXs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -79784,19 +79722,6 @@
 	},
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
-	})
-"kZh" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "kZl" = (
 /obj/structure/cable/yellow{
@@ -79812,6 +79737,28 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
+"kZJ" = (
+/obj/structure/chair,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"lan" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/wood/poker,
+/obj/item/deck/cards,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "law" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79825,6 +79772,12 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"lcy" = (
+/obj/structure/table,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "lcL" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -79832,27 +79785,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"lcM" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio6";
-	name = "Containment Blast Doors";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "len" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -79904,8 +79836,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"lhH" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+"lgK" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1
+	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -79923,30 +79857,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"lkK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lmi" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -79966,15 +79876,6 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
-"lps" = (
-/obj/machinery/constructable_frame/machine_frame,
-/obj/item/circuitboard/vendor,
-/obj/item/vending_refill/boozeomat,
-/obj/item/vending_refill/boozeomat,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "lpU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/warning_stripes/southeast,
@@ -79989,20 +79890,40 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
-"ltv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"ltd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"lwd" = (
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"lwz" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "lwN" = (
 /obj/effect/spawner/lootdrop{
 	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
@@ -80013,6 +79934,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"lys" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "lBy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -80036,6 +79973,16 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"lCY" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/item/radio/electropack,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lDa" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80046,6 +79993,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"lDx" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lFH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -80076,6 +80033,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"lGm" = (
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lGr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -80095,12 +80069,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
+"lID" = (
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "lIR" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/hydroponics)
+"lJn" = (
+/obj/item/radio/beacon,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lJX" = (
 /obj/structure/window/plasmareinforced,
 /obj/machinery/power/rad_collector{
@@ -80112,25 +80095,26 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"lMd" = (
-/turf/simulated/wall,
-/area/escapepodbay)
-"lNd" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/stock_parts/cell,
-/obj/item/flashlight,
-/obj/machinery/power/apc{
+"lMb" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Central";
 	dir = 8;
-	name = "Escape Podbay APC";
-	pixel_y = 25
+	network = list("SS13","RD")
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lOU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/west,
@@ -80154,12 +80138,14 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"lTF" = (
-/obj/structure/disposalpipe/segment{
+"lTk" = (
+/obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "pipe-c"
+	name = "Containment Pen #5";
+	req_access_txt = "55"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -80170,17 +80156,22 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"lUm" = (
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lUv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"lVh" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lWo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80190,20 +80181,8 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"lZx" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"mbm" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel,
+"lZa" = (
+/turf/simulated/wall,
 /area/escapepodbay)
 "mcP" = (
 /obj/structure/window/reinforced{
@@ -80270,28 +80249,6 @@
 	icon_state = "greenfull"
 	},
 /area/hallway/primary/central)
-"mil" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "miB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80310,6 +80267,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"mjY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mmk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80324,30 +80296,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"mnm" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "moi" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -80392,35 +80340,42 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"mso" = (
-/obj/machinery/light,
-/turf/simulated/floor/engine,
+"mtf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"mvP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
 /area/escapepodbay)
-"mvQ" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"mxQ" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio8";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "myY" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -80444,15 +80399,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"mzw" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge Podbay"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "mAa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80475,6 +80421,12 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"mBH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "mDj" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -80490,19 +80442,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"mEI" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mFx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80516,30 +80455,27 @@
 	},
 /area/medical/medbay3)
 "mGK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"mJS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -80551,16 +80487,6 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"mLG" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mOc" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80571,24 +80497,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"mPo" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mQu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80601,6 +80509,18 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"mQJ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "mRP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -80611,31 +80531,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay3)
-"mTW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mVG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80673,6 +80568,13 @@
 "mXy" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
+"mYN" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/chem_dispenser/soda,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "mZH" = (
 /obj/structure/chair{
 	dir = 1
@@ -80691,6 +80593,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"naO" = (
+/obj/machinery/shieldwallgen{
+	req_access = list(55)
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "naY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80722,26 +80633,6 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/wall,
 /area/construction)
-"ncC" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nej" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -80754,23 +80645,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"ngQ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nhK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80811,6 +80685,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
+"nkh" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"nko" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nnI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80838,18 +80736,6 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"nuh" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "nuB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80871,6 +80757,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/structure/railing/corner,
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -80973,6 +80860,24 @@
 "nMC" = (
 /turf/simulated/wall/r_wall,
 /area/storage/secure)
+"nON" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nPe" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
@@ -80980,27 +80885,11 @@
 /area/turret_protected/aisat_interior{
 	name = "\improper MiniSat Central Foyer"
 	})
-"nPv" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "nRh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"nTq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nTF" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small{
@@ -81008,6 +80897,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"nUc" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/space,
+/area/escapepodbay)
 "nUW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81039,6 +80936,14 @@
 	},
 /area/crew_quarters/locker/locker_toilet{
 	name = "\improper Restrooms"
+	})
+"nWf" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "nXf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81084,6 +80989,28 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"ogD" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ogE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -81100,22 +81027,10 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "oiv" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/railing/corner,
-/obj/structure/railing,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/wood,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"ojj" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "ojl" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -81124,6 +81039,12 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"omx" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "onG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
@@ -81141,27 +81062,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"oua" = (
-/obj/machinery/door/window/southleft{
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "oxC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -81173,12 +81073,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
-"oyC" = (
-/mob/living/simple_animal/slime,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "oCE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81195,16 +81089,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"oIL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table/wood/poker,
-/obj/item/deck/cards,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "oJQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81219,6 +81103,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"oJZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "oOs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/yellow,
@@ -81260,24 +81157,6 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
-"oUX" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "oVK" = (
 /obj/structure/chair{
 	dir = 1
@@ -81287,11 +81166,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"oVL" = (
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "oVM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -81318,7 +81192,8 @@
 	},
 /area/hallway/primary/central)
 "pad" = (
-/turf/simulated/floor/wood,
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -81356,6 +81231,23 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"pdX" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio8";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pef" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -81436,6 +81328,19 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"pkG" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pkX" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -81468,25 +81373,13 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
-"poX" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Central";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"ppg" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "ppw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81500,6 +81393,30 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
+"ppR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Port";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -81538,6 +81455,30 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"pvb" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pvu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81555,6 +81496,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"pzk" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pzX" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81596,33 +81560,29 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"pBf" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"pDM" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"pEM" = (
-/obj/structure/sink{
+"pDo" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
 	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+	icon_state = "right";
+	name = "Containment Pen #4";
+	req_access_txt = "55"
 	},
 /obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
+	})
+"pEt" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "pHQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -81747,6 +81707,27 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"pSQ" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pTP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81786,22 +81767,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"pVk" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"pVp" = (
-/obj/structure/grille,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
-	},
-/turf/space,
-/area/escapepodbay)
 "pXV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -81869,24 +81834,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
-"qeS" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qeW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81902,6 +81849,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
+"qgY" = (
+/obj/machinery/sparker{
+	id = "Xenobio";
+	pixel_x = -25
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qhx" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
@@ -81945,6 +81901,12 @@
 "qpO" = (
 /turf/simulated/wall,
 /area/engine/equipmentstorage)
+"qtg" = (
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -81964,14 +81926,12 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"qvQ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+"quX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/window/reinforced,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82031,20 +81991,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"qDC" = (
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"qEb" = (
 /obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82058,15 +82012,25 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"qGE" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/obj/machinery/firealarm{
-	pixel_y = 28
+"qFG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "qHi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -82140,6 +82104,17 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"qSv" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qTK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -82179,18 +82154,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"rbB" = (
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/table,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "rdz" = (
 /obj/item/twohanded/required/kirbyplants{
 	level = 4.1
@@ -82215,10 +82178,41 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"rhb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"riH" = (
+/obj/machinery/door_control{
+	desc = "A remote control-switch for the pod doors.";
+	id = "escapepodbay";
+	name = "Pod Door Control";
+	pixel_y = 24;
+	req_access_txt = "13"
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "riM" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
+"riV" = (
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rjj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -82246,12 +82240,19 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rlp" = (
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"rkl" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
+"rli" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "rlJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/light,
@@ -82263,54 +82264,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"rlR" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"rmr" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/ignition_switch{
-	id = "Xenobio";
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/machinery/door_control{
-	id = "Xenolab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = -2;
-	req_access_txt = "55"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "rmz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82328,10 +82281,13 @@
 	name = "Arrivals"
 	})
 "rpg" = (
-/obj/structure/chair/comfy/black,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "rqY" = (
 /obj/structure/window/reinforced,
@@ -82347,10 +82303,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rrn" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/escapepodbay)
 "rsT" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Mix to Gas"
@@ -82369,30 +82321,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"rte" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+"rvj" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
-	})
-"rvm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
 	})
 "rvu" = (
 /obj/structure/cable/yellow{
@@ -82447,24 +82388,14 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rzZ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
+"rAb" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rDe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -82474,10 +82405,9 @@
 	name = "\improper Arcade"
 	})
 "rDg" = (
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposaloutlet,
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -82649,29 +82579,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"rQV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "rRM" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow{
@@ -82715,19 +82622,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"rWi" = (
-/obj/machinery/camera{
-	c_tag = "Escape - Aft";
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "rYj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -82789,6 +82683,18 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
+"siV" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -82816,6 +82722,24 @@
 	icon_state = "dark"
 	},
 /area/space/nearstation)
+"smM" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "soT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -82852,13 +82776,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/library)
-"spw" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+"spH" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82880,6 +82802,35 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"stE" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"svx" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 18;
+	id = "skipjack_se";
+	name = "southeast of SS13";
+	width = 19
+	},
+/turf/space,
+/area/space)
 "svF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82907,6 +82858,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"swF" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sxA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -82917,33 +82881,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
-"sBv" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "sBY" = (
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"sEV" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+"sEG" = (
+/obj/structure/closet,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "sFz" = (
 /obj/effect/spawner/window/reinforced,
@@ -83003,6 +82948,22 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"sMx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sOB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -83011,8 +82972,20 @@
 	},
 /area/security/brig)
 "sOJ" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
@@ -83041,6 +83014,17 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"sZK" = (
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tbK" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83124,9 +83108,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
-"tme" = (
-/obj/item/radio/beacon,
-/turf/simulated/floor/engine,
+"tmV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83144,6 +83147,14 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"tsf" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tvk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -83217,6 +83228,16 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"tAY" = (
+/obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "tBw" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83225,6 +83246,14 @@
 	icon_state = "vault"
 	},
 /area/security/main)
+"tBT" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tCC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83256,16 +83285,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"tGH" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
+"tLJ" = (
 /turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "tNG" = (
 /obj/structure/cable/yellow{
@@ -83292,6 +83315,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"tQR" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"tRr" = (
+/obj/effect/decal/remains/xeno,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tSj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -83324,16 +83360,6 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
-"tTL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair,
-/obj/item/cigbutt,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tVw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 5
@@ -83360,6 +83386,12 @@
 	icon_state = "redfull"
 	},
 /area/security/permabrig)
+"tZr" = (
+/mob/living/simple_animal/slime,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tZI" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1441;
@@ -83380,6 +83412,12 @@
 /area/security/checkpoint2{
 	name = "Customs"
 	})
+"uaB" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "uaQ" = (
 /turf/simulated/wall,
 /area/engine/mechanic_workshop)
@@ -83388,22 +83426,13 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "ueD" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
+/obj/structure/window/reinforced,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83430,49 +83459,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"uih" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+"ujJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"ukt" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ujy" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"uln" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83497,59 +83492,36 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
-"unp" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"unE" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio7";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/surgery1)
-"uql" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uqy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"uuf" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "uuE" = (
 /obj/machinery/door/firedoor,
@@ -83580,20 +83552,32 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
-"uws" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uzt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
 	},
 /area/hydroponics)
+"uzx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uAA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -83620,6 +83604,17 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
+"uEq" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uEN" = (
 /obj/effect/landmark/start{
 	name = "Roboticist"
@@ -83630,21 +83625,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
-"uHc" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uJn" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
@@ -83691,6 +83671,21 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
+"uOq" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uOL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -83728,21 +83723,6 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"uTf" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uTZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -83764,6 +83744,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"uVb" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uWq" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -83838,6 +83840,24 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"vmK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vmT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -83846,12 +83866,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"vmX" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vmY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -83864,19 +83878,19 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
-"vqW" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+"vnn" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
+"vnM" = (
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -83901,6 +83915,30 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"vtM" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vtP" = (
 /obj/machinery/conveyor/west{
 	id = "garbage"
@@ -83935,10 +83973,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"vwL" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "vyo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -83946,6 +83980,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"vAJ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vBv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -83988,14 +84040,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
-"vDs" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "vDW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84015,27 +84059,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
-"vHx" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vHA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -84076,34 +84099,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"vMt" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
-"vML" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vNb" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84150,6 +84145,26 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"vRZ" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vSx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84193,22 +84208,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
-"wbe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"wcn" = (
-/obj/machinery/constructable_frame/machine_frame,
-/obj/item/circuitboard/chem_dispenser/soda,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "wfs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84234,6 +84233,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
+"wpx" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wri" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -84318,6 +84329,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
+"wvW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/item/cigbutt,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"wxB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "wxE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -84373,27 +84408,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/exam_room)
-"wAx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wAP" = (
 /obj/structure/transit_tube{
 	icon_state = "D-SW"
@@ -84411,25 +84425,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"wEj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "wEq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84460,10 +84455,34 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"wHr" = (
-/obj/structure/grille,
-/turf/space,
-/area/escapepodbay)
+"wHN" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/ignition_switch{
+	id = "Xenobio";
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/machinery/door_control{
+	id = "Xenolab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = -2;
+	req_access_txt = "55"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wHZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -84472,17 +84491,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"wIm" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wJQ" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -84498,8 +84506,9 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"wNo" = (
-/turf/simulated/floor/plasteel,
+"wOx" = (
+/obj/structure/grille,
+/turf/space,
 /area/escapepodbay)
 "wRy" = (
 /obj/effect/decal/warning_stripes/north,
@@ -84523,29 +84532,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
-"wSA" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wSP" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -84558,8 +84544,19 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"wTu" = (
-/obj/effect/decal/remains/xeno,
+"wTk" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -84582,53 +84579,6 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
-"wZy" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"wZJ" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"xaE" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"xaL" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "xbe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -84671,6 +84621,30 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"xiV" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xkY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -84692,13 +84666,18 @@
 	icon_state = "caution"
 	},
 /area/atmos)
+"xqw" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "xqz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
-"xrh" = (
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "xrG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -84710,6 +84689,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
+"xsV" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xtA" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -84750,14 +84749,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
-"xBb" = (
+"xyL" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio6";
+	name = "Containment Blast Doors";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/machinery/disposal,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -84783,14 +84792,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"xFa" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -84835,24 +84836,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"xJU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
-/obj/item/radio/electropack,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"xKl" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "xLf" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -84861,6 +84844,20 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"xNr" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "xOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84869,9 +84866,14 @@
 	icon_state = "stage_stairs"
 	},
 /area/security/podbay)
-"xQa" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
+"xPv" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Test Chamber";
+	dir = 1;
+	network = list("SS13","RD")
+	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -84974,14 +84976,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"yfQ" = (
-/obj/item/mounted/frame/light_fixture{
-	pixel_y = -16
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar{
-	name = "New Bar"
-	})
 "ygd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -106816,12 +106810,12 @@ aaa
 aaa
 aaa
 aaa
-wHr
+wOx
 aaa
 aaa
 aaa
 aaa
-wHr
+wOx
 aaa
 aaa
 aaa
@@ -107073,12 +107067,12 @@ aaa
 aaa
 aaa
 aaa
-pVp
+nUc
 aaa
 aaa
 aaa
 aaa
-pVp
+nUc
 aaa
 aaa
 aaa
@@ -107330,12 +107324,12 @@ dbW
 dbW
 dbW
 dbV
-lMd
-hhy
-hhy
-hhy
-hhy
-lMd
+lZa
+fxX
+fxX
+fxX
+fxX
+lZa
 aaa
 aaa
 aaa
@@ -107582,17 +107576,17 @@ aaa
 aaa
 dbV
 dcw
-ddW
-dfD
-wcn
-fUd
-lps
-lMd
-kwg
-kwg
-kwg
-dBK
-lMd
+ddU
+deT
+mYN
+kkh
+kik
+lZa
+gHn
+gHn
+gHn
+fGR
+lZa
 aaa
 aaa
 aaa
@@ -107840,16 +107834,16 @@ aaa
 dbW
 dcx
 dcx
-dfH
+dfD
 dcx
 dcx
 dcx
-lMd
-xrh
-xrh
-xrh
-xrh
-lMd
+lZa
+fpy
+fpy
+fpy
+fpy
+lZa
 aaa
 aaa
 aaa
@@ -108096,17 +108090,17 @@ aaa
 aaa
 dbW
 dcx
-ddX
-dfW
-ddX
-ddX
-ddX
-lMd
-xrh
-xrh
-xrh
-xrh
-lMd
+ddW
+dfH
+hHz
+lcy
+lcy
+lZa
+fpy
+fpy
+fpy
+fpy
+lZa
 aaa
 aaa
 aaa
@@ -108353,17 +108347,17 @@ aaa
 aaa
 dbV
 dcx
-dej
-dgB
-dej
-dej
-dej
-lMd
-eJd
-xrh
-xrh
-xrh
-lMd
+ddX
+dfW
+ddX
+ddX
+ddX
+lZa
+riH
+fpy
+fpy
+fpy
+lZa
 aaa
 aaa
 aaa
@@ -108610,17 +108604,17 @@ aaa
 aaa
 dbV
 dcy
-deo
-dgW
+dej
+dgB
 dcx
 dcx
-rvm
-lMd
-mzw
-xrh
-xrh
-mso
-lMd
+gNb
+lZa
+igR
+fpy
+fpy
+vnM
+lZa
 aaa
 aaa
 aaa
@@ -108868,16 +108862,16 @@ aaa
 dbW
 dcx
 dcx
-dhF
+dgW
 dcx
-etk
-yfQ
-lMd
-vwL
-vwL
-vwL
-vMt
-lMd
+kun
+dcx
+lZa
+gxd
+gxd
+gxd
+xqw
+lZa
 aaa
 aaa
 aaa
@@ -109124,17 +109118,17 @@ aaa
 aaa
 dbW
 dcz
-des
-ged
-iVr
-oIL
+deo
+dhF
+dnw
+lan
 dcx
-lMd
-qGE
-dsY
-wNo
-ewu
-lMd
+lZa
+hXj
+mBH
+lID
+eVu
+lZa
 aaa
 aaa
 aaa
@@ -109380,18 +109374,18 @@ aaa
 aaa
 aaa
 dbV
-dcA
 dcx
-hlZ
 dcx
-etk
-irT
-lMd
-lNd
-iHM
-jIN
-ojj
-lMd
+ged
+dcx
+kun
+vnn
+lZa
+fTC
+mvP
+gvA
+rli
+lZa
 aaa
 aaa
 aaa
@@ -109637,18 +109631,18 @@ aaa
 aaa
 aaa
 dbV
-dcB
+dcA
 dcx
-hlZ
+ged
 dcx
 dcx
 dcx
-lMd
-mbm
-ltv
-wNo
-xaL
-lMd
+lZa
+huC
+wxB
+lID
+xNr
+lZa
 aaa
 aaa
 aaa
@@ -109896,16 +109890,16 @@ cVk
 dbV
 dbV
 dbW
-jhQ
-jqq
+hlZ
+tAY
 dbW
 dbV
-lMd
-rrn
-rzZ
-gyw
-rrn
-lMd
+lZa
+huP
+eGd
+iIw
+huP
+lZa
 aaa
 aaa
 aaa
@@ -110151,17 +110145,17 @@ cYU
 cYf
 dbs
 cXv
-dcC
-det
-kNr
+dcB
+des
+jhQ
 cWi
 cWi
-nuh
-khx
+siV
+mJS
 cWi
-wEj
+qFG
 cWi
-jWA
+fun
 cTX
 aaa
 aaa
@@ -110409,14 +110403,14 @@ cUD
 dbz
 cUD
 cXz
-dez
-mGK
+det
+kNr
 cVc
 cLS
 cOZ
 cRt
 cVc
-kMl
+mtf
 cWb
 bPk
 cTX
@@ -110667,15 +110661,15 @@ dbA
 cZU
 gTp
 cWb
-nxh
-nPv
-hzZ
+mGK
+tBT
+kZJ
 cUu
-nxh
-wZy
-hzZ
+mGK
+tsf
+kZJ
 cWb
-sEV
+pEt
 cVk
 aaa
 aaa
@@ -110924,15 +110918,15 @@ dbA
 cZL
 gTp
 cWb
-nxh
-vDs
-hzZ
+mGK
+lwz
+kZJ
 dap
-nxh
-xKl
-hzZ
+mGK
+ppg
+kZJ
 cWb
-sEV
+pEt
 cVk
 aaa
 aaa
@@ -111181,15 +111175,15 @@ cTW
 cTW
 cNz
 cWb
-nxh
-xKl
-hzZ
+mGK
+ppg
+kZJ
 cWb
-nxh
-vDs
-hzZ
+mGK
+lwz
+kZJ
 cWb
-xaE
+mQJ
 cVk
 aaa
 aaa
@@ -111438,15 +111432,15 @@ cWh
 dbZ
 cUz
 cWb
-oiv
-wZy
-hzZ
-cWb
 nxh
-nPv
-hzZ
+tsf
+kZJ
 cWb
-sEV
+mGK
+tBT
+kZJ
+cWb
+pEt
 cVk
 aaa
 aaa
@@ -111703,7 +111697,7 @@ cTs
 cTW
 cNz
 cWb
-unp
+rkl
 cVk
 aaa
 aaa
@@ -111960,7 +111954,7 @@ cWb
 cWb
 cWb
 cTr
-ihe
+gOU
 cVk
 aaa
 aaa
@@ -112216,7 +112210,7 @@ dat
 cYV
 cYV
 cYV
-rWi
+eIT
 cVk
 cVk
 aaa
@@ -112464,15 +112458,15 @@ cZA
 daq
 dbD
 cWo
-dcD
+dcC
 cTX
-pad
+oiv
 cpe
-pad
+oiv
 cTX
-dcD
+dcC
 cTX
-dcD
+dcC
 cVk
 cVk
 aaa
@@ -112721,15 +112715,15 @@ cZD
 dar
 dbF
 cWo
-dcE
+dcD
 cTX
-rpg
-jTR
-dvM
+pad
+iXH
+nWf
 cTX
-oVL
+tLJ
 cTX
-ias
+uaB
 cVk
 aaa
 aaa
@@ -112978,15 +112972,15 @@ cZG
 das
 dbD
 cWo
-dcD
+dcC
 cTX
 cTX
 cTX
 cTX
 cTX
-dcD
+dcC
 cTX
-dcD
+dcC
 cVk
 aaa
 aaa
@@ -113235,7 +113229,7 @@ aaa
 aaa
 aaa
 aaa
-dcH
+dcE
 aaa
 aaa
 aaa
@@ -120441,9 +120435,9 @@ cVG
 cVG
 cVG
 cVG
-rDg
-lUm
-lUm
+rpg
+lwd
+lwd
 cVG
 cVG
 cVG
@@ -120688,21 +120682,21 @@ cVG
 dav
 dbI
 dci
-dcN
+dcH
+ddw
+rpg
+lwd
+tZr
+ddw
+rpg
+lwd
+tZr
 ddw
 rDg
-lUm
-oyC
-ddw
-rDg
-lUm
-oyC
-ddw
-sOJ
-lUm
-lUm
+lwd
+lwd
 cVG
-rlp
+sEG
 cVG
 cVG
 cVG
@@ -120945,28 +120939,28 @@ cVG
 daF
 cZc
 dcj
-dcX
+dcN
 ddw
-sOJ
-lUm
-lUm
+rDg
+lwd
+lwd
 ddw
-sOJ
-lUm
-lUm
+rDg
+lwd
+lwd
 ddw
-sOJ
-lUm
-lUm
+rDg
+lwd
+lwd
 cVG
-lTF
-jSw
-jSw
-jSw
-jSw
-jSw
-jSw
-gez
+dyI
+omx
+omx
+omx
+omx
+omx
+omx
+quX
 cVG
 aaa
 aaa
@@ -121202,28 +121196,28 @@ cVG
 daG
 dbJ
 dcj
-ddv
+dcX
 ddw
-sOJ
-lUm
-lUm
+rDg
+lwd
+lwd
 ddw
-sOJ
-lUm
-lUm
+rDg
+lwd
+lwd
 ddw
-vML
-uln
-mPo
+hFo
+xiV
+uuf
 cVG
-sBv
-cVG
-cVG
+gDI
 cVG
 cVG
 cVG
 cVG
-nTq
+cVG
+cVG
+ifN
 cVG
 abq
 aaa
@@ -121459,28 +121453,28 @@ cVG
 daR
 cZc
 dck
-ddJ
+ddv
+ddw
+sOJ
+pvb
+stE
+ddw
+fbp
+vtM
+jPA
 ddw
 ueD
-dsN
-ffs
-ddw
-iNt
-mnm
-qeS
-ddw
-qvQ
-mvQ
-fhT
-kqU
-qDC
-ilY
+lTk
+vAJ
+ppR
+lGm
+naO
 cVG
-lUm
-pDM
-wTu
+lwd
+qgY
+tRr
 cVG
-nTq
+ifN
 cVG
 abq
 aaa
@@ -121716,28 +121710,28 @@ cVG
 cVG
 dbK
 dcl
-ddK
+ddJ
 cpf
-qvQ
-lZx
-ieT
-mLG
-qvQ
-gBT
-wAx
-mLG
-kFj
+ueD
+hJV
+kWA
+lVh
+ueD
+qSv
+ltd
+lVh
+nON
 dcj
-rlR
-dol
-djK
-ngQ
-spw
-lUm
-lUm
-lUm
+xsV
+sMx
+koX
+wTk
+lDx
+lwd
+lwd
+lwd
 cVG
-nTq
+ifN
 cVG
 aaa
 aaa
@@ -121973,28 +121967,28 @@ cZH
 cVG
 dbM
 dcl
-ddL
-deB
-xFa
+ddK
+dez
+rAb
 dcj
-gsP
-ujy
-uih
+eQA
+dlS
+riV
 dcj
-gsP
-pEM
-uih
+eQA
+pkG
+riV
 dcj
-bWq
-lkK
-rmr
-wSA
-lhH
-lhH
-uws
-lUm
+fte
+hoM
+wHN
+pzk
+gFU
+gFU
+lgK
+lwd
 cVG
-tTL
+wvW
 cZN
 aaa
 aaa
@@ -122230,31 +122224,31 @@ cZJ
 dbd
 dbR
 dcq
-ddM
-deQ
-haZ
-uHc
-mTW
-kks
-uHc
-uql
-mTW
-uHc
-uHc
-jHM
-rQV
-iWF
-kxJ
-oua
-lUm
-lUm
-lUm
-jGF
+ddL
+deB
+lys
+mjY
+tmV
+hFX
+mjY
+kma
+tmV
+mjY
+mjY
+kFl
+gCK
+vmK
+sZK
+hAw
+lwd
+lwd
+lwd
+xPv
 cVG
-dyw
-vmX
-gtd
-emp
+hfi
+hvd
+ujJ
+tQR
 aaa
 aaa
 aaa
@@ -122487,26 +122481,26 @@ cZK
 cVG
 dbS
 dcs
-ddN
-deT
-xFa
+ddM
+deQ
+rAb
 dcj
-kZh
-poX
-cSw
+oJZ
+lMb
+ukt
 dcj
-kZh
-pVk
-cSw
+oJZ
+spH
+ukt
 dcj
-uTf
-eQb
-vqW
-fYn
-eZh
-lUm
-tme
-lUm
+uOq
+qEb
+nkh
+cWw
+qtg
+lwd
+lJn
+lwd
 cVG
 cVJ
 cZN
@@ -122744,26 +122738,26 @@ cVG
 cVG
 cZj
 dcs
-ddO
+ddN
 cpf
-mxQ
-egX
-oUX
-mLG
-unE
-mEI
-oUX
-mLG
-xFa
+rvj
+swF
+gVT
+lVh
+fpm
+pDo
+gVT
+lVh
+rAb
 dcj
-dHb
-dNi
-rbB
-rte
-spw
-lUm
-lUm
-hax
+uzx
+rhb
+wpx
+gRa
+lDx
+lwd
+lwd
+hqf
 cVG
 cVJ
 cVG
@@ -123001,26 +122995,26 @@ cVG
 cYZ
 dbT
 dct
-ddP
+ddO
 ddw
-hqs
+pdX
 ddD
 cYA
 ddw
 dca
-hhi
-vHx
+gcT
+pSQ
 ddw
-lcM
-wZJ
-ahy
-imP
-wIm
-ilY
+xyL
+kid
+iQe
+dyk
+nko
+naO
 cVG
-xJU
-eXj
-kjB
+lCY
+jkg
+ogD
 cVG
 cVJ
 cVG
@@ -123258,21 +123252,21 @@ cVG
 dbe
 cZW
 dcj
-ddR
+ddP
 ddw
-lUm
-lUm
-sOJ
+lwd
+lwd
+rDg
 ddw
-lUm
-lUm
-sOJ
+lwd
+lwd
+rDg
 ddw
-ncC
-mil
-hEc
+vRZ
+uVb
+smM
 cVG
-tGH
+iTt
 cVG
 cVG
 cVG
@@ -123515,19 +123509,19 @@ cVG
 dbo
 dcv
 dcj
-ddS
+ddR
 ddw
-lUm
-lUm
-sOJ
+lwd
+lwd
+rDg
 ddw
-lUm
-lUm
-sOJ
+lwd
+lwd
+rDg
 ddw
-hLm
-pBf
-wbe
+ioO
+iNp
+hHd
 cVG
 cVJ
 cVJ
@@ -123772,21 +123766,21 @@ cVG
 dbr
 dbU
 dcu
-ddU
+ddS
 ddw
-lUm
-lUm
-xBb
+lwd
+lwd
+uEq
 ddw
-oyC
-lUm
-xBb
+tZr
+lwd
+uEq
 ddw
-lUm
-lUm
-sOJ
+lwd
+lwd
+rDg
 cVG
-xQa
+daY
 cVG
 cVG
 cVG
@@ -124039,9 +124033,9 @@ cVG
 cVG
 cVG
 cVG
-lUm
-lUm
-xBb
+lwd
+lwd
+uEq
 cVG
 cVG
 cVG
@@ -130725,7 +130719,7 @@ aaa
 aaa
 aaa
 aaa
-hdY
+svx
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18562,11 +18562,11 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
 "aOE" = (
-/mob/living/simple_animal/slime,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "aOF" = (
 /turf/simulated/wall/r_wall,
 /area/storage/primary)
@@ -40060,14 +40060,11 @@
 	},
 /area/tcommsat/computer)
 "bGU" = (
-/obj/machinery/shieldwallgen{
-	req_access = list(55)
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/obj/structure/grille,
+/turf/space,
+/area/space/nearstation)
 "bGV" = (
 /obj/machinery/power/apc{
 	cell_type = 10000;
@@ -40085,22 +40082,13 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bGW" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
+/turf/simulated/floor/plasteel{
+	icon_state = "escape"
 	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/primary/aft)
 "bHb" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding{
@@ -40219,28 +40207,14 @@
 	name = "\improper Auxiliary Restrooms"
 	})
 "bHo" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/power/solar{
+	id = "aftstarboard";
+	name = "Aft-Starboard Solar Array"
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/solar/starboard)
 "bHp" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -42682,65 +42656,46 @@
 /turf/space,
 /area/space/nearstation)
 "bMo" = (
-/obj/machinery/door/window/southleft{
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"bMp" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/space,
+/area/solar/starboard)
+"bMp" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "bMq" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/solar/starboard)
 "bMr" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -42753,11 +42708,9 @@
 	name = "\improper MiniSat Exterior"
 	})
 "bMs" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/item/stack/cable_coil/random,
+/turf/space,
+/area/space)
 "bMt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -42780,15 +42733,25 @@
 	name = "\improper MiniSat Exterior"
 	})
 "bMu" = (
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/grille/broken,
+/turf/space,
+/area/space)
 "bMv" = (
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "bMB" = (
 /obj/structure/cable/yellow{
@@ -43245,24 +43208,39 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bNG" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/radio/electropack,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "bNH" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "bNI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -43440,10 +43418,21 @@
 /turf/space,
 /area/space/nearstation)
 "bNZ" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -43457,8 +43446,23 @@
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "bOc" = (
-/obj/item/radio/beacon,
-/turf/simulated/floor/engine,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -44023,34 +44027,33 @@
 	name = "E.V.A. Storage"
 	})
 "bPj" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "bPk" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "bPl" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Test Chamber";
-	dir = 1;
-	network = list("SS13","RD")
-	},
-/turf/simulated/floor/engine,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/bikehorn/rubberducky,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -44240,32 +44243,25 @@
 /turf/space,
 /area/space/nearstation)
 "bPI" = (
-/obj/item/radio/intercom{
-	pixel_y = -25
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/turf/simulated/floor/engine,
+/obj/item/lightreplacer,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "bPK" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -48426,11 +48422,14 @@
 	name = "Port Maintenance"
 	})
 "bYy" = (
-/obj/effect/decal/warning_stripes/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -54435,6 +54434,9 @@
 /area/medical/reception)
 "clN" = (
 /obj/item/storage/box,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "clO" = (
@@ -54708,14 +54710,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"cmy" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cmz" = (
 /turf/simulated/wall/r_wall,
 /area/medical/research)
@@ -54730,31 +54724,15 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/explab)
 "cmD" = (
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/dropper,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
-	},
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -54779,16 +54757,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
 "cmG" = (
-/obj/machinery/chem_master{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cmH" = (
 /obj/structure/cable{
@@ -55021,13 +54995,9 @@
 	name = "\improper Command Hallway"
 	})
 "cnk" = (
-/obj/structure/sink{
-	pixel_y = 22
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -55133,21 +55103,10 @@
 	},
 /area/hallway/primary/aft)
 "cnv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sink{
-	pixel_y = 22
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
+/area/space)
 "cnw" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -55360,55 +55319,46 @@
 	},
 /area/medical/cmo)
 "cnT" = (
-/obj/machinery/chem_heater{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
+/area/solar/starboard)
 "cnU" = (
-/obj/structure/table/glass,
-/obj/item/extinguisher{
-	pixel_x = -5;
-	pixel_y = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/item/extinguisher,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cnV" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cnW" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/table/wood,
+/obj/item/deck/cards,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cnY" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -55920,49 +55870,19 @@
 	},
 /area/toxins/lab)
 "cpe" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/glass,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cpf" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
+/obj/structure/sign/biohazard,
+/turf/simulated/wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "cpg" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio8";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
+/obj/structure/sign/securearea,
+/turf/simulated/wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -56440,29 +56360,13 @@
 	},
 /area/medical/exam_room)
 "cqc" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access_txt = "55"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plating,
+/area/solar/starboard)
 "cqe" = (
 /obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/decal/warning_stripes/north,
@@ -56507,27 +56411,15 @@
 	},
 /area/medical/research)
 "cqj" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #2";
-	req_access_txt = "55"
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio8";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/solar/starboard)
 "cqk" = (
 /obj/machinery/atm{
 	pixel_x = 32
@@ -56632,6 +56524,20 @@
 	icon_state = "whitehall"
 	},
 /area/medical/research)
+"cqy" = (
+/obj/structure/table/glass,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "cqB" = (
 /obj/machinery/light{
 	dir = 4
@@ -56720,23 +56626,13 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "cqJ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/solar/starboard)
 "cqK" = (
 /turf/simulated/floor/engine/n2,
 /area/atmos)
@@ -56836,26 +56732,9 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "cqX" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio8";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/solar/starboard)
 "cqY" = (
 /obj/structure/closet/secure_closet/bar{
 	pixel_x = -3;
@@ -56970,25 +56849,10 @@
 	},
 /area/toxins/lab)
 "crs" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil/random,
+/turf/space,
+/area/solar/starboard)
 "crx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -57328,68 +57192,26 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/explab)
 "csd" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/solar/starboard)
 "cse" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #3";
-	req_access_txt = "55"
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/solar/starboard)
 "csf" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #4";
-	req_access_txt = "55"
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plating/airless,
+/area/solar/starboard)
 "csg" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -57459,22 +57281,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "csm" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/table/wood,
+/obj/item/lighter/zippo,
+/obj/item/storage/fancy/cigarettes/cigpack_random,
+/obj/item/ashtray/plastic,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "csn" = (
 /obj/item/stack/packageWrap,
@@ -57566,43 +57379,24 @@
 /turf/simulated/floor/plating,
 /area/toxins/explab)
 "csA" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/table/wood,
+/obj/item/storage/box/characters,
+/obj/item/storage/pill_bottle/dice,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "csB" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -57622,25 +57416,13 @@
 	},
 /area/medical/exam_room)
 "csD" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/solar/starboard)
 "csE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -57657,29 +57439,9 @@
 	},
 /area/medical/exam_room)
 "csF" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "csG" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -57743,63 +57505,27 @@
 /turf/simulated/wall,
 /area/medical/cmo)
 "csK" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #6";
-	req_access_txt = "55"
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "neutral"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "csL" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "csM" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/lattice,
+/turf/space,
+/area/maintenance/aft)
 "csN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -59311,10 +59037,12 @@
 	},
 /area/medical/research)
 "cvY" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/mopbucket,
+/obj/item/mop,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cvZ" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
@@ -59441,9 +59169,11 @@
 	},
 /area/medical/chemistry)
 "cwt" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cwv" = (
 /obj/structure/sign/chemistry{
 	pixel_x = -32
@@ -65676,23 +65406,25 @@
 	name = "\improper Toxins Lab"
 	})
 "cJg" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/solar/starboard)
 "cJh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -66949,18 +66681,20 @@
 	name = "\improper Toxins Lab"
 	})
 "cLS" = (
-/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plating,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -67888,10 +67622,15 @@
 	name = "\improper Toxins Lab"
 	})
 "cNz" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cNA" = (
 /obj/structure/disposalpipe/segment,
@@ -68077,8 +67816,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "escape"
 	},
 /area/hallway/primary/aft)
 "cNX" = (
@@ -68095,7 +67833,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "escape"
+	},
 /area/hallway/primary/aft)
 "cNY" = (
 /obj/structure/cable/yellow{
@@ -68596,9 +68336,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cON" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "escape"
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge"
 	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cOO" = (
 /obj/structure/cable/yellow{
@@ -68609,18 +68351,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "escape"
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge"
 	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cOP" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Aft";
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "escape"
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge"
 	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cOR" = (
 /obj/structure/table,
@@ -68695,11 +68441,24 @@
 	},
 /area/assembly/robotics)
 "cOZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "neutralfull"
 	},
-/area/medical/research)
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cPb" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -68984,15 +68743,19 @@
 "cPH" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cPI" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -69000,7 +68763,8 @@
 "cPJ" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -69040,7 +68804,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -69053,19 +68817,14 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cPN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -69076,23 +68835,18 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cPP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
-	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/exit{
@@ -69192,8 +68946,7 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "white"
 	},
 /area/medical/research)
 "cPZ" = (
@@ -69340,9 +69093,6 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cQl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/closet,
 /obj/item/flashlight,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -69542,27 +69292,17 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"cQH" = (
+"cQI" = (
 /obj/structure/rack,
-/obj/effect/landmark/costume,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"cQJ" = (
+/obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cQI" = (
-/obj/structure/closet,
-/obj/item/clothing/glasses/science,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cQJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cQK" = (
@@ -69583,12 +69323,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"cQM" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "cQN" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -69644,12 +69378,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/research{
-	name = "Research Shuttle and  Xenobiology";
-	req_access_txt = "47"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/research{
+	name = "Secure Lab";
+	req_access_txt = "47"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -69665,8 +69399,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -69689,9 +69424,14 @@
 	name = "Port Maintenance"
 	})
 "cQU" = (
-/obj/item/storage/box/lights/mixed,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cQW" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboardsolar)
@@ -69811,12 +69551,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRn" = (
-/obj/effect/decal/warning_stripes/north,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -69842,14 +69584,13 @@
 	},
 /area/medical/medbay3)
 "cRq" = (
-/obj/machinery/atm{
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -69866,7 +69607,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRt" = (
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -69896,7 +69648,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -69912,7 +69672,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -69922,36 +69685,37 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cRB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -70014,49 +69778,39 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRI" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/medical/research)
-"cRJ" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cRJ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/medical/research)
+/mob/living/simple_animal/mouse/white,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cRK" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -70090,17 +69844,17 @@
 	},
 /area/medical/medbay3)
 "cRO" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -70111,8 +69865,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "7;12;47"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -70130,10 +69884,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cRR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cRS" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -70217,7 +69980,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70314,9 +70077,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cSk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/structure/railing,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -70357,8 +70122,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cSo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -70377,18 +70144,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"cSr" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "cSs" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -70401,27 +70156,12 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
-"cSt" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "7;12;47"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cSu" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "xeno_blastdoor";
-	name = "biohazard containment door"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cSv" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-11"
@@ -70577,8 +70317,10 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -70654,62 +70396,55 @@
 	},
 /area/chapel/main)
 "cSV" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cSW" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "xeno_blastdoor";
-	name = "biohazard containment door"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
 "cSX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cSY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cSY" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cSZ" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -70730,29 +70465,35 @@
 	},
 /area/medical/virology)
 "cTa" = (
-/obj/machinery/space_heater,
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow/fake,
+/obj/item/stack/cable_coil/random,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cTc" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair/comfy/beige,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTd" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/vending/cola,
+/obj/machinery/camera{
+	c_tag = "Escape - Mid Fore";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cTe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -70798,83 +70539,36 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTh" = (
-/obj/structure/chair,
-/obj/structure/sign/double/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
-	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTi" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sign/double/map/right{
-	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
-	icon_state = "map-right-MS";
-	pixel_y = 32
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cTk" = (
-/obj/structure/sign/biohazard,
-/turf/simulated/wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cTl" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Secure Lab";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cTm" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cTo" = (
-/obj/structure/closet/crate,
-/obj/item/poster/random_official,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cTp" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -70890,37 +70584,44 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cTq" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/camera{
-	c_tag = "Departure Lounge - Port Fore";
+	c_tag = "Escape - Fore";
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-24";
-	layer = 4.1
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTr" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTs" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTt" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71011,18 +70712,15 @@
 	},
 /area/chapel/office)
 "cTC" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.2-Escape-2";
 	location = "9.1-Escape-1"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71104,58 +70802,56 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cTO" = (
-/obj/structure/chair{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "neutral"
 	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cTR" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/bush,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cTS" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+"cTR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"cTS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cTT" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71163,50 +70859,51 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "white"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "cTU" = (
-/obj/structure/chair/office/dark{
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "cTV" = (
-/obj/machinery/light{
-	dir = 4
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/obj/machinery/camera{
-	c_tag = "Departure Lounge - Starboard Fore";
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-14";
-	layer = 4.1
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTW" = (
-/obj/structure/chair{
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71218,12 +70915,16 @@
 	})
 "cTY" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -71456,17 +71157,21 @@
 	},
 /area/chapel/main)
 "cUu" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cUv" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/chair/comfy/beige,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71487,81 +71192,52 @@
 	},
 /area/chapel/main)
 "cUz" = (
-/obj/machinery/status_display{
-	layer = 4
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "neutral"
 	},
-/turf/simulated/wall,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cUA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cUB" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cUC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Departure Lounge Security Post";
-	req_access_txt = "63"
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cUD" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/turf/space,
+/area/solar/starboard)
+"cUD" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cUE" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71581,14 +71257,10 @@
 	},
 /area/medical/medbay3)
 "cUG" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71603,15 +71275,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"cUK" = (
-/obj/item/seeds/berry,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cUL" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cUN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -71621,18 +71284,11 @@
 	},
 /area/chapel/office)
 "cUO" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching output from station security cameras.";
-	name = "Security Camera Monitor";
-	network = list("SS13");
-	pixel_y = 30
-	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -71732,61 +71388,39 @@
 	},
 /area/medical/morgue)
 "cVc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cVe" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cVf" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cVg" = (
-/obj/item/plant_analyzer,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/rack,
-/obj/item/seeds/corn,
-/obj/item/seeds/cabbage,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/grass,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cVi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cVj" = (
-/obj/structure/rack,
-/obj/item/seeds/wheat,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/grape,
-/obj/item/seeds/glowshroom,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+"cVf" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cVi" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cVk" = (
 /turf/simulated/wall,
 /area/hallway/secondary/exit{
@@ -71823,14 +71457,54 @@
 	},
 /area/medical/morgue)
 "cVn" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cVo" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "xeno_blastdoor";
+	name = "biohazard containment door"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cVp" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "xeno_blastdoor";
+	name = "biohazard containment door"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cVq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "xeno_blastdoor";
+	name = "biohazard containment door"
 	},
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -71839,37 +71513,20 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cVo" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/carrot,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cVp" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/plant_analyzer,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cVq" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/glowshroom,
-/obj/item/seeds/corn,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cVr" = (
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cVs" = (
-/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71930,30 +71587,48 @@
 	},
 /area/chapel/main)
 "cVC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
 	},
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cVD" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cVF" = (
-/obj/structure/sign/biohazard,
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "63"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cVG" = (
 /turf/simulated/wall/r_wall,
@@ -71961,28 +71636,20 @@
 	name = "\improper Secure Lab"
 	})
 "cVI" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cVJ" = (
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cVJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "xeno_blastdoor";
-	name = "biohazard containment door"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
 "cVL" = (
 /obj/structure/closet/coffin,
 /obj/machinery/light/small{
@@ -72078,18 +71745,27 @@
 	},
 /area/chapel/main)
 "cVX" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+	icon_state = "white"
 	},
-/area/chapel/main)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cWb" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -72138,32 +71814,32 @@
 	},
 /area/medical/virology)
 "cWg" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cWh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutral"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cWi" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -72210,31 +71886,8 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "cWo" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/folder/white{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/restraints/handcuffs,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/off,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = 30
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/simulated/wall/r_wall,
+/area/hallway/secondary/exit)
 "cWp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72244,9 +71897,23 @@
 	},
 /area/chapel/main)
 "cWq" = (
-/obj/structure/chair,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 25
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 35
+	},
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Security";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cWs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72280,71 +71947,38 @@
 	},
 /area/chapel/main)
 "cWA" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cWB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cWE" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Airlock";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cWF" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cWE" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cWF" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cWG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -72464,14 +72098,14 @@
 	name = "\improper Recreation Area"
 	})
 "cWT" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/obj/structure/sign/electricshock{
-	pixel_x = 32
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -72517,66 +72151,76 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cXa" = (
 /obj/structure/table,
 /obj/item/candle,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cXb" = (
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXc" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/structure/railing/corner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cXe" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cXg" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutral"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXh" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXi" = (
 /obj/structure/cable/yellow{
@@ -72584,14 +72228,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXj" = (
 /obj/structure/closet/coffin,
@@ -72654,20 +72296,15 @@
 	name = "\improper Recreation Area"
 	})
 "cXq" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplefull"
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXr" = (
 /turf/simulated/floor/plasteel{
@@ -72676,30 +72313,6 @@
 	},
 /area/medical/medbay3)
 "cXs" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXt" = (
-/obj/machinery/chem_master{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/obj/structure/disaster_counter/scichem{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cXv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -72709,22 +72322,13 @@
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1449;
-	id_tag = "xeno_airlock_interior";
+	id_tag = "xeno_airlock_exterior";
 	locked = 1;
-	name = "Secure Lab Internal Airlock";
+	name = "Secure Lab External Airlock";
 	req_access_txt = "55"
 	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	frequency = 1449;
-	id_tag = "xeno_airlock_control";
-	pixel_x = -25;
-	pixel_y = -10;
-	req_access_txt = "55";
-	tag_exterior_door = "xeno_airlock_exterior";
-	tag_interior_door = "xeno_airlock_interior"
-	},
 /obj/machinery/access_button{
-	command = "cycle_interior";
+	command = "cycle_exterior";
 	master_tag = "xeno_airlock_control";
 	pixel_x = -25;
 	req_access_txt = "55"
@@ -72732,11 +72336,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
+	icon_state = "white"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
+	})
+"cXt" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cXv" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXw" = (
 /obj/machinery/vending/medical,
@@ -72760,13 +72383,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cXz" = (
-/obj/machinery/smartfridge/secure/extract,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXA" = (
 /obj/structure/table,
@@ -72777,29 +72410,12 @@
 	},
 /area/medical/medbay3)
 "cXB" = (
-/obj/structure/table,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 29;
-	pixel_y = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Departure Lounge - Security Post";
-	dir = 1
-	},
-/obj/item/book/manual/security_space_law{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/taperecorder{
-	pixel_x = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72897,8 +72513,14 @@
 /obj/structure/sign/vacuum{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -72908,52 +72530,86 @@
 /turf/simulated/floor/plating,
 /area/solar/starboard)
 "cXO" = (
-/obj/machinery/chem_heater{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "cXQ" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/secondary/exit)
 "cXR" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit)
 "cXS" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 26
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+	dir = 4;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
+"cXT" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"cXU" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cXT" = (
+"cXV" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cXW" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -72964,77 +72620,31 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cXU" = (
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Fore";
-	network = list("SS13","RD")
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cXV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cXW" = (
-/obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXY" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -73104,13 +72714,13 @@
 	name = "\improper Recreation Area"
 	})
 "cYf" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "emergency_home";
-	locked = 1;
-	name = "Departure Lounge Airlock"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -73132,14 +72742,24 @@
 	},
 /area/chapel/main)
 "cYi" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/space,
-/area/solar/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cYj" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -73171,56 +72791,93 @@
 	},
 /area/chapel/main)
 "cYm" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/glowshroom,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
 "cYr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cYt" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cYu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cYw" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/ambrosia,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/hallway/secondary/exit)
+"cYt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit)
+"cYu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit)
 "cYx" = (
 /obj/structure/chair{
 	dir = 1
@@ -73259,20 +72916,34 @@
 	name = "\improper Recreation Area"
 	})
 "cYA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio8";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cYB" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -73318,13 +72989,19 @@
 	},
 /area/medical/morgue)
 "cYK" = (
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
+/obj/structure/chair{
+	dir = 8
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
 "cYL" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -73349,24 +73026,31 @@
 	},
 /area/medical/medbay3)
 "cYP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "cYQ" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/slime_scanner,
-/obj/item/slime_scanner,
-/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -73374,7 +73058,23 @@
 	name = "\improper Secure Lab"
 	})
 "cYR" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Airlock";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -73406,28 +73106,30 @@
 	name = "\improper Toxins Lab"
 	})
 "cYU" = (
-/obj/machinery/monkey_recycler,
+/obj/structure/table,
+/obj/item/paicard,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	dir = 4;
+	icon_state = "neutral"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cYV" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "63"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/secondary/exit)
 "cYW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
@@ -73441,23 +73143,31 @@
 /turf/simulated/floor/plating,
 /area/medical/morgue)
 "cYX" = (
-/obj/machinery/light/small{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cYY" = (
-/obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/hallway/secondary/exit)
 "cYZ" = (
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/obj/machinery/chem_master{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplefull"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cZa" = (
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -73474,51 +73184,45 @@
 	},
 /area/chapel/office)
 "cZb" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar{
-	id = "aftstarboard";
-	name = "Aft-Starboard Solar Array"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
-/area/solar/starboard)
+/obj/structure/sign/biohazard,
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cZc" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cZd" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cZe" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cZf" = (
 /obj/structure/table/wood,
 /obj/machinery/bottler,
@@ -73539,13 +73243,21 @@
 	name = "\improper Arcade"
 	})
 "cZj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cZl" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-24";
@@ -73572,16 +73284,11 @@
 	name = "\improper Arcade"
 	})
 "cZp" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 18;
-	id = "emergency_home";
-	name = "emergency evac bay";
-	width = 29
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/turf/space,
-/area/space)
+/area/hallway/secondary/exit)
 "cZq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -73595,10 +73302,10 @@
 	},
 /area/maintenance/aft)
 "cZr" = (
-/turf/simulated/wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
+/area/hallway/secondary/exit)
 "cZs" = (
 /obj/structure/closet/secure_closet/chaplain,
 /obj/machinery/alarm{
@@ -73623,14 +73330,13 @@
 	},
 /area/chapel/office)
 "cZu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
 "cZv" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73689,10 +73395,14 @@
 	name = "\improper Arcade"
 	})
 "cZA" = (
-/obj/item/stack/cable_coil,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
 "cZC" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -73703,31 +73413,40 @@
 	},
 /area/chapel/main)
 "cZD" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"cZG" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cZG" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "cZH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -73744,47 +73463,40 @@
 	},
 /area/medical/medbay3)
 "cZJ" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cZK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/closet/l3closet/scientist,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
+	})
+"cZK" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cZL" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cZN" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cZN" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/watermelon,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cZO" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psych Office";
@@ -73818,37 +73530,42 @@
 	},
 /area/engine/break_room)
 "cZT" = (
-/obj/structure/lattice,
 /obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cZU" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cZU" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"cZW" = (
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cZW" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
 "cZX" = (
 /obj/machinery/light{
 	dir = 8
@@ -73862,17 +73579,13 @@
 	},
 /area/chapel/main)
 "cZY" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/berry,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"daa" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -73882,22 +73595,26 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dab" = (
+"daa" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/secondary/exit)
+"dab" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "dac" = (
-/obj/structure/chair{
-	dir = 8
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -73963,107 +73680,105 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dap" = (
-/obj/item/radio/beacon,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "daq" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dar" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"dar" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "das" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
 	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "dat" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge - Starboard Aft";
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-16";
-	layer = 4.1
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "dau" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge - Port Aft";
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "dav" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
 	},
-/turf/simulated/floor/engine,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/dropper,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplefull"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -74106,25 +73821,54 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
-"daF" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+"daz" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/wall,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"daF" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplefull"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "daG" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/chem_master{
+	pixel_x = -2;
+	pixel_y = 1
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/structure/disaster_counter/scichem{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74203,15 +73947,40 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "daR" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "xeno_airlock_interior";
+	locked = 1;
+	name = "Secure Lab Internal Airlock";
+	req_access_txt = "55"
 	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	frequency = 1449;
+	id_tag = "xeno_airlock_control";
+	pixel_x = -25;
+	pixel_y = -10;
+	req_access_txt = "55";
+	tag_exterior_door = "xeno_airlock_exterior";
+	tag_interior_door = "xeno_airlock_interior"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	master_tag = "xeno_airlock_control";
+	pixel_x = -25;
+	req_access_txt = "55"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74230,8 +73999,10 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "daT" = (
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -74262,31 +74033,55 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dbd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/landmark{
-	name = "lightsout"
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/chem_dispenser,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "dbe" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/table/glass,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Xenobiology APC";
+	pixel_y = 27
 	},
-/obj/structure/window/reinforced,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplefull"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -74303,12 +74098,17 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "dbj" = (
-/obj/effect/decal/warning_stripes/south,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.4-Escape-4";
 	location = "9.3-Escape-3"
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -74338,19 +74138,25 @@
 	},
 /area/medical/cryo)
 "dbm" = (
-/obj/effect/decal/warning_stripes/south,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.3-Escape-3";
 	location = "9.2-Escape-2"
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "dbo" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74370,25 +74176,31 @@
 	},
 /area/chapel/main)
 "dbr" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dbs" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dbu" = (
 /obj/structure/sign/lifestar,
@@ -74452,59 +74264,38 @@
 	},
 /area/maintenance/aft)
 "dbz" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 10;
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/secondary/exit)
 "dbA" = (
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 6;
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/secondary/exit)
 "dbB" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #1";
-	req_access_txt = "55"
+/obj/machinery/door/airlock/external{
+	id_tag = "emergency_home";
+	locked = 1;
+	name = "Departure Lounge Airlock"
 	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/secondary/exit)
 "dbC" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"dbD" = (
+/obj/machinery/chem_heater{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
+	dir = 9;
+	icon_state = "whitepurple"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dbD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -74521,36 +74312,15 @@
 /turf/space,
 /area/space)
 "dbF" = (
-/obj/structure/table/glass,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Xenobiology APC";
-	pixel_y = 27
+/obj/structure/chair/office/light{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74590,51 +74360,44 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dbI" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access_txt = "55"
+/obj/structure/sink{
+	pixel_y = 22
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "dbJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 26
 	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "dbK" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74657,8 +74420,22 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dbM" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/engine,
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Fore";
+	network = list("SS13","RD")
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -74672,117 +74449,65 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "dbR" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "dbS" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
+/obj/machinery/chem_heater{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "dbT" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/random/toolbox,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutral"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dbU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "63"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "red"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/hallway/secondary/exit)
 "dbV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "dbW" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/glass,
+/obj/item/extinguisher{
+	pixel_x = -5;
+	pixel_y = 8
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
+/obj/item/extinguisher,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74799,19 +74524,29 @@
 	},
 /area/chapel/main)
 "dbZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dca" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dca" = (
-/obj/structure/cable,
-/obj/machinery/power/tracker,
-/turf/simulated/floor/plating/airless,
-/area/solar/starboard)
 "dcd" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -74826,49 +74561,6 @@
 	name = "\improper Research Division Server Room"
 	})
 "dcf" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dch" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door_control{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dci" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -74878,16 +74570,39 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcj" = (
-/obj/structure/disposalpipe/segment{
+"dch" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dci" = (
+/obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dcj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -74895,19 +74610,179 @@
 	name = "\improper Secure Lab"
 	})
 "dck" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #4";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "dcl" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dcq" = (
+/obj/machinery/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"dcs" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/camera{
+	c_tag = "Garden"
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"dct" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"dcu" = (
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"dcv" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dcw" = (
+/obj/structure/table/glass,
+/obj/item/seeds/apple,
+/obj/item/seeds/banana,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/grape,
+/obj/item/seeds/orange,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/wheat,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/tower,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"dcx" = (
+/obj/machinery/biogenerator,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"dcy" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/cheesiehonkers,
+/obj/item/reagent_containers/food/drinks/cans/cola,
+/obj/machinery/camera{
+	c_tag = "Escape - Mid Aft";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"dcz" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "emergency_home";
+	locked = 1;
+	name = "Departure Lounge Airlock"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"dcA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"dcB" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 11;
+	height = 18;
+	id = "emergency_home";
+	name = "emergency evac bay";
+	width = 29
+	},
+/turf/space,
+/area/space)
+"dcC" = (
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dcD" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dcE" = (
+/obj/machinery/disposal,
+/obj/structure/sign/deathsposal{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dcH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -74933,200 +74808,17 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcq" = (
-/obj/machinery/disposal,
-/obj/structure/sign/deathsposal{
-	pixel_y = -32
+"dcI" = (
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	dir = 1;
+	icon_state = "neutral"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcs" = (
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dct" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcu" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
-"dcw" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio6";
-	name = "Containment Blast Doors";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcx" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcy" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcz" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcA" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Port";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcC" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcD" = (
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcE" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcH" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dcK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -75136,19 +74828,19 @@
 /turf/simulated/floor/plasteel,
 /area/medical/cryo)
 "dcN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/table/glass,
+/obj/item/slime_scanner,
+/obj/item/slime_scanner,
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dcO" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -75162,105 +74854,156 @@
 /turf/space,
 /area/space)
 "dcX" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "ddk" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "aftstarboard";
-	name = "Aft-Starboard Solar Array"
+/obj/machinery/shower{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/area/solar/starboard)
-"ddv" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 18;
-	id = "skipjack_se";
-	name = "southeast of SS13";
-	width = 19
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/space,
-/area/space)
-"ddw" = (
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
-"ddD" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
-"ddJ" = (
-/obj/structure/disposalpipe/segment{
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddl" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/computer/security/telescreen{
 	dir = 1;
+	name = "Test Chamber Monitor";
+	network = list("Xeno");
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddw" = (
+/turf/simulated/wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddD" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio8";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddJ" = (
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "ddK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "ddL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 1
 	},
-/obj/structure/chair,
-/obj/item/cigbutt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplecorner"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "ddM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/monkey_recycler,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
 	},
-/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "ddN" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
+/obj/machinery/processor{
+	desc = "A machine used to process slimes and retrieve their extract.";
+	name = "Slime Processor"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "ddO" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
-"ddP" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/reagentgrinder,
+/obj/structure/table/glass,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitepurple"
 	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddP" = (
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "ddQ" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -75274,97 +75017,67 @@
 /turf/space,
 /area/space)
 "ddR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/firealarm{
+/turf/simulated/floor/plasteel{
 	dir = 4;
-	pixel_x = 24
+	icon_state = "green"
 	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Starboard";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "ddS" = (
-/obj/item/crowbar/red,
-/obj/item/wrench,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"ddU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddU" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/obj/machinery/ignition_switch{
-	id = "Xenobio";
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/machinery/door_control{
-	id = "Xenolab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = -2;
-	req_access_txt = "55"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "ddW" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio8";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
 "ddX" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -75417,13 +75130,14 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dej" = (
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -75452,24 +75166,14 @@
 	},
 /area/chapel/main)
 "deo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Outer Window"
-	},
-/obj/machinery/door/window/brigdoor{
-	name = "Security Desk";
-	req_access_txt = "1"
-	},
-/obj/item/folder/red,
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "dep" = (
 /obj/structure/table/wood,
@@ -75498,58 +75202,81 @@
 /turf/simulated/floor/plating,
 /area/medical/psych)
 "des" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"det" = (
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/table,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dez" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/table/glass,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/plant_analyzer,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"det" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"dez" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "greencorner"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "deB" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "green"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "deC" = (
 /obj/structure/table/reinforced,
@@ -75675,17 +75402,20 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "deQ" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -75712,25 +75442,29 @@
 	},
 /area/security/main)
 "deT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "deU" = (
 /obj/machinery/power/apc{
@@ -75978,24 +75712,16 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dfD" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Central";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/structure/railing,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dfG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76010,18 +75736,17 @@
 	},
 /area/chapel/main)
 "dfH" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio7";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/railing/corner,
+/obj/structure/railing,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dfI" = (
 /obj/structure/cable/yellow{
@@ -76140,25 +75865,9 @@
 	},
 /area/medical/virology)
 "dfW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/wood,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dfX" = (
 /obj/structure/cable/yellow{
@@ -76380,17 +76089,10 @@
 	name = "Arrivals"
 	})
 "dgB" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Test Chamber Monitor";
-	network = list("Xeno");
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dgC" = (
 /obj/structure/chair/stool,
@@ -76485,12 +76187,17 @@
 /turf/simulated/wall,
 /area/engine/mechanic_workshop)
 "dgW" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dgY" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -76689,17 +76396,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dhF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "storage room";
-	req_access = "12"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dhG" = (
-/obj/item/seeds/watermelon,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Secure Lab";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dhI" = (
 /mob/living/simple_animal/bot/cleanbot{
 	name = "Mopfficer Sweepsky";
@@ -76749,6 +76471,27 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"dkg" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio6";
+	name = "Containment Blast Doors";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dmU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76881,11 +76624,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/medical/research)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dFD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76898,19 +76646,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"dGT" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"dGb" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"dGT" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -77198,6 +76954,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
+"epb" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "erv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -77267,6 +77034,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
+"eJZ" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eKV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77367,6 +77145,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"eWP" = (
+/obj/item/radio/intercom{
+	pixel_y = -25
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eYE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77383,6 +77169,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"feJ" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "fga" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -77477,6 +77283,44 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"fpy" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"fsy" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fsY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -77506,6 +77350,23 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
+"fuR" = (
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fvO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77555,6 +77416,48 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
+"fDC" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"fDS" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fEr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77602,6 +77505,12 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"fOa" = (
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -77729,19 +77638,22 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "ged" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
 	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -77756,6 +77668,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"gfV" = (
+/obj/effect/decal/remains/xeno,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gid" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -77823,11 +77741,11 @@
 	},
 /area/medical/research)
 "gnZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -77864,6 +77782,28 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/construction)
+"gwW" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gyy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -77904,6 +77844,42 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
+"gHU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Port";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"gIq" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "gIN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -77928,6 +77904,10 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
+"gLe" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/escapepodbay)
 "gMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77982,12 +77962,21 @@
 	},
 /area/medical/medbay3)
 "gTp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
+	})
+"gYB" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "gYM" = (
 /obj/machinery/light{
@@ -78011,6 +78000,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
+"hcj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "hdL" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -78018,6 +78013,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"hdX" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "het" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -78106,21 +78122,24 @@
 	name = "Port Maintenance"
 	})
 "hlZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/obj/structure/window/reinforced,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
+	})
+"hmv" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "hmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -78157,6 +78176,15 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
+	})
+"hpS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "hqN" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -78204,6 +78232,27 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"hyA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hAg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78293,6 +78342,19 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
+"hFx" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hHE" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -78376,6 +78438,15 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"hPp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hRw" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78416,6 +78487,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"hXQ" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "hYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78423,6 +78503,19 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"hYs" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hYZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
@@ -78469,6 +78562,10 @@
 	},
 /turf/space,
 /area/space)
+"icI" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "idx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78653,6 +78750,34 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"ivo" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/ignition_switch{
+	id = "Xenobio";
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/machinery/door_control{
+	id = "Xenolab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = -2;
+	req_access_txt = "55"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "iyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78661,6 +78786,31 @@
 	icon_state = "white"
 	},
 /area/toxins/explab)
+"iyw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "iAT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -78707,6 +78857,9 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
+"iHU" = (
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "iIk" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -78751,6 +78904,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"iRE" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "iSH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78853,6 +79017,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
+"jfH" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Test Chamber";
+	dir = 1;
+	network = list("SS13","RD")
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "jgD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -78860,17 +79035,7 @@
 	},
 /area/medical/surgery2)
 "jhQ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -78898,6 +79063,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"jtD" = (
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "jwh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -78907,6 +79078,13 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
+"jyt" = (
+/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
+	id_tag = "escapepodbay";
+	req_one_access_txt = "13"
+	},
+/turf/space,
+/area/escapepodbay)
 "jCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78951,6 +79129,12 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"jIL" = (
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Podbay"
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "jKJ" = (
 /obj/structure/chair{
 	dir = 1
@@ -79016,6 +79200,29 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"jTO" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "jUV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79063,11 +79270,34 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"kgL" = (
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kgV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"khp" = (
+/obj/structure/chair,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kmF" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -79196,6 +79426,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"kzo" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kzH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -79245,6 +79497,14 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"kCd" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kDt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -79254,6 +79514,12 @@
 	icon_state = "brown"
 	},
 /area/storage/primary)
+"kFB" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kGw" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
@@ -79305,9 +79571,15 @@
 	},
 /area/engine/engineering)
 "kNr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -79470,6 +79742,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
+"lhX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lid" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -79490,6 +79771,15 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"lmK" = (
+/obj/machinery/sparker{
+	id = "Xenobio";
+	pixel_x = -25
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79516,6 +79806,20 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
+"lrJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lwN" = (
 /obj/effect/spawner/lootdrop{
 	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
@@ -79559,6 +79863,22 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"lDL" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/stock_parts/cell,
+/obj/item/flashlight,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Escape Podbay APC";
+	pixel_y = 25
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "lFH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -79625,6 +79945,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"lNS" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "lOU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/west,
@@ -79635,6 +79969,15 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
+	})
+"lRu" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -79670,6 +80013,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
+"lYW" = (
+/obj/machinery/shieldwallgen{
+	req_access = list(55)
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"mcu" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mcP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -79708,6 +80066,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"meb" = (
+/obj/structure/table/glass,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
+"mfw" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79735,6 +80121,17 @@
 	icon_state = "greenfull"
 	},
 /area/hallway/primary/central)
+"mhZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "miB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79753,6 +80150,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"mkj" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mmk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79884,20 +80296,16 @@
 	},
 /area/medical/medbay3)
 "mGK" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -79907,6 +80315,42 @@
 	},
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
+	})
+"mLc" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"mMV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "mOc" = (
 /obj/structure/cable/yellow{
@@ -80027,10 +80471,9 @@
 /turf/simulated/wall,
 /area/construction)
 "nej" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -80079,6 +80522,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
+"nkK" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "nnI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80124,16 +80574,31 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "nxh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio8";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"nyt" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/obj/machinery/firealarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/escapepodbay)
 "nza" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -80196,6 +80661,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
+"nIy" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nIZ" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -80292,6 +80763,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"obK" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "odF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80339,21 +80820,7 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "oiv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -80365,11 +80832,42 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"omf" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "onG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
+"opa" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "orm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -80382,6 +80880,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"ouq" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "oxC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -80409,6 +80919,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"oEz" = (
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "oJQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80423,11 +80938,41 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"oKr" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "oOs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"oQy" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "oQz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80504,28 +81049,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "xeno_airlock_exterior";
-	locked = 1;
-	name = "Secure Lab External Airlock";
-	req_access_txt = "55"
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	master_tag = "xeno_airlock_control";
-	pixel_x = -25;
-	req_access_txt = "55"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "paZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80561,6 +81087,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"pdc" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pef" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -80597,6 +81131,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"pfX" = (
+/mob/living/simple_animal/slime,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "phx" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -80705,15 +81245,39 @@
 	},
 /area/medical/research)
 "pue" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
+	})
+"puB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "pvu" = (
 /obj/effect/spawner/window/reinforced,
@@ -80732,6 +81296,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"pzm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/item/cigbutt,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pzX" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80773,6 +81347,38 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"pDD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"pGo" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 18;
+	id = "skipjack_se";
+	name = "southeast of SS13";
+	width = 19
+	},
+/turf/space,
+/area/space)
 "pHQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -80797,6 +81403,26 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"pKB" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pMx" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall,
@@ -80813,6 +81439,26 @@
 	icon_state = "purple"
 	},
 /area/hallway/primary/aft)
+"pNt" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Central";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pNG" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80935,6 +81581,29 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"pWA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Starboard";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pXV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -80980,6 +81649,16 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"qbG" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/item/radio/electropack,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qcE" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
@@ -81002,6 +81681,17 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
+"qeH" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qeW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81045,6 +81735,30 @@
 	icon_state = "white"
 	},
 /area/medical/research)
+"qnz" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qob" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81135,6 +81849,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"qBY" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "qFg" = (
 /obj/machinery/space_heater,
 /obj/machinery/power/apc{
@@ -81178,6 +81896,23 @@
 	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/starboard)
+"qIH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"qMq" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/space,
+/area/escapepodbay)
 "qME" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81193,6 +81928,27 @@
 	icon_state = "red"
 	},
 /area/security/main)
+"qOk" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"qPJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "qQy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81206,6 +81962,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"qRQ" = (
+/turf/space,
+/area/escapepodbay)
 "qSf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -81217,6 +81976,20 @@
 	},
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
+	})
+"qSN" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio7";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "qTK" = (
 /obj/structure/chair/stool{
@@ -81340,14 +82113,24 @@
 	name = "Arrivals"
 	})
 "rpg" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/rh,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/space,
-/area/solar/starboard)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "rqY" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81442,26 +82225,11 @@
 	name = "\improper Arcade"
 	})
 "rDg" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "greencorner"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "rDy" = (
 /obj/docking_port/stationary{
@@ -81604,6 +82372,17 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
+"rNP" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rOZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -81673,6 +82452,30 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"rXq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rYj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -81734,6 +82537,21 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
+"sfF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -81761,6 +82579,20 @@
 	icon_state = "dark"
 	},
 /area/space/nearstation)
+"snv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "soT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -81779,6 +82611,10 @@
 	icon_state = "showroomfloor"
 	},
 /area/security/main)
+"spi" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "spj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81797,6 +82633,19 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/library)
+"sqr" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "srJ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81865,6 +82714,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/mechanic_workshop)
+"sGG" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sHl" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -81885,6 +82754,24 @@
 	},
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
+	})
+"sLm" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "sLs" = (
 /obj/structure/cable/yellow{
@@ -81913,6 +82800,9 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"sOe" = (
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "sOB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -81921,15 +82811,16 @@
 	},
 /area/security/brig)
 "sOJ" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 0;
+	icon_state = "green"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
 	})
 "sRB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -81937,12 +82828,41 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"sUp" = (
+/obj/machinery/door/window/southleft{
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sVC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"sWP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sYp" = (
 /obj/structure/chair{
 	dir = 1
@@ -82011,6 +82931,12 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"tha" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "thC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82037,6 +82963,41 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
+"tnI" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/camera{
+	c_tag = "Escape - Aft";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"toM" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tpg" = (
 /obj/machinery/firealarm{
 	pixel_y = 29
@@ -82099,6 +83060,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
+"tyy" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tAk" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -82163,6 +83142,68 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"tFL" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"tGW" = (
+/obj/structure/closet,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"tJL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"tLd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"tNw" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82194,6 +83235,10 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
+"tSB" = (
+/obj/structure/grille,
+/turf/space,
+/area/escapepodbay)
 "tST" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82231,6 +83276,26 @@
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"tYd" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tYX" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -82269,19 +83334,23 @@
 "uaQ" = (
 /turf/simulated/wall,
 /area/engine/mechanic_workshop)
+"ucQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "udB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "ueD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "ugy" = (
 /obj/structure/cable/yellow{
@@ -82306,6 +83375,24 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"uiw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "umD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -82333,6 +83420,23 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
+"uqv" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uqy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -82354,6 +83458,30 @@
 	},
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
+	})
+"uuW" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "uvM" = (
 /obj/structure/cable/yellow{
@@ -82389,6 +83517,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"uBy" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uBN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -82401,6 +83540,15 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
+"uDU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uEN" = (
 /obj/effect/landmark/start{
 	name = "Roboticist"
@@ -82486,6 +83634,14 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"uRQ" = (
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uRT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -82515,6 +83671,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"uWg" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uWq" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -82544,6 +83713,13 @@
 "vaO" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry)
+"vaY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "vfe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82557,6 +83733,16 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"vff" = (
+/obj/machinery/door_control{
+	desc = "A remote control-switch for the pod doors.";
+	id = "escapepodbay";
+	name = "Pod Door Control";
+	pixel_y = 24;
+	req_access_txt = "13"
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "vfv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -82667,6 +83853,25 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"vwL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vyo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -82764,6 +83969,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"vJT" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine/vacuum,
+/area/escapepodbay)
 "vLL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82829,6 +84038,20 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"vTh" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Garden APC";
+	pixel_y = -25
+	},
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "vUD" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -82864,6 +84087,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
+"wcc" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wfs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82884,11 +84127,48 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"whL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"wiN" = (
+/obj/item/radio/beacon,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wma" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
+"wnG" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wri" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -82936,17 +84216,12 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "wuT" = (
-/obj/structure/chair{
+/obj/structure/chair/comfy/beige{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -82993,6 +84268,14 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
+"wyv" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -83050,6 +84333,21 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"wDH" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wEq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83137,6 +84435,16 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
+"wTa" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wUE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -83169,6 +84477,19 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
+"xdv" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -83197,12 +84518,38 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"xjU" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xkY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/reception)
+"xmr" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xno" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -83264,6 +84611,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"xwe" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xxA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -83281,6 +84646,24 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"xDN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xDS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83365,6 +84748,9 @@
 	icon_state = "white"
 	},
 /area/medical/reception)
+"xUa" = (
+/turf/simulated/wall,
+/area/escapepodbay)
 "xUe" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -83446,6 +84832,20 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"yeg" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "yeW" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -83495,6 +84895,21 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
+"ykm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"ylD" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 
 (1,1,1) = {"
 aaa
@@ -105039,7 +106454,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaD
 aaa
 aaa
 aaa
@@ -105288,12 +106703,12 @@ aaa
 aaa
 aaa
 aaa
+tSB
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+tSB
 aaa
 aaa
 aaa
@@ -105545,12 +106960,12 @@ aaa
 aaa
 aaa
 aaa
+qMq
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+qMq
 aaa
 aaa
 aaa
@@ -105802,12 +107217,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xUa
+vJT
+vJT
+vJT
+vJT
+xUa
 aaa
 aaa
 aaa
@@ -106052,19 +107467,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaD
+aNQ
+aNQ
+aRZ
+aRZ
+aRZ
+aRZ
+aNQ
+xUa
+qRQ
+qRQ
+qRQ
+jyt
+xUa
 aaa
 aaa
 aaa
@@ -106309,19 +107724,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRZ
+dcq
+ddP
+dcq
+dcq
+ddP
+dcq
+xUa
+sOe
+sOe
+sOe
+sOe
+xUa
 aaa
 aaa
 aaa
@@ -106566,19 +107981,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRZ
+dcq
+ddP
+dcq
+dcq
+ddP
+dcq
+xUa
+sOe
+sOe
+sOe
+sOe
+xUa
 aaa
 aaa
 aaa
@@ -106823,19 +108238,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRZ
+dcq
+ddP
+dcq
+dcq
+ddP
+dcq
+xUa
+vff
+sOe
+sOe
+sOe
+xUa
 aaa
 aaa
 aaa
@@ -107080,19 +108495,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aNQ
+dcs
+ddP
+dcq
+dcq
+ddP
+dcq
+xUa
+jIL
+sOe
+sOe
+sOe
+xUa
 aaa
 aaa
 aaa
@@ -107337,19 +108752,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRZ
+dct
+ddP
+deo
+pad
+pad
+vTh
+xUa
+icI
+icI
+icI
+icI
+xUa
 aaa
 aaa
 aaa
@@ -107594,19 +109009,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRZ
+dcu
+ddP
+des
+rpg
+ddP
+meb
+xUa
+nyt
+tha
+iHU
+jtD
+xUa
 aaa
 aaa
 aaa
@@ -107851,19 +109266,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRZ
+dcw
+ddP
+det
+ddP
+ddP
+cqy
+xUa
+lDL
+snv
+hcj
+qBY
+xUa
 aaa
 aaa
 aaa
@@ -108097,7 +109512,7 @@ cTM
 cUt
 cSO
 cSO
-cVX
+cZR
 cWz
 cWY
 cZC
@@ -108108,19 +109523,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aNQ
+dcx
+ddR
+dez
+rDg
+ddR
+lRu
+xUa
+ylD
+qPJ
+iHU
+lNS
+xUa
 aaa
 aaa
 aaa
@@ -108358,26 +109773,26 @@ cSO
 cSO
 cSO
 cSO
+cSO
+cSO
 cVk
+cTX
+cTX
+cTX
 cVk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aNQ
+aNQ
+aRZ
+deB
+sOJ
+aRZ
+aNQ
+xUa
+gLe
+dGb
+vaY
+gLe
+xUa
 aaa
 aaa
 aaa
@@ -108604,37 +110019,37 @@ bgZ
 bZU
 cPH
 cSN
-cSr
+cVs
 cTq
 cTO
 cVD
-cTt
-cUv
-cUv
-dau
+cWb
+csK
 cWi
-cXc
+dau
+cRR
+cYf
 cYf
 cYB
 cYf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cXv
+cYf
+cYU
+cYf
+cYf
+cXv
+dcy
+ddS
+deQ
+cWi
+cWi
+gIq
+ykm
+cWi
+deQ
+cWi
+cZe
+cTX
 aaa
 aaa
 aaa
@@ -108860,38 +110275,38 @@ cIm
 hLt
 bZU
 cPI
-cQM
+cWb
 pue
 cRt
 cVc
-pue
-cRt
-cRt
-nej
-cRt
-cTr
+cnU
+cVc
+cVc
+cLS
+cOZ
+cSV
 cXb
+cUD
+cUD
+cUD
+cXz
+cXW
+cXb
+cUD
+dbr
+cUD
+cXz
+ddU
+deT
+cVc
+cLS
+cOZ
+cRt
+cVc
+tLd
+cWb
+bPk
 cTX
-cTX
-cTX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -109117,38 +110532,38 @@ cYW
 cQh
 bZU
 cPJ
-cQM
+cUz
 cTg
 cSk
 gnZ
 cTQ
 cSo
-cSo
+cmG
 gTp
-cRt
+cUu
 dbj
-cXb
-cYf
-cXb
-cYf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cSk
+cUE
+cWg
+cUG
+gTp
+cXX
+cSk
+cZK
+dbs
+cZL
+gTp
+cWb
+dfD
+ueD
+khp
+cUu
+dfD
+tNw
+khp
+cWb
+iRE
+cVk
 aaa
 aaa
 aaa
@@ -109376,36 +110791,36 @@ bZU
 bZU
 cQR
 cRv
-cRt
-cRt
-cRt
-cRt
-cRt
-cRt
-cRt
-cTr
-cXb
-cTX
-cTX
-cTX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cSk
+cmG
+cSo
+cTQ
+gnZ
+gTp
+cUu
+cRq
+cSk
+cUG
+cWg
+cUE
+gTp
+cXX
+cSk
+cZL
+dbs
+cZK
+gTp
+cWb
+dfD
+wyv
+khp
+dap
+dfD
+wnG
+khp
+cWb
+iRE
+cVk
 aaa
 aaa
 aaa
@@ -109638,31 +111053,31 @@ cTW
 cTW
 cTW
 cTW
-cTW
+cNz
 cUu
-cTr
-cXb
-cTX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cRq
+cTs
+cTW
+cTW
+cTW
+cNz
+cXX
+cTs
+cTW
+cTW
+cTW
+cNz
+cWb
+dfD
+wnG
+khp
+cWb
+dfD
+wyv
+khp
+cWb
+dcI
+cVk
 aaa
 aaa
 aaa
@@ -109889,37 +111304,37 @@ bgZ
 bZU
 cPL
 bYy
-cRx
+bMv
 cTr
-cUz
-cTR
-cXs
-cVf
+cTX
+cTX
+cTX
+cTX
 cUz
 dap
-cTr
+cRq
 cXe
-cTX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cUO
+cWh
+cXg
+cXB
+cYi
+daT
+cXB
+cWh
+dbT
+cUz
+cWb
+dfH
+tNw
+khp
+cWb
+dfD
+ueD
+khp
+cWb
+iRE
+cVk
 aaa
 aaa
 aaa
@@ -110145,38 +111560,38 @@ cIm
 clu
 bZU
 cPM
-bYy
-cRx
+cRq
+bNG
 cTt
 cUv
-cUv
-cUv
-cUv
-cUv
+cnV
+csm
+csL
+cPN
 cWb
-cTr
-cXb
-cTX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cRq
+cTd
+cVf
+cWo
+cWo
+cXO
+cYm
+cYV
+cZU
+cWo
+cWo
+cPN
+cWb
+cTs
+cTW
+cNz
+cWb
+cTs
+cTW
+cNz
+cWb
+hmv
+cVk
 aaa
 aaa
 aaa
@@ -110401,39 +111816,39 @@ cIm
 cIm
 cNV
 czI
-bZU
+bMp
 cRq
 cRx
-cRt
-cRt
-cRt
-cRt
-cRt
-cRt
-cRt
+bPk
+cUv
+cnW
+csA
+csL
+cPN
+cWb
+cRq
+cTh
+cVf
+cWq
+cXh
+cXQ
+cYr
+cYY
+cXQ
+dbz
+dbU
+cPN
+cWb
+cWb
+cWb
+cWb
+cWb
+cWb
+cWb
+cWb
 cTr
-cXb
-cTX
-cTX
-cTX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hXQ
+cVk
 aaa
 aaa
 aaa
@@ -110659,38 +112074,38 @@ cNS
 cNW
 cON
 cPN
-bYy
+cRq
 cRx
-cRt
+bPk
 nej
-cRt
-cRt
-cRt
-cVc
-cRt
+cpe
+cpe
+nej
+cPN
+cWb
 dbm
-cXb
-cYf
+cTi
+cVn
 cYX
-cYf
+cWb
 cZp
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cYt
+cZr
+daa
+dbA
+dbV
+cPP
+dat
+daT
+daT
+daT
+dat
+daT
+daT
+daT
+tnI
+cVk
+cVk
 aaa
 aaa
 aaa
@@ -110921,32 +112336,32 @@ cRA
 cTC
 cTc
 dGT
-cUA
+dGT
 cVi
 cVC
-cRt
-cTr
-cXb
+cQU
+cSY
+cTR
+cVF
+cWA
+cXi
+cXR
+cYu
+cZu
+dab
+dbB
+cWo
+dcz
 cTX
+dfW
+cpe
+dfW
 cTX
+dcz
 cTX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dcz
+cVk
+cVk
 aaa
 aaa
 aaa
@@ -111170,39 +112585,39 @@ bXi
 cWH
 lHZ
 cmm
-cCQ
+bGW
 cOP
 cPP
 cRO
 cSX
 cTV
-cUB
+cWT
 wuT
-cWB
+wuT
 cWT
 dac
 dat
 daT
 cXM
-cYf
-cXb
-cYf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cVI
+cWE
+cXq
+cXS
+cYK
+cZA
+daq
+dbC
+cWo
+dcA
+cTX
+dgB
+qOk
+kCd
+cTX
+oEz
+cTX
+kFB
+cVk
 aaa
 aaa
 aaa
@@ -111433,33 +112848,33 @@ cIx
 cIx
 cRC
 bZU
-deo
-cLS
-cUC
 cVk
-cTX
 cVk
-cTX
+cVk
 cVk
 cTX
 cTX
+cTX
+cVk
+cVk
+cWF
 cZT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cXT
+cYP
+cZD
+dar
+dbB
+cWo
+dcz
+cTX
+cTX
+cTX
+cTX
+cTX
+dcz
+cTX
+dcz
+cVk
 aaa
 aaa
 aaa
@@ -111688,13 +113103,8 @@ bQa
 cOR
 cPQ
 cIx
-cSY
+ebA
 bZU
-cUO
-cTT
-cUD
-cVk
-abq
 aaa
 aaa
 aaa
@@ -111708,6 +113118,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+dcB
 aaa
 aaa
 aaa
@@ -111947,12 +113362,12 @@ cpR
 cIx
 ebA
 bZU
-cUG
-nxh
-cUE
-cSV
-abq
-abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112202,14 +113617,14 @@ pzX
 cOT
 cPS
 cIx
-ebA
+bNH
 bZU
-cTh
-cTU
-deQ
-cTS
 aaa
-abq
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112461,12 +113876,12 @@ cSx
 cIx
 ebA
 bZU
-cTi
-cWo
-cXB
-cVk
 aaa
-abq
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112721,7 +114136,7 @@ bZU
 bZU
 bZU
 qbl
-bZU
+csM
 abq
 abq
 aaa
@@ -113998,28 +115413,12 @@ cLs
 cic
 cNj
 cOf
-cOZ
+cuv
 cPX
 cfw
 cRI
 cSu
-cTk
-cNz
-cNz
-cNz
-cNz
-cNz
-cNz
-cNz
-cNz
-aaa
-aaa
-aaa
-aaa
-abq
-aaa
-aaa
-abq
+cZN
 aaa
 aaa
 aaa
@@ -114034,9 +115433,25 @@ aaa
 aaa
 aaa
 aaa
-abq
-abq
-abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114260,23 +115675,7 @@ bVC
 cQQ
 cRJ
 cVJ
-cTl
-cTY
-cTY
-cVn
-cTY
-cTY
-cTY
-mGK
-cNz
-aaa
-aaa
-aaa
-abq
-abq
-abq
-abq
-abq
+cZN
 aaa
 aaa
 aaa
@@ -114293,7 +115692,23 @@ aaa
 aaa
 aaa
 aaa
-abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114516,50 +115931,50 @@ cPb
 cic
 cfw
 dDV
-cSW
-cTm
-cNz
-cNz
-cNz
-cNz
-cNz
-cNz
-cJg
-cNz
+cVJ
+cZN
 aaa
 aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
 aaa
 aaa
-abq
-cVG
-cVG
-cVG
-cVG
-cVG
 aaa
 aaa
-abq
-abq
 aaa
-abq
-abq
 aaa
-abq
-abq
-abe
-abf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114772,52 +116187,52 @@ cOi
 cPc
 cPc
 cOp
-cSt
-bZU
-bZU
-aaa
-abq
-aaa
-aaa
-aaa
-cNz
-cJg
-cNz
+dDV
+bPl
+ddw
 aaa
 aaa
 aaa
 aaa
-cVG
-cVG
-cNz
-cNz
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cZG
-bMu
-bMu
-cVG
-cVG
-cVG
-abq
-aaa
-aaa
-abq
 aaa
 aaa
 aaa
-abq
 aaa
-abf
-abf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115029,52 +116444,52 @@ cOj
 cPd
 cPZ
 cOp
-bgZ
+dDV
 cvY
-cmi
+cZN
 aaa
 aaa
 aaa
 aaa
 aaa
-cNz
-rDg
-cNz
 aaa
 aaa
 aaa
-abq
-cVG
-cXq
-cXO
-cnU
-cYK
-cZr
-cZG
-bMu
-aOE
-cZr
-cZG
-bMu
-aOE
-cZr
-cZH
-bMu
-bMu
-cVG
-dcs
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-abq
-abq
 aaa
-abe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115286,52 +116701,52 @@ cPi
 cPe
 cQa
 cOp
-tfV
+dDV
 cwt
-cmi
+cZN
 aaa
 aaa
 aaa
 aaa
 aaa
-cNz
-cJg
-cNz
 aaa
 aaa
 aaa
 aaa
-cVG
-cmD
-cXR
-dab
-cnW
-cZr
-cZH
-bMu
-bMu
-cZr
-cZH
-bMu
-bMu
-cZr
-cZH
-bMu
-bMu
-cVG
-dct
-dcH
-dcH
-dcH
-dcH
-dcH
-dcH
-ddJ
-cVG
 aaa
 aaa
 aaa
-abf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115543,53 +116958,53 @@ cOl
 cPf
 dcd
 cOp
-bgZ
-cuV
-cmi
+bNZ
+bPI
+cnk
 aaa
 aaa
 aaa
 aaa
 aaa
-cNz
-cJg
-cNz
 aaa
 aaa
 aaa
 aaa
-cVG
-dbC
-cXQ
-dab
-dcq
-cZr
-cZH
-bMu
-bMu
-cZr
-cZH
-bMu
-bMu
-cZr
-csB
-csF
-csL
-cVG
-dcu
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-ddK
-cVG
-abq
 aaa
 aaa
-abf
-abf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115800,53 +117215,53 @@ cJL
 cPg
 cKN
 cOp
-bgZ
-bZU
-bZU
-bZU
-bZU
-bZU
-bZU
-aaa
-cNz
-cJg
-cNz
+dDV
+cVJ
+ddw
 aaa
 aaa
 aaa
 aaa
-cVG
-cXt
-cXR
-kNr
-dcl
-cZr
-cpf
-cqc
-cqJ
-cZr
-crs
-cse
-csm
-cZr
-dbe
-dcx
-dcz
-dcB
-ddS
-bGU
-cVG
-bMu
-bNH
-bPk
-cVG
-ddK
-cVG
-abq
 aaa
 aaa
 aaa
-abe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116057,53 +117472,53 @@ cOn
 cPh
 cQd
 cOp
-hLt
-bZU
-cVe
-chy
-chy
-cYm
-bZU
-aaa
-cNz
-cJg
-cNz
-aaa
-cVF
-cVG
-cVG
-cVG
-cVG
-cnk
-cYr
-cYQ
-cTk
-dbe
-dbB
-deT
-daF
-dbe
-dcf
-dfW
-daF
-dch
-dab
-dbS
-dcj
-dgB
-bGW
-dcX
-bMu
-bMu
-bMu
-cVG
-ddK
-cVG
+dDV
+cVJ
+cZN
 aaa
 aaa
 aaa
-abq
-abf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116314,48 +117729,48 @@ cOo
 cQq
 cQe
 cOp
-bgZ
-bZU
-cVj
-cuV
-cuV
-cZJ
-bZU
+dDV
+cVJ
+cZN
+abq
 aaa
-cNz
-cJg
-cNz
-cNz
-cVG
-ged
-cWA
-cXg
-cVG
-cXS
-cYr
-cYP
-cZu
-daq
-dab
-daG
-daR
-dbo
-dab
-daG
-dbz
-dbo
-dab
-dbT
-dci
-ddU
-bHo
-bMs
-bMs
-bNZ
-bMu
-cVG
-ddL
-cNz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116571,50 +117986,50 @@ cOp
 cOp
 cOp
 cOp
-bgZ
-cPT
-cVg
-cuV
-chy
-cYw
-bZU
+dDV
+cVJ
+cZN
+abq
+abq
 aaa
-cNz
-jhQ
-hlZ
-cTY
-pad
-cWh
-cWF
-cXi
-cXv
-cXT
-cYt
-cZK
-cZU
-das
-daa
-dar
-oiv
-daa
-dbd
-dar
-daa
-daa
-dbJ
-dbU
-dez
-dej
-bMo
-bMu
-bMu
-bMu
-bPl
-cVG
-ddM
-ddN
-ddO
-ddP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116827,54 +118242,54 @@ cEK
 cln
 clN
 crq
-chy
-bgZ
-cPT
-cPT
-cmy
-cvW
 bZU
-bZU
-aaa
-cNz
-cNz
-cNz
-cNz
-cVG
-cWg
-cWE
-cXh
-cVG
-cXU
-cYu
-cYR
-cZD
-daq
-dab
-dbs
-dfD
-dbr
-dab
-dbs
-dbA
-dbr
-dab
-dbV
-sOJ
-ddX
-bMp
-bMv
-bMu
-bOc
-bMu
-cVG
-dcD
-cNz
-aaa
-aaa
-aaa
-aaa
+dDV
+cVJ
+ddw
+ddw
 abq
+abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117085,53 +118500,53 @@ cQE
 cPj
 cxT
 cRP
-clT
-cPT
+bOc
+cVJ
 cVo
-chy
-cUK
+cpf
 cZN
-bZU
+cZN
+cZN
+cZN
+cZN
+cZN
+cZN
 aaa
 aaa
 aaa
 aaa
 aaa
-cVI
-cVG
-cVG
-cVG
-cVG
-cnv
-cYu
-cZL
-cTk
-ddW
-dbI
-dbR
-daF
-dfH
-dck
-dbR
-daF
-daq
-dab
-dbW
-deB
-det
-bMq
-dcX
-bMu
-bMu
-bPI
-cVG
-dcD
-cVG
-abq
 aaa
 aaa
 aaa
-abf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117339,56 +118754,56 @@ cNy
 cPm
 cEK
 cOs
-bZU
-bZU
-dhF
-bZU
-bZU
-cVq
-dhG
 chy
-cZY
+chy
 bZU
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cVG
-cmG
-cXV
-ueD
-dgW
-cZr
-cpg
-cqj
-cqX
-cZr
-csd
-csf
-csA
-cZr
-dcw
-dcy
-dcA
-ddR
-des
-bGU
-cVG
-bNG
 bPj
 bPK
-cVG
-dcD
-cVG
-abq
-abq
-abq
-abq
-abf
+cVq
+dhG
+csB
+cZY
+csB
+csB
+csB
+cTS
+cZN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117596,16 +119011,20 @@ cEK
 cEK
 cEK
 cOt
-bZU
-cQH
-cRR
-cTa
-bZU
-cVp
 chy
-cUL
-cYw
+cQI
 bZU
+cTa
+cmD
+cVp
+cpg
+cZN
+cZN
+cZN
+cZN
+cZN
+cTT
+cZN
 aaa
 aaa
 aaa
@@ -117614,38 +119033,34 @@ aaa
 aaa
 aaa
 aaa
-cVG
-dbK
-cXW
-dab
-cYU
-cZr
-bMu
-bMu
-cZH
-cZr
-bMu
-bMu
-cZH
-cZr
-csD
-csK
-csM
-cVG
-dcC
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-dcD
-cVG
-abq
 aaa
 aaa
-abf
-abf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117853,55 +119268,55 @@ cdN
 cjn
 chy
 jaV
-bZU
+chy
 cQJ
-cQU
-cTo
 bZU
-bZU
-ckD
-bZU
-bZU
-bZU
+ddw
+ddw
+ddw
+ddw
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cVG
-dbF
-cXX
-dab
-cYV
-cZr
-bMu
-bMu
-cZH
-cZr
-bMu
-bMu
-cZH
-cZr
-dbD
-dbM
-dbZ
-cVG
-dcD
-dcD
-dcD
-dcD
-dcD
-dcD
-dcD
-dcD
-cVG
-abq
 abq
 aaa
-abe
+aaa
+cZN
+cTT
+cZN
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118110,55 +119525,55 @@ cLB
 chy
 cuV
 jaV
-bZU
-cQI
 chy
-cTd
-cdO
-ceE
-cWq
-cmi
+cQI
+bZU
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cVG
-cXz
-cnT
-cnV
-cpe
-cZr
-bMu
-bMu
-dav
-cZr
-aOE
-bMu
-dav
-cZr
-bMu
-bMu
-cZH
-cVG
-dcE
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
 abq
 aaa
 aaa
-abf
+cZN
+cTT
+cZN
+aaa
+aaa
+aaa
+aaa
+abq
+aaa
+aaa
+abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abq
+abq
+abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118367,8 +119782,8 @@ ceN
 ceN
 chP
 cOu
-bZU
-bZU
+chy
+chy
 cQW
 cQW
 cQW
@@ -118378,33 +119793,11 @@ cQW
 abq
 abq
 aaa
+cZN
+cTU
+cZN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cVG
-cVG
-cNz
-cNz
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-cVG
-bMu
-bMu
-dav
-cVG
-cVG
-cVG
 aaa
 abq
 abq
@@ -118412,11 +119805,33 @@ abq
 abq
 abq
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abq
-abq
-abf
-abf
-abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118622,7 +120037,7 @@ bZU
 cfY
 cuV
 chy
-chy
+aOE
 cmY
 chy
 chy
@@ -118635,33 +120050,11 @@ cOy
 aaa
 aaa
 aaa
+cZN
+cTT
+cZN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cVG
-cVG
-cVG
-cVG
-cVG
-aaa
-abq
 aaa
 aaa
 aaa
@@ -118671,7 +120064,29 @@ aaa
 aaa
 aaa
 aaa
+abq
+aaa
+aaa
+aaa
+aaa
+abq
+cVG
+cVG
+cVG
+cVG
+cVG
+aaa
+aaa
+abq
+abq
+aaa
+abq
+abq
+aaa
+abq
+abq
 abe
+abf
 aaa
 aaa
 aaa
@@ -118892,44 +120307,44 @@ cOy
 aaa
 aaa
 aaa
+cZN
+cTT
+cZN
+abq
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
+cVG
+cVG
+cZN
+cZN
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+dgW
+oiv
+oiv
+cVG
+cVG
+cVG
+abq
 aaa
 aaa
 abq
 aaa
 aaa
 aaa
+abq
 aaa
-abq
-abq
-abq
-abq
-abq
-abq
-abq
-abq
-abq
-abe
 abf
-aaa
+abf
 aaa
 aaa
 aaa
@@ -119149,44 +120564,44 @@ cOy
 aaa
 aaa
 aaa
-aaa
-abq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZN
+cTT
+cZN
 abq
 abq
 abq
 abq
+cVG
+das
+dbD
+dbW
+dcC
+ddw
+dgW
+oiv
+pfX
+ddw
+dgW
+oiv
+pfX
+ddw
+dhF
+oiv
+oiv
+cVG
+tGW
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
 abq
 abq
-abq
-abq
 aaa
-abq
-aaa
-aaa
-aaa
-aaa
-abq
-aaa
-aaa
-aaa
-aaa
+abe
 aaa
 aaa
 aaa
@@ -119403,47 +120818,47 @@ cQW
 cOy
 cWK
 cXN
-abq
-abq
-abq
 aaa
 abq
 abq
+cZN
+cTU
+cZN
+aaa
+aaa
+aaa
 abq
-abq
-abq
-abq
-abq
-abq
-abq
-abq
-abq
-abq
-arB
-abq
-abe
-arB
+cVG
+dav
+cZc
+dbZ
+dcD
+ddw
+dhF
+oiv
+oiv
+ddw
+dhF
+oiv
+oiv
+ddw
+dhF
+oiv
+oiv
+cVG
+qIH
+mcu
+mcu
+mcu
+mcu
+mcu
+mcu
+hpS
+cVG
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abf
 aaa
 aaa
 aaa
@@ -119660,48 +121075,48 @@ aaa
 cOy
 cWK
 xZq
-aaa
 abq
 abq
 aaa
+cZN
+cTT
+cZN
 aaa
-aup
 aaa
 aaa
+aaa
+cVG
+daF
+dbF
+dbZ
+dcE
+ddw
+dhF
+oiv
+oiv
+ddw
+dhF
+oiv
+oiv
+ddw
+feJ
+fDC
+fpy
+cVG
+yeg
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+sWP
+cVG
 abq
-abq
 aaa
 aaa
-abq
-abq
-aaa
-aaa
-abq
-abq
-aaa
-abe
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abf
+abf
 aaa
 aaa
 aaa
@@ -119915,50 +121330,50 @@ aaa
 abq
 abq
 cOy
-cWK
+cqc
 xZq
 abq
-abq
 aaa
 aaa
-abq
-arB
-abq
-cZb
+cZN
+cTT
+cZN
+aaa
+aaa
+aaa
+aaa
+cVG
+daG
 cZc
-ddk
+dcf
+dcH
+ddw
+ged
+qnz
+daz
+ddw
+fsy
+uuW
+xwe
+ddw
+hlZ
+uBy
+sLm
+gHU
+fuR
+lYW
+cVG
+oiv
+lmK
+gfV
+cVG
+sWP
+cVG
 abq
-cZb
-cZc
-ddk
-abq
-cZb
-cZc
-ddk
-aaa
-arB
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abe
 aaa
 aaa
 aaa
@@ -120174,48 +121589,48 @@ aaa
 aaa
 rOZ
 aaa
+abq
+abq
+abq
+cZN
+cTT
+cZN
+aaa
+cZb
+cVG
+cVG
+cVG
+cVG
+dbI
+dch
+dcN
+cpf
+hlZ
+mfw
+pDD
+obK
+hlZ
+qeH
+hyA
+obK
+uiw
+dbZ
+wcc
+puB
+ddl
+mLc
+wTa
+oiv
+oiv
+oiv
+cVG
+sWP
+cVG
+aaa
+aaa
 aaa
 abq
-aaa
-aaa
-aaa
-aup
-aaa
-cZb
-cZd
-ddk
-aaa
-cZb
-cZd
-ddk
-aaa
-cZb
-cZd
-ddk
-abq
-arB
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abf
 aaa
 aaa
 aaa
@@ -120432,42 +121847,42 @@ aaa
 rOZ
 aaa
 aaa
-abq
-aaa
-aaa
 aaa
 abq
-abq
-cZb
+cZN
+cTT
+cZN
+cZN
+cVG
 cZd
 ddk
-abq
-cZb
-cZd
-ddk
-abq
-cZb
-cZd
-ddk
-abq
-arB
-abq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZG
+cVG
+dbJ
+dch
+dcX
+ddW
+jhQ
+dbZ
+sqr
+lrJ
+uRQ
+dbZ
+sqr
+xjU
+uRQ
+dbZ
+tYd
+rXq
+ivo
+jTO
+ucQ
+ucQ
+oKr
+oiv
+cVG
+pzm
+cZN
 aaa
 aaa
 aaa
@@ -120688,45 +122103,45 @@ aaa
 aaa
 rOZ
 aaa
-abq
-abq
-abq
-aaa
-aaa
-abq
-aaa
-cZb
-cZd
-ddk
-abq
-cZb
-cZd
-ddk
-aaa
-cZb
-cZd
-ddk
-abq
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZN
+cTY
+cVX
+csB
+cXs
+cXU
+cYQ
+cZH
+daR
+dbK
+dci
+ddv
+ddX
+kNr
+sfF
+iyw
+mMV
+sfF
+omf
+iyw
+sfF
+sfF
+vwL
+whL
+xDN
+kgL
+sUp
+oiv
+oiv
+oiv
+jfH
+cVG
+lhX
+dgY
+spi
+nkK
 aaa
 aaa
 aaa
@@ -120945,48 +122360,48 @@ aaa
 aaa
 rOZ
 aaa
-abq
-aaa
-aaa
 aaa
 aaa
 abq
+cZN
+cZN
+cZN
+cZN
+cVG
+cXV
+cYR
+cZJ
+cVG
+dbM
+dcj
+ddJ
+dej
+jhQ
+dbZ
+xdv
+pNt
+tFL
+dbZ
+xdv
+pdc
+tFL
+dbZ
+mkj
+eJZ
+uWg
+gwW
+fOa
+oiv
+wiN
+oiv
+cVG
+cVJ
+cZN
 aaa
-cZb
-cZd
-ddk
+aaa
+aaa
+aaa
 abq
-cZb
-cZd
-ddk
-abq
-cZb
-cZd
-ddk
-aaa
-aaa
-arB
-arB
-arB
-abq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -121202,48 +122617,48 @@ aaa
 aaa
 rOZ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
+abq
+abq
 abq
 aaa
-abq
+aaa
+aaa
+cXt
+cVG
+cVG
+cVG
+cVG
 cZj
-aaa
-aaa
+dcj
+ddK
+cpf
+mGK
+opa
+tyy
+obK
+qSN
+hFx
+tyy
+obK
+jhQ
+dbZ
+pKB
+hYs
+ouq
+uqv
+wTa
+oiv
+oiv
+eWP
+cVG
+cVJ
+cVG
 abq
-cZj
-aaa
-aaa
-abq
-cZj
 aaa
 aaa
 aaa
-abq
-aaa
-arB
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abf
 aaa
 aaa
 aaa
@@ -121457,50 +122872,50 @@ aaa
 abq
 aaa
 aaa
-rpg
-cYi
-cYA
-cYA
-cYA
-cYA
-cYA
-cYA
-cYY
+rOZ
+abq
+abq
+abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cVG
 cYZ
-cZA
-cYZ
-cYZ
-cYZ
-cYZ
-cYZ
-cYZ
+dbR
+dck
+ddL
 ddw
-cYZ
+nxh
 ddD
 cYA
-cYA
+ddw
 dca
+toM
+hdX
+ddw
+dkg
+xmr
+tJL
+pWA
+mhZ
+lYW
+cVG
+qbG
+wDH
+oQy
+cVG
+cVJ
+cVG
 abq
-arB
 abq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
+abq
+abf
 aaa
 aaa
 aaa
@@ -121714,50 +123129,50 @@ abq
 abq
 abq
 abq
-aup
-arB
-arB
-arB
-aup
-aaa
-aaa
+cqj
+abq
 abq
 aaa
-abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cVG
+dbd
 cZW
-aaa
-aaa
+dbZ
+ddM
+ddw
+oiv
+oiv
+dhF
+ddw
+oiv
+oiv
+dhF
+ddw
+sGG
+kzo
+fDS
+cVG
+epb
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVJ
+cVG
 abq
-cZW
-abq
-aaa
-abq
-cZW
-aaa
-abq
-aaa
-abq
-aaa
-arB
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abf
+abf
 aaa
 aaa
 aaa
@@ -121968,52 +123383,52 @@ aaa
 aaa
 aaa
 aaa
-abq
+aaa
+aaa
+aaa
+rOZ
 aaa
 aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
 aaa
-abq
 aaa
-cZb
+aaa
+aaa
+cVG
+dbe
 dcv
-ddk
+dbZ
+ddN
+ddw
+oiv
+oiv
+dhF
+ddw
+oiv
+oiv
+dhF
+ddw
+hPp
+nIy
+uDU
+cVG
+cVJ
+cVJ
+cVJ
+cVJ
+cVJ
+cVJ
+cVJ
+cVJ
+cVG
 abq
-cZb
-dcv
-ddk
 abq
-cZb
-dcv
-ddk
 aaa
-aaa
-arB
-arB
-arB
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abe
 aaa
 aaa
 aaa
@@ -122225,52 +123640,52 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+rOZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cVG
+dbo
+dbS
+dcl
+ddO
+ddw
+oiv
+oiv
+rNP
+ddw
+pfX
+oiv
+rNP
+ddw
+oiv
+oiv
+dhF
+cVG
+gYB
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
 abq
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abq
-abq
-abq
-cZb
-dcv
-ddk
-aaa
-cZb
-dcv
-ddk
-aaa
-cZb
-dcv
-ddk
-aaa
-aaa
-aaa
-abq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abf
 aaa
 aaa
 aaa
@@ -122481,54 +123896,54 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+rOZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abq
+cVG
+cVG
+cZN
+cZN
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+cVG
+oiv
+oiv
+rNP
+cVG
+cVG
+cVG
+aaa
 abq
 abq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
+abq
 abq
 aaa
-cZb
-dcv
-ddk
 abq
-cZb
-dcv
-ddk
 abq
-cZb
-dcv
-ddk
+abf
+abf
 abq
-arB
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -122734,56 +124149,56 @@ aaa
 abq
 abq
 abq
-abq
-abq
-abq
-abq
-abq
+bGU
+arB
+arB
+czm
+aaa
 aaD
 aaa
 aaa
+rOZ
 aaa
 aaa
 aaa
 aaa
+czm
+abd
+abd
+abd
+aaa
+abq
+abq
+abq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cVG
+cVG
+cVG
+cVG
+cVG
+aaa
+abq
 aaa
 aaa
 aaa
 abq
 aaa
-cZb
-dcv
-ddk
-aaa
-cZb
-dcv
-ddk
-abq
-cZb
-dcv
-ddk
-abq
-arB
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abe
 aaa
 aaa
 aaa
@@ -122991,36 +124406,24 @@ abq
 abq
 aaa
 aaa
+abd
+aaa
+abq
+abq
 aaa
 aaa
+abq
+aaa
+cqJ
+aaa
+abq
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
+abq
 abe
-aaa
-cZb
-dcN
-ddk
+abd
 abq
-cZb
-dcN
-ddk
-abq
-cZb
-dcN
-ddk
-aaa
-arB
 abq
 aaa
 aaa
@@ -123037,10 +124440,22 @@ aaa
 aaa
 aaa
 aaa
+abq
 aaa
 aaa
 aaa
 aaa
+abq
+abq
+abq
+abq
+abq
+abq
+abq
+abq
+abq
+abe
+abf
 aaa
 aaa
 aaa
@@ -123248,6 +124663,24 @@ abq
 aaa
 aaa
 aaa
+abd
+aaa
+bHo
+bHo
+bHo
+bHo
+bHo
+abq
+cqX
+abq
+bHo
+bHo
+bHo
+bHo
+bHo
+abq
+abd
+abq
 aaa
 aaa
 aaa
@@ -123260,41 +124693,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-arB
-aup
-arB
 aaa
 aaa
 abq
 abq
-aaa
-abq
-abq
-aaa
 abq
 abq
 abq
+abq
+abq
+abq
 aaa
-aaa
-aup
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
 aaa
 aaa
 aaa
@@ -123505,6 +124920,23 @@ abq
 aaa
 aaa
 aaa
+abd
+aaa
+bMo
+bMq
+bMq
+bMq
+bMq
+cnv
+cqX
+csD
+cJg
+cJg
+cJg
+cJg
+cUC
+abq
+bGU
 aaa
 aaa
 aaa
@@ -123518,23 +124950,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-arB
-aup
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-aup
-arB
-arB
-arB
-arB
-arB
 aaa
 aaa
 aaa
@@ -123762,6 +125177,23 @@ abq
 aaa
 aaa
 aaa
+abd
+aaa
+bHo
+bHo
+bHo
+bHo
+bHo
+aaa
+cqX
+aaa
+bHo
+bHo
+bHo
+bHo
+bHo
+aaa
+abd
 aaa
 aaa
 aaa
@@ -123773,23 +125205,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abq
 aaa
 aaa
 aaa
@@ -124019,6 +125434,23 @@ abq
 aaa
 aaa
 aaa
+abd
+abq
+abq
+aaa
+abq
+abq
+abq
+aaa
+crs
+aaa
+abq
+aaa
+aaa
+abq
+abq
+abq
+abd
 aaa
 aaa
 aaa
@@ -124027,23 +125459,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaD
 aaa
 aaa
 aaa
@@ -124276,23 +125691,23 @@ abq
 aaa
 aaa
 aaa
+abd
 aaa
+bHo
+bHo
+bHo
+bHo
+bHo
+abq
+cqX
+abq
+bHo
+bHo
+bHo
+bHo
+bHo
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
 aaa
 aaa
 aaa
@@ -124533,23 +125948,23 @@ abq
 aaa
 aaa
 aaa
+abd
 aaa
+bMo
+bMq
+bMq
+bMq
+bMq
+cnT
+cqX
+csD
+cJg
+cJg
+cJg
+cJg
+cUC
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
 aaa
 aaa
 aaa
@@ -124790,6 +126205,23 @@ abq
 aaa
 aaa
 aaa
+abd
+aaa
+bHo
+bHo
+bHo
+bHo
+bHo
+aaa
+cqX
+aaa
+bHo
+bHo
+bHo
+bHo
+bHo
+aaa
+czm
 aaa
 aaa
 aaa
@@ -124810,23 +126242,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ddv
 aaa
 aaa
 aaa
@@ -125047,23 +126462,23 @@ abq
 aaa
 aaa
 aaa
+czm
+abq
+abq
+abq
+abq
+abq
+abq
+aaa
+cqX
 aaa
 aaa
+abq
+abq
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
+abq
+czm
 aaa
 aaa
 aaa
@@ -125304,23 +126719,23 @@ abq
 aaa
 aaa
 aaa
+abd
 aaa
+bHo
+bHo
+bHo
+bHo
+bHo
+abq
+cqX
+csF
+bHo
+bHo
+bHo
+bHo
+bHo
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
 aaa
 aaa
 aaa
@@ -125561,23 +126976,23 @@ abq
 aaa
 aaa
 aaa
+abd
 aaa
+bMo
+bMq
+bMq
+bMq
+bMq
+cnT
+csd
+csD
+cJg
+cJg
+cJg
+cJg
+cUC
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
 aaa
 aaa
 aaa
@@ -125818,23 +127233,23 @@ abq
 abq
 aaa
 aaa
+abd
 aaa
+bHo
+bHo
+bHo
+bHo
+bHo
 aaa
+cqX
 aaa
+bHo
+bHo
+bHo
+bHo
+bHo
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
 aaa
 aaa
 aaa
@@ -126075,23 +127490,23 @@ abq
 aaa
 aaa
 aaa
+abd
 aaa
 aaa
+bMs
+abq
+abq
+abq
+aaa
+cqX
 aaa
 aaa
+abq
+abq
+abq
+abq
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
 aaa
 aaa
 aaa
@@ -126332,23 +127747,23 @@ abq
 aaa
 aaa
 aaa
+abd
+abq
+abq
+aaa
+aaa
+abq
+aaa
+aaa
+cse
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
+abd
 aaa
 aaa
 aaa
@@ -126589,23 +128004,23 @@ abq
 aaa
 aaa
 aaa
+abd
+abd
+abd
+abd
+bMu
 aaa
 aaa
 aaa
+csf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
+abd
+abd
+abd
+abd
 aaa
 aaa
 aaa
@@ -126852,11 +128267,11 @@ aaa
 aaa
 aaa
 aaa
+abd
 aaa
 aaa
 aaa
-aaa
-aaa
+abd
 aaa
 aaa
 aaa
@@ -127109,11 +128524,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
+abd
+abd
+abd
+abd
 aaa
 aaa
 aaa
@@ -129197,7 +130612,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+pGo
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2604,6 +2604,24 @@
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
+"ahy" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ahz" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -23852,26 +23870,6 @@
 /area/bridge/meeting_room{
 	name = "\improper Command Hallway"
 	})
-"baz" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "baB" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -36487,24 +36485,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"bzq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "bzr" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -47448,6 +47428,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep)
+"bWq" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "bWs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -47807,12 +47807,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"bXf" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "bXi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57311,8 +57305,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "csm" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/grass,
+/obj/structure/table/wood,
+/obj/item/lighter/zippo,
+/obj/item/storage/fancy/cigarettes/cigpack_random,
+/obj/item/ashtray/plastic,
+/turf/simulated/floor/carpet,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -57407,20 +57404,25 @@
 /area/toxins/explab)
 "csA" = (
 /obj/structure/table/wood,
-/obj/item/lighter/zippo,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
-/obj/item/ashtray/plastic,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"csB" = (
-/obj/structure/table/wood,
 /obj/item/storage/box/characters,
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
+	})
+"csB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "csC" = (
 /obj/machinery/power/apc{
@@ -57438,19 +57440,13 @@
 	},
 /area/medical/exam_room)
 "csD" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/solar/starboard)
 "csE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -57467,13 +57463,9 @@
 	},
 /area/medical/exam_room)
 "csF" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/structure/lattice,
 /turf/space,
-/area/solar/starboard)
+/area/space)
 "csG" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -57537,10 +57529,6 @@
 /turf/simulated/wall,
 /area/medical/cmo)
 "csK" = (
-/obj/structure/lattice,
-/turf/space,
-/area/space)
-"csL" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "neutral"
@@ -57548,7 +57536,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"csM" = (
+"csL" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
@@ -57558,6 +57546,10 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"csM" = (
+/obj/structure/lattice,
+/turf/space,
+/area/maintenance/aft)
 "csN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -65438,9 +65430,25 @@
 	name = "\improper Toxins Lab"
 	})
 "cJg" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/space,
-/area/maintenance/aft)
+/area/solar/starboard)
 "cJh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -66697,25 +66705,23 @@
 	name = "\improper Toxins Lab"
 	})
 "cLS" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+/obj/structure/railing/corner{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/turf/space,
-/area/solar/starboard)
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cLT" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -67640,15 +67646,8 @@
 	name = "\improper Toxins Lab"
 	})
 "cNz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/railing/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -68466,8 +68465,16 @@
 	},
 /area/assembly/robotics)
 "cOZ" = (
-/obj/structure/railing/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69441,17 +69448,7 @@
 	name = "Port Maintenance"
 	})
 "cQU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -69911,10 +69908,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cRR" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70193,6 +70195,14 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"cSw" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cSx" = (
 /obj/structure/table,
 /obj/item/mmi,
@@ -70418,15 +70428,20 @@
 	},
 /area/chapel/main)
 "cSV" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70451,16 +70466,9 @@
 	name = "\improper Departure Lounge"
 	})
 "cSY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -70506,13 +70514,14 @@
 	name = "\improper Departure Lounge"
 	})
 "cTd" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/machinery/vending/cola,
+/obj/machinery/camera{
+	c_tag = "Escape - Mid Fore";
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70575,11 +70584,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cTh" = (
-/obj/machinery/vending/cola,
-/obj/machinery/camera{
-	c_tag = "Escape - Mid Fore";
-	dir = 1
-	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -70588,7 +70593,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cTi" = (
-/obj/machinery/vending/snack,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -70837,22 +70842,11 @@
 	name = "\improper Departure Lounge"
 	})
 "cTQ" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
+/turf/space,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTR" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cTS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -70864,7 +70858,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cTT" = (
+"cTS" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
@@ -70882,11 +70876,33 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"cTT" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "cTU" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70928,19 +70944,15 @@
 	})
 "cTY" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1;
-	on = 1
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -71217,24 +71229,6 @@
 	name = "\improper Departure Lounge"
 	})
 "cUC" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cUD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -71249,7 +71243,7 @@
 	},
 /turf/space,
 /area/solar/starboard)
-"cUE" = (
+"cUD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71265,6 +71259,14 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cUE" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71284,9 +71286,9 @@
 	},
 /area/medical/medbay3)
 "cUG" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -71311,10 +71313,12 @@
 	},
 /area/chapel/office)
 "cUO" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71431,12 +71435,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cVf" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
+/turf/simulated/wall/r_wall,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71487,7 +71486,12 @@
 	},
 /area/medical/morgue)
 "cVn" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71634,21 +71638,6 @@
 	name = "\improper Departure Lounge"
 	})
 "cVF" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cVG" = (
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cVI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
 	req_access_txt = "63"
@@ -71667,6 +71656,21 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cVG" = (
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cVI" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71770,14 +71774,21 @@
 	},
 /area/chapel/main)
 "cVX" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "cWb" = (
 /turf/simulated/floor/plasteel{
@@ -71832,27 +71843,24 @@
 	},
 /area/medical/virology)
 "cWg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cWh" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cWh" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71907,19 +71915,8 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "cWo" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/simulated/wall/r_wall,
+/area/hallway/secondary/exit)
 "cWp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71929,8 +71926,23 @@
 	},
 /area/chapel/main)
 "cWq" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/secondary/exit)
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 25
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 35
+	},
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Security";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cWs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71964,24 +71976,6 @@
 	},
 /area/chapel/main)
 "cWA" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 25
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 35
-	},
-/obj/machinery/camera{
-	c_tag = "Departure Lounge Security";
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cWE" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -71994,7 +71988,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cWF" = (
+"cWE" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -72002,6 +71996,16 @@
 	dir = 5;
 	icon_state = "red"
 	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cWF" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -72222,16 +72226,6 @@
 	name = "\improper Departure Lounge"
 	})
 "cXg" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXh" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -72246,13 +72240,26 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cXi" = (
+"cXh" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cXi" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72318,14 +72325,12 @@
 	name = "\improper Recreation Area"
 	})
 "cXq" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72337,17 +72342,6 @@
 	},
 /area/medical/medbay3)
 "cXs" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -72376,11 +72370,25 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cXv" = (
+"cXt" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
+	})
+"cXv" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cXw" = (
 /obj/machinery/vending/medical,
@@ -72404,28 +72412,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cXz" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXA" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "whiteblue"
-	},
-/area/medical/medbay3)
-"cXB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72440,6 +72426,25 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cXA" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue"
+	},
+/area/medical/medbay3)
+"cXB" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72554,17 +72559,6 @@
 /turf/simulated/floor/plating,
 /area/solar/starboard)
 "cXO" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -72572,13 +72566,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"cXR" = (
+"cXQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"cXS" = (
+"cXR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72590,7 +72584,7 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
-"cXT" = (
+"cXS" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -72599,7 +72593,7 @@
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"cXU" = (
+"cXT" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72612,7 +72606,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"cXV" = (
+"cXU" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -72627,7 +72621,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cXW" = (
+"cXV" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
@@ -72636,7 +72630,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cXX" = (
+"cXW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -72654,6 +72648,25 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cXX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72771,7 +72784,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72807,25 +72820,6 @@
 	},
 /area/chapel/main)
 "cYm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cYr" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
 	req_access_txt = "63"
@@ -72857,7 +72851,7 @@
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"cYt" = (
+"cYr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -72874,7 +72868,7 @@
 	icon_state = "redcorner"
 	},
 /area/hallway/secondary/exit)
-"cYu" = (
+"cYt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -72885,6 +72879,28 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit)
+"cYu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72953,6 +72969,9 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -73002,25 +73021,17 @@
 	},
 /area/medical/morgue)
 "cYK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/chair{
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
 "cYL" = (
@@ -73047,20 +73058,6 @@
 	},
 /area/medical/medbay3)
 "cYP" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/hallway/secondary/exit)
-"cYQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -73074,7 +73071,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"cYR" = (
+"cYQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -73085,6 +73082,30 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cYR" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Airlock";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -73117,34 +73138,18 @@
 	name = "\improper Toxins Lab"
 	})
 "cYU" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Airlock";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cYV" = (
 /obj/structure/table,
 /obj/item/paicard,
 /turf/simulated/floor/plasteel{
 	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cYV" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
@@ -73968,6 +73973,7 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "daT" = (
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -74184,20 +74190,16 @@
 	name = "\improper Secure Lab"
 	})
 "dbs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/railing{
+/obj/structure/chair{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -29
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -74264,6 +74266,25 @@
 	},
 /area/maintenance/aft)
 "dbz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"dbA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -74271,29 +74292,25 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dbA" = (
+"dbB" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"dbB" = (
+"dbC" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"dbC" = (
+"dbD" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "emergency_home";
 	locked = 1;
 	name = "Departure Lounge Airlock"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"dbD" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "dbE" = (
 /obj/docking_port/stationary{
@@ -74308,17 +74325,9 @@
 /turf/space,
 /area/space)
 "dbF" = (
-/obj/machinery/chem_heater{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "dbG" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -74354,6 +74363,18 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dbI" = (
+/obj/machinery/chem_heater{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dbJ" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
@@ -74367,21 +74388,9 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbJ" = (
+"dbK" = (
 /obj/structure/sink{
 	pixel_y = 22
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dbK" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -74408,6 +74417,27 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dbM" = (
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 26
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dbN" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Psychiatrist"
+	},
+/turf/simulated/floor/carpet,
+/area/medical/psych)
+"dbR" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -74427,16 +74457,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbN" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Psychiatrist"
-	},
-/turf/simulated/floor/carpet,
-/area/medical/psych)
-"dbR" = (
+"dbS" = (
 /obj/machinery/camera{
 	c_tag = "Secure Lab - Fore";
 	network = list("SS13","RD")
@@ -74456,7 +74477,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbS" = (
+"dbT" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -74469,7 +74490,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbT" = (
+"dbU" = (
 /obj/machinery/chem_heater{
 	pixel_x = -4;
 	pixel_y = 4
@@ -74481,26 +74502,16 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbU" = (
-/turf/simulated/wall,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
 "dbV" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/turf/simulated/wall,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dbW" = (
-/obj/structure/table,
-/obj/random/toolbox,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dbX" = (
 /obj/machinery/light/small,
@@ -74514,16 +74525,15 @@
 	},
 /area/chapel/main)
 "dbZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
+/obj/structure/table,
+/obj/random/toolbox,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutral"
 	},
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "dca" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -74555,10 +74565,21 @@
 	name = "\improper Research Division Server Room"
 	})
 "dcf" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
+"dch" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"dch" = (
+"dci" = (
 /obj/structure/table/glass,
 /obj/item/extinguisher{
 	pixel_x = -5;
@@ -74572,14 +74593,14 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dci" = (
+"dcj" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcj" = (
+"dck" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -74589,7 +74610,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dck" = (
+"dcl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74599,7 +74620,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcl" = (
+"dcq" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -74618,7 +74639,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcq" = (
+"dcs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -74628,7 +74649,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcs" = (
+"dct" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -74638,7 +74659,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dct" = (
+"dcu" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
 	pixel_x = -3;
@@ -74655,12 +74676,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcu" = (
-/obj/machinery/hydroponics/soil,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
 "dcv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -74675,62 +74690,55 @@
 	name = "\improper Secure Lab"
 	})
 "dcw" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/camera{
-	c_tag = "Garden"
+/obj/item/mounted/frame/light_fixture{
+	dir = 8;
+	pixel_x = -16
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dcx" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dcy" = (
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
+/obj/item/mounted/frame/apc_frame{
+	pixel_y = 28
 	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dcz" = (
-/obj/structure/table/glass,
-/obj/item/seeds/apple,
-/obj/item/seeds/banana,
-/obj/item/seeds/cocoapod,
-/obj/item/seeds/grape,
-/obj/item/seeds/orange,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/wheat,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/tower,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dcA" = (
-/obj/machinery/biogenerator,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "green"
+/obj/item/mounted/frame/firealarm{
+	pixel_y = 27
 	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dcB" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
+"dcC" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheesiehonkers,
 /obj/item/reagent_containers/food/drinks/cans/cola,
@@ -74745,7 +74753,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcC" = (
+"dcD" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "emergency_home";
 	locked = 1;
@@ -74755,7 +74763,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcD" = (
+"dcE" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -74763,7 +74771,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcE" = (
+"dcH" = (
 /obj/docking_port/stationary{
 	dir = 4;
 	dwidth = 11;
@@ -74774,14 +74782,6 @@
 	},
 /turf/space,
 /area/space)
-"dcH" = (
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dcK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -74790,8 +74790,8 @@
 /turf/simulated/floor/plasteel,
 /area/medical/cryo)
 "dcN" = (
-/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
+	dir = 10;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
@@ -74810,13 +74810,7 @@
 /turf/space,
 /area/space)
 "dcX" = (
-/obj/machinery/disposal,
-/obj/structure/sign/deathsposal{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -74837,39 +74831,16 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddn" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ddv" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/disposal,
+/obj/structure/sign/deathsposal{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_y = 4
-	},
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 8
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74906,6 +74877,32 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/glass,
 /obj/item/slime_scanner,
 /obj/item/slime_scanner,
 /obj/effect/decal/warning_stripes/southeastcorner,
@@ -74915,7 +74912,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddK" = (
+"ddL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -74926,7 +74923,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddL" = (
+"ddM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -74945,7 +74942,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddM" = (
+"ddN" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -74953,7 +74950,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddN" = (
+"ddO" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
@@ -74964,20 +74961,12 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddO" = (
+"ddP" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddP" = (
-/obj/machinery/monkey_recycler,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74995,6 +74984,14 @@
 /turf/space,
 /area/space)
 "ddR" = (
+/obj/machinery/monkey_recycler,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddS" = (
 /obj/machinery/processor{
 	desc = "A machine used to process slimes and retrieve their extract.";
 	name = "Slime Processor"
@@ -75009,7 +75006,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddS" = (
+"ddU" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
@@ -75019,30 +75016,17 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddU" = (
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
 "ddW" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/obj/structure/reagent_dispensers/beerkeg/nuke,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "ddX" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/table,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "ddZ" = (
 /obj/machinery/meter,
@@ -75093,23 +75077,10 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dej" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/chair/stool/bar,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dek" = (
 /obj/structure/cable/yellow{
@@ -75136,13 +75107,14 @@
 	},
 /area/chapel/main)
 "deo" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dep" = (
 /obj/structure/table/wood,
@@ -75171,62 +75143,50 @@
 /turf/simulated/floor/plating,
 /area/medical/psych)
 "des" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
+"det" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"dez" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"det" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dez" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "deB" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/plant_analyzer,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "deC" = (
 /obj/structure/table/reinforced,
@@ -75352,20 +75312,21 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "deQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "deR" = (
 /obj/structure/cable/yellow{
@@ -75389,23 +75350,16 @@
 	},
 /area/security/main)
 "deT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "greencorner"
+	icon_state = "white"
 	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "deU" = (
 /obj/machinery/power/apc{
@@ -75653,27 +75607,13 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dfD" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/obj/machinery/disposal,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dfG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75688,23 +75628,12 @@
 	},
 /area/chapel/main)
 "dfH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dfI" = (
 /obj/structure/cable/yellow{
@@ -75823,29 +75752,13 @@
 	},
 /area/medical/virology)
 "dfW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing/corner,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/table,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dfX" = (
 /obj/structure/cable/yellow{
@@ -76067,16 +75980,13 @@
 	name = "Arrivals"
 	})
 "dgB" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/railing,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/chair/stool/bar,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dgC" = (
 /obj/structure/chair/stool,
@@ -76171,17 +76081,17 @@
 /turf/simulated/wall,
 /area/engine/mechanic_workshop)
 "dgW" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/railing/corner,
-/obj/structure/railing,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dhf" = (
 /obj/effect/decal/warning_stripes/west,
@@ -76378,9 +76288,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dhF" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "dhG" = (
 /obj/structure/cable/yellow{
@@ -76445,6 +76363,19 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/exam_room)
+"djK" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Test Chamber Monitor";
+	network = list("Xeno");
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "djL" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -76465,6 +76396,22 @@
 	icon_state = "showroomfloor"
 	},
 /area/security/main)
+"dol" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dom" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -76505,14 +76452,36 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"dsI" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+"dsN" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #1";
+	req_access_txt = "55"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"dsY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "dtM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76521,25 +76490,13 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"dwt" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"dvM" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dwC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -76555,21 +76512,12 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
-"dxH" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+"dyw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -76591,18 +76539,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"dCH" = (
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/table,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+"dBK" = (
+/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
+	id_tag = "escapepodbay";
+	req_one_access_txt = "13"
+	},
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "dCV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76668,6 +76614,26 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"dHb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dHr" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76708,18 +76674,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
-"dLr" = (
-/mob/living/simple_animal/slime,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dMC" = (
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dMV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -76729,6 +76683,19 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"dNi" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dOQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76837,12 +76804,6 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
-"dZW" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ebA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76918,6 +76879,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"egX" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -76959,6 +76933,13 @@
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
 /area/security/permabrig)
+"emp" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "eoq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76989,11 +76970,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"etm" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"etk" = (
+/obj/structure/table/wood/poker,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "evR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -77001,35 +76982,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
-"eAE" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Test Chamber";
-	dir = 1;
-	network = list("SS13","RD")
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"eCC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"eDL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+"ewu" = (
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "eEV" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -77074,6 +77032,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
+"eJd" = (
+/obj/machinery/door_control{
+	desc = "A remote control-switch for the pod doors.";
+	id = "escapepodbay";
+	name = "Pod Door Control";
+	pixel_y = 24;
+	req_access_txt = "13"
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "eKV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77106,24 +77074,6 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
-"eNg" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ePy" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77132,6 +77082,17 @@
 	icon_state = "grimy"
 	},
 /area/hallway/primary/port)
+"eQb" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eQf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77149,30 +77110,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"eQv" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "eRU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -77216,6 +77153,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"eXj" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eYE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77232,6 +77184,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"eZh" = (
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ffs" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "fga" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -77270,6 +77246,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/security/brig)
+"fhT" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fhW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -77279,19 +77273,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
-	})
-"fkV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "fla" = (
 /obj/structure/chair/office/dark{
@@ -77386,20 +77367,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"fxe" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fxB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -77478,24 +77445,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"fIC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -77503,12 +77452,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"fOP" = (
-/obj/structure/spacepoddoor{
-	luminosity = 3
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "fPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77516,19 +77459,12 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"fRK" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio7";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+"fUd" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/chem_dispenser/beer,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "fUI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -77550,6 +77486,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"fYn" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fZa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -77602,12 +77560,6 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
-"gao" = (
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gbT" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
@@ -77649,10 +77601,32 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "ged" = (
-/obj/structure/chair/comfy/black,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
+"gez" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "gfB" = (
 /obj/structure/window/plasmareinforced,
@@ -77720,12 +77694,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"gnC" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "gnJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77769,35 +77737,40 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"grP" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #6";
-	req_access_txt = "55"
+"gsP" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"gtd" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "gtu" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
-"guD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "gwJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/construction)
+"gyw" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "gyy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -77821,6 +77794,17 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"gBT" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77862,13 +77846,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
-"gMc" = (
-/obj/structure/table/wood,
-/obj/item/candle,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "gMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77881,12 +77858,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"gNn" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gOD" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -77947,16 +77918,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"gZM" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
-/obj/item/radio/electropack,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gZY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77965,36 +77926,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"had" = (
-/obj/item/radio/beacon,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "har" = (
 /obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
-"hcE" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
+"hax" = (
+/obj/item/radio/intercom{
+	pixel_y = -25
 	},
 /turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"haZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -78005,6 +77963,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"hdY" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 18;
+	id = "skipjack_se";
+	name = "southeast of SS13";
+	width = 19
+	},
+/turf/space,
+/area/space)
 "het" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -78047,6 +78016,28 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"hhi" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hht" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78058,36 +78049,10 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"hhK" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"hid" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+"hhy" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine/vacuum,
+/area/escapepodbay)
 "hio" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78123,13 +78088,23 @@
 	name = "Port Maintenance"
 	})
 "hlZ" = (
-/obj/structure/disposalpipe/trunk{
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "hmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -78167,6 +78142,23 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"hqs" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio8";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hqN" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -78200,16 +78192,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"hwY" = (
-/obj/machinery/door_control{
-	desc = "A remote control-switch for the pod doors.";
-	id = "escapepodbay";
-	name = "Pod Door Control";
-	pixel_y = 24;
-	req_access_txt = "13"
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "hxv" = (
 /obj/machinery/camera{
 	c_tag = "Telecoms - Server Room - Aft";
@@ -78223,6 +78205,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"hzZ" = (
+/obj/structure/chair,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "hAg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78244,14 +78238,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
-"hCH" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "hCM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78288,13 +78274,24 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"hEl" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
+"hEc" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hEA" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -78363,6 +78360,15 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"hLm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hLt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78410,21 +78416,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"hOp" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/escapepodbay)
-"hQi" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
-"hRr" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "greencorner"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
 "hRw" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78439,14 +78430,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"hRN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hVe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78497,6 +78480,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
+"ias" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "ibi" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow{
@@ -78526,21 +78515,6 @@
 	},
 /turf/space,
 /area/space)
-"icb" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"icT" = (
-/obj/machinery/light,
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "idx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78565,6 +78539,36 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"ieT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ihe" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "ihM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78597,19 +78601,6 @@
 	},
 /turf/space,
 /area/space)
-"iiL" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ijf" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78639,30 +78630,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"ijV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Port";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ikO" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -78674,6 +78641,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"ilY" = (
+/obj/machinery/shieldwallgen{
+	req_access = list(55)
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "imC" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78688,6 +78664,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"imP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Starboard";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "imQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -78732,26 +78731,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"irT" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "isf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
-	})
-"iud" = (
-/obj/structure/table/glass,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
 	})
 "iuh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78765,14 +78759,6 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
-"iuB" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "ivn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78783,26 +78769,6 @@
 	},
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
-	})
-"iwQ" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Central";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "iyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78825,22 +78791,6 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"iDq" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/stock_parts/cell,
-/obj/item/flashlight,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Escape Podbay APC";
-	pixel_y = 25
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "iDw" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -78874,19 +78824,20 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
-"iHp" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access_txt = "55"
+"iHM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/area/escapepodbay)
 "iIk" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -78904,6 +78855,26 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
+	})
+"iNt" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "iNu" = (
 /turf/simulated/floor/plasteel{
@@ -78976,6 +78947,12 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
+"iVr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "iWv" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -78983,27 +78960,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"iXg" = (
+"iWF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
-"iXo" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -79068,12 +79035,31 @@
 	},
 /area/medical/surgery2)
 "jhQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "jlB" = (
 /obj/structure/cable/yellow{
@@ -79090,6 +79076,16 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"jqq" = (
+/obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "jrE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79105,21 +79101,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
-"jzb" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "jCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79157,6 +79138,17 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"jGF" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Test Chamber";
+	dir = 1;
+	network = list("SS13","RD")
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "jGU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79164,24 +79156,31 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"jHj" = (
-/obj/effect/spawner/window/reinforced,
+"jHM" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
-/turf/simulated/floor/engine,
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"jIN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "jKJ" = (
 /obj/structure/chair{
 	dir = 1
@@ -79247,6 +79246,19 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"jSw" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"jTR" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "jUV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79259,28 +79271,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"jVN" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+"jWA" = (
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
-"jXA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "jZd" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_y = -32
@@ -79289,34 +79288,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"kdL" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/ignition_switch{
-	id = "Xenobio";
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/machinery/door_control{
-	id = "Xenolab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = -2;
-	req_access_txt = "55"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kez" = (
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -79349,19 +79320,60 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"kky" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Garden APC";
-	pixel_y = -25
+"khx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
+	dir = 4;
+	icon_state = "neutral"
 	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"kjB" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"kks" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "kmF" = (
 /obj/effect/spawner/window/reinforced,
@@ -79380,6 +79392,30 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"kqU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Port";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kry" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -79432,14 +79468,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
-"ktZ" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "kuf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79459,6 +79487,12 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/hor)
+"kwg" = (
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "kwD" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79499,6 +79533,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"kxJ" = (
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kzH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -79557,6 +79602,24 @@
 	icon_state = "brown"
 	},
 /area/storage/primary)
+"kFj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kGw" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
@@ -79607,25 +79670,49 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"kMl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kNr" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "kNJ" = (
 /turf/simulated/floor/plasteel{
@@ -79687,17 +79774,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"kXe" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kXs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -79708,6 +79784,19 @@
 	},
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
+	})
+"kZh" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "kZl" = (
 /obj/structure/cable/yellow{
@@ -79743,6 +79832,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"lcM" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio6";
+	name = "Containment Blast Doors";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "len" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -79758,10 +79868,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"lfC" = (
-/obj/structure/grille,
-/turf/space,
-/area/escapepodbay)
 "lfV" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79798,6 +79904,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
+"lhH" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lid" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -79811,6 +79923,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"lkK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lmi" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -79818,24 +79954,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"lmv" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79848,32 +79966,20 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"lps" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/vendor,
+/obj/item/vending_refill/boozeomat,
+/obj/item/vending_refill/boozeomat,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "lpU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"lqk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lrA" = (
 /obj/structure/sign/biohazard{
 	pixel_x = -32
@@ -79883,8 +79989,19 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
-"lsO" = (
-/turf/simulated/floor/engine,
+"ltv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/escapepodbay)
 "lwN" = (
 /obj/effect/spawner/lootdrop{
@@ -79896,17 +80013,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
-	})
-"lxe" = (
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "lBy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -80006,6 +80112,25 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"lMd" = (
+/turf/simulated/wall,
+/area/escapepodbay)
+"lNd" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/stock_parts/cell,
+/obj/item/flashlight,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Escape Podbay APC";
+	pixel_y = 25
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "lOU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/west,
@@ -80016,41 +80141,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
-	})
-"lQl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"lQE" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80064,6 +80154,15 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
+"lTF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lUc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80071,6 +80170,11 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"lUm" = (
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lUv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -80086,6 +80190,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
+"lZx" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"mbm" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "mcP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -80151,6 +80270,28 @@
 	icon_state = "greenfull"
 	},
 /area/hallway/primary/central)
+"mil" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "miB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80183,6 +80324,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"mnm" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "moi" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -80227,9 +80392,35 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"mxe" = (
-/turf/simulated/wall,
+"mso" = (
+/obj/machinery/light,
+/turf/simulated/floor/engine,
 /area/escapepodbay)
+"mvQ" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"mxQ" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "myY" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -80253,6 +80444,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"mzw" = (
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Podbay"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "mAa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80290,6 +80490,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"mEI" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mFx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80303,15 +80516,33 @@
 	},
 /area/medical/medbay3)
 "mGK" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "mKy" = (
 /turf/simulated/floor/plasteel{
@@ -80319,6 +80550,16 @@
 	},
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
+	})
+"mLG" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "mOc" = (
 /obj/structure/cable/yellow{
@@ -80330,6 +80571,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"mPo" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mQu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80352,6 +80611,31 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay3)
+"mTW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mVG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80389,23 +80673,6 @@
 "mXy" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
-"mZF" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mZH" = (
 /obj/structure/chair{
 	dir = 1
@@ -80455,6 +80722,26 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/wall,
 /area/construction)
+"ncC" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nej" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -80467,6 +80754,23 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"ngQ" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nhK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80507,12 +80811,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
-"nmQ" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nnI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80540,14 +80838,18 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"nsC" = (
-/obj/structure/grille,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
+"nuh" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/space,
-/area/escapepodbay)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "nuB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80565,41 +80867,17 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"nwy" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nxh" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/railing,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"nxQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "nza" = (
 /obj/effect/decal/warning_stripes/north,
@@ -80620,29 +80898,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"nEE" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nEQ" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -80718,17 +80973,6 @@
 "nMC" = (
 /turf/simulated/wall/r_wall,
 /area/storage/secure)
-"nOD" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "nPe" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
@@ -80736,15 +80980,11 @@
 /area/turret_protected/aisat_interior{
 	name = "\improper MiniSat Central Foyer"
 	})
-"nRc" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
+"nPv" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -80753,6 +80993,14 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"nTq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nTF" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small{
@@ -80852,21 +81100,22 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "oiv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/railing/corner,
+/obj/structure/railing,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
+"ojj" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "ojl" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -80875,47 +81124,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"okh" = (
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
-"olH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door_control{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"omy" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "onG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
@@ -80933,32 +81141,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"otw" = (
-/obj/structure/table/glass,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/firealarm{
-	pixel_y = -24
+"oua" = (
+/obj/machinery/door/window/southleft{
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
-"owJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
-"owP" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -80982,28 +81173,9 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
-"oBi" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+"oyC" = (
+/mob/living/simple_animal/slime,
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -81023,21 +81195,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"oDU" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
+"oIL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"oEJ" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/table/wood/poker,
+/obj/item/deck/cards,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
 	})
 "oJQ" = (
 /obj/structure/cable/yellow{
@@ -81094,16 +81260,23 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
-"oVk" = (
-/obj/machinery/light{
-	dir = 8
+"oUX" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "oVK" = (
 /obj/structure/chair{
@@ -81114,6 +81287,11 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"oVL" = (
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "oVM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -81140,18 +81318,9 @@
 	},
 /area/hallway/primary/central)
 "pad" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio8";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/wood,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "paZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81160,25 +81329,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"pbZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pcN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -81206,29 +81356,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"pdt" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pef" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -81280,28 +81407,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
-"phC" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pjn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -81363,6 +81468,26 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
+"poX" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Central";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ppw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -81375,15 +81500,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
-"pqV" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -81480,6 +81596,34 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"pBf" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"pDM" = (
+/obj/machinery/sparker{
+	id = "Xenobio";
+	pixel_x = -25
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"pEM" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pHQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -81503,15 +81647,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
-	})
-"pKK" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
 	})
 "pMx" = (
 /obj/effect/spawner/airlock/w_to_e,
@@ -81651,9 +81786,21 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"pWq" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+"pVk" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"pVp" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/space,
 /area/escapepodbay)
 "pXV" = (
 /obj/effect/spawner/window/reinforced,
@@ -81700,53 +81847,10 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"qcD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qcE" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/construction)
-"qdH" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qee" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81765,6 +81869,24 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
+"qeS" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qeW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81795,16 +81917,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/storage/primary)
-"qme" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair,
-/obj/item/cigbutt,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qnt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81830,11 +81942,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"qoA" = (
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "qpO" = (
 /turf/simulated/wall,
 /area/engine/equipmentstorage)
@@ -81857,6 +81964,17 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"qvQ" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qwd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -81889,34 +82007,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"qxL" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"qxY" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"qzy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81941,6 +82031,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"qDC" = (
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qFg" = (
 /obj/machinery/space_heater,
 /obj/machinery/power/apc{
@@ -81951,6 +82058,15 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"qGE" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "qHi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -81984,14 +82100,6 @@
 	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/starboard)
-"qJk" = (
-/obj/item/radio/intercom{
-	pixel_y = -25
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qME" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82007,12 +82115,6 @@
 	icon_state = "red"
 	},
 /area/security/main)
-"qMS" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "qQy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82038,17 +82140,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"qTu" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 18;
-	id = "skipjack_se";
-	name = "southeast of SS13";
-	width = 19
-	},
-/turf/space,
-/area/space)
 "qTK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -82080,19 +82171,6 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"qYE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "raV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82101,6 +82179,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"rbB" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rdz" = (
 /obj/item/twohanded/required/kirbyplants{
 	level = 4.1
@@ -82125,19 +82215,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"rhN" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Test Chamber Monitor";
-	network = list("Xeno");
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "riM" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -82169,6 +82246,12 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"rlp" = (
+/obj/structure/closet,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rlJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/light,
@@ -82180,6 +82263,54 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"rlR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"rmr" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/ignition_switch{
+	id = "Xenobio";
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/machinery/door_control{
+	id = "Xenolab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = -2;
+	req_access_txt = "55"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rmz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82197,21 +82328,10 @@
 	name = "Arrivals"
 	})
 "rpg" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio8";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "rqY" = (
 /obj/structure/window/reinforced,
@@ -82227,6 +82347,10 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"rrn" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/escapepodbay)
 "rsT" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Mix to Gas"
@@ -82245,6 +82369,31 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"rte" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"rvm" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "rvu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82298,6 +82447,24 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"rzZ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "rDe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -82307,6 +82474,10 @@
 	name = "\improper Arcade"
 	})
 "rDg" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet,
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -82405,19 +82576,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"rHU" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/camera{
-	c_tag = "Escape - Aft";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "rIq" = (
 /obj/structure/table,
 /obj/item/clothing/mask/breath{
@@ -82428,15 +82586,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"rIs" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "rID" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -82470,27 +82619,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rMm" = (
-/obj/machinery/door/window/southleft{
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "rNt" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -82521,9 +82649,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"rQY" = (
+"rQV" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82570,22 +82715,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"rWh" = (
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+"rWi" = (
+/obj/machinery/camera{
+	c_tag = "Escape - Aft";
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "rYj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -82612,13 +82753,6 @@
 	icon_state = "white"
 	},
 /area/medical/research)
-"rZK" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
 "say" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -82655,15 +82789,6 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"sje" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge Podbay"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -82727,23 +82852,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/library)
-"srv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"spw" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82756,30 +82871,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"ssL" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ssZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82826,15 +82917,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
+"sBv" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sBY" = (
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"sCI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+"sEV" = (
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "sFz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -82893,22 +83003,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"sMy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "sOB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -82917,33 +83011,10 @@
 	},
 /area/security/brig)
 "sOJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
-"sRk" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio6";
-	name = "Containment Blast Doors";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82953,30 +83024,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"sTg" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"sTi" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "sVC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83001,21 +83048,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"tbZ" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tca" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83030,38 +83062,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"tdX" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"tew" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "teE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83082,15 +83082,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
-"tfb" = (
-/obj/machinery/shieldwallgen{
-	req_access = list(55)
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tfV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -83133,13 +83124,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
-"tlA" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall,
+"tme" = (
+/obj/item/radio/beacon,
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83269,6 +83256,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"tGH" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -83326,17 +83324,15 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
-"tVq" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"tTL" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/chair,
+/obj/item/cigbutt,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "tVw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
@@ -83384,7 +83380,14 @@
 /area/security/checkpoint2{
 	name = "Customs"
 	})
-"uaG" = (
+"uaQ" = (
+/turf/simulated/wall,
+/area/engine/mechanic_workshop)
+"udB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"ueD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83396,37 +83399,6 @@
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"uaQ" = (
-/turf/simulated/wall,
-/area/engine/mechanic_workshop)
-"udB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"uex" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
 	id_tag = "xenobio3";
 	name = "containment blast door";
 	opacity = 0
@@ -83434,25 +83406,6 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
-	})
-"ueD" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/rh,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
 	})
 "ugy" = (
 /obj/structure/cable/yellow{
@@ -83477,6 +83430,52 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"uih" = (
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ujy" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"uln" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "umD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -83498,58 +83497,59 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
+"unp" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"unE" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio7";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/surgery1)
+"uql" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uqy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
-	})
-"uqF" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"uuu" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "uuE" = (
 /obj/machinery/door/firedoor,
@@ -83580,16 +83580,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
-"uxy" = (
-/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id_tag = "escapepodbay";
-	req_one_access_txt = "13"
-	},
-/obj/structure/spacepoddoor{
-	luminosity = 3
+"uws" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/escapepodbay)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uzt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -83632,6 +83630,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
+"uHc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uJn" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
@@ -83715,27 +83728,18 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"uSn" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+"uTf" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"uTJ" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83748,18 +83752,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"uUp" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Departures Garden"
-	})
 "uUE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -83777,48 +83769,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
-	})
-"uWY" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"uXv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "uYO" = (
 /obj/effect/spawner/window/reinforced,
@@ -83896,6 +83846,12 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"vmX" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vmY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -83908,13 +83864,19 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
-"vru" = (
+"vqW" = (
+/obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 2
 	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -83973,6 +83935,10 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"vwL" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "vyo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -84022,6 +83988,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
+"vDs" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "vDW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84041,30 +84015,33 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
+"vHx" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vHA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
-"vHP" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "vHW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84088,15 +84065,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"vKy" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "vLL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -84108,6 +84076,34 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"vMt" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
+"vML" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "vNb" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84154,15 +84150,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"vSd" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "vSx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84206,6 +84193,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
+"wbe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"wcn" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/chem_dispenser/soda,
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "wfs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84370,6 +84373,27 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/exam_room)
+"wAx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wAP" = (
 /obj/structure/transit_tube{
 	icon_state = "D-SW"
@@ -84387,6 +84411,25 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"wEj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wEq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84417,29 +84460,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"wGe" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Starboard";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+"wHr" = (
+/obj/structure/grille,
+/turf/space,
+/area/escapepodbay)
 "wHZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -84448,17 +84472,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"wIB" = (
-/obj/structure/chair,
-/obj/structure/railing{
-	dir = 1
+"wIm" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "wJQ" = (
 /obj/effect/decal/warning_stripes/north,
@@ -84467,15 +84490,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"wLy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wLN" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -84484,6 +84498,9 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"wNo" = (
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "wRy" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84506,6 +84523,29 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
+"wSA" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wSP" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -84517,6 +84557,12 @@
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
+	})
+"wTu" = (
+/obj/effect/decal/remains/xeno,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "wUE" = (
 /obj/effect/spawner/window/reinforced,
@@ -84536,6 +84582,53 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
+"wZy" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"wZJ" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"xaE" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"xaL" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "xbe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -84578,24 +84671,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"xjZ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xkY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -84621,6 +84696,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
+"xrh" = (
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "xrG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -84632,16 +84710,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
-"xsx" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xtA" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -84682,6 +84750,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
+"xBb" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xDw" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/meter,
@@ -84704,6 +84783,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"xFa" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -84748,6 +84835,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"xJU" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/item/radio/electropack,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"xKl" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "xLf" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -84756,10 +84861,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"xLr" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "xOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84768,6 +84869,12 @@
 	icon_state = "stage_stairs"
 	},
 /area/security/podbay)
+"xQa" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xSh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84815,19 +84922,6 @@
 /area/quartermaster/sorting{
 	name = "\improper Warehouse"
 	})
-"xZj" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xZq" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -84864,21 +84958,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"ybj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "ycU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -84887,10 +84966,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"ydQ" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine/vacuum,
-/area/escapepodbay)
 "yeW" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -84899,6 +84974,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"yfQ" = (
+/obj/item/mounted/frame/light_fixture{
+	pixel_y = -16
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/abandonedbar{
+	name = "New Bar"
+	})
 "ygd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84940,15 +85023,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
-"ykB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 
 (1,1,1) = {"
 aaa
@@ -106742,12 +106816,12 @@ aaa
 aaa
 aaa
 aaa
-lfC
+wHr
 aaa
 aaa
 aaa
 aaa
-lfC
+wHr
 aaa
 aaa
 aaa
@@ -106999,12 +107073,12 @@ aaa
 aaa
 aaa
 aaa
-nsC
+pVp
 aaa
 aaa
 aaa
 aaa
-nsC
+pVp
 aaa
 aaa
 aaa
@@ -107249,19 +107323,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-mxe
-ydQ
-ydQ
-ydQ
-ydQ
-mxe
+dbV
+dbV
+dbW
+dbW
+dbW
+dbW
+dbV
+lMd
+hhy
+hhy
+hhy
+hhy
+lMd
 aaa
 aaa
 aaa
@@ -107506,19 +107580,19 @@ aaa
 aaa
 aaa
 aaa
-dbU
-dbU
 dbV
-dbV
-dbV
-dbV
-dbU
-mxe
-fOP
-fOP
-fOP
-uxy
-mxe
+dcw
+ddW
+dfD
+wcn
+fUd
+lps
+lMd
+kwg
+kwg
+kwg
+dBK
+lMd
 aaa
 aaa
 aaa
@@ -107763,19 +107837,19 @@ aaa
 aaa
 aaa
 aaa
-dbV
-dcu
-ddU
-dcu
-dcu
-ddU
-dcu
-mxe
-lsO
-lsO
-lsO
-lsO
-mxe
+dbW
+dcx
+dcx
+dfH
+dcx
+dcx
+dcx
+lMd
+xrh
+xrh
+xrh
+xrh
+lMd
 aaa
 aaa
 aaa
@@ -108020,19 +108094,19 @@ aaa
 aaa
 aaa
 aaa
-dbV
-dcu
-ddU
-dcu
-dcu
-ddU
-dcu
-mxe
-lsO
-lsO
-lsO
-lsO
-mxe
+dbW
+dcx
+ddX
+dfW
+ddX
+ddX
+ddX
+lMd
+xrh
+xrh
+xrh
+xrh
+lMd
 aaa
 aaa
 aaa
@@ -108278,18 +108352,18 @@ aaa
 aaa
 aaa
 dbV
-dcu
-ddU
-dcu
-dcu
-ddU
-dcu
-mxe
-hwY
-lsO
-lsO
-lsO
-mxe
+dcx
+dej
+dgB
+dej
+dej
+dej
+lMd
+eJd
+xrh
+xrh
+xrh
+lMd
 aaa
 aaa
 aaa
@@ -108534,19 +108608,19 @@ aaa
 aaa
 aaa
 aaa
-dbU
-dcw
-ddU
-dcu
-dcu
-ddU
-rZK
-mxe
-sje
-lsO
-lsO
-icT
-mxe
+dbV
+dcy
+deo
+dgW
+dcx
+dcx
+rvm
+lMd
+mzw
+xrh
+xrh
+mso
+lMd
 aaa
 aaa
 aaa
@@ -108791,19 +108865,19 @@ aaa
 aaa
 aaa
 aaa
-dbV
+dbW
 dcx
-ddU
-dez
-sOJ
-sOJ
-kky
-mxe
-hOp
-hOp
-hOp
-hOp
-mxe
+dcx
+dhF
+dcx
+etk
+yfQ
+lMd
+vwL
+vwL
+vwL
+vMt
+lMd
 aaa
 aaa
 aaa
@@ -109048,19 +109122,19 @@ aaa
 aaa
 aaa
 aaa
-dbV
-dcy
-ddU
-deB
-ueD
-ddU
-otw
-mxe
-vKy
-sCI
-okh
-qMS
-mxe
+dbW
+dcz
+des
+ged
+iVr
+oIL
+dcx
+lMd
+qGE
+dsY
+wNo
+ewu
+lMd
 aaa
 aaa
 aaa
@@ -109306,18 +109380,18 @@ aaa
 aaa
 aaa
 dbV
-dcz
-ddU
-deQ
-ddU
-ddU
-iud
-mxe
-iDq
-iXg
-guD
-xLr
-mxe
+dcA
+dcx
+hlZ
+dcx
+etk
+irT
+lMd
+lNd
+iHM
+jIN
+ojj
+lMd
 aaa
 aaa
 aaa
@@ -109562,19 +109636,19 @@ aaa
 aaa
 aaa
 aaa
-dbU
-dcA
-ddW
-deT
-hRr
-ddW
-pKK
-mxe
-hQi
-jXA
-okh
-tew
-mxe
+dbV
+dcB
+dcx
+hlZ
+dcx
+dcx
+dcx
+lMd
+mbm
+ltv
+wNo
+xaL
+lMd
 aaa
 aaa
 aaa
@@ -109819,19 +109893,19 @@ cTX
 cTX
 cTX
 cVk
-dbU
-dbU
 dbV
-dfD
-uUp
 dbV
-dbU
-mxe
-pWq
-vHP
-hEl
-pWq
-mxe
+dbW
+jhQ
+jqq
+dbW
+dbV
+lMd
+rrn
+rzZ
+gyw
+rrn
+lMd
 aaa
 aaa
 aaa
@@ -110063,31 +110137,31 @@ cTq
 cTO
 cVD
 cWb
-csL
+csK
 cWi
 dau
-cSV
+cRR
 cYf
 cYf
 cYB
 cYf
-cXz
+cXv
 cYf
-cYV
+cYU
 cYf
-cYf
-cXz
-dcB
-ddX
-dfH
+dbs
+cXv
+dcC
+det
+kNr
 cWi
 cWi
-tVq
-oVk
+nuh
+khx
 cWi
-dfH
+wEj
 cWi
-pqV
+jWA
 cTX
 aaa
 aaa
@@ -110321,28 +110395,28 @@ cVc
 cnU
 cVc
 cVc
-cNz
-cQU
-cSY
+cLS
+cOZ
+cSV
 cXb
-cUE
-cUE
-cUE
-cXB
-cXX
+cUD
+cUD
+cUD
+cXz
+cXW
 cXb
-cUE
-dbs
-cUE
-cXB
-dej
-dfW
+cUD
+dbz
+cUD
+cXz
+dez
+mGK
 cVc
-cNz
-cQU
+cLS
+cOZ
 cRt
 cVc
-hid
+kMl
 cWb
 bPk
 cTX
@@ -110582,26 +110656,26 @@ gTp
 cUu
 dbj
 cSk
+cUE
+cWg
 cUG
-cWh
-cUO
 gTp
-cYi
+cXX
 cSk
 cZL
-dbz
+dbA
 cZU
 gTp
 cWb
-dgB
-iuB
-wIB
+nxh
+nPv
+hzZ
 cUu
-dgB
-ktZ
-wIB
+nxh
+wZy
+hzZ
 cWb
-nOD
+sEV
 cVk
 aaa
 aaa
@@ -110833,32 +110907,32 @@ cRv
 cSk
 cmG
 cSo
-csm
+cTQ
 gnZ
 gTp
 cUu
 cRq
 cSk
-cUO
-cWh
 cUG
+cWg
+cUE
 gTp
-cYi
+cXX
 cSk
 cZU
-dbz
+dbA
 cZL
 gTp
 cWb
-dgB
-qxL
-wIB
+nxh
+vDs
+hzZ
 dap
-dgB
-hCH
-wIB
+nxh
+xKl
+hzZ
 cWb
-nOD
+sEV
 cVk
 aaa
 aaa
@@ -111092,30 +111166,30 @@ cTW
 cTW
 cTW
 cTW
-cOZ
+cNz
 cUu
 cRq
 cTs
 cTW
 cTW
 cTW
-cOZ
-cYi
+cNz
+cXX
 cTs
 cTW
 cTW
 cTW
-cOZ
+cNz
 cWb
-dgB
-hCH
-wIB
+nxh
+xKl
+hzZ
 cWb
-dgB
-qxL
-wIB
+nxh
+vDs
+hzZ
 cWb
-nRc
+xaE
 cVk
 aaa
 aaa
@@ -111353,26 +111427,26 @@ cUz
 dap
 cRq
 cXe
-cVf
-cWo
-cXh
-cXO
-cYm
-daT
-cXO
-cWo
-dbW
+cUO
+cWh
+cXg
+cXB
+cYi
+cYV
+cXB
+cWh
+dbZ
 cUz
 cWb
-dgW
-ktZ
-wIB
+oiv
+wZy
+hzZ
 cWb
-dgB
-iuB
-wIB
+nxh
+nPv
+hzZ
 cWb
-nOD
+sEV
 cVk
 aaa
 aaa
@@ -111604,32 +111678,32 @@ bNG
 cTt
 cUv
 cnV
-csA
-csM
+csm
+csL
 cPN
 cWb
 cRq
-cTh
-cVn
-cWq
-cWq
-cXQ
-cYr
+cTd
+cVf
+cWo
+cWo
+cXO
+cYm
 cYY
 daa
-cWq
-cWq
+cWo
+cWo
 cPN
 cWb
 cTs
 cTW
-cOZ
+cNz
 cWb
 cTs
 cTW
-cOZ
+cNz
 cWb
-rIs
+unp
 cVk
 aaa
 aaa
@@ -111861,21 +111935,21 @@ cRx
 bPk
 cUv
 cnW
-csB
-csM
+csA
+csL
 cPN
 cWb
 cRq
-cTi
-cVn
-cWA
-cXi
-cXR
-cYt
+cTh
+cVf
+cWq
+cXh
+cXQ
+cYr
 cZr
-cXR
-dbA
-dbZ
+cXQ
+dbB
+dcf
 cPN
 cWb
 cWb
@@ -111886,7 +111960,7 @@ cWb
 cWb
 cWb
 cTr
-vSd
+ihe
 cVk
 aaa
 aaa
@@ -112123,26 +112197,26 @@ nej
 cPN
 cWb
 dbm
-cTR
-cVF
+cTi
+cVn
 cYX
 cWb
 cZp
-cYu
+cYt
 cZu
 dab
-dbB
-dcf
+dbC
+dch
 cPP
 dat
-daT
-daT
-daT
+cYV
+cYV
+cYV
 dat
-daT
-daT
-daT
-rHU
+cYV
+cYV
+cYV
+rWi
 cVk
 cVk
 aaa
@@ -112378,27 +112452,27 @@ dGT
 dGT
 cVi
 cVC
-cRR
-cTd
-cTS
-cVI
-cWE
-cXq
-cXS
-cYK
+cQU
+cSY
+cTR
+cVF
+cWA
+cXi
+cXR
+cYu
 cZA
 daq
-dbC
-cWq
-dcC
+dbD
+cWo
+dcD
 cTX
-dhF
+pad
 cpe
-dhF
+pad
 cTX
-dcC
+dcD
 cTX
-dcC
+dcD
 cVk
 cVk
 aaa
@@ -112638,24 +112712,24 @@ dac
 dat
 daT
 cXM
-cVX
-cWF
-cXs
-cXT
-cYP
+cVI
+cWE
+cXq
+cXS
+cYK
 cZD
 dar
-dbD
-cWq
-dcD
+dbF
+cWo
+dcE
 cTX
-ged
-gMc
-hhK
+rpg
+jTR
+dvM
 cTX
-qoA
+oVL
 cTX
-gnC
+ias
 cVk
 aaa
 aaa
@@ -112896,23 +112970,23 @@ cTX
 cTX
 cVk
 cVk
-cXg
+cWF
 cZT
-cXU
-cYQ
+cXT
+cYP
 cZG
 das
-dbC
-cWq
-dcC
+dbD
+cWo
+dcD
 cTX
 cTX
 cTX
 cTX
 cTX
-dcC
+dcD
 cTX
-dcC
+dcD
 cVk
 aaa
 aaa
@@ -113161,7 +113235,7 @@ aaa
 aaa
 aaa
 aaa
-dcE
+dcH
 aaa
 aaa
 aaa
@@ -114175,7 +114249,7 @@ bZU
 bZU
 bZU
 qbl
-cJg
+csM
 abq
 abq
 aaa
@@ -118800,12 +118874,12 @@ bPj
 bPK
 cVq
 dhG
-csD
+csB
 cZY
-csD
-csD
-csD
-cTT
+csB
+csB
+csB
+cTS
 cZN
 aaa
 aaa
@@ -119062,7 +119136,7 @@ cZN
 cZN
 cZN
 cZN
-cTU
+cTT
 cZN
 aaa
 aaa
@@ -119319,7 +119393,7 @@ abq
 aaa
 aaa
 cZN
-cTU
+cTT
 cZN
 aaa
 aaa
@@ -119576,7 +119650,7 @@ abq
 aaa
 aaa
 cZN
-cTU
+cTT
 cZN
 aaa
 aaa
@@ -119833,7 +119907,7 @@ abq
 abq
 aaa
 cZN
-cTY
+cTU
 cZN
 aaa
 aaa
@@ -120090,7 +120164,7 @@ aaa
 aaa
 aaa
 cZN
-cTU
+cTT
 cZN
 aaa
 aaa
@@ -120347,7 +120421,7 @@ aaa
 aaa
 aaa
 cZN
-cTU
+cTT
 cZN
 abq
 aaa
@@ -120367,9 +120441,9 @@ cVG
 cVG
 cVG
 cVG
-hlZ
 rDg
-rDg
+lUm
+lUm
 cVG
 cVG
 cVG
@@ -120604,7 +120678,7 @@ aaa
 aaa
 aaa
 cZN
-cTU
+cTT
 cZN
 abq
 abq
@@ -120612,23 +120686,23 @@ abq
 abq
 cVG
 dav
-dbF
-dch
-dcH
+dbI
+dci
+dcN
 ddw
-hlZ
 rDg
-dLr
+lUm
+oyC
 ddw
-hlZ
 rDg
-dLr
+lUm
+oyC
 ddw
-jhQ
-rDg
-rDg
+sOJ
+lUm
+lUm
 cVG
-gao
+rlp
 cVG
 cVG
 cVG
@@ -120861,7 +120935,7 @@ aaa
 abq
 abq
 cZN
-cTY
+cTU
 cZN
 aaa
 aaa
@@ -120870,29 +120944,29 @@ abq
 cVG
 daF
 cZc
-dci
-dcN
+dcj
+dcX
 ddw
-jhQ
-rDg
-rDg
+sOJ
+lUm
+lUm
 ddw
-jhQ
-rDg
-rDg
+sOJ
+lUm
+lUm
 ddw
-jhQ
-rDg
-rDg
+sOJ
+lUm
+lUm
 cVG
-qzy
-bXf
-bXf
-bXf
-bXf
-bXf
-bXf
-eDL
+lTF
+jSw
+jSw
+jSw
+jSw
+jSw
+jSw
+gez
 cVG
 aaa
 aaa
@@ -121118,7 +121192,7 @@ abq
 abq
 aaa
 cZN
-cTU
+cTT
 cZN
 aaa
 aaa
@@ -121126,30 +121200,30 @@ aaa
 aaa
 cVG
 daG
-dbI
-dci
-dcX
+dbJ
+dcj
+ddv
 ddw
-jhQ
-rDg
-rDg
+sOJ
+lUm
+lUm
 ddw
-jhQ
-rDg
-rDg
+sOJ
+lUm
+lUm
 ddw
-uaG
-ssL
-jHj
+vML
+uln
+mPo
 cVG
-fxe
-cVG
-cVG
+sBv
 cVG
 cVG
 cVG
 cVG
-hRN
+cVG
+cVG
+nTq
 cVG
 abq
 aaa
@@ -121375,7 +121449,7 @@ abq
 aaa
 aaa
 cZN
-cTU
+cTT
 cZN
 aaa
 aaa
@@ -121384,29 +121458,29 @@ aaa
 cVG
 daR
 cZc
-dcj
-ddv
+dck
+ddJ
 ddw
-kNr
-uex
-dxH
+ueD
+dsN
+ffs
 ddw
-dwt
-eQv
-lmv
+iNt
+mnm
+qeS
 ddw
-mGK
-uTJ
-tdX
-ijV
-rWh
-tfb
+qvQ
+mvQ
+fhT
+kqU
+qDC
+ilY
 cVG
-rDg
-nwy
-gNn
+lUm
+pDM
+wTu
 cVG
-hRN
+nTq
 cVG
 abq
 aaa
@@ -121632,7 +121706,7 @@ abq
 abq
 abq
 cZN
-cTU
+cTT
 cZN
 aaa
 cZb
@@ -121640,30 +121714,30 @@ cVG
 cVG
 cVG
 cVG
-dbJ
-dck
-ddJ
+dbK
+dcl
+ddK
 cpf
-mGK
-lQE
-lqk
-tlA
-mGK
-kXe
-qcD
-tlA
-olH
-dci
-srv
-sMy
-rhN
-owP
-xsx
-rDg
-rDg
-rDg
+qvQ
+lZx
+ieT
+mLG
+qvQ
+gBT
+wAx
+mLG
+kFj
+dcj
+rlR
+dol
+djK
+ngQ
+spw
+lUm
+lUm
+lUm
 cVG
-hRN
+nTq
 cVG
 aaa
 aaa
@@ -121889,7 +121963,7 @@ aaa
 aaa
 abq
 cZN
-cTU
+cTT
 cZN
 cZN
 cVG
@@ -121897,30 +121971,30 @@ cZd
 ddk
 cZH
 cVG
-dbK
-dck
-ddK
-deo
-nxh
-dci
-qYE
-iXo
-oEJ
-dci
-qYE
-uSn
-oEJ
-dci
-omy
-lQl
-kdL
-nEE
-etm
-etm
-oDU
-rDg
+dbM
+dcl
+ddL
+deB
+xFa
+dcj
+gsP
+ujy
+uih
+dcj
+gsP
+pEM
+uih
+dcj
+bWq
+lkK
+rmr
+wSA
+lhH
+lhH
+uws
+lUm
 cVG
-qme
+tTL
 cZN
 aaa
 aaa
@@ -122146,41 +122220,41 @@ aaa
 aaa
 aaa
 cZN
-cUC
-cWg
-csD
-cXt
-cXV
-cYR
+cTY
+cVX
+csB
+cXs
+cXU
+cYQ
 cZJ
 dbd
-dbM
-dcl
-ddL
-des
-oiv
-ybj
-oBi
-pbZ
-ybj
-fIC
-oBi
-ybj
-ybj
-nxQ
-pdt
-bzq
-lxe
-rMm
-rDg
-rDg
-rDg
-eAE
+dbR
+dcq
+ddM
+deQ
+haZ
+uHc
+mTW
+kks
+uHc
+uql
+mTW
+uHc
+uHc
+jHM
+rQV
+iWF
+kxJ
+oua
+lUm
+lUm
+lUm
+jGF
 cVG
-wLy
-rQY
-owJ
-vru
+dyw
+vmX
+gtd
+emp
 aaa
 aaa
 aaa
@@ -122407,32 +122481,32 @@ cZN
 cZN
 cZN
 cVG
-cXW
-cYU
+cXV
+cYR
 cZK
 cVG
-dbR
-dcq
-ddM
-det
-nxh
-dci
-fkV
-iwQ
-jVN
-dci
-fkV
-dsI
-jVN
-dci
-jzb
-ddn
-iiL
-qdH
-dMC
-rDg
-had
-rDg
+dbS
+dcs
+ddN
+deT
+xFa
+dcj
+kZh
+poX
+cSw
+dcj
+kZh
+pVk
+cSw
+dcj
+uTf
+eQb
+vqW
+fYn
+eZh
+lUm
+tme
+lUm
 cVG
 cVJ
 cZN
@@ -122663,33 +122737,33 @@ abq
 aaa
 aaa
 aaa
-cXv
+cXt
 cVG
 cVG
 cVG
 cVG
 cZj
-dcq
-ddN
+dcs
+ddO
 cpf
-pad
-iHp
-eNg
-tlA
-fRK
-sTi
-eNg
-tlA
-nxh
-dci
-uXv
-xZj
-dCH
-mZF
-xsx
-rDg
-rDg
-qJk
+mxQ
+egX
+oUX
+mLG
+unE
+mEI
+oUX
+mLG
+xFa
+dcj
+dHb
+dNi
+rbB
+rte
+spw
+lUm
+lUm
+hax
 cVG
 cVJ
 cVG
@@ -122925,28 +122999,28 @@ aaa
 aaa
 cVG
 cYZ
-dbS
-dcs
-ddO
+dbT
+dct
+ddP
 ddw
-rpg
+hqs
 ddD
 cYA
 ddw
 dca
-uWY
-hcE
+hhi
+vHx
 ddw
-sRk
-grP
-uqF
-wGe
-icb
-tfb
+lcM
+wZJ
+ahy
+imP
+wIm
+ilY
 cVG
-gZM
-tbZ
-uuu
+xJU
+eXj
+kjB
 cVG
 cVJ
 cVG
@@ -123183,22 +123257,22 @@ aaa
 cVG
 dbe
 cZW
-dci
-ddP
+dcj
+ddR
 ddw
-rDg
-rDg
-jhQ
+lUm
+lUm
+sOJ
 ddw
-rDg
-rDg
-jhQ
+lUm
+lUm
+sOJ
 ddw
-baz
-phC
-xjZ
+ncC
+mil
+hEc
 cVG
-qxY
+tGH
 cVG
 cVG
 cVG
@@ -123440,20 +123514,20 @@ aaa
 cVG
 dbo
 dcv
-dci
-ddR
+dcj
+ddS
 ddw
-rDg
-rDg
-jhQ
+lUm
+lUm
+sOJ
 ddw
-rDg
-rDg
-jhQ
+lUm
+lUm
+sOJ
 ddw
-ykB
-dZW
-eCC
+hLm
+pBf
+wbe
 cVG
 cVJ
 cVJ
@@ -123696,23 +123770,23 @@ aaa
 aaa
 cVG
 dbr
-dbT
-dct
-ddS
+dbU
+dcu
+ddU
 ddw
-rDg
-rDg
-sTg
+lUm
+lUm
+xBb
 ddw
-dLr
-rDg
-sTg
+oyC
+lUm
+xBb
 ddw
-rDg
-rDg
-jhQ
+lUm
+lUm
+sOJ
 cVG
-nmQ
+xQa
 cVG
 cVG
 cVG
@@ -123965,9 +124039,9 @@ cVG
 cVG
 cVG
 cVG
-rDg
-rDg
-sTg
+lUm
+lUm
+xBb
 cVG
 cVG
 cVG
@@ -124968,12 +125042,12 @@ bMq
 bMq
 cnv
 cqX
-csF
-cLS
-cLS
-cLS
-cLS
-cUD
+csD
+cJg
+cJg
+cJg
+cJg
+cUC
 abq
 bGU
 aaa
@@ -125996,12 +126070,12 @@ bMq
 bMq
 cnT
 cqX
-csF
-cLS
-cLS
-cLS
-cLS
-cUD
+csD
+cJg
+cJg
+cJg
+cJg
+cUC
 aaa
 abd
 aaa
@@ -126767,7 +126841,7 @@ bHo
 bHo
 abq
 cqX
-csK
+csF
 bHo
 bHo
 bHo
@@ -127024,12 +127098,12 @@ bMq
 bMq
 cnT
 csd
-csF
-cLS
-cLS
-cLS
-cLS
-cUD
+csD
+cJg
+cJg
+cJg
+cJg
+cUC
 aaa
 abd
 aaa
@@ -130651,7 +130725,7 @@ aaa
 aaa
 aaa
 aaa
-qTu
+hdY
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -23852,6 +23852,26 @@
 /area/bridge/meeting_room{
 	name = "\improper Command Hallway"
 	})
+"baz" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "baB" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -36467,6 +36487,24 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"bzq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "bzr" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -47769,6 +47807,12 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"bXf" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "bXi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56524,20 +56568,6 @@
 	icon_state = "whitehall"
 	},
 /area/medical/research)
-"cqy" = (
-/obj/structure/table/glass,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
 "cqB" = (
 /obj/machinery/light{
 	dir = 4
@@ -57281,11 +57311,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "csm" = (
-/obj/structure/table/wood,
-/obj/item/lighter/zippo,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
-/obj/item/ashtray/plastic,
-/turf/simulated/floor/carpet,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -57380,25 +57407,20 @@
 /area/toxins/explab)
 "csA" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/characters,
-/obj/item/storage/pill_bottle/dice,
+/obj/item/lighter/zippo,
+/obj/item/storage/fancy/cigarettes/cigpack_random,
+/obj/item/ashtray/plastic,
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "csB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/table/wood,
+/obj/item/storage/box/characters,
+/obj/item/storage/pill_bottle/dice,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "csC" = (
 /obj/machinery/power/apc{
@@ -57416,13 +57438,19 @@
 	},
 /area/medical/exam_room)
 "csD" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/space,
-/area/solar/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "csE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -57439,9 +57467,13 @@
 	},
 /area/medical/exam_room)
 "csF" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/space,
-/area/space)
+/area/solar/starboard)
 "csG" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -57505,6 +57537,10 @@
 /turf/simulated/wall,
 /area/medical/cmo)
 "csK" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"csL" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "neutral"
@@ -57512,7 +57548,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"csL" = (
+"csM" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
@@ -57522,10 +57558,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"csM" = (
-/obj/structure/lattice,
-/turf/space,
-/area/maintenance/aft)
 "csN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -65406,25 +65438,9 @@
 	name = "\improper Toxins Lab"
 	})
 "cJg" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/structure/lattice,
 /turf/space,
-/area/solar/starboard)
+/area/maintenance/aft)
 "cJh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -66681,23 +66697,25 @@
 	name = "\improper Toxins Lab"
 	})
 "cLS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/railing/corner{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/space,
+/area/solar/starboard)
 "cLT" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -67622,8 +67640,15 @@
 	name = "\improper Toxins Lab"
 	})
 "cNz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/structure/railing/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -68441,16 +68466,8 @@
 	},
 /area/assembly/robotics)
 "cOZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69424,7 +69441,17 @@
 	name = "Port Maintenance"
 	})
 "cQU" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -69884,15 +69911,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cRR" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
-	},
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70396,20 +70418,15 @@
 	},
 /area/chapel/main)
 "cSV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/sign/vacuum{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70434,9 +70451,16 @@
 	name = "\improper Departure Lounge"
 	})
 "cSY" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -70482,14 +70506,13 @@
 	name = "\improper Departure Lounge"
 	})
 "cTd" = (
-/obj/machinery/vending/cola,
-/obj/machinery/camera{
-	c_tag = "Escape - Mid Fore";
-	dir = 1
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70552,7 +70575,11 @@
 	name = "\improper Departure Lounge"
 	})
 "cTh" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cola,
+/obj/machinery/camera{
+	c_tag = "Escape - Mid Fore";
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -70561,7 +70588,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cTi" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -70812,12 +70839,20 @@
 "cTQ" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/bush,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTR" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cTS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -70829,7 +70864,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cTS" = (
+"cTT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
@@ -70847,33 +70882,11 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cTT" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "cTU" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1;
-	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70915,15 +70928,19 @@
 	})
 "cTY" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -71200,6 +71217,24 @@
 	name = "\improper Departure Lounge"
 	})
 "cUC" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cUD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -71214,7 +71249,7 @@
 	},
 /turf/space,
 /area/solar/starboard)
-"cUD" = (
+"cUE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71230,14 +71265,6 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cUE" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71257,9 +71284,9 @@
 	},
 /area/medical/medbay3)
 "cUG" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -71284,12 +71311,10 @@
 	},
 /area/chapel/office)
 "cUO" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71406,7 +71431,12 @@
 	name = "\improper Departure Lounge"
 	})
 "cVf" = (
-/turf/simulated/wall/r_wall,
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71457,12 +71487,7 @@
 	},
 /area/medical/morgue)
 "cVn" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71609,6 +71634,21 @@
 	name = "\improper Departure Lounge"
 	})
 "cVF" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cVG" = (
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cVI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
 	req_access_txt = "63"
@@ -71627,21 +71667,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cVG" = (
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cVI" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71745,21 +71770,14 @@
 	},
 /area/chapel/main)
 "cVX" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "cWb" = (
 /turf/simulated/floor/plasteel{
@@ -71814,24 +71832,27 @@
 	},
 /area/medical/virology)
 "cWg" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cWh" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
+	icon_state = "white"
 	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cWh" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -71886,8 +71907,19 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "cWo" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/secondary/exit)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cWp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71897,23 +71929,8 @@
 	},
 /area/chapel/main)
 "cWq" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 25
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 35
-	},
-/obj/machinery/camera{
-	c_tag = "Departure Lounge Security";
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/simulated/wall/r_wall,
+/area/hallway/secondary/exit)
 "cWs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71947,6 +71964,24 @@
 	},
 /area/chapel/main)
 "cWA" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 25
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 35
+	},
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Security";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cWE" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -71959,7 +71994,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cWE" = (
+"cWF" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -71967,16 +72002,6 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cWF" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -72197,6 +72222,16 @@
 	name = "\improper Departure Lounge"
 	})
 "cXg" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cXh" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -72211,26 +72246,13 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cXh" = (
+"cXi" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXi" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72296,12 +72318,14 @@
 	name = "\improper Recreation Area"
 	})
 "cXq" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72313,6 +72337,17 @@
 	},
 /area/medical/medbay3)
 "cXs" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cXt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -72341,25 +72376,11 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cXt" = (
+"cXv" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
-	})
-"cXv" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
 	})
 "cXw" = (
 /obj/machinery/vending/medical,
@@ -72383,6 +72404,28 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cXz" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cXA" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue"
+	},
+/area/medical/medbay3)
+"cXB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72397,25 +72440,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXA" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "whiteblue"
-	},
-/area/medical/medbay3)
-"cXB" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72530,6 +72554,17 @@
 /turf/simulated/floor/plating,
 /area/solar/starboard)
 "cXO" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cXQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -72537,13 +72572,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"cXQ" = (
+"cXR" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"cXR" = (
+"cXS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72555,7 +72590,7 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
-"cXS" = (
+"cXT" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -72564,7 +72599,7 @@
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"cXT" = (
+"cXU" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72577,7 +72612,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"cXU" = (
+"cXV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -72592,7 +72627,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cXV" = (
+"cXW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
@@ -72601,7 +72636,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cXW" = (
+"cXX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -72619,25 +72654,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72755,7 +72771,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutral"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -72791,6 +72807,25 @@
 	},
 /area/chapel/main)
 "cYm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cYr" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
 	req_access_txt = "63"
@@ -72822,7 +72857,7 @@
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"cYr" = (
+"cYt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -72839,39 +72874,17 @@
 	icon_state = "redcorner"
 	},
 /area/hallway/secondary/exit)
-"cYt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit)
 "cYu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72989,17 +73002,25 @@
 	},
 /area/medical/morgue)
 "cYK" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "cYL" = (
@@ -73026,6 +73047,20 @@
 	},
 /area/medical/medbay3)
 "cYP" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
+"cYQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -73039,7 +73074,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"cYQ" = (
+"cYR" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -73050,30 +73085,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cYR" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Airlock";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -73106,6 +73117,30 @@
 	name = "\improper Toxins Lab"
 	})
 "cYU" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Airlock";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cYV" = (
 /obj/structure/table,
 /obj/item/paicard,
 /turf/simulated/floor/plasteel{
@@ -73115,21 +73150,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cYV" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "63"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/area/hallway/secondary/exit)
 "cYW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
@@ -73151,9 +73171,18 @@
 	name = "\improper Departure Lounge"
 	})
 "cYY" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "63"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
 "cYZ" = (
@@ -73213,15 +73242,6 @@
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
-	})
-"cZe" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
 	})
 "cZf" = (
 /obj/structure/table/wood,
@@ -73303,6 +73323,7 @@
 /area/maintenance/aft)
 "cZr" = (
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/hallway/secondary/exit)
@@ -73330,11 +73351,8 @@
 	},
 /area/chapel/office)
 "cZu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	icon_state = "redcorner"
 	},
 /area/hallway/secondary/exit)
 "cZv" = (
@@ -73395,11 +73413,10 @@
 	name = "\improper Arcade"
 	})
 "cZA" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
@@ -73413,6 +73430,15 @@
 	},
 /area/chapel/main)
 "cZD" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
+"cZG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -73422,28 +73448,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"cZG" = (
+"cZH" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"cZH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -73463,6 +73474,21 @@
 	},
 /area/medical/medbay3)
 "cZJ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"cZK" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -73475,18 +73501,10 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"cZK" = (
+"cZL" = (
 /obj/structure/flora/bush,
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cZL" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -73545,10 +73563,13 @@
 	name = "\improper Departure Lounge"
 	})
 "cZU" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit)
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cZW" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -73596,18 +73617,15 @@
 	name = "\improper Secure Lab"
 	})
 "daa" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"dab" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
 	},
-/area/hallway/secondary/exit)
-"dab" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "dac" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -73696,6 +73714,14 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"dar" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -73703,7 +73729,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"dar" = (
+"das" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -73713,22 +73739,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"das" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dat" = (
 /obj/machinery/light{
 	dir = 4
@@ -73754,27 +73764,14 @@
 	name = "\improper Departure Lounge"
 	})
 "dav" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
 /obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
+/obj/item/storage/box/syringes{
+	pixel_y = 5
 	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplefull"
@@ -73821,33 +73818,28 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
-"daz" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "daF" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
 	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplefull"
@@ -73856,15 +73848,13 @@
 	name = "\improper Secure Lab"
 	})
 "daG" = (
-/obj/machinery/chem_master{
-	pixel_x = -2;
-	pixel_y = 1
+/obj/machinery/chem_dispenser,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/obj/structure/disaster_counter/scichem{
-	pixel_x = 32
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -73947,37 +73937,16 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "daR" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/chem_master{
+	pixel_x = -2;
+	pixel_y = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "xeno_airlock_interior";
-	locked = 1;
-	name = "Secure Lab Internal Airlock";
-	req_access_txt = "55"
+/obj/structure/noticeboard{
+	pixel_y = 30
 	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	frequency = 1449;
-	id_tag = "xeno_airlock_control";
-	pixel_x = -25;
-	pixel_y = -10;
-	req_access_txt = "55";
-	tag_exterior_door = "xeno_airlock_exterior";
-	tag_interior_door = "xeno_airlock_interior"
+/obj/structure/disaster_counter/scichem{
+	pixel_x = 32
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	master_tag = "xeno_airlock_control";
-	pixel_x = -25;
-	req_access_txt = "55"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplefull"
@@ -74033,6 +74002,45 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dbd" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "xeno_airlock_interior";
+	locked = 1;
+	name = "Secure Lab Internal Airlock";
+	req_access_txt = "55"
+	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	frequency = 1449;
+	id_tag = "xeno_airlock_control";
+	pixel_x = -25;
+	pixel_y = -10;
+	req_access_txt = "55";
+	tag_exterior_door = "xeno_airlock_exterior";
+	tag_interior_door = "xeno_airlock_interior"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	master_tag = "xeno_airlock_control";
+	pixel_x = -25;
+	req_access_txt = "55"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplefull"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dbe" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -74043,41 +74051,6 @@
 	pixel_y = 30
 	},
 /obj/machinery/chem_dispenser,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplefull"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dbe" = (
-/obj/structure/table/glass,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Xenobiology APC";
-	pixel_y = 27
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplefull"
@@ -74153,7 +74126,33 @@
 	name = "\improper Departure Lounge"
 	})
 "dbo" = (
-/obj/machinery/smartfridge/secure/extract,
+/obj/structure/table/glass,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Xenobiology APC";
+	pixel_y = 27
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplefull"
@@ -74176,6 +74175,15 @@
 	},
 /area/chapel/main)
 "dbr" = (
+/obj/machinery/smartfridge/secure/extract,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplefull"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dbs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
@@ -74191,14 +74199,6 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"dbs" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -74264,18 +74264,26 @@
 	},
 /area/maintenance/aft)
 "dbz" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"dbA" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"dbA" = (
+"dbB" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
-"dbB" = (
+"dbC" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "emergency_home";
 	locked = 1;
@@ -74283,22 +74291,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
-"dbC" = (
+"dbD" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"dbD" = (
-/obj/machinery/chem_heater{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dbE" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -74312,14 +74308,12 @@
 /turf/space,
 /area/space)
 "dbF" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
+/obj/machinery/chem_heater{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 9;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
@@ -74360,6 +74354,20 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dbI" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dbJ" = (
 /obj/structure/sink{
 	pixel_y = 22
 	},
@@ -74370,31 +74378,11 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbJ" = (
+"dbK" = (
 /obj/machinery/light_switch{
 	pixel_x = -6;
 	pixel_y = 26
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dbK" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -74420,6 +74408,35 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dbM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dbN" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Psychiatrist"
+	},
+/turf/simulated/floor/carpet,
+/area/medical/psych)
+"dbR" = (
 /obj/machinery/camera{
 	c_tag = "Secure Lab - Fore";
 	network = list("SS13","RD")
@@ -74439,16 +74456,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbN" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Psychiatrist"
-	},
-/turf/simulated/floor/carpet,
-/area/medical/psych)
-"dbR" = (
+"dbS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -74461,7 +74469,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbS" = (
+"dbT" = (
 /obj/machinery/chem_heater{
 	pixel_x = -4;
 	pixel_y = 4
@@ -74473,7 +74481,18 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dbT" = (
+"dbU" = (
+/turf/simulated/wall,
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"dbV" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"dbW" = (
 /obj/structure/table,
 /obj/random/toolbox,
 /turf/simulated/floor/plasteel{
@@ -74482,35 +74501,6 @@
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
-	})
-"dbU" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/hallway/secondary/exit)
-"dbV" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit)
-"dbW" = (
-/obj/structure/table/glass,
-/obj/item/extinguisher{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/extinguisher,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "dbX" = (
 /obj/machinery/light/small,
@@ -74524,12 +74514,16 @@
 	},
 /area/chapel/main)
 "dbZ" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "63"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/hallway/secondary/exit)
 "dca" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -74561,6 +74555,31 @@
 	name = "\improper Research Division Server Room"
 	})
 "dcf" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"dch" = (
+/obj/structure/table/glass,
+/obj/item/extinguisher{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/extinguisher,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dci" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dcj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -74570,7 +74589,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dch" = (
+"dck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74580,7 +74599,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dci" = (
+"dcl" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -74599,7 +74618,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcj" = (
+"dcq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -74609,7 +74628,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dck" = (
+"dcs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -74619,7 +74638,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcl" = (
+"dct" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
 	pixel_x = -3;
@@ -74636,37 +74655,11 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcq" = (
-/obj/machinery/hydroponics/soil,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
-"dcs" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/camera{
-	c_tag = "Garden"
-	},
-/turf/simulated/floor/grass,
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
-"dct" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
 "dcu" = (
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
+/obj/machinery/hydroponics/soil,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
-	name = "\improper Garden"
+	name = "\improper Departures Garden"
 	})
 "dcv" = (
 /obj/structure/cable/yellow{
@@ -74682,6 +74675,35 @@
 	name = "\improper Secure Lab"
 	})
 "dcw" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/camera{
+	c_tag = "Garden"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"dcx" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"dcy" = (
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"dcz" = (
 /obj/structure/table/glass,
 /obj/item/seeds/apple,
 /obj/item/seeds/banana,
@@ -74697,18 +74719,18 @@
 	icon_state = "green"
 	},
 /area/hallway/secondary/construction{
-	name = "\improper Garden"
+	name = "\improper Departures Garden"
 	})
-"dcx" = (
+"dcA" = (
 /obj/machinery/biogenerator,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "green"
 	},
 /area/hallway/secondary/construction{
-	name = "\improper Garden"
+	name = "\improper Departures Garden"
 	})
-"dcy" = (
+"dcB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheesiehonkers,
 /obj/item/reagent_containers/food/drinks/cans/cola,
@@ -74723,7 +74745,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcz" = (
+"dcC" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "emergency_home";
 	locked = 1;
@@ -74733,7 +74755,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcA" = (
+"dcD" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -74741,7 +74763,7 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"dcB" = (
+"dcE" = (
 /obj/docking_port/stationary{
 	dir = 4;
 	dwidth = 11;
@@ -74752,7 +74774,7 @@
 	},
 /turf/space,
 /area/space)
-"dcC" = (
+"dcH" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -74760,7 +74782,14 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcD" = (
+"dcK" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/medical/cryo)
+"dcN" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -74768,7 +74797,19 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcE" = (
+"dcO" = (
+/obj/docking_port/stationary{
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 22;
+	id = "syndicate_sw";
+	name = "southwest of station";
+	width = 18
+	},
+/turf/space,
+/area/space)
+"dcX" = (
 /obj/machinery/disposal,
 /obj/structure/sign/deathsposal{
 	pixel_y = -32
@@ -74782,7 +74823,32 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dcH" = (
+"ddk" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddn" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -74804,108 +74870,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcI" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"dcK" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/medical/cryo)
-"dcN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/item/slime_scanner,
-/obj/item/slime_scanner,
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dcO" = (
-/obj/docking_port/stationary{
-	dheight = 9;
-	dir = 2;
-	dwidth = 5;
-	height = 22;
-	id = "syndicate_sw";
-	name = "southwest of station";
-	width = 18
-	},
-/turf/space,
-/area/space)
-"dcX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddk" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddl" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Test Chamber Monitor";
-	network = list("Xeno");
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -74938,7 +74902,13 @@
 	name = "\improper Secure Lab"
 	})
 "ddJ" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/slime_scanner,
+/obj/item/slime_scanner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -74946,6 +74916,44 @@
 	name = "\improper Secure Lab"
 	})
 "ddK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddM" = (
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddN" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
@@ -74956,7 +74964,7 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddL" = (
+"ddO" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
@@ -74966,43 +74974,13 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddM" = (
+"ddP" = (
 /obj/machinery/monkey_recycler,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
-	})
-"ddN" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddO" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/glass,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddP" = (
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
 	})
 "ddQ" = (
 /obj/docking_port/stationary{
@@ -75017,14 +74995,44 @@
 /turf/space,
 /area/space)
 "ddR" = (
+/obj/machinery/processor{
+	desc = "A machine used to process slimes and retrieve their extract.";
+	name = "Slime Processor"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddS" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/glass,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"ddU" = (
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"ddW" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/hallway/secondary/construction{
-	name = "\improper Garden"
+	name = "\improper Departures Garden"
 	})
-"ddS" = (
+"ddX" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -75035,51 +75043,6 @@
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
-	})
-"ddU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"ddW" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"ddX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "ddZ" = (
 /obj/machinery/meter,
@@ -75130,16 +75093,23 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dej" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dek" = (
 /obj/structure/cable/yellow{
@@ -75166,14 +75136,13 @@
 	},
 /area/chapel/main)
 "deo" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "dep" = (
 /obj/structure/table/wood,
@@ -75202,6 +75171,45 @@
 /turf/simulated/floor/plating,
 /area/medical/psych)
 "des" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"det" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dez" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"deB" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/plant_analyzer,
@@ -75218,65 +75226,7 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
-"det" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
-"dez" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "greencorner"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
-"deB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
+	name = "\improper Departures Garden"
 	})
 "deC" = (
 /obj/structure/table/reinforced,
@@ -75413,12 +75363,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
 	})
 "deR" = (
 /obj/structure/cable/yellow{
@@ -75442,29 +75389,23 @@
 	},
 /area/security/main)
 "deT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing/corner,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "greencorner"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
 	})
 "deU" = (
 /obj/machinery/power/apc{
@@ -75712,16 +75653,27 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dfD" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
 	},
-/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "green"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
 	})
 "dfG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75736,14 +75688,20 @@
 	},
 /area/chapel/main)
 "dfH" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/railing/corner,
-/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -75865,7 +75823,27 @@
 	},
 /area/medical/virology)
 "dfW" = (
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -76089,8 +76067,14 @@
 	name = "Arrivals"
 	})
 "dgB" = (
-/obj/structure/chair/comfy/black,
-/turf/simulated/floor/carpet,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -76187,19 +76171,17 @@
 /turf/simulated/wall,
 /area/engine/mechanic_workshop)
 "dgW" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"dgY" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/railing/corner,
+/obj/structure/railing,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dhf" = (
 /obj/effect/decal/warning_stripes/west,
@@ -76396,12 +76378,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dhF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/turf/simulated/floor/wood,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "dhG" = (
 /obj/structure/cable/yellow{
@@ -76471,27 +76450,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"dkg" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio6";
-	name = "Containment Blast Doors";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "dmU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76547,6 +76505,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"dsI" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dtM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76555,6 +76521,26 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
+"dwt" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dwC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76569,6 +76555,24 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
+"dxH" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dAs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -76587,6 +76591,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"dCH" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dCV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76646,24 +76662,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"dGb" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "dGT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
@@ -76710,6 +76708,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
+"dLr" = (
+/mob/living/simple_animal/slime,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"dMC" = (
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "dMV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -76827,6 +76837,12 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
+"dZW" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ebA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76954,17 +76970,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
-"epb" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "erv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76984,12 +76989,47 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"etm" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "evR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
+"eAE" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Test Chamber";
+	dir = 1;
+	network = list("SS13","RD")
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"eCC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"eDL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eEV" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -77034,17 +77074,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
-"eJZ" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "eKV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77077,6 +77106,24 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
+"eNg" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ePy" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77102,6 +77149,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"eQv" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "eRU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -77145,14 +77216,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"eWP" = (
-/obj/item/radio/intercom{
-	pixel_y = -25
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "eYE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77169,26 +77232,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
-	})
-"feJ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "fga" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -77237,6 +77280,19 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"fkV" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fla" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -77283,44 +77339,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"fpy" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"fsy" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fsY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -77350,23 +77368,6 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
-"fuR" = (
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fvO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77385,6 +77386,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"fxe" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fxB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -77416,48 +77431,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
-"fDC" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio1";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"fDS" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "fEr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77505,9 +77478,21 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"fOa" = (
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/engine,
+"fIC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -77518,6 +77503,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"fOP" = (
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "fPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77525,6 +77516,20 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"fRK" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio7";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "fUI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77597,6 +77602,12 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"gao" = (
+/obj/structure/closet,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gbT" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
@@ -77638,24 +77649,10 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "ged" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "gfB" = (
 /obj/structure/window/plasmareinforced,
@@ -77668,12 +77665,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"gfV" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gid" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -77729,6 +77720,12 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"gnC" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "gnJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77772,38 +77769,35 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"grP" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gtu" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
+"guD" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "gwJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/construction)
-"gwW" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gyy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -77844,42 +77838,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
-"gHU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Port";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"gIq" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "gIN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -77904,10 +77862,13 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
-"gLe" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/escapepodbay)
+"gMc" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "gMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77920,6 +77881,12 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"gNn" = (
+/obj/effect/decal/remains/xeno,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gOD" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -77972,12 +77939,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"gYB" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "gYM" = (
 /obj/machinery/light{
 	dir = 8
@@ -77986,6 +77947,16 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"gZM" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/item/radio/electropack,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "gZY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77994,26 +77965,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"had" = (
+/obj/item/radio/beacon,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "har" = (
 /obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
-"hcj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
-"hdL" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
-"hdX" = (
+"hcE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78034,6 +77998,13 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"hdL" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "het" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -78087,6 +78058,36 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"hhK" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"hid" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "hio" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78122,24 +78123,13 @@
 	name = "Port Maintenance"
 	})
 "hlZ" = (
-/obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
-	})
-"hmv" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
 	})
 "hmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -78177,15 +78167,6 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"hpS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hqN" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -78219,6 +78200,16 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"hwY" = (
+/obj/machinery/door_control{
+	desc = "A remote control-switch for the pod doors.";
+	id = "escapepodbay";
+	name = "Pod Door Control";
+	pixel_y = 24;
+	req_access_txt = "13"
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "hxv" = (
 /obj/machinery/camera{
 	c_tag = "Telecoms - Server Room - Aft";
@@ -78232,27 +78223,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"hyA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio2";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hAg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78274,6 +78244,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
+"hCH" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "hCM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78310,6 +78288,13 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"hEl" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "hEA" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -78342,19 +78327,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
-"hFx" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hHE" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -78438,14 +78410,20 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"hPp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+"hOp" = (
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/escapepodbay)
+"hQi" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"hRr" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "greencorner"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
 	})
 "hRw" = (
 /obj/structure/cable/yellow{
@@ -78461,6 +78439,14 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"hRN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "hVe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78487,15 +78473,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"hXQ" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "hYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78503,19 +78480,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"hYs" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "hYZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
@@ -78562,8 +78526,19 @@
 	},
 /turf/space,
 /area/space)
-"icI" = (
-/obj/effect/decal/warning_stripes/east,
+"icb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"icT" = (
+/obj/machinery/light,
 /turf/simulated/floor/engine,
 /area/escapepodbay)
 "idx" = (
@@ -78622,6 +78597,19 @@
 	},
 /turf/space,
 /area/space)
+"iiL" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ijf" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78650,6 +78638,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"ijV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Port";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "ikO" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -78727,6 +78739,20 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"iud" = (
+/obj/structure/table/glass,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
 "iuh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78739,6 +78765,14 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"iuB" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "ivn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78750,31 +78784,23 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"ivo" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/window/reinforced{
-	dir = 4
+"iwQ" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/obj/machinery/ignition_switch{
-	id = "Xenobio";
-	pixel_x = -6;
-	pixel_y = -2
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Central";
+	dir = 8;
+	network = list("SS13","RD")
 	},
-/obj/machinery/door_control{
-	id = "Xenolab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = -2;
-	req_access_txt = "55"
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -78786,31 +78812,6 @@
 	icon_state = "white"
 	},
 /area/toxins/explab)
-"iyw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "iAT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -78824,6 +78825,22 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"iDq" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/stock_parts/cell,
+/obj/item/flashlight,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Escape Podbay APC";
+	pixel_y = 25
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "iDw" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -78857,9 +78874,19 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
-"iHU" = (
+"iHp" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "iIk" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -78904,17 +78931,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"iRE" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "iSH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78967,6 +78983,34 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"iXg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"iXo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "iXL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79017,17 +79061,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
-"jfH" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Test Chamber";
-	dir = 1;
-	network = list("SS13","RD")
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "jgD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -79035,10 +79068,10 @@
 	},
 /area/medical/surgery2)
 "jhQ" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -79063,12 +79096,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"jtD" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "jwh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79078,13 +79105,21 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
-"jyt" = (
-/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id_tag = "escapepodbay";
-	req_one_access_txt = "13"
+"jzb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/escapepodbay)
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "jCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79129,12 +79164,24 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"jIL" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge Podbay"
+"jHj" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
-/area/escapepodbay)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "jKJ" = (
 /obj/structure/chair{
 	dir = 1
@@ -79200,29 +79247,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"jTO" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "jUV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79235,6 +79259,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"jVN" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"jXA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "jZd" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_y = -32
@@ -79243,6 +79289,34 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"kdL" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/ignition_switch{
+	id = "Xenobio";
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/machinery/door_control{
+	id = "Xenolab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = -2;
+	req_access_txt = "55"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kez" = (
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -79270,33 +79344,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"kgL" = (
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kgV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"khp" = (
-/obj/structure/chair,
-/obj/structure/railing{
-	dir = 1
+"kky" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Garden APC";
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 0;
+	icon_state = "green"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
 	})
 "kmF" = (
 /obj/effect/spawner/window/reinforced,
@@ -79367,6 +79432,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"ktZ" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kuf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79426,28 +79499,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"kzo" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "kzH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -79497,14 +79548,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"kCd" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "kDt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -79514,12 +79557,6 @@
 	icon_state = "brown"
 	},
 /area/storage/primary)
-"kFB" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "kGw" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
@@ -79571,18 +79608,22 @@
 	},
 /area/engine/engineering)
 "kNr" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
 	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -79646,6 +79687,17 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"kXe" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "kXs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -79706,6 +79758,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"lfC" = (
+/obj/structure/grille,
+/turf/space,
+/area/escapepodbay)
 "lfV" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79742,15 +79798,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"lhX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "lid" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -79771,10 +79818,19 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"lmK" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
+"lmv" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio2";
+	name = "containment blast door";
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
@@ -79797,6 +79853,27 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"lqk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "lrA" = (
 /obj/structure/sign/biohazard{
 	pixel_x = -32
@@ -79806,20 +79883,9 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
-"lrJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+"lsO" = (
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "lwN" = (
 /obj/effect/spawner/lootdrop{
 	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
@@ -79830,6 +79896,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"lxe" = (
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "lBy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -79863,22 +79940,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"lDL" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/stock_parts/cell,
-/obj/item/flashlight,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Escape Podbay APC";
-	pixel_y = 25
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "lFH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -79945,20 +80006,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"lNS" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "lOU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/west,
@@ -79970,14 +80017,40 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"lRu" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "green"
+"lQl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"lQE" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80013,21 +80086,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"lYW" = (
-/obj/machinery/shieldwallgen{
-	req_access = list(55)
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"mcu" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mcP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -80066,34 +80124,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"meb" = (
-/obj/structure/table/glass,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
-"mfw" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80121,17 +80151,6 @@
 	icon_state = "greenfull"
 	},
 /area/hallway/primary/central)
-"mhZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "miB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80150,21 +80169,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"mkj" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "mmk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80223,6 +80227,9 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
+"mxe" = (
+/turf/simulated/wall,
+/area/escapepodbay)
 "myY" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -80296,15 +80303,12 @@
 	},
 /area/medical/medbay3)
 "mGK" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio8";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/structure/window/reinforced,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -80315,42 +80319,6 @@
 	},
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
-	})
-"mLc" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"mMV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "mOc" = (
 /obj/structure/cable/yellow{
@@ -80421,6 +80389,23 @@
 "mXy" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
+"mZF" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "mZH" = (
 /obj/structure/chair{
 	dir = 1
@@ -80522,13 +80507,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
-"nkK" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
+"nmQ" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nnI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80556,6 +80540,14 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"nsC" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/space,
+/area/escapepodbay)
 "nuB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80573,32 +80565,42 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"nxh" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio8";
-	name = "containment blast door";
-	opacity = 0
+"nwy" = (
+/obj/machinery/sparker{
+	id = "Xenobio";
+	pixel_x = -25
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"nyt" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/obj/machinery/firealarm{
-	pixel_y = 28
+"nxh" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"nxQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nza" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -80618,6 +80620,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"nEE" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "nEQ" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -80661,12 +80686,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
-"nIy" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "nIZ" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -80699,12 +80718,35 @@
 "nMC" = (
 /turf/simulated/wall/r_wall,
 /area/storage/secure)
+"nOD" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "nPe" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
 /area/turret_protected/aisat_interior{
 	name = "\improper MiniSat Central Foyer"
+	})
+"nRc" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "nRh" = (
 /turf/simulated/floor/plasteel{
@@ -80763,16 +80805,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"obK" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "odF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80820,7 +80852,18 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "oiv" = (
-/turf/simulated/floor/engine,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -80832,18 +80875,41 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"omf" = (
-/obj/structure/disposalpipe/segment,
+"okh" = (
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
+"olH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"omy" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/landmark{
-	name = "lightsout"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -80855,19 +80921,6 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
-"opa" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "orm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -80880,15 +80933,41 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"ouq" = (
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/table,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+"otw" = (
+/obj/structure/table/glass,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
+"owJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"owP" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -80903,6 +80982,31 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
+"oBi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "oCE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80919,10 +81023,21 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"oEz" = (
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+"oDU" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"oEJ" = (
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "oJQ" = (
 /obj/structure/cable/yellow{
@@ -80938,41 +81053,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"oKr" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "oOs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"oQy" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "oQz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81009,6 +81094,17 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
+"oVk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "oVK" = (
 /obj/structure/chair{
 	dir = 1
@@ -81044,14 +81140,18 @@
 	},
 /area/hallway/primary/central)
 "pad" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio8";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "paZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81060,6 +81160,25 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"pbZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pcN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -81087,8 +81206,23 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"pdc" = (
-/obj/effect/decal/warning_stripes/east,
+"pdt" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -81131,12 +81265,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"pfX" = (
-/mob/living/simple_animal/slime,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "phx" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -81152,6 +81280,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
+"phC" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "pjn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -81225,6 +81375,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
+"pqV" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -81263,22 +81422,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"puB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pvu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81296,16 +81439,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"pzm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair,
-/obj/item/cigbutt,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pzX" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81347,38 +81480,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"pDD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"pGo" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 18;
-	id = "skipjack_se";
-	name = "southeast of SS13";
-	width = 19
-	},
-/turf/space,
-/area/space)
 "pHQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -81403,25 +81504,14 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"pKB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
+"pKK" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 6;
+	icon_state = "green"
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
 	})
 "pMx" = (
 /obj/effect/spawner/airlock/w_to_e,
@@ -81439,26 +81529,6 @@
 	icon_state = "purple"
 	},
 /area/hallway/primary/aft)
-"pNt" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Central";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "pNG" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81581,29 +81651,10 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"pWA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Aft-Starboard";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+"pWq" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/escapepodbay)
 "pXV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -81649,13 +81700,24 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"qbG" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
+"qcD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio2";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
-/obj/item/radio/electropack,
-/turf/simulated/floor/engine,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -81663,6 +81725,28 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/construction)
+"qdH" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qee" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81681,17 +81765,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
-"qeH" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qeW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81722,6 +81795,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/storage/primary)
+"qme" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/item/cigbutt,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qnt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81735,30 +81818,6 @@
 	icon_state = "white"
 	},
 /area/medical/research)
-"qnz" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio3";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "qob" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81770,6 +81829,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"qoA" = (
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "qpO" = (
 /turf/simulated/wall,
@@ -81825,6 +81889,34 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"qxL" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"qxY" = (
+/obj/machinery/door/airlock/command{
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
+	name = "Test Chamber Maintenance";
+	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"qzy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "qAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81849,10 +81941,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"qBY" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "qFg" = (
 /obj/machinery/space_heater,
 /obj/machinery/power/apc{
@@ -81896,23 +81984,14 @@
 	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/starboard)
-"qIH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+"qJk" = (
+/obj/item/radio/intercom{
+	pixel_y = -25
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"qMq" = (
-/obj/structure/grille,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
-	},
-/turf/space,
-/area/escapepodbay)
 "qME" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81928,25 +82007,10 @@
 	icon_state = "red"
 	},
 /area/security/main)
-"qOk" = (
-/obj/structure/table/wood,
-/obj/item/candle,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"qPJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"qMS" = (
+/obj/structure/closet/emcloset,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
 "qQy" = (
@@ -81962,9 +82026,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"qRQ" = (
-/turf/space,
-/area/escapepodbay)
 "qSf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -81977,20 +82038,17 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"qSN" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "xenobio7";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+"qTu" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 18;
+	id = "skipjack_se";
+	name = "southeast of SS13";
+	width = 19
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/space,
+/area/space)
 "qTK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -82021,6 +82079,19 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
+	})
+"qYE" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "raV" = (
 /obj/structure/cable/yellow{
@@ -82054,6 +82125,19 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"rhN" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Test Chamber Monitor";
+	network = list("Xeno");
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "riM" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -82113,23 +82197,21 @@
 	name = "Arrivals"
 	})
 "rpg" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/rh,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio8";
+	name = "containment blast door";
+	opacity = 0
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "rqY" = (
 /obj/structure/window/reinforced,
@@ -82225,11 +82307,9 @@
 	name = "\improper Arcade"
 	})
 "rDg" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "greencorner"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "rDy" = (
 /obj/docking_port/stationary{
@@ -82325,6 +82405,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"rHU" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/camera{
+	c_tag = "Escape - Aft";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "rIq" = (
 /obj/structure/table,
 /obj/item/clothing/mask/breath{
@@ -82335,6 +82428,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"rIs" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "rID" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -82368,21 +82470,31 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rNt" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"rNP" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+"rMm" = (
+/obj/machinery/door/window/southleft{
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
 	},
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Xenolab";
+	name = "test chamber blast door";
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"rNt" = (
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "rOZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -82409,6 +82521,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"rQY" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "rRM" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow{
@@ -82452,27 +82570,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"rXq" = (
+"rWh" = (
+/obj/item/crowbar/red,
+/obj/item/wrench,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
 /obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82501,6 +82612,13 @@
 	icon_state = "white"
 	},
 /area/medical/research)
+"rZK" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
 "say" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -82537,21 +82655,15 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"sfF" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"sje" = (
+/obj/machinery/camera{
+	c_tag = "Departure Lounge Podbay"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/light{
+	dir = 1
 	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -82579,20 +82691,6 @@
 	icon_state = "dark"
 	},
 /area/space/nearstation)
-"snv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "soT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -82611,10 +82709,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/security/main)
-"spi" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
 "spj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82633,13 +82727,20 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/library)
-"sqr" = (
+"srv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -82655,6 +82756,30 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"ssL" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ssZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82704,6 +82829,12 @@
 "sBY" = (
 /turf/simulated/floor/plating,
 /area/storage/secure)
+"sCI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "sFz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -82714,26 +82845,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/mechanic_workshop)
-"sGG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio6";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "sHl" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -82754,24 +82865,6 @@
 	},
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
-	})
-"sLm" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
 	})
 "sLs" = (
 /obj/structure/cable/yellow{
@@ -82800,9 +82893,22 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"sOe" = (
-/turf/simulated/floor/engine,
-/area/escapepodbay)
+"sMy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "sOB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -82811,16 +82917,35 @@
 	},
 /area/security/brig)
 "sOJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/construction{
-	name = "\improper Garden"
+	name = "\improper Departures Garden"
+	})
+"sRk" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door_control{
+	id = "xenobio6";
+	name = "Containment Blast Doors";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "sRB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -82828,24 +82953,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"sUp" = (
-/obj/machinery/door/window/southleft{
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
+"sTg" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
+/obj/structure/disposaloutlet{
+	dir = 1
 	},
 /turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"sTi" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -82855,14 +82983,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"sWP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "sYp" = (
 /obj/structure/chair{
 	dir = 1
@@ -82881,6 +83001,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
+"tbZ" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tca" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82895,6 +83030,38 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"tdX" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"tew" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "teE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82915,6 +83082,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
+"tfb" = (
+/obj/machinery/shieldwallgen{
+	req_access = list(55)
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "tfV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82931,12 +83107,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"tha" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "thC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82963,38 +83133,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
-"tnI" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/camera{
-	c_tag = "Escape - Aft";
-	dir = 1
+"tlA" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"toM" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio7";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/wall,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -83060,24 +83205,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"tyy" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tAk" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -83142,68 +83269,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"tFL" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"tGW" = (
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"tJL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"tLd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"tNw" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -83235,10 +83300,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
-"tSB" = (
-/obj/structure/grille,
-/turf/space,
-/area/escapepodbay)
 "tST" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83265,6 +83326,18 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"tVq" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tVw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 5
@@ -83276,26 +83349,6 @@
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"tYd" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "tYX" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -83331,26 +83384,75 @@
 /area/security/checkpoint2{
 	name = "Customs"
 	})
-"uaQ" = (
-/turf/simulated/wall,
-/area/engine/mechanic_workshop)
-"ucQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+"uaG" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio1";
+	name = "containment blast door";
+	opacity = 0
+	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"uaQ" = (
+/turf/simulated/wall,
+/area/engine/mechanic_workshop)
 "udB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"uex" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio3";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ueD" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/rh,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
 	})
 "ugy" = (
 /obj/structure/cable/yellow{
@@ -83375,24 +83477,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"uiw" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door_control{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "umD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -83420,29 +83504,52 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
-"uqv" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Xenolab";
-	name = "test chamber blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uqy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
+	})
+"uqF" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"uuu" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "uuE" = (
 /obj/machinery/door/firedoor,
@@ -83459,30 +83566,6 @@
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
 	})
-"uuW" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uvM" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -83497,6 +83580,16 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
+"uxy" = (
+/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
+	id_tag = "escapepodbay";
+	req_one_access_txt = "13"
+	},
+/obj/structure/spacepoddoor{
+	luminosity = 3
+	},
+/turf/simulated/floor/engine,
+/area/escapepodbay)
 "uzt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -83517,17 +83610,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"uBy" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #5";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uBN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -83540,15 +83622,6 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
-"uDU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uEN" = (
 /obj/effect/landmark/start{
 	name = "Roboticist"
@@ -83634,14 +83707,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
-"uRQ" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uRT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -83650,6 +83715,30 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"uSn" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"uTJ" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "uTZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -83659,6 +83748,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"uUp" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/construction{
+	name = "\improper Departures Garden"
+	})
 "uUE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -83671,24 +83772,53 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"uWg" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "uWq" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
+	})
+"uWY" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio7";
+	name = "containment blast door";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
+"uXv" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
 "uYO" = (
 /obj/effect/spawner/window/reinforced,
@@ -83713,13 +83843,6 @@
 "vaO" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry)
-"vaY" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Pod Bay"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "vfe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -83733,16 +83856,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"vff" = (
-/obj/machinery/door_control{
-	desc = "A remote control-switch for the pod doors.";
-	id = "escapepodbay";
-	name = "Pod Door Control";
-	pixel_y = 24;
-	req_access_txt = "13"
-	},
-/turf/simulated/floor/engine,
-/area/escapepodbay)
 "vfv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -83795,6 +83908,13 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
+"vru" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -83853,25 +83973,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"vwL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "vyo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -83946,6 +84047,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
+"vHP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Pod Bay"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "vHW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83969,9 +84088,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"vJT" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine/vacuum,
+"vKy" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel,
 /area/escapepodbay)
 "vLL" = (
 /obj/structure/cable/yellow{
@@ -84030,6 +84154,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"vSd" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "vSx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84038,20 +84171,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"vTh" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Garden APC";
-	pixel_y = -25
-	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden"
-	})
 "vUD" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -84087,26 +84206,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
-"wcc" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wfs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84127,48 +84226,11 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"whL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
-"wiN" = (
-/obj/item/radio/beacon,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wma" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
-"wnG" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "wri" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -84268,14 +84330,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
-"wyv" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "wyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -84333,21 +84387,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"wDH" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wEq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84378,6 +84417,29 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"wGe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Aft-Starboard";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wHZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -84386,6 +84448,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"wIB" = (
+/obj/structure/chair,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wJQ" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -84393,6 +84467,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"wLy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "wLN" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -84435,16 +84518,6 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"wTa" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "wUE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84477,19 +84550,6 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
-"xdv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84518,16 +84578,21 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"xjU" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+"xjZ" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenobio6";
+	name = "containment blast door";
+	opacity = 0
 	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
@@ -84537,19 +84602,6 @@
 	icon_state = "white"
 	},
 /area/medical/reception)
-"xmr" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xno" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -84580,6 +84632,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
+"xsx" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xtA" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -84611,24 +84673,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"xwe" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "xenobio2";
-	name = "containment blast door";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xxA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -84646,24 +84690,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"xDN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
 "xDS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -84730,6 +84756,10 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"xLr" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "xOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84748,9 +84778,6 @@
 	icon_state = "white"
 	},
 /area/medical/reception)
-"xUa" = (
-/turf/simulated/wall,
-/area/escapepodbay)
 "xUe" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84788,6 +84815,19 @@
 /area/quartermaster/sorting{
 	name = "\improper Warehouse"
 	})
+"xZj" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "xZq" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -84824,6 +84864,21 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"ybj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
+	})
 "ycU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -84832,20 +84887,10 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"yeg" = (
-/obj/machinery/door/airlock/command{
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi';
-	name = "Test Chamber Maintenance";
-	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi';
-	req_access_txt = "47"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology{
-	name = "\improper Secure Lab"
-	})
+"ydQ" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine/vacuum,
+/area/escapepodbay)
 "yeW" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -84895,21 +84940,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
-"ykm" = (
-/obj/machinery/light{
-	dir = 8
+"ykB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/turf/simulated/floor/engine,
+/area/toxins/xenobiology{
+	name = "\improper Secure Lab"
 	})
-"ylD" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 
 (1,1,1) = {"
 aaa
@@ -106703,12 +106742,12 @@ aaa
 aaa
 aaa
 aaa
-tSB
+lfC
 aaa
 aaa
 aaa
 aaa
-tSB
+lfC
 aaa
 aaa
 aaa
@@ -106960,12 +106999,12 @@ aaa
 aaa
 aaa
 aaa
-qMq
+nsC
 aaa
 aaa
 aaa
 aaa
-qMq
+nsC
 aaa
 aaa
 aaa
@@ -107217,12 +107256,12 @@ aaa
 aaa
 aaa
 aaa
-xUa
-vJT
-vJT
-vJT
-vJT
-xUa
+mxe
+ydQ
+ydQ
+ydQ
+ydQ
+mxe
 aaa
 aaa
 aaa
@@ -107467,19 +107506,19 @@ aaa
 aaa
 aaa
 aaa
-aNQ
-aNQ
-aRZ
-aRZ
-aRZ
-aRZ
-aNQ
-xUa
-qRQ
-qRQ
-qRQ
-jyt
-xUa
+dbU
+dbU
+dbV
+dbV
+dbV
+dbV
+dbU
+mxe
+fOP
+fOP
+fOP
+uxy
+mxe
 aaa
 aaa
 aaa
@@ -107724,19 +107763,19 @@ aaa
 aaa
 aaa
 aaa
-aRZ
-dcq
-ddP
-dcq
-dcq
-ddP
-dcq
-xUa
-sOe
-sOe
-sOe
-sOe
-xUa
+dbV
+dcu
+ddU
+dcu
+dcu
+ddU
+dcu
+mxe
+lsO
+lsO
+lsO
+lsO
+mxe
 aaa
 aaa
 aaa
@@ -107981,19 +108020,19 @@ aaa
 aaa
 aaa
 aaa
-aRZ
-dcq
-ddP
-dcq
-dcq
-ddP
-dcq
-xUa
-sOe
-sOe
-sOe
-sOe
-xUa
+dbV
+dcu
+ddU
+dcu
+dcu
+ddU
+dcu
+mxe
+lsO
+lsO
+lsO
+lsO
+mxe
 aaa
 aaa
 aaa
@@ -108238,19 +108277,19 @@ aaa
 aaa
 aaa
 aaa
-aRZ
-dcq
-ddP
-dcq
-dcq
-ddP
-dcq
-xUa
-vff
-sOe
-sOe
-sOe
-xUa
+dbV
+dcu
+ddU
+dcu
+dcu
+ddU
+dcu
+mxe
+hwY
+lsO
+lsO
+lsO
+mxe
 aaa
 aaa
 aaa
@@ -108495,19 +108534,19 @@ aaa
 aaa
 aaa
 aaa
-aNQ
-dcs
-ddP
-dcq
-dcq
-ddP
-dcq
-xUa
-jIL
-sOe
-sOe
-sOe
-xUa
+dbU
+dcw
+ddU
+dcu
+dcu
+ddU
+rZK
+mxe
+sje
+lsO
+lsO
+icT
+mxe
 aaa
 aaa
 aaa
@@ -108752,19 +108791,19 @@ aaa
 aaa
 aaa
 aaa
-aRZ
-dct
-ddP
-deo
-pad
-pad
-vTh
-xUa
-icI
-icI
-icI
-icI
-xUa
+dbV
+dcx
+ddU
+dez
+sOJ
+sOJ
+kky
+mxe
+hOp
+hOp
+hOp
+hOp
+mxe
 aaa
 aaa
 aaa
@@ -109009,19 +109048,19 @@ aaa
 aaa
 aaa
 aaa
-aRZ
-dcu
-ddP
-des
-rpg
-ddP
-meb
-xUa
-nyt
-tha
-iHU
-jtD
-xUa
+dbV
+dcy
+ddU
+deB
+ueD
+ddU
+otw
+mxe
+vKy
+sCI
+okh
+qMS
+mxe
 aaa
 aaa
 aaa
@@ -109266,19 +109305,19 @@ aaa
 aaa
 aaa
 aaa
-aRZ
-dcw
-ddP
-det
-ddP
-ddP
-cqy
-xUa
-lDL
-snv
-hcj
-qBY
-xUa
+dbV
+dcz
+ddU
+deQ
+ddU
+ddU
+iud
+mxe
+iDq
+iXg
+guD
+xLr
+mxe
 aaa
 aaa
 aaa
@@ -109523,19 +109562,19 @@ aaa
 aaa
 aaa
 aaa
-aNQ
-dcx
-ddR
-dez
-rDg
-ddR
-lRu
-xUa
-ylD
-qPJ
-iHU
-lNS
-xUa
+dbU
+dcA
+ddW
+deT
+hRr
+ddW
+pKK
+mxe
+hQi
+jXA
+okh
+tew
+mxe
 aaa
 aaa
 aaa
@@ -109780,19 +109819,19 @@ cTX
 cTX
 cTX
 cVk
-aNQ
-aNQ
-aRZ
-deB
-sOJ
-aRZ
-aNQ
-xUa
-gLe
-dGb
-vaY
-gLe
-xUa
+dbU
+dbU
+dbV
+dfD
+uUp
+dbV
+dbU
+mxe
+pWq
+vHP
+hEl
+pWq
+mxe
 aaa
 aaa
 aaa
@@ -110024,31 +110063,31 @@ cTq
 cTO
 cVD
 cWb
-csK
+csL
 cWi
 dau
-cRR
+cSV
 cYf
 cYf
 cYB
 cYf
-cXv
+cXz
 cYf
-cYU
+cYV
 cYf
 cYf
-cXv
-dcy
-ddS
-deQ
+cXz
+dcB
+ddX
+dfH
 cWi
 cWi
-gIq
-ykm
+tVq
+oVk
 cWi
-deQ
+dfH
 cWi
-cZe
+pqV
 cTX
 aaa
 aaa
@@ -110282,28 +110321,28 @@ cVc
 cnU
 cVc
 cVc
-cLS
-cOZ
-cSV
+cNz
+cQU
+cSY
 cXb
-cUD
-cUD
-cUD
-cXz
-cXW
+cUE
+cUE
+cUE
+cXB
+cXX
 cXb
-cUD
-dbr
-cUD
-cXz
-ddU
-deT
+cUE
+dbs
+cUE
+cXB
+dej
+dfW
 cVc
-cLS
-cOZ
+cNz
+cQU
 cRt
 cVc
-tLd
+hid
 cWb
 bPk
 cTX
@@ -110543,26 +110582,26 @@ gTp
 cUu
 dbj
 cSk
-cUE
-cWg
 cUG
+cWh
+cUO
 gTp
-cXX
+cYi
 cSk
-cZK
-dbs
 cZL
+dbz
+cZU
 gTp
 cWb
-dfD
-ueD
-khp
+dgB
+iuB
+wIB
 cUu
-dfD
-tNw
-khp
+dgB
+ktZ
+wIB
 cWb
-iRE
+nOD
 cVk
 aaa
 aaa
@@ -110794,32 +110833,32 @@ cRv
 cSk
 cmG
 cSo
-cTQ
+csm
 gnZ
 gTp
 cUu
 cRq
 cSk
+cUO
+cWh
 cUG
-cWg
-cUE
 gTp
-cXX
+cYi
 cSk
+cZU
+dbz
 cZL
-dbs
-cZK
 gTp
 cWb
-dfD
-wyv
-khp
+dgB
+qxL
+wIB
 dap
-dfD
-wnG
-khp
+dgB
+hCH
+wIB
 cWb
-iRE
+nOD
 cVk
 aaa
 aaa
@@ -111053,30 +111092,30 @@ cTW
 cTW
 cTW
 cTW
-cNz
+cOZ
 cUu
 cRq
 cTs
 cTW
 cTW
 cTW
-cNz
-cXX
+cOZ
+cYi
 cTs
 cTW
 cTW
 cTW
-cNz
+cOZ
 cWb
-dfD
-wnG
-khp
+dgB
+hCH
+wIB
 cWb
-dfD
-wyv
-khp
+dgB
+qxL
+wIB
 cWb
-dcI
+nRc
 cVk
 aaa
 aaa
@@ -111314,26 +111353,26 @@ cUz
 dap
 cRq
 cXe
-cUO
-cWh
-cXg
-cXB
-cYi
+cVf
+cWo
+cXh
+cXO
+cYm
 daT
-cXB
-cWh
-dbT
+cXO
+cWo
+dbW
 cUz
 cWb
-dfH
-tNw
-khp
+dgW
+ktZ
+wIB
 cWb
-dfD
-ueD
-khp
+dgB
+iuB
+wIB
 cWb
-iRE
+nOD
 cVk
 aaa
 aaa
@@ -111565,32 +111604,32 @@ bNG
 cTt
 cUv
 cnV
-csm
-csL
+csA
+csM
 cPN
 cWb
 cRq
-cTd
-cVf
-cWo
-cWo
-cXO
-cYm
-cYV
-cZU
-cWo
-cWo
+cTh
+cVn
+cWq
+cWq
+cXQ
+cYr
+cYY
+daa
+cWq
+cWq
 cPN
 cWb
 cTs
 cTW
-cNz
+cOZ
 cWb
 cTs
 cTW
-cNz
+cOZ
 cWb
-hmv
+rIs
 cVk
 aaa
 aaa
@@ -111822,21 +111861,21 @@ cRx
 bPk
 cUv
 cnW
-csA
-csL
+csB
+csM
 cPN
 cWb
 cRq
-cTh
-cVf
-cWq
-cXh
-cXQ
-cYr
-cYY
-cXQ
-dbz
-dbU
+cTi
+cVn
+cWA
+cXi
+cXR
+cYt
+cZr
+cXR
+dbA
+dbZ
 cPN
 cWb
 cWb
@@ -111847,7 +111886,7 @@ cWb
 cWb
 cWb
 cTr
-hXQ
+vSd
 cVk
 aaa
 aaa
@@ -112084,16 +112123,16 @@ nej
 cPN
 cWb
 dbm
-cTi
-cVn
+cTR
+cVF
 cYX
 cWb
 cZp
-cYt
-cZr
-daa
-dbA
-dbV
+cYu
+cZu
+dab
+dbB
+dcf
 cPP
 dat
 daT
@@ -112103,7 +112142,7 @@ dat
 daT
 daT
 daT
-tnI
+rHU
 cVk
 cVk
 aaa
@@ -112339,27 +112378,27 @@ dGT
 dGT
 cVi
 cVC
-cQU
-cSY
-cTR
-cVF
-cWA
-cXi
-cXR
-cYu
-cZu
-dab
-dbB
-cWo
-dcz
+cRR
+cTd
+cTS
+cVI
+cWE
+cXq
+cXS
+cYK
+cZA
+daq
+dbC
+cWq
+dcC
 cTX
-dfW
+dhF
 cpe
-dfW
+dhF
 cTX
-dcz
+dcC
 cTX
-dcz
+dcC
 cVk
 cVk
 aaa
@@ -112599,24 +112638,24 @@ dac
 dat
 daT
 cXM
-cVI
-cWE
-cXq
-cXS
-cYK
-cZA
-daq
-dbC
-cWo
-dcA
+cVX
+cWF
+cXs
+cXT
+cYP
+cZD
+dar
+dbD
+cWq
+dcD
 cTX
-dgB
-qOk
-kCd
+ged
+gMc
+hhK
 cTX
-oEz
+qoA
 cTX
-kFB
+gnC
 cVk
 aaa
 aaa
@@ -112857,23 +112896,23 @@ cTX
 cTX
 cVk
 cVk
-cWF
+cXg
 cZT
-cXT
-cYP
-cZD
-dar
-dbB
-cWo
-dcz
+cXU
+cYQ
+cZG
+das
+dbC
+cWq
+dcC
 cTX
 cTX
 cTX
 cTX
 cTX
-dcz
+dcC
 cTX
-dcz
+dcC
 cVk
 aaa
 aaa
@@ -113122,7 +113161,7 @@ aaa
 aaa
 aaa
 aaa
-dcB
+dcE
 aaa
 aaa
 aaa
@@ -114136,7 +114175,7 @@ bZU
 bZU
 bZU
 qbl
-csM
+cJg
 abq
 abq
 aaa
@@ -118761,12 +118800,12 @@ bPj
 bPK
 cVq
 dhG
-csB
+csD
 cZY
-csB
-csB
-csB
-cTS
+csD
+csD
+csD
+cTT
 cZN
 aaa
 aaa
@@ -119023,7 +119062,7 @@ cZN
 cZN
 cZN
 cZN
-cTT
+cTU
 cZN
 aaa
 aaa
@@ -119280,7 +119319,7 @@ abq
 aaa
 aaa
 cZN
-cTT
+cTU
 cZN
 aaa
 aaa
@@ -119537,7 +119576,7 @@ abq
 aaa
 aaa
 cZN
-cTT
+cTU
 cZN
 aaa
 aaa
@@ -119794,7 +119833,7 @@ abq
 abq
 aaa
 cZN
-cTU
+cTY
 cZN
 aaa
 aaa
@@ -120051,7 +120090,7 @@ aaa
 aaa
 aaa
 cZN
-cTT
+cTU
 cZN
 aaa
 aaa
@@ -120308,7 +120347,7 @@ aaa
 aaa
 aaa
 cZN
-cTT
+cTU
 cZN
 abq
 aaa
@@ -120328,9 +120367,9 @@ cVG
 cVG
 cVG
 cVG
-dgW
-oiv
-oiv
+hlZ
+rDg
+rDg
 cVG
 cVG
 cVG
@@ -120565,31 +120604,31 @@ aaa
 aaa
 aaa
 cZN
-cTT
+cTU
 cZN
 abq
 abq
 abq
 abq
 cVG
-das
-dbD
-dbW
-dcC
+dav
+dbF
+dch
+dcH
 ddw
-dgW
-oiv
-pfX
+hlZ
+rDg
+dLr
 ddw
-dgW
-oiv
-pfX
+hlZ
+rDg
+dLr
 ddw
-dhF
-oiv
-oiv
+jhQ
+rDg
+rDg
 cVG
-tGW
+gao
 cVG
 cVG
 cVG
@@ -120822,38 +120861,38 @@ aaa
 abq
 abq
 cZN
-cTU
+cTY
 cZN
 aaa
 aaa
 aaa
 abq
 cVG
-dav
+daF
 cZc
-dbZ
-dcD
+dci
+dcN
 ddw
-dhF
-oiv
-oiv
+jhQ
+rDg
+rDg
 ddw
-dhF
-oiv
-oiv
+jhQ
+rDg
+rDg
 ddw
-dhF
-oiv
-oiv
+jhQ
+rDg
+rDg
 cVG
-qIH
-mcu
-mcu
-mcu
-mcu
-mcu
-mcu
-hpS
+qzy
+bXf
+bXf
+bXf
+bXf
+bXf
+bXf
+eDL
 cVG
 aaa
 aaa
@@ -121079,38 +121118,38 @@ abq
 abq
 aaa
 cZN
-cTT
+cTU
 cZN
 aaa
 aaa
 aaa
 aaa
 cVG
-daF
-dbF
-dbZ
-dcE
+daG
+dbI
+dci
+dcX
 ddw
-dhF
-oiv
-oiv
+jhQ
+rDg
+rDg
 ddw
-dhF
-oiv
-oiv
+jhQ
+rDg
+rDg
 ddw
-feJ
-fDC
-fpy
+uaG
+ssL
+jHj
 cVG
-yeg
-cVG
-cVG
+fxe
 cVG
 cVG
 cVG
 cVG
-sWP
+cVG
+cVG
+hRN
 cVG
 abq
 aaa
@@ -121336,38 +121375,38 @@ abq
 aaa
 aaa
 cZN
-cTT
+cTU
 cZN
 aaa
 aaa
 aaa
 aaa
 cVG
-daG
+daR
 cZc
-dcf
-dcH
+dcj
+ddv
 ddw
-ged
-qnz
-daz
+kNr
+uex
+dxH
 ddw
-fsy
-uuW
-xwe
+dwt
+eQv
+lmv
 ddw
-hlZ
-uBy
-sLm
-gHU
-fuR
-lYW
+mGK
+uTJ
+tdX
+ijV
+rWh
+tfb
 cVG
-oiv
-lmK
-gfV
+rDg
+nwy
+gNn
 cVG
-sWP
+hRN
 cVG
 abq
 aaa
@@ -121593,7 +121632,7 @@ abq
 abq
 abq
 cZN
-cTT
+cTU
 cZN
 aaa
 cZb
@@ -121601,30 +121640,30 @@ cVG
 cVG
 cVG
 cVG
-dbI
-dch
-dcN
+dbJ
+dck
+ddJ
 cpf
-hlZ
-mfw
-pDD
-obK
-hlZ
-qeH
-hyA
-obK
-uiw
-dbZ
-wcc
-puB
-ddl
-mLc
-wTa
-oiv
-oiv
-oiv
+mGK
+lQE
+lqk
+tlA
+mGK
+kXe
+qcD
+tlA
+olH
+dci
+srv
+sMy
+rhN
+owP
+xsx
+rDg
+rDg
+rDg
 cVG
-sWP
+hRN
 cVG
 aaa
 aaa
@@ -121850,38 +121889,38 @@ aaa
 aaa
 abq
 cZN
-cTT
+cTU
 cZN
 cZN
 cVG
 cZd
 ddk
-cZG
+cZH
 cVG
-dbJ
-dch
-dcX
-ddW
-jhQ
-dbZ
-sqr
-lrJ
-uRQ
-dbZ
-sqr
-xjU
-uRQ
-dbZ
-tYd
-rXq
-ivo
-jTO
-ucQ
-ucQ
-oKr
-oiv
+dbK
+dck
+ddK
+deo
+nxh
+dci
+qYE
+iXo
+oEJ
+dci
+qYE
+uSn
+oEJ
+dci
+omy
+lQl
+kdL
+nEE
+etm
+etm
+oDU
+rDg
 cVG
-pzm
+qme
 cZN
 aaa
 aaa
@@ -122107,41 +122146,41 @@ aaa
 aaa
 aaa
 cZN
-cTY
-cVX
-csB
-cXs
-cXU
-cYQ
-cZH
-daR
-dbK
-dci
-ddv
-ddX
-kNr
-sfF
-iyw
-mMV
-sfF
-omf
-iyw
-sfF
-sfF
-vwL
-whL
-xDN
-kgL
-sUp
+cUC
+cWg
+csD
+cXt
+cXV
+cYR
+cZJ
+dbd
+dbM
+dcl
+ddL
+des
 oiv
-oiv
-oiv
-jfH
+ybj
+oBi
+pbZ
+ybj
+fIC
+oBi
+ybj
+ybj
+nxQ
+pdt
+bzq
+lxe
+rMm
+rDg
+rDg
+rDg
+eAE
 cVG
-lhX
-dgY
-spi
-nkK
+wLy
+rQY
+owJ
+vru
 aaa
 aaa
 aaa
@@ -122368,32 +122407,32 @@ cZN
 cZN
 cZN
 cVG
-cXV
-cYR
-cZJ
+cXW
+cYU
+cZK
 cVG
-dbM
-dcj
-ddJ
-dej
-jhQ
-dbZ
-xdv
-pNt
-tFL
-dbZ
-xdv
-pdc
-tFL
-dbZ
-mkj
-eJZ
-uWg
-gwW
-fOa
-oiv
-wiN
-oiv
+dbR
+dcq
+ddM
+det
+nxh
+dci
+fkV
+iwQ
+jVN
+dci
+fkV
+dsI
+jVN
+dci
+jzb
+ddn
+iiL
+qdH
+dMC
+rDg
+had
+rDg
 cVG
 cVJ
 cZN
@@ -122624,33 +122663,33 @@ abq
 aaa
 aaa
 aaa
-cXt
+cXv
 cVG
 cVG
 cVG
 cVG
 cZj
-dcj
-ddK
+dcq
+ddN
 cpf
-mGK
-opa
-tyy
-obK
-qSN
-hFx
-tyy
-obK
-jhQ
-dbZ
-pKB
-hYs
-ouq
-uqv
-wTa
-oiv
-oiv
-eWP
+pad
+iHp
+eNg
+tlA
+fRK
+sTi
+eNg
+tlA
+nxh
+dci
+uXv
+xZj
+dCH
+mZF
+xsx
+rDg
+rDg
+qJk
 cVG
 cVJ
 cVG
@@ -122886,28 +122925,28 @@ aaa
 aaa
 cVG
 cYZ
-dbR
-dck
-ddL
+dbS
+dcs
+ddO
 ddw
-nxh
+rpg
 ddD
 cYA
 ddw
 dca
-toM
-hdX
+uWY
+hcE
 ddw
-dkg
-xmr
-tJL
-pWA
-mhZ
-lYW
+sRk
+grP
+uqF
+wGe
+icb
+tfb
 cVG
-qbG
-wDH
-oQy
+gZM
+tbZ
+uuu
 cVG
 cVJ
 cVG
@@ -123142,24 +123181,24 @@ aaa
 aaa
 aaa
 cVG
-dbd
+dbe
 cZW
-dbZ
-ddM
+dci
+ddP
 ddw
-oiv
-oiv
-dhF
+rDg
+rDg
+jhQ
 ddw
-oiv
-oiv
-dhF
+rDg
+rDg
+jhQ
 ddw
-sGG
-kzo
-fDS
+baz
+phC
+xjZ
 cVG
-epb
+qxY
 cVG
 cVG
 cVG
@@ -123399,22 +123438,22 @@ aaa
 aaa
 aaa
 cVG
-dbe
+dbo
 dcv
-dbZ
-ddN
+dci
+ddR
 ddw
-oiv
-oiv
-dhF
+rDg
+rDg
+jhQ
 ddw
-oiv
-oiv
-dhF
+rDg
+rDg
+jhQ
 ddw
-hPp
-nIy
-uDU
+ykB
+dZW
+eCC
 cVG
 cVJ
 cVJ
@@ -123656,24 +123695,24 @@ aaa
 aaa
 aaa
 cVG
-dbo
-dbS
-dcl
-ddO
+dbr
+dbT
+dct
+ddS
 ddw
-oiv
-oiv
-rNP
+rDg
+rDg
+sTg
 ddw
-pfX
-oiv
-rNP
+dLr
+rDg
+sTg
 ddw
-oiv
-oiv
-dhF
+rDg
+rDg
+jhQ
 cVG
-gYB
+nmQ
 cVG
 cVG
 cVG
@@ -123926,9 +123965,9 @@ cVG
 cVG
 cVG
 cVG
-oiv
-oiv
-rNP
+rDg
+rDg
+sTg
 cVG
 cVG
 cVG
@@ -124929,12 +124968,12 @@ bMq
 bMq
 cnv
 cqX
-csD
-cJg
-cJg
-cJg
-cJg
-cUC
+csF
+cLS
+cLS
+cLS
+cLS
+cUD
 abq
 bGU
 aaa
@@ -125957,12 +125996,12 @@ bMq
 bMq
 cnT
 cqX
-csD
-cJg
-cJg
-cJg
-cJg
-cUC
+csF
+cLS
+cLS
+cLS
+cLS
+cUD
 aaa
 abd
 aaa
@@ -126728,7 +126767,7 @@ bHo
 bHo
 abq
 cqX
-csF
+csK
 bHo
 bHo
 bHo
@@ -126985,12 +127024,12 @@ bMq
 bMq
 cnT
 csd
-csD
-cJg
-cJg
-cJg
-cJg
-cUC
+csF
+cLS
+cLS
+cLS
+cLS
+cUD
 aaa
 abd
 aaa
@@ -130612,7 +130651,7 @@ aaa
 aaa
 aaa
 aaa
-pGo
+qTu
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> This remaps MetaStation's Escape/departures with the goal of having the shuttle be at normal docking orientation compared to being sideways. As a result, it extends departures by quite a bit, so I've had to shimmy a solar array by 90 degrees, move xenobiology so that there is space between it and the shuttle dock, added a podbay to escape for mechanic/sec pod, and added a bar that is "under construction" to fill some dead space.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Having the shuttle dock in the same way as Delta and Box is nice not only for parity, but makes it much less jarring when the shuttle departs/docks at CC

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Wayyyyy too much going on here, look at Map Diff Bot for changes.

## Changelog
:cl:
tweak: Remaps MetaStation Escape
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
