### PR TITLE
Fixes ghost teleport menu

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -389,23 +389,23 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!isobserver(usr))
 		to_chat(usr, "Not when you're not dead!")
 		return
+	var/target //the area to teleport to
+	target = input(src, "Area to teleport to", "Teleport to a location") as null|anything in return_sorted_areas()
+	if(target)
+		return teleport(target)
 
-	var/datum/async_input/A = input_autocomplete_async(usr, "Area to jump to: ", SSmapping.ghostteleportlocs)
-	A.on_close(CALLBACK(src, .proc/teleport))
-
-/mob/dead/observer/proc/teleport(area/thearea)
-	if(!thearea || !isobserver(usr))
+/mob/dead/observer/proc/teleport(area/A)
+	if(!A || !isobserver(usr))
 		return
 
-	var/list/L = list()
-	for(var/turf/T in get_area_turfs(thearea.type))
-		L += T
+	var/list/turfs = list()
+	for(var/turf/T in A)
+		turfs += T
 
-	if(!L || !L.len)
-		to_chat(usr, "<span class='warning'>No area available.</span>")
+	if(!turfs)
+		to_chat(src, "Nowhere to jump to!")
 		return
-
-	forceMove(pick(L))
+	forceMove(pick(turfs))
 	update_parallax_contents()
 
 /mob/dead/observer/verb/follow()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -389,21 +389,20 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!isobserver(usr))
 		to_chat(usr, "Not when you're not dead!")
 		return
-	var/target //the area to teleport to
-	target = input(src, "Area to teleport to", "Teleport to a location") as null|anything in return_sorted_areas()
-	if(target)
-		return teleport(target)
+	var/target = input("Area to teleport to", "Teleport to a location") as null|anything in SSmapping.ghostteleportlocs
+	var/area/A = SSmapping.teleportlocs[target]
+	teleport(A)
 
 /mob/dead/observer/proc/teleport(area/A)
 	if(!A || !isobserver(usr))
 		return
 
 	var/list/turfs = list()
-	for(var/turf/T in A)
+	for(var/turf/T in get_area_turfs(A.type))
 		turfs += T
 
-	if(!turfs)
-		to_chat(src, "Nowhere to jump to!")
+	if(!length(turfs))
+		to_chat(src, "<span class='warning'>Nowhere to jump to!</span>")
 		return
 	forceMove(pick(turfs))
 	update_parallax_contents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR moves the old ghost teleport menu over to the one used by admins (but only allowing jumping to areas).
Fixes https://github.com/ParadiseSS13/Paradise/issues/16692
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The old one has been broken since we moved to 514, and was a little unwieldy to use.
This menu is a sorted list that you can jump around using the keyboard.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
### OLD:
![image](https://user-images.githubusercontent.com/12197162/135759313-567cfb0a-5fca-43ef-ba0b-590802860562.png)
### NEW:
![image](https://user-images.githubusercontent.com/12197162/135759213-e451bb8b-1389-4d25-87f0-6d89b29fec25.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Fixed and migrated ghost teleport menu to a new system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
