### PR TITLE
Removes crewsimov from possible roundstart lawsets

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -15,7 +15,6 @@
 	name = "Crewsimov"
 	law_header = "Three Laws of Robotics"
 	selectable = TRUE
-	default = TRUE
 
 /datum/ai_laws/crewsimov/New()
 	add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the possibility of the AI and borgs starting the round with the crewsimov lawset. The AI can still start with Corporate or NT Default, and Crewsimov can still be uploaded manually.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The lawset isn't fun for anyone, and discourages good roleplay. Saying "AI open law 2" isn't exactly the peak of roleplay, and other lawsets serve the station's interests much better without letting greyshirts and other miscreants use the AI as a expensive door remote. Crewsimov is also disliked by most people, including several admins. 

Here's a few quotes from admins in a recent forum thread about AI lawsets:

Spacemanspark - "...this isn't even getting into how horrible it is from a crew interaction perspective. "AI law 2 open door" is about as interesting to have spammed at you as it is to huff glue." "I agree that crewsimov belongs in a trash can".

Esenno - "I hate crewsimov."
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
del: AI and borgs can no longer start the round with the crewsimov lawset.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
