### PR TITLE
Fix - Fake sandstone walls use right sprites, and fake wall animations don't skip anymore

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -94,9 +94,9 @@
 	if(density)
 		smooth = SMOOTH_FALSE
 		clear_smooth_overlays()
-		icon_state = "fwall_opening"
+		flick("fwall_opening", src)
 	else
-		icon_state = "fwall_closing"
+		flick("fwall_closing", src)
 
 /obj/structure/falsewall/update_icon()
 	if(density)
@@ -297,6 +297,7 @@
 /obj/structure/falsewall/sandstone
 	name = "sandstone wall"
 	desc = "A wall with sandstone plating."
+	icon = 'icons/turf/walls/sandstone_wall.dmi'
 	icon_state = "sandstone"
 	mineral = /obj/item/stack/sheet/mineral/sandstone
 	walltype = /turf/simulated/wall/mineral/sandstone


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Assigns the right sprite file for fake sandstone walls. At the same time, tweaks the animation for fake walls to use `flick` instead of changing the `icon_state`, the latter which would result in the animation skipping sometimes.

## Why It's Good For The Game
Fixes #16851, also stops the animation from occasionally skipping.

## Images of changes
https://user-images.githubusercontent.com/80771500/135734626-efaaf9d3-f7a7-49cf-914d-01ebb2b03562.mp4

## Changelog
:cl:
fix: Fixed fake sandstone walls not using the right sprites
fix: Fixed fake walls animations skipping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
