### PR TITLE
Refactors Item Blood Overlays

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -658,7 +658,7 @@
 GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 /atom/proc/blood_splatter_index()
-	return "\ref[initial(icon)]-[initial(icon_state)]"
+	return "\ref[initial(icon)]-[initial(icon_state)]-[blood_color]"
 
 //returns the mob's dna info as a list, to be inserted in an object's blood_DNA list
 /mob/living/proc/get_blood_dna_list()
@@ -726,56 +726,54 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	return add_blood(blood_dna, bloodcolor)
 
 //to add blood onto something, with blood dna info to include.
-/atom/proc/add_blood(list/blood_dna, color)
+/atom/proc/add_blood(list/blood_dna, b_color)
 	return FALSE
 
-/obj/add_blood(list/blood_dna, color)
+/obj/add_blood(list/blood_dna, b_color)
 	return transfer_blood_dna(blood_dna)
 
-/obj/item/add_blood(list/blood_dna, color)
-	var/blood_count = !blood_DNA ? 0 : blood_DNA.len
+/obj/item/add_blood(list/blood_dna, b_color)
 	if(!..())
 		return FALSE
-	if(!blood_count)//apply the blood-splatter overlay if it isn't already in there
-		add_blood_overlay(color)
+	var/index = blood_splatter_index() //Remove the old overlay, if any
+	var/icon/blood_splatter_icon = GLOB.blood_splatter_icons[index]
+	if(blood_splatter_icon)
+		cut_overlay(blood_splatter_icon)
+	blood_color = b_color // update the blood color
+	add_blood_overlay() // apply the new overlay
 	return TRUE //we applied blood to the item
 
-/obj/item/clothing/gloves/add_blood(list/blood_dna, color)
+/obj/item/clothing/gloves/add_blood(list/blood_dna, b_color)
 	. = ..()
 	transfer_blood = rand(2, 4)
 
-/turf/add_blood(list/blood_dna, color)
+/turf/add_blood(list/blood_dna, b_color)
 	var/obj/effect/decal/cleanable/blood/splatter/B = locate() in src
 	if(!B)
 		B = new /obj/effect/decal/cleanable/blood/splatter(src)
 	B.transfer_blood_dna(blood_dna) //give blood info to the blood decal.
-	B.basecolor = color
+	B.basecolor = b_color
 	return TRUE //we bloodied the floor
 
-/mob/living/carbon/human/add_blood(list/blood_dna, color)
+/mob/living/carbon/human/add_blood(list/blood_dna, b_color)
 	if(wear_suit)
-		wear_suit.add_blood(blood_dna, color)
-		wear_suit.blood_color = color
+		wear_suit.add_blood(blood_dna, b_color)
 		update_inv_wear_suit()
 	else if(w_uniform)
-		w_uniform.add_blood(blood_dna, color)
-		w_uniform.blood_color = color
+		w_uniform.add_blood(blood_dna, b_color)
 		update_inv_w_uniform()
 	if(head)
-		head.add_blood(blood_dna, color)
-		head.blood_color = color
+		head.add_blood(blood_dna, b_color)
 		update_inv_head()
 	if(glasses)
-		glasses.add_blood(blood_dna, color)
-		glasses.blood_color = color
+		glasses.add_blood(blood_dna, b_color)
 		update_inv_glasses()
 	if(gloves)
 		var/obj/item/clothing/gloves/G = gloves
-		G.add_blood(blood_dna, color)
-		G.blood_color = color
+		G.add_blood(blood_dna, b_color)
 		verbs += /mob/living/carbon/human/proc/bloody_doodle
 	else
-		hand_blood_color = color
+		hand_blood_color = b_color
 		bloody_hands = rand(2, 4)
 		transfer_blood_dna(blood_dna)
 		verbs += /mob/living/carbon/human/proc/bloody_doodle
@@ -783,7 +781,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	update_inv_gloves()	//handles bloody hands overlays and updating
 	return TRUE
 
-/obj/item/proc/add_blood_overlay(color)
+/obj/item/proc/add_blood_overlay()
 	if(initial(icon) && initial(icon_state))
 		//try to find a pre-processed blood-splatter. otherwise, make a new one
 		var/index = blood_splatter_index()
@@ -792,12 +790,10 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 			blood_splatter_icon = icon(initial(icon), initial(icon_state), frame = 1)		//we only want to apply blood-splatters to the initial icon_state for each object
 			blood_splatter_icon.Blend("#ffffff", ICON_ADD) 			//fills the icon_state with white (except where it's transparent)
 			blood_splatter_icon.Blend(icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
+			blood_splatter_icon.Blend(blood_color, ICON_MULTIPLY) // Color the blood
 			blood_splatter_icon = fcopy_rsc(blood_splatter_icon)
 			GLOB.blood_splatter_icons[index] = blood_splatter_icon
-
-		blood_overlay = image(blood_splatter_icon)
-		blood_overlay.color = color
-		add_overlay(blood_overlay)
+		add_overlay(blood_splatter_icon)
 
 /atom/proc/clean_blood(radiation_clean = FALSE)
 	germ_level = 0
@@ -827,9 +823,12 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 /obj/item/clean_blood(radiation_clean = FALSE)
 	. = ..()
-	if(. && blood_overlay)
-		cut_overlay(blood_overlay)
-		QDEL_NULL(blood_overlay)
+	if(.)
+		if(initial(icon) && initial(icon_state))
+			var/index = blood_splatter_index()
+			var/icon/blood_splatter_icon = GLOB.blood_splatter_icons[index]
+			if(blood_splatter_icon)
+				cut_overlay(blood_splatter_icon)
 
 /obj/item/clothing/gloves/clean_blood(radiation_clean = FALSE)
 	. = ..()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -730,11 +730,12 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	return transfer_blood_dna(blood_dna)
 
 /obj/item/add_blood(list/blood_dna, b_color)
+	var/blood_count = !blood_DNA ? 0 : length(blood_DNA)
 	if(!..())
 		return FALSE
-	remove_filter("blood_splatter")
 	blood_color = b_color // update the blood color
-	add_blood_overlay() // apply the new overlay
+	if(!blood_count) //apply the blood-splatter overlay if it isn't already in there
+		add_blood_overlay()
 	return TRUE //we applied blood to the item
 
 /obj/item/clothing/gloves/add_blood(list/blood_dna, b_color)

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -109,9 +109,7 @@
 			H.apply_damage(10, BRUTE, "chest", H.run_armor_check(target_part, MELEE))
 
 			//blood splatters
-			blood_color = H.dna.species.blood_color
-
-			new /obj/effect/temp_visual/dir_setting/bloodsplatter(H.drop_location(), splatter_dir, blood_color)
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter(H.drop_location(), splatter_dir, H.dna.species.blood_color)
 
 					//organs go everywhere
 			if(target_part && prob(10 * drill_level))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -5,7 +5,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 
 	move_resist = null // Set in the Initialise depending on the item size. Unless it's overriden by a specific item
 	var/discrete = 0 // used in item_attack.dm to make an item not show an attack message to viewers
-	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/item_state = null
 	var/lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -187,28 +187,5 @@
 		var/mob/living/carbon/human/H = user
 		H.update_inv_l_hand()
 		H.update_inv_r_hand()
-	// Update blood splatter
-	if(blood_overlay)
-		var/blood_color = blood_overlay.color
-		cut_overlay(blood_overlay)
-		qdel(blood_overlay)
-		add_blood_overlay(blood_color)
 	playsound(loc, extend_sound, 50, TRUE)
 	add_fingerprint(user)
-
-/obj/item/melee/classic_baton/telescopic/blood_splatter_index()
-	return "\ref[icon]-[icon_state]"
-
-/obj/item/melee/classic_baton/telescopic/add_blood_overlay(color)
-	var/index = blood_splatter_index()
-	var/icon/blood_splatter_icon = GLOB.blood_splatter_icons[index]
-	if(!blood_splatter_icon)
-		blood_splatter_icon = icon(icon, icon_state)
-		blood_splatter_icon.Blend("#ffffff", ICON_ADD)
-		blood_splatter_icon.Blend(icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY)
-		blood_splatter_icon = fcopy_rsc(blood_splatter_icon)
-		GLOB.blood_splatter_icons[index] = blood_splatter_icon
-
-	blood_overlay = image(blood_splatter_icon)
-	blood_overlay.color = color
-	add_overlay(blood_overlay)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -206,29 +206,6 @@
 		H.update_inv_l_hand()
 		H.update_inv_r_hand()
 	add_fingerprint(user)
-	if(blood_overlay)	//updated blood overlay, if any
-		var/blood_color = blood_overlay.color
-		cut_overlay(blood_overlay)
-		qdel(blood_overlay)
-		add_blood_overlay(blood_color)
-
-/obj/item/scythe/tele/blood_splatter_index()
-	return "\ref[icon]-[icon_state]"
-
-/obj/item/scythe/tele/add_blood_overlay(color)
-	var/index = blood_splatter_index()
-	var/icon/blood_splatter_icon = GLOB.blood_splatter_icons[index]
-	if(!blood_splatter_icon)
-		blood_splatter_icon = icon(icon, icon_state)
-		blood_splatter_icon.Blend("#ffffff", ICON_ADD)
-		blood_splatter_icon.Blend(icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY)
-		blood_splatter_icon = fcopy_rsc(blood_splatter_icon)
-		GLOB.blood_splatter_icons[index] = blood_splatter_icon
-
-	blood_overlay = image(blood_splatter_icon)
-	blood_overlay.color = color
-	add_overlay(blood_overlay)
-
 
 // *************************************
 // Nutrient defines for hydroponics

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -88,9 +88,8 @@
 
 /datum/species/slime/proc/blend(mob/living/carbon/human/H)
 	var/new_color = BlendRGB(H.skin_colour, "#acacac", 0.5) // Blends this to make it work better
-	if(H.blood_color != new_color) // Put here, so if it's a roundstart, dyed, or CMA'd slime, their blood changes to match skin
-		H.blood_color = new_color
-		H.dna.species.blood_color = H.blood_color
+	if(H.dna.species.blood_color != new_color) // Put here, so if it's a roundstart, dyed, or CMA'd slime, their blood changes to match skin
+		H.dna.species.blood_color = new_color
 
 /datum/species/slime/handle_life(mob/living/carbon/human/H)
 	// Slowly shifting to the color of the reagents


### PR DESCRIPTION
Refactors how item blood overlays are handled.

Previously, this was kinda awful. We had an icon cache for every blood overlay for every item, but we also had another image on every single item that needed a blood overlay stored, locally on it, as an image---why? Just for color.

This isn't really necessary and can be handled better---and we can do so for less CPU.

What this does:
- Makes blood overlays be based on filters, rather than rendered for each item, cached, and re-used and also held as an image on the item itself.
- Renames instances of blooed-related arg names of `color` to `b_color`.
  - Having `color` as an arg isn't great because it's a pre-existing var on all atoms.
- Cleans up some improper usage of `blood_color` and refactors how it's used--it's now incorporated into the `/obj/item` level of `add_blood` 
- Greatly simplifies blood overlay adding/removing code.

The fact this is filter based now means that it's a lot easier to add/remove things and it pushes the processing (hypothetically) to be client side as opposed to server side. This does save CPU compared to the original method, but not much. The only downside is that due to how filters are utilized (priority lists), this uses up a little less than twice the memory of the original method and about twice the iterim method I originally went with in my original commit here. That said, you're talking 5 MB total to add a blood overlay to every single item in the world vs 2.4 MB (iterim method in first commit) or 2.8 MB (the version prior to this PR).

System works fine:

![img](https://i.gyazo.com/e94e5ec3d65ebcd5fc8241877fcbe7e7.png)

Not CL as this doesn't really impact the player experience.