### PR TITLE
Fix fireaxe cabinet not dropping the axe when destroyed

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -2,7 +2,7 @@
 /obj/structure/closet/fireaxecabinet
 	name = "fire axe cabinet"
 	desc = "There is small label that reads \"For Emergency use only\" along with details for safe use of the axe. As if."
-	var/obj/item/twohanded/fireaxe/fireaxe = new/obj/item/twohanded/fireaxe
+	var/obj/item/twohanded/fireaxe/fireaxe
 	icon_state = "fireaxe1000"
 	icon_closed = "fireaxe1000"
 	icon_opened = "fireaxe1100"
@@ -14,6 +14,11 @@
 	var/hitstaken = FALSE
 	locked = TRUE
 	var/smashed = FALSE
+
+/obj/structure/closet/fireaxecabinet/populate_contents()
+	fireaxe = new/obj/item/twohanded/fireaxe(src)
+	update_icon()	// So its initial icon doesn't show it without the fireaxe
+	. = ..()
 
 /obj/structure/closet/fireaxecabinet/examine(mob/user)
 	. = ..()
@@ -123,6 +128,11 @@
 			update_icon_opening()
 		else
 			update_icon_closing()
+
+/obj/structure/closet/fireaxecabinet/Destroy()
+	fireaxe.forceMove(get_turf(src))
+	fireaxe = null
+	return ..()
 
 /obj/structure/closet/fireaxecabinet/attack_tk(mob/user as mob)
 	if(localopened && fireaxe)

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -129,7 +129,6 @@
 		else
 			update_icon_closing()
 
-
 /obj/structure/closet/fireaxecabinet/attack_tk(mob/user as mob)
 	if(localopened && fireaxe)
 		fireaxe.forceMove(loc)

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -129,10 +129,6 @@
 		else
 			update_icon_closing()
 
-/obj/structure/closet/fireaxecabinet/Destroy()
-	fireaxe.forceMove(get_turf(src))
-	fireaxe = null
-	return ..()
 
 /obj/structure/closet/fireaxecabinet/attack_tk(mob/user as mob)
 	if(localopened && fireaxe)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #6845.
The fireaxe cabinet should now properly add the fireaxe to itself on initialization, rather than in its instance definition. It seems like it was somehow getting deleted alongside the object on deletion, rather than treated as a contained object.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As noted in the initial issue, losing an item of which only two exist on the station (for box, at least) is not fun. Especially if you left your multitool in your other pants.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![uh](https://i.imgur.com/uZ0JVlR.gif)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fireaxe cabinets should now drop a held fireaxe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
