### PR TITLE
stealthmin fix 

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -85,6 +85,10 @@
 	original = null
 	return ..()
 
+/datum/mind/proc/get_display_key()
+	var/clientKey = current?.client.get_display_key()
+	return clientKey ? clientKey : key
+
 /datum/mind/proc/transfer_to(mob/living/new_character)
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud //we need this because leave_hud() will clear this list
 	var/mob/living/old_current = current

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -451,7 +451,7 @@
 	var/jobtext = ""
 	if(ply.assigned_role)
 		jobtext = " the <b>[ply.assigned_role]</b>"
-	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
+	var/text = "<b>[ply.get_display_key()]</b> was <b>[ply.name]</b>[jobtext] and"
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " <span class='redtext'>died</span>"
@@ -468,7 +468,7 @@
 	return text
 
 /proc/printeventplayer(datum/mind/ply)
-	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>"
+	var/text = "<b>[ply.get_display_key()]</b> was <b>[ply.name]</b>"
 	if(ply.special_role != SPECIAL_ROLE_EVENTMISC)
 		text += " the [ply.special_role]"
 	text += " and"

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -202,6 +202,11 @@
 
 	..()	//redirect to hsrc.Topic()
 
+
+/client/proc/get_display_key()
+	var/fakekey = src?.holder?.fakekey
+	return fakekey ? fakekey : key
+
 /client/proc/is_content_unlocked()
 	if(!prefs.unlock_content)
 		to_chat(src, "Become a BYOND member to access member-perks and features, as well as support the engine that makes this game possible. <a href='http://www.byond.com/membership'>Click here to find out more</a>.")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes stealthmins' real ckeys showing up on the round end report.

This fixes #1771, the oldest open issue.

The job objective part of the issue is no longer a problem, since that report only prints your character's name now.

Regular players only get to see ckeys when they check Who, Adminwho, see OOC/dchat talk or see the round end report, so I think I've covered that last base here. Let me know if the issue report is missing something, I'll handle it as well.

![](https://c.tenor.com/rtRn9EH3lBMAAAAC/cartoon-ghost.gif)
Complementary ghost ("stealthmin" always makes me think of ghosts and it's spooktober)

Also, this is a great example of why encapsulation could really help DM. Most of the references to clients' ckeys really do just access the raw variables and the code used to check for fakekeys is duplicated in dozens of places all over the codebase. Awful.