### PR TITLE
Readds Midori Tabako to cig vendors

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1118,10 +1118,26 @@
 	ads_list = list("Probably not bad for you!","Don't believe the scientists!","It's good for you!","Don't quit, buy more!","Smoke!","Nicotine heaven.","Best cigarettes since 2150.","Award-winning cigs.")
 	vend_delay = 34
 	icon_state = "cigs"
-	products = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 12, /obj/item/storage/fancy/cigarettes/cigpack_uplift = 6, /obj/item/storage/fancy/cigarettes/cigpack_random = 6, /obj/item/reagent_containers/food/pill/patch/nicotine = 10, /obj/item/storage/box/matches = 10,/obj/item/lighter/random = 4,/obj/item/storage/fancy/rollingpapers = 5)
+	products = list(
+		/obj/item/storage/fancy/cigarettes/cigpack_robust = 12,
+		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
+		/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
+		/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
+		/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
+		/obj/item/storage/box/matches = 10,
+		/obj/item/lighter/random = 4,
+		/obj/item/storage/fancy/rollingpapers = 5)
 	contraband = list(/obj/item/lighter/zippo = 4)
-	premium = list(/obj/item/clothing/mask/cigarette/cigar/havana = 2, /obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1)
-	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 60, /obj/item/storage/fancy/cigarettes/cigpack_uplift = 80, /obj/item/storage/fancy/cigarettes/cigpack_random = 120, /obj/item/reagent_containers/food/pill/patch/nicotine = 70, /obj/item/storage/box/matches = 10,/obj/item/lighter/random = 60, /obj/item/storage/fancy/rollingpapers = 20)
+	premium = list(/obj/item/clothing/mask/cigarette/cigar/havana = 2,
+		/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1)
+	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 60,
+		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 80,
+		/obj/item/storage/fancy/cigarettes/cigpack_midori = 100,
+		/obj/item/storage/fancy/cigarettes/cigpack_random = 120,
+		/obj/item/reagent_containers/food/pill/patch/nicotine = 70,
+		/obj/item/storage/box/matches = 10,
+		/obj/item/lighter/random = 60,
+		/obj/item/storage/fancy/rollingpapers = 20)
 	refill_canister = /obj/item/vending_refill/cigarette
 
 /obj/machinery/vending/cigarette/free

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -262,6 +262,9 @@ LIGHTERS ARE IN LIGHTERS.DM
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 
+/obj/item/clothing/mask/cigarette/rollie/nicotine
+	list_reagents = list("nicotine" = 40)
+
 
 /obj/item/cigbutt/roach
 	name = "roach"

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -293,6 +293,7 @@
 	desc = "You can't understand the runes, but the packet smells funny."
 	icon_state = "midoripacket"
 	item_state = "midoripacket"
+	cigarette_type = /obj/item/clothing/mask/cigarette/rollie/nicotine
 
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims
 	name ="\improper Shady Jim's Super Slims"


### PR DESCRIPTION
Smooth, hand-rolled tradition bursts from every packet of Midori brand cigarettes. 
The original recipe, created by Master Midori himself during the late Shōwa era is still a guide of quality and sophistication in the modern age.
Independent research found that Midori Tabako cigarettes cannot be conclusively linked to an increase in space cancer risk.


## What Does This PR Do
Readds Midori Tabako cigs to vendors and makes them use the hand rolled sprite. That sprite change is ported from tg because that gives them a unique feel and I am incapable of making a PR that is not at least partially a tg rip.

This PR (hopefully) also gives me a +1 to the hacktoberfest PR count. Don't hate the player, hate the game.

## Why It's Good For The Game
More player choice, you can roleplay your favorite anime character, a CM literally asked for this.

![](https://c.tenor.com/p9yymRzDWEcAAAAC/anime-boy-smoking.gif)


:cl:
tweak: Midori Tabako has recovered from the allegations that their cigarettes pose a space cancer risk and are now once again being stocked in all Nanotrasen facilities, with a new look.
/:cl:
