### PR TITLE
Nutriment Pump Implants make you projectile vomit when EMPed

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -75,7 +75,7 @@
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/chest/nutriment
+		/obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	)
 	belt = /obj/item/gun/energy/gun/blueshield/pdw9
 
@@ -108,7 +108,7 @@
 		)
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/arm/flash
@@ -160,7 +160,7 @@
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/flash,
-		/obj/item/organ/internal/cyberimp/chest/nutriment,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security
 	)
 
@@ -196,7 +196,7 @@
 	)
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/arm/telebaton,
@@ -247,7 +247,7 @@
 	mask = /obj/item/clothing/mask/gas
 	cybernetic_implants = list(
 	 /obj/item/organ/internal/eyes/cybernetic/shield,
-	 /obj/item/organ/internal/cyberimp/chest/nutriment
+	 /obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	)
 	l_pocket = /obj/item/t_scanner
 	r_pocket = /obj/item/melee/classic_baton/telescopic
@@ -280,7 +280,7 @@
 	)
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/eyes/cybernetic/shield,
@@ -338,7 +338,7 @@
 	suit_store = /obj/item/gun/energy/gun
 	cybernetic_implants = list(
 	 /obj/item/organ/internal/cyberimp/arm/surgery,
-	 /obj/item/organ/internal/cyberimp/chest/nutriment
+	 /obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	)
 	belt = /obj/item/defibrillator/compact/advanced/loaded
 
@@ -387,7 +387,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/surgery/l,
 		/obj/item/organ/internal/cyberimp/arm/medibeam,
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
@@ -437,7 +437,7 @@
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/chest/nutriment
+		/obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	)
 
 	implants = list(/obj/item/implant/mindshield,
@@ -454,7 +454,7 @@
 	r_pocket = /obj/item/nullrod/ert
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
@@ -505,7 +505,7 @@
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/janitorial,
-		/obj/item/organ/internal/cyberimp/chest/nutriment
+		/obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	)
 
 /datum/outfit/job/centcom/response_team/janitorial/gamma
@@ -526,7 +526,7 @@
 	)
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/arm/advmop,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -304,11 +304,10 @@
 	slot = "stomach"
 	origin_tech = "materials=2;powerstorage=2;biotech=2"
 
-/obj/item/organ/internal/cyberimp/chest/nutriment/Initialize(mapload)
+/obj/item/organ/internal/cyberimp/chest/nutriment/examine(mob/user)
 	. = ..()
-	// Define this here so it doesn't need to be redefined for each sub-implant
 	if(emp_proof)
-		desc += " The implant has been hardened. It is invulnerable to EMPs."
+		. += " The implant has been hardened. It is invulnerable to EMPs."
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/on_life()
 	if(!owner)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -335,13 +335,13 @@
 	if(!owner || emp_proof)
 		return
 	owner.vomit(100, FALSE, TRUE, 3, FALSE)	// because when else do we ever use projectile vomiting
-	owner.loc.visible_message("<span class='warning'>The contents of [owner]'s stomach erupt violently from [owner.p_their()] mouth!</span>",
-	"<span class='warning'>You hear vomiting and a sickening splattering against the floor!")
+	owner.visible_message("<span class='warning'>The contents of [owner]'s stomach erupt violently from [owner.p_their()] mouth!</span>",
+		"<span class='warning'>You feel like your insides are burning as you vomit profusely!</span>",
+		"<span class='warning'>You hear vomiting and a sickening splattering against the floor!")
 	owner.reagents.add_reagent("????",poison_amount / severity) //food poisoning
 	disabled_by_emp = TRUE		// Disable the implant for a little bit so this effect actually matters
 	synthesizing = FALSE
 	addtimer(CALLBACK(src, .proc/emp_cool), 60 SECONDS)
-	to_chat(owner, "<span class='warning'>You feel like your insides are burning!</span>")
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	name = "Nutriment pump implant PLUS"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -300,6 +300,7 @@
 	var/hunger_threshold = NUTRITION_LEVEL_STARVING
 	var/synthesizing = 0
 	var/poison_amount = 5
+	var/disabled_by_emp = FALSE
 	slot = "stomach"
 	origin_tech = "materials=2;powerstorage=2;biotech=2"
 
@@ -307,6 +308,8 @@
 	if(!owner)
 		return
 	if(synthesizing)
+		return
+	if(disabled_by_emp)
 		return
 	if(owner.stat == DEAD)
 		return
@@ -319,11 +322,20 @@
 /obj/item/organ/internal/cyberimp/chest/nutriment/proc/synth_cool()
 	synthesizing = FALSE
 
+/obj/item/organ/internal/cyberimp/chest/nutriment/proc/emp_cool()
+	disabled_by_emp = FALSE
+
 /obj/item/organ/internal/cyberimp/chest/nutriment/emp_act(severity)
 	if(!owner || emp_proof)
 		return
+	owner.vomit(100, FALSE, TRUE, 3, FALSE)	// because when else do we ever use projectile vomiting
+	owner.loc.visible_message("<span class='warning'>The contents of [owner]'s stomach erupt violently from [owner.p_their()] mouth!</span>",
+	"<span class='warning'>You hear vomiting and a sickening splattering against the floor!")
 	owner.reagents.add_reagent("????",poison_amount / severity) //food poisoning
-	to_chat(owner, "<span class='warning'>You feel like your insides are burning.</span>")
+	disabled_by_emp = TRUE		// Disable the implant for a little bit so this effect actually matters
+	synthesizing = FALSE
+	addtimer(CALLBACK(src, .proc/emp_cool), 60 SECONDS)
+	to_chat(owner, "<span class='warning'>You feel like your insides are burning!</span>")
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	name = "Nutriment pump implant PLUS"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -304,6 +304,12 @@
 	slot = "stomach"
 	origin_tech = "materials=2;powerstorage=2;biotech=2"
 
+/obj/item/organ/internal/cyberimp/chest/nutriment/hardened/Initialize(mapload)
+	. = ..()
+	// Define this here so it doesn't need to be redefined for each sub-implant
+	if (emp_proof)
+		desc += " The implant has been hardened. It is invulnerable to EMPs."
+
 /obj/item/organ/internal/cyberimp/chest/nutriment/on_life()
 	if(!owner)
 		return
@@ -345,6 +351,13 @@
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY
 	poison_amount = 10
 	origin_tech = "materials=4;powerstorage=3;biotech=3"
+/obj/item/organ/internal/cyberimp/chest/nutriment/hardened
+	name = "hardened nutrient pump implant"
+	emp_proof = TRUE
+
+/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened
+	name = "hardened nutrient pump implant PLUS"
+	emp_proof = TRUE
 
 /obj/item/organ/internal/cyberimp/chest/reviver
 	name = "Reviver implant"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -304,10 +304,10 @@
 	slot = "stomach"
 	origin_tech = "materials=2;powerstorage=2;biotech=2"
 
-/obj/item/organ/internal/cyberimp/chest/nutriment/hardened/Initialize(mapload)
+/obj/item/organ/internal/cyberimp/chest/nutriment/Initialize(mapload)
 	. = ..()
 	// Define this here so it doesn't need to be redefined for each sub-implant
-	if (emp_proof)
+	if(emp_proof)
 		desc += " The implant has been hardened. It is invulnerable to EMPs."
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/on_life()

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -337,7 +337,7 @@
 	owner.vomit(100, FALSE, TRUE, 3, FALSE)	// because when else do we ever use projectile vomiting
 	owner.visible_message("<span class='warning'>The contents of [owner]'s stomach erupt violently from [owner.p_their()] mouth!</span>",
 		"<span class='warning'>You feel like your insides are burning as you vomit profusely!</span>",
-		"<span class='warning'>You hear vomiting and a sickening splattering against the floor!")
+		"<span class='warning'>You hear vomiting and a sickening splattering against the floor!</span>")
 	owner.reagents.add_reagent("????",poison_amount / severity) //food poisoning
 	disabled_by_emp = TRUE		// Disable the implant for a little bit so this effect actually matters
 	synthesizing = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Idea emerged from a discussion in dchat; adjusts the emp behavior for nutriment plus to make you projectile vomit. This results in a minor stun from the vomiting, a significant loss in nutriment, and a temporary disabling of the implant itself so it doesn't automatically refill your stomach. 

~~IC, the pump malfunctioning is pumping your stomach with ??? anyway, and if we have a distance parameter on vomiting anyway, it seems too good not to use~~

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
From what I've seen, there really isn't a reason to consider not using a nutriment implant if you can get someone to put it into you, as the current only downside is that you take a little bit of toxin damage if you get EMPed.
If the stun seems too long or unnecessary with the slowdown from nutriment loss, I can easily tweak/remove it, as there is a temp slowdown from the low nutriment afterwards anyway. The nutriment also regens back to base levels pretty quickly once the EMP effect wears off, so it won't ruin you.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![fdgsfg](https://i.imgur.com/XlLPRzb.gif)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Nutriment Pump/Plus implants now make you projectile vomit when EMPed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
