### PR TITLE
Adds Mining Shuttle computer boards to the circuit imprinter

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -162,6 +162,16 @@
 	build_path = /obj/item/circuitboard/med_data
 	category = list("Computer Boards")
 
+/datum/design/mining_shuttle
+	name = "Console Board (Mining Shuttle)"
+	desc = "Allows for the construction of circuit boards used to build a mining shuttle control console."
+	id = "mining_shuttle"
+	req_tech = list("programming" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/mining_shuttle
+	category = list("Computer Boards")
+
 /datum/design/message_monitor
 	name = "Console Board (Messaging Monitor Console)"
 	desc = "Allows for the construction of circuit boards used to build a messaging monitor console."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #16900. Adds the board to the circuit imprinter, Gives it the same tech requirements as printing the cargo supply shuttle control board.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Mining shuttle console board is now printable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
