### PR TITLE
Fixes decal spawners replacing turfs because it feels like it

### DIFF
--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -3,8 +3,7 @@
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
 	var/list/result = list(
-	/turf/simulated/floor/plasteel = 1,
-	/turf/simulated/floor/plating = 1,
+	/datum/nothing = 1,
 	/obj/effect/decal/cleanable/blood/splatter = 1,
 	/obj/effect/decal/cleanable/blood/oil = 1,
 	/obj/effect/decal/cleanable/fungus = 1)
@@ -37,25 +36,25 @@
 /obj/effect/spawner/random_spawners/blood_maybe
 	name = "blood maybe"
 	result = list(
-	/turf/simulated/floor/plating = 20,
+	/datum/nothing = 20,
 	/obj/effect/decal/cleanable/blood/splatter = 1)
 
 /obj/effect/spawner/random_spawners/blood_often
 	name = "blood often"
 	result = list(
-	/turf/simulated/floor/plating = 5,
+	/datum/nothing = 5,
 	/obj/effect/decal/cleanable/blood/splatter = 1)
 
 /obj/effect/spawner/random_spawners/oil_maybe
 	name = "oil maybe"
 	result = list(
-	/turf/simulated/floor/plating = 20,
+	/datum/nothing = 20,
 	/obj/effect/decal/cleanable/blood/oil = 1)
 
 /obj/effect/spawner/random_spawners/oil_maybe
 	name = "oil often"
 	result = list(
-	/turf/simulated/floor/plating = 5,
+	/datum/nothing = 5,
 	/obj/effect/decal/cleanable/blood/oil = 1)
 
 /obj/effect/spawner/random_spawners/wall_rusted_probably
@@ -73,37 +72,37 @@
 /obj/effect/spawner/random_spawners/cobweb_left_frequent
 	name = "cobweb left frequent"
 	result = list(
-	/turf/simulated/floor/plating = 1,
+	/datum/nothing = 1,
 	/obj/effect/decal/cleanable/cobweb = 1)
 
 /obj/effect/spawner/random_spawners/cobweb_right_frequent
 	name = "cobweb right frequent"
 	result = list(
-	/turf/simulated/floor/plating = 1,
+	/datum/nothing = 1,
 	/obj/effect/decal/cleanable/cobweb2 = 1)
 
 /obj/effect/spawner/random_spawners/cobweb_left_rare
 	name = "cobweb left rare"
 	result = list(
-	/turf/simulated/floor/plating = 10,
+	/datum/nothing = 10,
 	/obj/effect/decal/cleanable/cobweb = 1)
 
 /obj/effect/spawner/random_spawners/cobweb_right_rare
 	name = "cobweb right rare"
 	result = list(
-	/turf/simulated/floor/plating = 10,
+	/datum/nothing = 10,
 	/obj/effect/decal/cleanable/cobweb2 = 1)
 
 /obj/effect/spawner/random_spawners/dirt_frequent
 	name = "dirt frequent"
 	result = list(
-	/turf/simulated/floor/plating = 1,
+	/datum/nothing = 1,
 	/obj/effect/decal/cleanable/dirt = 1)
 
 /obj/effect/spawner/random_spawners/dirt_rare
 	name = "dirt rare"
 	result = list(
-	/turf/simulated/floor/plating = 10,
+	/datum/nothing = 10,
 	/obj/effect/decal/cleanable/dirt = 1)
 
 /obj/effect/spawner/random_spawners/fungus_maybe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Random decal spawners were coded in such a poor way, they replaced the turf they were on if the decal never applies. This changes that.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You should not have to lose a turf for a random spawn, and mess up atmos.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed random spawners sometimes overwriting turfs and causing atmos issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
