### PR TITLE
Adds 20% armour penetration to the edagger

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -140,6 +140,7 @@
 	var/on = 0
 	var/brightness_on = 2
 	light_color = LIGHT_COLOR_RED
+	armour_penetration = 20
 
 /obj/item/pen/edagger/attack_self(mob/living/user)
 	if(on)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds armour_penetration = 20 to the edagger

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

While an edagger may sound nice as a nice stealthy murder weapon that is easy to conceal, it is almost matched by any saw / welder / knife, it is loud as hell, with the standard esword sound, which will attract everyones attention, and unlike a saw or knife, you will get perma'd if you are found for it. As such, a nice simple buff of 20 armour penetration may help it a bit, with armoured targets, similar to other energy weapons.


## Changelog
:cl:
tweak: Edaggers now have 20 armor penetration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
