### PR TITLE
Replace maintenance batswarm by regular bats

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -85075,7 +85075,7 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "xWX" = (
-/mob/living/simple_animal/hostile/scarybat/batswarm,
+/mob/living/simple_animal/hostile/scarybat,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "ycV" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -83532,7 +83532,7 @@
 /obj/item/paper{
 	info = "I.O.U. some shinies - Mr V. Ox"
 	},
-/mob/living/simple_animal/hostile/scarybat/batswarm,
+/mob/living/simple_animal/hostile/scarybat,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "kYw" = (

--- a/code/datums/spells/shapeshift.dm
+++ b/code/datums/spells/shapeshift.dm
@@ -96,10 +96,10 @@
 	invocation_type = "none"
 	action_icon_state = "vampire_bats"
 
-	shapeshift_type = /mob/living/simple_animal/hostile/scarybat/batswarm
-	current_shapes = list(/mob/living/simple_animal/hostile/scarybat/batswarm)
+	shapeshift_type = /mob/living/simple_animal/hostile/scarybat/adminvampire
+	current_shapes = list(/mob/living/simple_animal/hostile/scarybat/adminvampire)
 	current_casters = list()
-	possible_shapes = list(/mob/living/simple_animal/hostile/scarybat/batswarm)
+	possible_shapes = list(/mob/living/simple_animal/hostile/scarybat/adminvampire)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/hellhound
 	name = "Lesser Hellhound Form"

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -52,7 +52,8 @@
 			L.visible_message("<span class='danger'>\the [src] scares \the [L]!</span>")
 
 
-/mob/living/simple_animal/hostile/scarybat/batswarm
+//This mob is for the admin-only ancient vampire, DO NOT USE ELSEWHERE
+/mob/living/simple_animal/hostile/scarybat/adminvampire
 	name = "bat swarm"
 	desc = "A swarm of vicious, angry-looking space bats."
 	speed = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Replace the admin-only ancient vampire mob batswarm by the regular bats.

BATSWARM HAS 300 HEALTH AND DEALS LIKE 25 DAMAGE PER HIT

This also repath the mob from batswarm to adminvampire and adds a comment so hopefully I will never have to die to this mob again. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Maybe we shouldnt have megafauna just chilling in maintenance.

## Changelog
:cl:
tweak: Nerf the engineering maintenance bats to the level of regular bats and not admin-overpowered bats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
