### PR TITLE
Fix - Toy Griefsky doesn't spam admins with its attacks

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/griefsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/griefsky.dm
@@ -92,7 +92,7 @@
 		C.apply_damage(dmg, BRUTE)
 		if(prob(stun_chance)) 
 			C.Weaken(5)
-	if(!dmg == 0)
+	if(dmg)
 		add_attack_logs(src, C, "sliced")
 	if(declare_arrests)
 		var/area/location = get_area(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so if Griefsky has a damage value of 0, it won't spam the admins with attack messages.

## Why It's Good For The Game
Fixes #16923

## Images of changes
![GriefskyNoSpam](https://user-images.githubusercontent.com/80771500/137025348-066f854f-d2f8-405f-b449-c19d325df04c.PNG)

## Changelog
:cl:
fix: Giftskee doesn't spam admins on attacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
