### PR TITLE
Updates Goonchat Loading Error Message

### DIFF
--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -31,7 +31,9 @@
 		<div>
 			Loading...<br><br>
 			If this takes longer than 10 seconds, it will automatically reload, multiple times if necessary.<br>
-			If it <b>still</b> doesn't work, please adminhelp (F1) and tell us your operating system and Internet Explorer version.
+			If it <b>still</b> doesn't work, do not adminhelp (F1), you will not see our responses.<br>
+			Please see <a href="https://paradisestation.org/wiki/index.php/Goonchat_Troubleshooting">This Guide</a> and seek help on our discord #helpchat
+
 		</div>
 	</div>
 	<div id="messages">


### PR DESCRIPTION
## What Does This PR Do
Tells people not to make an ahelp when GoonChat doesn't load and instead directs them to use the goonchat troubleshooting guide on the wiki and ask questions on the discord #helpchat

## Why It's Good For The Game
This will help automate the troubleshooting process


## Changelog
tweak: Tweaks the Goonchat Loading Error Message
/:cl: