### PR TITLE
Prevents uploading codex gigas to library

### DIFF
--- a/code/modules/library/codex_gigas.dm
+++ b/code/modules/library/codex_gigas.dm
@@ -8,3 +8,4 @@
 	author = "Forces beyond your comprehension"
 	unique = TRUE
 	title = "The codex gigas"
+	has_drm = TRUE


### PR DESCRIPTION
## What Does This PR Do
Prevents uploading codex gigas to library. It causes SQL errors and shouldnt be possible anyway.

Yes I webedit this. Go file a complaint in the nearest bin (translation for the americans: garbage can)

## Why It's Good For The Game
SQL errors bad.

## Changelog
:cl: AffectedArc07
fix: You can no longer upload codex gigas to the library console
/:cl:
