### PR TITLE
CE closet has a loaded RCD

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -73736,13 +73736,6 @@
 	pixel_y = 24
 	},
 /obj/structure/table/reinforced,
-/obj/item/rcd,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
-/obj/item/rcd_ammo,
 /obj/item/stock_parts/cell/high{
 	charge = 100;
 	maxcharge = 15000

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -41,6 +41,7 @@
 	new /obj/item/organ/internal/eyes/cybernetic/meson(src)
 	new /obj/item/clothing/accessory/medal/engineering(src)
 	new /obj/item/holosign_creator/atmos(src)
+	new /obj/item/rcd/preloaded(src)
 
 
 /obj/structure/closet/secure_closet/engineering_electrical


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds a preloaded RCD to the contents of the CE's closet, and removes the mapped in one from Boxstation. Deltastation and Metastation were missing the RCD.

## Why It's Good For The Game
Makes the RCD available without having to map it in. Also, stuffing it with cartridges on roundstart is a pain.

## Images of changes
![RCD](https://user-images.githubusercontent.com/80771500/134889900-5084bf41-6444-4558-a28c-f355d0246be6.PNG)

## Changelog
:cl:
add: Added a full RCD to the CE's closet
del: Boxstation - Removed mapped in RCD and matter cartridges from the CE's office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
