### PR TITLE
Embedded objects stay embedded on dismembered limbs. Can be removed by sharp objects

### DIFF
--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -79,7 +79,7 @@
 						for(var/X in C.bodyparts)
 							var/obj/item/organ/external/part = X
 							if(item_to_retrieve in part.embedded_objects)
-								part.embedded_objects -= item_to_retrieve
+								part.remove_embedded_object(item_to_retrieve)
 								to_chat(C, "<span class='warning'>\The [item_to_retrieve] that was embedded in your [part] has mysteriously vanished. How fortunate!</span>")
 								if(!C.has_embedded_objects())
 									C.clear_alert("embeddedobject")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -618,7 +618,7 @@
 			if(do_after(usr, time_taken, needhand = 1, target = src))
 				if(!I || !L || I.loc != src || !(I in L.embedded_objects))
 					return
-				L.embedded_objects -= I
+				L.remove_embedded_object(I)
 				L.receive_damage(I.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
 				I.forceMove(get_turf(src))
 				usr.put_in_hands(I)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -535,9 +535,8 @@ emp_act
 				if(prob(I.embed_chance) && !HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
 					throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
 					var/obj/item/organ/external/L = pick(bodyparts)
-					L.embedded_objects |= I
+					L.add_embedded_object(I)
 					I.add_mob_blood(src)//it embedded itself in you, of course it's bloody!
-					I.forceMove(src)
 					L.receive_damage(I.w_class*I.embedded_impact_pain_multiplier)
 					visible_message("<span class='danger'>[I] embeds itself in [src]'s [L.name]!</span>","<span class='userdanger'>[I] embeds itself in your [L.name]!</span>")
 					hitpush = FALSE

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -836,7 +836,7 @@
 
 			if(prob(I.embedded_fall_chance))
 				BP.receive_damage(I.w_class*I.embedded_fall_pain_multiplier)
-				BP.embedded_objects -= I
+				BP.remove_embedded_object(I)
 				I.forceMove(get_turf(src))
 				visible_message("<span class='danger'>[I] falls out of [name]'s [BP.name]!</span>","<span class='userdanger'>[I] falls out of your [BP.name]!</span>")
 				if(!has_embedded_objects())

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -97,6 +97,14 @@
 
 	return ..()
 
+/obj/item/organ/external/examine(mob/user)
+	. = ..()
+
+	var/list/embedded_names = list()
+	for(var/obj/item/I in embedded_objects)
+		embedded_names += "[I]"
+	if(length(embedded_names))
+		. += "<span class='warning'>You can see [english_list(embedded_names)] embedded.</span>"
 
 /obj/item/organ/external/update_health()
 	damage = min(max_damage, (brute_dam + burn_dam))
@@ -571,6 +579,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			"<span class='notice'>You begin to cut open [src]...</span>")
 		if(do_after(user, 54, target = src))
 			drop_organs(user)
+			drop_embedded_objects()
 	else
 		return ..()
 
@@ -702,8 +711,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 		victim.splinted_limbs -= src
 
 	for(var/obj/item/I in embedded_objects)
-		embedded_objects -= I
+		UnregisterSignal(I, COMSIG_MOVABLE_MOVED) // Else it gets removed from the embedded list
 		I.forceMove(src)
+		RegisterSignal(I, COMSIG_MOVABLE_MOVED, .proc/remove_embedded_object)
+
 	if(!owner.has_embedded_objects())
 		owner.clear_alert("embeddedobject")
 
@@ -781,6 +792,21 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(data["dna"])
 		sync_colour_to_dna()
 
+/obj/item/organ/external/proc/remove_embedded_object(obj/item/I)
+	embedded_objects -= I
+	UnregisterSignal(I, COMSIG_MOVABLE_MOVED)
+
+/obj/item/organ/external/proc/drop_embedded_objects()
+	var/turf/T = get_turf(src)
+	for(var/obj/item/I in embedded_objects)
+		remove_embedded_object(I)
+		forceMove(T)
+
+/obj/item/organ/external/proc/add_embedded_object(obj/item/I)
+	embedded_objects += I
+	I.forceMove(owner)
+	RegisterSignal(I, COMSIG_MOVABLE_MOVED, .proc/remove_embedded_object)
+
 //Remove all embedded objects from all limbs on the carbon mob
 /mob/living/carbon/human/proc/remove_all_embedded_objects()
 	var/turf/T = get_turf(src)
@@ -788,7 +814,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	for(var/X in bodyparts)
 		var/obj/item/organ/external/L = X
 		for(var/obj/item/I in L.embedded_objects)
-			L.embedded_objects -= I
+			L.remove_embedded_object(I)
 			I.forceMove(T)
 
 	clear_alert("embeddedobject")

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -50,8 +50,8 @@
 			var/objects = 0
 			for(var/obj/item/I in L.embedded_objects)
 				objects++
+				L.remove_embedded_object(I)
 				I.forceMove(get_turf(H))
-				L.embedded_objects -= I
 			if(!H.has_embedded_objects())
 				H.clear_alert("embeddedobject")
 


### PR DESCRIPTION
## What Does This PR Do
Makes embedded objects stay embedded in dismembered limbs. Instead of them seemingly disappearing. (in practice they were just made part of the limb forever without a method of getting it out).
An examine text is added to dismembered limbs that have embedded objects in them.
You can remove them using a sharp object. Like how you remove organs from a head.

I've decided to make them stay embedded to avoid surgery shortcuts where you just amputate the limb and reattach it to remove embedded objects. It could be changed to just drop on the floor if that is desired

Fixes #16817
Also fixes a very rare edge case where embedding an organ into a limb would make it insert itself into said limb when it got reattached. Doubt this ever occurred but it was funny to find.

Also improves the safety of the embedded list.

## Why It's Good For The Game
Having items be removed from the game is a bad thing in general.

## Changelog
:cl:
tweak: Embedded items in limbs now will show this on the organ when examined
tweak: Embedded items in limbs are now removable from dismembered limbs using a sharp object
fix: Embedded items won't disappear when the limb they are in gets dismembered
/:cl: