### PR TITLE
Fixes jaunting not respecting density of objects on turf

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -57,15 +57,15 @@
 	if(!QDELETED(target))
 		if(!(target.Move(mobloc)))
 			for(var/turf/T in orange(7))
-				if(istype(T, /turf/space))
+				if(isspaceturf(T))
 					continue
 				if(T && target.Move(T))
-					target.canmove = 1
+					target.canmove = TRUE
 					return
 			for(var/turf/space/S in orange(7)) //loop for space turfs in case there were no normal ones last loop
 				if(S && target.Move(S))
 					break
-		target.canmove = 1 //if there are no valid tiles in a range of 7, just let them spawn wherever they are currently
+		target.canmove = TRUE //if there are no valid tiles in a range of 7, just let them spawn wherever they are currently
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/jaunt_steam(mobloc)
 	var/datum/effect_system/steam_spread/steam = new /datum/effect_system/steam_spread()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes jaunting respect densities of atoms on a turf, not just the turf itself. This is already done when searching for other locations if they try to jaunt into a dense turf, why is it not done here? Likely an oversight.

This PR also makes the jaunt proc prefer non-space turfs if found within 7 tiles, so you don't end up in space accidentally if you manifest in a window or wall bordering it.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This stops wraiths and other jaunting things from jaunting into normally inaccessible areas, such as ON the AI core, inside SMES', inside the gravity generator, etc.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed jaunting not respecting density of objects on a turf
fix: Jaunting prioritises non-space turfs before spacing you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
