### PR TITLE
Transformation diseases do the jobban check properly

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -17,6 +17,7 @@
 	var/list/stage5 = list("Oh the humanity!")
 	var/transformation_text = null
 	var/new_form = /mob/living/carbon/human
+	var/job_role = null
 
 /datum/disease/transformation/stage_act()
 	..()
@@ -40,7 +41,7 @@
 	if(istype(affected_mob, /mob/living/carbon) && affected_mob.stat != DEAD)
 		if(stage5)
 			to_chat(affected_mob, pick(stage5))
-		if(jobban_isbanned(affected_mob, new_form))
+		if(jobban_isbanned(affected_mob, job_role))
 			affected_mob.death(1)
 			return
 		if(affected_mob.notransform)
@@ -133,6 +134,7 @@
 	stage4	= list("<span class='danger'>Your skin feels very loose.</span>", "<span class='danger'>You can feel... something...inside you.</span>")
 	stage5	= list("<span class='danger'>Your skin feels as if it's about to burst off!</span>")
 	new_form = /mob/living/silicon/robot
+	job_role = "Cyborg"
 
 
 /datum/disease/transformation/robot/stage_act()
@@ -165,6 +167,7 @@
 	stage4	= list("<span class='danger'>Your skin feels very tight.</span>", "<span class='danger'>Your blood boils!</span>", "<span class='danger'>You can feel... something...inside you.</span>")
 	stage5	= list("<span class='danger'>Your skin feels as if it's about to burst off!</span>")
 	new_form = /mob/living/carbon/alien/humanoid/hunter
+	job_role = ROLE_ALIEN
 
 /datum/disease/transformation/xeno/stage_act()
 	..()
@@ -248,3 +251,4 @@
 	stage5	= list("<span class='danger'>You have become a morph.</span>")
 	transformation_text = "<span class='userdanger'>This transformation does NOT make you an antagonist if you were not one already. If you were not an antagonist, you should not eat any steal objectives or the contents of the armory.</span>"
 	new_form = /mob/living/simple_animal/hostile/morph
+	job_role = ROLE_MORPH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Transformation diseases had a check for jobbans that would never be true due to passing a path to `jobban_isbanned` which expects a string or defined role. Roles are now defined for diseases if need be.

The check will kill if the player is jobbanned, as it was originally coded that way. Trying to pass it onto a ghost instead would have been a more significant rework due to the mix of special roles and silicon.

## Why It's Good For The Game
Fix #12700, and possibly other issues. Ban dodging bad.

## Images of changes
![TransformDeath](https://user-images.githubusercontent.com/80771500/135944492-b2212f13-cbc1-4a4d-938c-a51771cc4289.PNG)

## Changelog
:cl:
fix: Transformation diseases no longer bypass jobbans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
