### PR TITLE
Replaces clown magboots on the uplink with a new pair of slippers

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -423,6 +423,13 @@
 /datum/action/item_action/remove_badge
 	name = "Remove Holobadge"
 
+
+// Clown Acrobat Shoes
+/datum/action/item_action/rolling
+	name = "Tactical Roll"
+	desc = "Activates the clown shoes' ankle-stimulating module, allowing the user to do a short slide forward going through anyone."
+	button_icon_state = "clown"
+
 // Jump boots
 /datum/action/item_action/bhop
 	name = "Activate Jump Boots"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/clownslippers
 	name = "Clown Acrobatic Shoes"
-	desc = "A pair of modified clown shoes fitted with a built-in propultion system that allows the user to perform a short slip below anyone."
+	desc = "A pair of modified clown shoes fitted with a built-in propultion system that allows the user to perform a short slip below anyone. Turning on the waddle dampeners removes the slowdown on the shoes."
 	reference = "CAS"
 	item = /obj/item/clothing/shoes/clown_shoes/tactical
 	cost = 3

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -167,18 +167,19 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //Clown
 /datum/uplink_item/jobspecific/clowngrenade
 	name = "Banana Grenade"
-	desc = "A grenade that explodes into HONK! brand banana peels that are genetically modified to be extra slippery and extrude caustic acid when stepped on"
+	desc = "A grenade that explodes into HONK! brand banana peels that are genetically modified to be extra slippery and extrude caustic acid when stepped on."
 	reference = "BG"
 	item = /obj/item/grenade/clown_grenade
 	cost = 5
 	job = list("Clown")
 
-/datum/uplink_item/jobspecific/clownmagboots
-	name = "Clown Magboots"
-	desc = "A pair of modified clown shoes fitted with an advanced magnetic traction system. Look and sound exactly like regular clown shoes unless closely inspected."
-	reference = "CM"
-	item = /obj/item/clothing/shoes/magboots/clown
+/datum/uplink_item/jobspecific/clownslippers
+	name = "Clown Acrobatic Shoes"
+	desc = "A pair of modified clown shoes fitted with a built-in propultion system that allows the user to perform a short slip below anyone."
+	reference = "CAS"
+	item = /obj/item/clothing/shoes/clown_shoes/tactical
 	cost = 3
+	surplus = 75
 	job = list("Clown")
 
 /datum/uplink_item/jobspecific/trick_revolver

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -111,6 +111,30 @@
 	desc = "Standard-issue shoes of the wizarding class clown. Damn they're huge! And powerful! Somehow."
 	magical = TRUE
 
+/obj/item/clothing/shoes/clown_shoes/tactical
+	actions_types = list(/datum/action/item_action/rolling)
+	var/slide_distance = 6
+	var/recharging_rate = 100
+	var/recharging_time = 0
+
+/obj/item/clothing/shoes/clown_shoes/tactical/ui_action_click(mob/user, action)
+	if(!isliving(user))
+		return
+	if(recharging_time > world.time)
+		to_chat(user, "<span class='warning'>The boot's internal propulsion needs to recharge still!</span>")
+		return
+	user.pass_flags += PASSMOB
+	user.Weaken(2)
+	playsound(src, 'sound/effects/stealthoff.ogg', 50, 1, 1)
+	recharging_time = world.time + recharging_rate
+	user.visible_message("<span class='warning'>[usr] slides forward!</span>")
+	var/sliding_this_way = user.dir
+	for(var/i=0, i<slide_distance, i++)
+		step(user, sliding_this_way)
+		sleep(1)
+	user.SetWeakened(0)
+	user.pass_flags -= PASSMOB
+
 /obj/item/clothing/shoes/jackboots
 	name = "jackboots"
 	desc = "Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time."

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -114,7 +114,7 @@
 /obj/item/clothing/shoes/clown_shoes/tactical
 	actions_types = list(/datum/action/item_action/rolling)
 	var/slide_distance = 6
-	var/recharging_rate = 100
+	var/recharging_rate = 80
 	var/recharging_time = 0
 
 /obj/item/clothing/shoes/clown_shoes/tactical/ui_action_click(mob/user, action)
@@ -123,17 +123,34 @@
 	if(recharging_time > world.time)
 		to_chat(user, "<span class='warning'>The boot's internal propulsion needs to recharge still!</span>")
 		return
-	user.pass_flags += PASSMOB
+	var/prev_dir = user.dir
+	var/prev_pass_flags = user.pass_flags
+	user.pass_flags |= PASSMOB
 	user.Weaken(2)
+	user.dir = prev_dir
 	playsound(src, 'sound/effects/stealthoff.ogg', 50, 1, 1)
 	recharging_time = world.time + recharging_rate
-	user.visible_message("<span class='warning'>[usr] slides forward!</span>")
-	var/sliding_this_way = user.dir
+	user.visible_message("<span class='warning'>[usr] slips forward!</span>")
 	for(var/i=0, i<slide_distance, i++)
-		step(user, sliding_this_way)
+		step(user, user.dir)
 		sleep(1)
 	user.SetWeakened(0)
-	user.pass_flags -= PASSMOB
+	user.pass_flags = prev_pass_flags
+
+/obj/item/clothing/shoes/clown_shoes/tactical/CtrlClick(mob/living/user)
+	if(!isliving(user))
+		return
+	if(user.get_active_hand() != src)
+		to_chat(user, "You must hold [src] in your hand to do this.")
+		return
+	if(!enabled_waddle)
+		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
+		enabled_waddle = TRUE
+		slowdown = SHOES_SLOWDOWN+1
+	else
+		to_chat(user, "<span class='notice'>You switch on the waddle dampeners, [src] no longer slows you down!</span>")
+		enabled_waddle = FALSE
+		slowdown = SHOES_SLOWDOWN
 
 /obj/item/clothing/shoes/jackboots
 	name = "jackboots"


### PR DESCRIPTION
## What Does This PR Do
Replaces the clown-specific traitor item "clown magboots" with a new clown traitor item, "clown acrobatic shoes".
These new pair of slippers allow the user to slip six tiles forward, allowing you to slip right through trouble in a wacky fashion.
The shoes can also have their clown shoes slowdown removed so it's usable in combat, and have an 8 second cooldown between each slip.

## Why It's Good For The Game
The clown magboots are a bad mix of bad and bland qualities for a traitor item, which this PR fixes by making them a more entertaining option.

## Images of changes
![8ktKBEolr2](https://user-images.githubusercontent.com/48032385/136125778-fdc27d5a-8804-4699-bc83-d22079817b52.gif)

## Changelog
:cl:
tweak: Replaces the clown magboots from the uplink with acrobatic clown shoes, which allow you to slip forward to dodge incoming threats.
/:cl: