### PR TITLE
Polishes up and fixes bugs with the syndicate teleporter

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -170,7 +170,7 @@ effective or pretty fucking useless.
 		GLOB.active_jammers -= src
 
 /obj/item/teleporter
-	name = "\improper Syndicate teleporter"
+	name = "syndicate teleporter"
 	desc = "A strange syndicate version of a cult veil shifter. Warrenty voided if exposed to EMP."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "syndi-tele"
@@ -208,24 +208,32 @@ effective or pretty fucking useless.
 		charges++
 
 /obj/item/teleporter/emp_act(severity)
+	var/teleported_something = FALSE
 	if(prob(50 / severity))
 		if(istype(loc, /mob/living/carbon/human))
 			var/mob/living/carbon/human/user = loc
 			to_chat(user, "<span class='userdanger'>[src] buzzes and activates!</span>")
 			attempt_teleport(user, TRUE)
-		else
-			visible_message("<span class='danger'>[src] activates and blinks out of existence!</span>")
-			do_sparks(2, 1, src)
-			qdel(src)
+		else //Well, it either is on a floor / locker, and won't teleport someone, OR it's in someones bag. As such, we need to check the turf to see if people are there.
+			var/turf/teleportturf = get_turf(src)
+			for(var/mob/living/user in teleportturf)
+				if(!teleported_something)
+					teleportturf.visible_message("<span class='danger'>[src] activates spoderaticaly, teleporting everyone around it!</span>")
+					teleported_something = TRUE
+				attempt_teleport(user, TRUE)
+			if(!teleported_something)
+				visible_message("<span class='danger'>[src] activates and blinks out of existence!</span>")
+				do_sparks(2, 1, src)
+				qdel(src)
 
 /obj/item/teleporter/proc/attempt_teleport(mob/user, EMP_D = FALSE)
 	dir_correction(user)
-	if(!charges)
+	if(!charges && !EMP_D) //If it's empd, you are moving no matter what.
 		to_chat(user, "<span class='warning'>[src] is still recharging.</span>")
 		return
 
-	var/mob/living/carbon/C = user
-	var/turf/mobloc = get_turf(C)
+	var/mob/living/M = user
+	var/turf/mobloc = get_turf(M)
 	var/list/turfs = new/list()
 	var/found_turf = FALSE
 	var/list/bagholding = user.search_contents_for(/obj/item/storage/backpack/holding)
@@ -233,7 +241,7 @@ effective or pretty fucking useless.
 		if(!is_teleport_allowed(T.z))
 			break
 		if(!(length(bagholding) && !flawless)) //Chaos if you have a bag of holding
-			if(get_dir(C, T) != C.dir)
+			if(get_dir(M, T) != M.dir)
 				continue
 		if(T in range(user, inner_tp_range))
 			continue
@@ -247,13 +255,14 @@ effective or pretty fucking useless.
 
 	if(found_turf)
 		if(user.loc != mobloc) // No locker / mech / sleeper teleporting, that breaks stuff
-			to_chat(C, "<span class='danger'>[src] will not work here!</span>")
-		charges--
+			to_chat(M, "<span class='danger'>[src] will not work here!</span>")
+		if(charges > 0) //While we want EMP triggered teleports to drain charge, we also do not want it to go negative charge, as such we need this check here
+			charges--
 		var/turf/destination = pick(turfs)
 		if(tile_check(destination) || flawless) // Why is there so many bloody floor types
 			var/turf/fragging_location = destination
 			telefrag(fragging_location, user)
-			C.forceMove(destination)
+			M.forceMove(destination)
 			playsound(mobloc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 			new/obj/effect/temp_visual/teleport_abductor/syndi_teleporter(mobloc)
 			playsound(destination, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
@@ -264,7 +273,7 @@ effective or pretty fucking useless.
 		else // Emp activated? Bag of holding? No saving throw for you
 			get_fragged(user, destination)
 	else
-		to_chat(C, "<span class='danger'>[src] will not work here!</span>")
+		to_chat(M, "<span class='danger'>[src] will not work here!</span>")
 
 /obj/item/teleporter/proc/tile_check(turf/T)
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/space))
@@ -294,8 +303,8 @@ effective or pretty fucking useless.
 		else
 			saving_throw = NORTH // just in case
 
-	var/mob/living/carbon/C = user
-	var/turf/mobloc = get_turf(C)
+	var/mob/living/M = user
+	var/turf/mobloc = get_turf(M)
 	var/list/turfs = list()
 	var/found_turf = FALSE
 	for(var/turf/T in range(destination, saving_throw_distance))
@@ -314,7 +323,7 @@ effective or pretty fucking useless.
 		var/turf/new_destination = pick(turfs)
 		var/turf/fragging_location = new_destination
 		telefrag(fragging_location, user)
-		C.forceMove(new_destination)
+		M.forceMove(new_destination)
 		playsound(mobloc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(mobloc)
 		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(new_destination)
@@ -332,11 +341,12 @@ effective or pretty fucking useless.
 	playsound(destination, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	playsound(destination, "sound/magic/disintegrate.ogg", 50, TRUE)
 	destination.ex_act(rand(1,2))
-	for(var/obj/item/W in user)
-		if(istype(W, /obj/item/implant))
-			continue
-		if(!user.unEquip(W))
-			qdel(W)
+	if(iscarbon(user)) //don't want cyborgs dropping their stuff
+		for(var/obj/item/W in user)
+			if(istype(W, /obj/item/implant))
+				continue
+			if(!user.unEquip(W))
+				qdel(W)
 	to_chat(user, "<span class='biggerdanger'>You teleport into the wall, the teleporter tries to save you, but--</span>")
 	user.gib()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Removes the capitalization of the syndicate teleporter, did not look good, most items are not capitalized like that.

Fixes syndicate teleporters from vanishing from existence when empd in someones bag, instead of teleporting the user. Now, if the teleporter is not in a person directly (hands, pockets) it will teleport all living mobs on the turf, following the empd teleporter rules. If no mobs are found, as before the teleporter will teleport out of existence.

Makes it so teleporters can be forced teleported even if it has no charge via EMP, making ion rifles even more dangerous to teleporter users, as they can always be forced to move.

As part of the above teleport all living mobs, the teleporter is no longer restricted to carbon mobs, and could now be used by cyborgs, if it was put in their module list.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Strange looking item names are bad.
Teleporters vanishing from bags when empd instead of teleporting the user is bad, as such now if the teleporter is in someones bag when empd, it will teleport the user (and anyone else on the turf) rather than vanishing. EMP always working on the teleporter is good, it reinforces the downside, rather than it only working if the teleporter has charge.

## Changelog
:cl:
tweak: Tweaked the name from "Syndicate teleporter" to "syndicate teleporter"
fix: Fixed the syndicate teleported teleporting out of existence when in someones bag and empd
tweak: Syndicate teleporters will teleport everyone on the turf when empd and not in someones hands / pockets, rather then teleporting out of existence due to a bug. If no one is on the turf, then it teleports out of existence.
tweak: Syndicate teleporters will now always dangerously teleport the user when empd, even if the teleporter has no charge left.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
