### PR TITLE
Fixes being able to install 0 cost upgrades on an energy crossbow

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -21,8 +21,6 @@
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()
-	/// Can upgrades be installed on the gun?
-	var/modable = TRUE
 
 	var/recharge_timerid
 
@@ -31,14 +29,14 @@
 /obj/item/gun/energy/kinetic_accelerator/examine(mob/user)
 	. = ..()
 	if(in_range(user, src))
-		if(modable)
+		if(max_mod_capacity)
 			. += "<b>[get_remaining_mod_capacity()]%</b> mod capacity remaining."
 			for(var/A in get_modkits())
 				var/obj/item/borg/upgrade/modkit/M = A
 				. += "<span class='notice'>There is a [M.name] mod installed, using <b>[M.cost]%</b> capacity.</span>"
 
 /obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/borg/upgrade/modkit) && modable)
+	if(istype(I, /obj/item/borg/upgrade/modkit) && max_mod_capacity)
 		var/obj/item/borg/upgrade/modkit/MK = I
 		MK.install(src, user)
 	else
@@ -46,7 +44,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!modable)
+	if(max_mod_capacity == 0)
 		return
 	if(!modkits.len)
 		to_chat(user, "<span class='notice'>There are no modifications currently installed.</span>")
@@ -275,7 +273,7 @@
 /obj/item/borg/upgrade/modkit/attackby(obj/item/A, mob/user)
 	if(istype(A, /obj/item/gun/energy/kinetic_accelerator) && !issilicon(user))
 		var/obj/item/gun/energy/kinetic_accelerator/KA = A
-		if(KA.modable)
+		if(KA.max_mod_capacity)
 			install(A, user)
 		else
 			return ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -44,7 +44,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
-	if(max_mod_capacity == 0)
+	if(!max_mod_capacity)
 		return
 	if(!modkits.len)
 		to_chat(user, "<span class='notice'>There are no modifications currently installed.</span>")

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -21,6 +21,8 @@
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()
+	/// Can upgrades be installed on the gun?
+	var/modable = TRUE
 
 	var/recharge_timerid
 
@@ -29,14 +31,14 @@
 /obj/item/gun/energy/kinetic_accelerator/examine(mob/user)
 	. = ..()
 	if(in_range(user, src))
-		if(max_mod_capacity)
+		if(modable)
 			. += "<b>[get_remaining_mod_capacity()]%</b> mod capacity remaining."
 			for(var/A in get_modkits())
 				var/obj/item/borg/upgrade/modkit/M = A
 				. += "<span class='notice'>There is a [M.name] mod installed, using <b>[M.cost]%</b> capacity.</span>"
 
 /obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/borg/upgrade/modkit))
+	if(istype(I, /obj/item/borg/upgrade/modkit) && modable)
 		var/obj/item/borg/upgrade/modkit/MK = I
 		MK.install(src, user)
 	else
@@ -44,6 +46,8 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
+	if(!modable)
+		return
 	if(!modkits.len)
 		to_chat(user, "<span class='notice'>There are no modifications currently installed.</span>")
 		return
@@ -270,7 +274,11 @@
 
 /obj/item/borg/upgrade/modkit/attackby(obj/item/A, mob/user)
 	if(istype(A, /obj/item/gun/energy/kinetic_accelerator) && !issilicon(user))
-		install(A, user)
+		var/obj/item/gun/energy/kinetic_accelerator/KA = A
+		if(KA.modable)
+			install(A, user)
+		else
+			return ..()
 	else
 		return ..()
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -110,7 +110,6 @@
 	unique_frequency = TRUE
 	can_flashlight = 0
 	max_mod_capacity = 0
-	modable = FALSE
 	empty_state = null
 	can_holster = TRUE
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -110,6 +110,7 @@
 	unique_frequency = TRUE
 	can_flashlight = 0
 	max_mod_capacity = 0
+	modable = FALSE
 	empty_state = null
 	can_holster = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Fixes being able to install 0 cost kinetic accelerator upgrades on energy crossbows, by checking for max_mod_capacity. If max_mod_capacity is false, like on crossbows, modkits can not be installed or removed.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This is bad.
![image](https://user-images.githubusercontent.com/52090703/135760215-58b5dab3-6b6c-4a24-9b49-2866437e2b31.png)
You should not be able to do that. Yes, that is an energy crossbow.

Also lets people potentialy make kinetic accelerators in the future with upgrades pre-installed that can not be removed.

## Changelog
:cl:
fix: Fixes being able to install zero cost KA modkits to Energy Crossbows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
