### PR TITLE
Deltastation: fixes few things my PR broke

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -8711,8 +8711,16 @@
 	},
 /area/janitor)
 "aAx" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/janitorialcart,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door/window/westleft{
+	name = "Janitoral Delivery";
+	req_access_txt = "26"
+	},
 /turf/simulated/floor/plating,
 /area/janitor)
 "aAy" = (
@@ -9239,6 +9247,8 @@
 /obj/machinery/light_switch{
 	pixel_y = -26
 	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/janitorialcart,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen"
 	},

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -7787,6 +7787,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "ayp" = (
@@ -8150,10 +8153,11 @@
 /area/janitor)
 "azm" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 32
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "azn" = (
@@ -8709,10 +8713,6 @@
 "aAx" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/janitorialcart,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
 /turf/simulated/floor/plating,
 /area/janitor)
 "aAy" = (
@@ -95631,7 +95631,7 @@
 	dir = 8;
 	location = "Janitor"
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/janitor)
 "gpX" = (
 /obj/effect/landmark{
@@ -96300,7 +96300,7 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/toxins/misc_lab)
 "iiM" = (
 /obj/structure/window/reinforced{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
My PR for unknown reason was completely changed from what was intended and all the flaps had walls under them, on top of janitorial office items being missplaced.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mulebots will work in two additional locations + there won't be a floating fire alarm.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
https://user-images.githubusercontent.com/62257265/134769661-0a4f165a-8987-4406-bf1f-fe3e741475b8.png
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Removes misplaced walls and floating fire alarm in custodial closet and science break room.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
