### PR TITLE
Allows pulse rifle projectiles to destroy machinery and objects

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -70,7 +70,7 @@
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
 		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
 	if(istype(P, /obj/item/projectile/beam/pulse))
-		src.ex_act(2)
+		ex_act(2)
 
 ///Called to get the damage that hulks will deal to the obj.
 /obj/proc/hulk_damage()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This allows pulse rifles to destroy objects the same way it does to walls, via telling the object it exploded.
This allows the pulse rifle to destroy doors in 2-3 shots, and anything bomb proof, like many of the doors and shutters at centcom armory, centcom teleporter, centcom specop office, centcom mech storage, nuclear authentication disks, gravgen, and the gateway.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
After object integrity got added, the amount of 'health' doors, computers and many other things had increased exponentially, having a death squad be stopped by some computers or bolted doors is just dumb, on top of destroying machinery like nobodies business.  

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl: ppi
tweak: Pulse rifle can now destroy machinery and objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
