### PR TITLE
Factory protected disk, Separated Chemicals in code(not it normal game)

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -484,6 +484,9 @@
 		name = "plant data disk"
 
 /obj/item/disk/plantgene/attack_self(mob/user)
+	if(read_only == 2)
+		to_chat(user, "<span class='notice'>Disk is factory protected.</span>")
+		return
 	read_only = !read_only
 	to_chat(user, "<span class='notice'>You flip the write-protect tab to [read_only ? "protected" : "unprotected"].</span>")
 
@@ -491,6 +494,18 @@
 	. = ..()
 	. += "The write-protect tab is set to [read_only ? "protected" : "unprotected"]."
 
+/*
+ *  Disks with genes
+ */
+/obj/item/disk/plantgene/full
+	read_only = 2 //You can't rewrite it
+
+/obj/item/disk/plantgene/full/New()
+	..()
+	update_name() //Update names only for filled disks
+
+/obj/item/disk/plantgene/full/noreact
+	gene = new /datum/plant_gene/trait/noreact
 
 /*
  *  Plant DNA Disks Box

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -142,6 +142,7 @@
 	var/examine_line = ""
 	var/list/origin_tech = null
 	var/trait_id // must be set and equal for any two traits of the same type
+	var/strange_seed = TRUE	//IF strange seed can get it
 
 /datum/plant_gene/trait/Copy()
 	var/datum/plant_gene/trait/G = ..()
@@ -257,8 +258,6 @@
 		if(batteries_recharged)
 			to_chat(target, "<span class='notice'>Your batteries are recharged!</span>")
 
-
-
 /datum/plant_gene/trait/glow
 	// Makes plant glow. Makes plant in tray glow too.
 	// Adds 1 + potency*rate light range and potency*(rate + 0.01) light_power to products.
@@ -326,6 +325,20 @@
 		to_chat(C, "<span class='warning'>[src] sparks, and burns up!</span>")
 		new /obj/effect/decal/cleanable/molten_object(T)
 		qdel(G)
+
+/datum/plant_gene/trait/noreact
+	// Makes plant reagents not react until squashed.
+	name = "Separated Chemicals"
+	strange_seed = FALSE
+
+/datum/plant_gene/trait/noreact/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	G.reagents.set_reacting(FALSE)
+
+/datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	if(G && G.reagents)
+		G.reagents.set_reacting(TRUE)
+		G.reagents.handle_reactions()
 
 /datum/plant_gene/trait/maxchem
 	// 2x to max reagents volume.

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -413,7 +413,7 @@
 	for(var/i in 1 to amount_random_traits)
 		var/random_trait = pick((subtypesof(/datum/plant_gene/trait)-typesof(/datum/plant_gene/trait/plant_type)))
 		var/datum/plant_gene/trait/T = new random_trait
-		if(T.can_add(src))
+		if(T.can_add(src) && T.strange_seed) //Add only allowed traits
 			genes += T
 		else
 			qdel(T)


### PR DESCRIPTION
## What Does This PR Do
- Return Separated Chemicals - https://github.com/ParadiseSS13/Paradise/pull/16716
- Strange seeds can't get Separated Chemicals trait - new var and check
- Disks with recorded genes. Factory protected(you can't overwrite it)

## Why It's Good For The Game
- Separated Chemicals trait is still in code and game but players can't get them normaly(read "every round")
- Admins can spawn disk with this trait and add to traders stock. (Or even add low spawn chance for trader stock by default)
- Factory disk - full rewrite protect. But it can still be stolen(traitor target if disk exists?)

## Images of changes
![image](https://user-images.githubusercontent.com/11385249/135285697-71e30ae8-494a-4354-bfdb-c866cce5c29e.png)

## Changelog
:cl:
add: Factory plant disk - full rewrite protect
tweak: Strange plants can`t get prohibited traits
tweak: Separated Chemicals trait can only be obtained through admin panel
/:cl:
