### PR TITLE
Fixes unused cloners becoming bugged after emagging

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	var/obj/effect/countdown/clonepod/countdown
 
 	var/list/brine_types = list("corazone", "perfluorodecalin", "epinephrine", "salglu_solution") //stops heart attacks, heart failure, shock, and keeps their O2 levels normal
-	var/list/missing_organs
+	var/list/missing_organs = list()
 	var/organs_number = 0
 
 	light_color = LIGHT_COLOR_PURE_GREEN
@@ -338,9 +338,9 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 				progress += (100 - MINIMUM_HEAL_LEVEL)
 				var/milestone = CLONE_INITIAL_DAMAGE / organs_number
 // Doing this as a #define so that the value can change when evaluated multiple times
-#define INSTALLED (organs_number - LAZYLEN(missing_organs))
+#define INSTALLED (organs_number - length(missing_organs))
 
-				while((progress / milestone) > INSTALLED && LAZYLEN(missing_organs))
+				while((progress / milestone) > INSTALLED && length(missing_organs))
 					var/obj/item/organ/I = pick_n_take(missing_organs)
 					I.safe_replace(occupant)
 
@@ -494,9 +494,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 		clonemind = null
 
 
-	for(var/i in missing_organs)
-		qdel(i)
-	missing_organs.Cut()
+	QDEL_LIST(missing_organs)
 	occupant.SetLoseBreath(0) // Stop friggin' dying, gosh damn
 	occupant.setOxyLoss(0)
 	for(var/datum/disease/critical/crit in occupant.viruses)
@@ -523,9 +521,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 			message += "<i>Is this what dying is like? Yes it is.</i>"
 			to_chat(occupant, "<span class='warning'>[message]</span>")
 			SEND_SOUND(occupant, sound('sound/hallucinations/veryfar_noise.ogg', 0, 1, 50))
-		for(var/i in missing_organs)
-			qdel(i)
-		missing_organs.Cut()
+		QDEL_LIST(missing_organs)
 		clonemind = null
 		spawn(40)
 			qdel(occupant)
@@ -577,10 +573,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	malfunction(go_easy = TRUE)
 
 /obj/machinery/clonepod/proc/maim_clone(mob/living/carbon/human/H)
-	LAZYINITLIST(missing_organs)
-	for(var/i in missing_organs)
-		qdel(i)
-	missing_organs.Cut()
+	QDEL_LIST(missing_organs)
 
 	H.setCloneLoss(CLONE_INITIAL_DAMAGE, FALSE)
 	H.setBrainLoss(BRAIN_INITIAL_DAMAGE)
@@ -604,7 +597,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 		I.forceMove(src)
 		missing_organs += I
 
-	organs_number = LAZYLEN(missing_organs)
+	organs_number = length(missing_organs)
 	H.updatehealth()
 
 /obj/machinery/clonepod/proc/check_brine()


### PR DESCRIPTION
## What Does This PR Do
Most likely fixes #16018
I was unable to fully repro the issue described there. I was able to repro it if you emagged the cloner without ever having started cloning somebody. Since that was the only point in time where the `missing_organs` variable was null. If somebody started to get cloned it would be a list and never after be null.

Also did some refactoring and removed the lazy usages of the list since it ain't a lazy list anymore. The lazy implementation was quite *lazy* itself and it didn't make much sense to have this list be lazy at all with the previous implementation. It only ever saved some memory on cloners that were never used.

## Why It's Good For The Game
Bug fix. Work around was to deconstruct the cloner and clone somebody

## Changelog
:cl:
fix: Emagging a cloner before it ever cloned somebody is now fixable again without having to deconstruct the cloner
/:cl: