### PR TITLE
Fixes Golems not being properly augmented

### DIFF
--- a/code/modules/surgery/organs/subtypes/unbreakable.dm
+++ b/code/modules/surgery/organs/subtypes/unbreakable.dm
@@ -16,7 +16,7 @@
 
 /obj/item/organ/external/leg/unbreakable
 	cannot_break = TRUE
-	convertable_children = list(/obj/item/organ/external/foot/right/unbreakable)
+	convertable_children = list(/obj/item/organ/external/foot/unbreakable)
 
 /obj/item/organ/external/leg/right/unbreakable
 	cannot_break = TRUE
@@ -41,21 +41,26 @@
 // Cannot dismember or break
 /obj/item/organ/external/chest/unbreakable/sturdy
 	cannot_amputate = TRUE
+	convertable_children = list(/obj/item/organ/external/groin/unbreakable/sturdy)
 
 /obj/item/organ/external/groin/unbreakable/sturdy
 	cannot_amputate = TRUE
 
 /obj/item/organ/external/arm/unbreakable/sturdy
 	cannot_amputate = TRUE
+	convertable_children = list(/obj/item/organ/external/hand/unbreakable/sturdy)
 
 /obj/item/organ/external/arm/right/unbreakable/sturdy
 	cannot_amputate = TRUE
+	convertable_children = list(/obj/item/organ/external/hand/right/unbreakable/sturdy)
 
 /obj/item/organ/external/leg/unbreakable/sturdy
 	cannot_amputate = TRUE
+	convertable_children = list(/obj/item/organ/external/foot/unbreakable/sturdy)
 
 /obj/item/organ/external/leg/right/unbreakable/sturdy
 	cannot_amputate = TRUE
+	convertable_children = list(/obj/item/organ/external/foot/right/unbreakable/sturdy)
 
 /obj/item/organ/external/foot/unbreakable/sturdy
 	cannot_amputate = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds the Sturdy hands and feet to the convertable_children limbs. 
Fixes the left leg augmenting the right foot on unbreakable limbs.  

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad, being able to properly augment stuff is good.  Fixes #16830 

## Changelog
:cl: Exavere
fix: Fixed golems not being able to be properly augmented, as well as the wrong limb being augmented.  
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
