### PR TITLE
Replaces synth flashes with regular flashes in the exo fab

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -270,6 +270,3 @@
 
 /obj/item/flash/armimplant/proc/cooldown()
 	overheat = FALSE
-
-
-/obj/item/flash/synthetic //just a regular flash now

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1204,15 +1204,15 @@
 	construction_time = 200
 	category = list("Misc")
 
-/datum/design/synthetic_flash
-	name = "Synthetic Flash"
-	desc = "A synthetic flash used mostly in borg construction."
+/datum/design/flash
+	name = "Flash"
+	desc = "A flash used mostly in borg construction or self defense."
 	id = "sflash"
 	req_tech = list("magnets" = 3, "combat" = 2)
 	build_type = MECHFAB
 	materials = list(MAT_METAL = 750, MAT_GLASS = 750)
 	construction_time = 100
-	build_path = /obj/item/flash/synthetic
+	build_path = /obj/item/flash
 	category = list("Misc")
 
 /datum/design/voice_standard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
They were literally identical. removing unused code.

## Why It's Good For The Game
they are identical to flashes, they have no purpose to exist.

## Changelog
:cl:
tweak: Flashes in the exosuit fab are just called flash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
