### PR TITLE
Airtights turf changes

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -283,10 +283,10 @@
 		var/asleep = 0
 		var/ab = 0
 		var/atemp = 0
+
 		var/turf_count = 0
 
-		for(var/direction in GLOB.cardinal)//Only use cardinals to cut down on lag
-			var/turf/T = get_step(src, direction)
+		for(var/turf/T in atmos_adjacent_turfs)
 			if(istype(T, /turf/space))//Counted as no air
 				turf_count++//Considered a valid turf for air calcs
 				continue


### PR DESCRIPTION
## What Does This PR Do
Fixes #2913.

A turf change slurped air from all adjacent turfs even if they were not atmos-adjacent.

## Changelog
:cl:
fix: changing a turf (for example by adding/removing plating) will no longer create atmos leaks
/:cl: