### PR TITLE
Makes disabled martial arts not block north-star. Such as chef CQC outside of the kitchen

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -165,12 +165,10 @@
 /obj/item/clothing/gloves/fingerless/rapid/Touch(mob/living/target, proximity = TRUE)
 	var/mob/living/M = loc
 
-	if(M.a_intent in accepted_intents)
-		if(M.mind.martial_art || HAS_TRAIT(M, TRAIT_HULK))
-			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
-		else
-			M.changeNext_move(click_speed_modifier)
-	.= FALSE
+	if((M.a_intent in accepted_intents) && !M.mind.martial_art?.can_use(M) && !HAS_TRAIT(M, TRAIT_HULK))
+		M.changeNext_move(click_speed_modifier)
+
+	return FALSE
 
 /obj/item/clothing/gloves/fingerless/rapid/admin
 	name = "advanced interactive gloves"


### PR DESCRIPTION
## What Does This PR Do
Fixes #16816
Fixes: #16468
Makes martial arts not block the north star gloves when the user can't use the martial arts.
Tested and the damage boost is not applied when the user can't use the martial arts. So it is just like a normal punch

## Why It's Good For The Game
Bug/weirdness fix. Not sure if it is considered a bug but it is weird at least.

## Changelog
:cl:
tweak: Chefs can use the north star gloves when outside of the kitchen as any normal crew can. Disabled martial arts don't affect the north star gloves anymore
/:cl: