### PR TITLE
Makes laser pointers not go through walls

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -80,7 +80,7 @@
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
 		to_chat(user, "<span class='warning'>Your fingers can't press the button!</span>")
 		return
-	if(!(target in view(7, get_turf(user))))
+	if(!(target in view(7, get_turf(user)))) // Use the turf as center so it won't use the potential xray of the user
 		to_chat(user, "<span class='warning'>There is something in the way!</span>")
 		return
 

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -71,8 +71,6 @@
 	laser_act(target, user, params)
 
 /obj/item/laser_pointer/proc/laser_act(atom/target, mob/living/user, params)
-	if( !(user in (viewers(7,target))) )
-		return
 	if(!diode)
 		to_chat(user, "<span class='notice'>You point [src] at [target], but nothing happens!</span>")
 		return
@@ -81,6 +79,9 @@
 		return
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
 		to_chat(user, "<span class='warning'>Your fingers can't press the button!</span>")
+		return
+	if(!(target in view(7, get_turf(user))))
+		to_chat(user, "<span class='warning'>There is something in the way!</span>")
 		return
 
 	add_fingerprint(user)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -80,7 +80,7 @@
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
 		to_chat(user, "<span class='warning'>Your fingers can't press the button!</span>")
 		return
-	if(!(target in view(7, get_turf(user)))) // Use the turf as center so it won't use the potential xray of the user
+	if(!(target in view(7, get_turf(src)))) // Use the turf as center so it won't use the potential xray of the user
 		to_chat(user, "<span class='warning'>There is something in the way!</span>")
 		return
 


### PR DESCRIPTION
## What Does This PR Do
Makes it so that laser pointers use non x-ray `view` to see if you can hit the target or not. Thus fixing being able to blind/emp things through walls if you had x-ray.

Fixes #16237

## Why It's Good For The Game
Exploit? Bug? It's weird at least for a laser to go through walls

## Changelog
:cl:
fix: Laser pointers now can't be used on targets behind walls or other occlusions. No more blinding people behind walls as a full powered vampire
/:cl: