### PR TITLE
Fix - Skrell headpockets will empty on destroy instead of deleting their contents

### DIFF
--- a/code/modules/surgery/organs/subtypes/skrell.dm
+++ b/code/modules/surgery/organs/subtypes/skrell.dm
@@ -16,7 +16,7 @@
 	var/obj/item/held_item
 
 /obj/item/organ/internal/headpocket/Destroy()
-	QDEL_NULL(held_item)
+	empty_contents()
 	return ..()
 
 /obj/item/organ/internal/headpocket/on_life()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes headpockets empty their contents on destroy. In most cases with the pockets, other calls are made, but some edge cases like changeling sting/transform would simply destroy the pocket since the mob isn't killed nor is the organ technically removed.

## Why It's Good For The Game
Fixes #16848

## Images of changes
https://user-images.githubusercontent.com/80771500/135759189-ab9eba41-5d28-4099-80e4-f54239af48a7.mp4

## Changelog
:cl:
fix: Skrell headpockets drop their contents on destroy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
