### PR TITLE
Serving Tray Quality of Life - 8 Slots

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -371,7 +371,7 @@
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "tray"
 	desc = "A metal tray to lay food on."
-	storage_slots = 7
+	storage_slots = 8
 	force = 5
 	throwforce = 10
 	throw_speed = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Increases the slots in Serving Trays to 8.

## Why It's Good For The Game
A fully upgraded Kitchen produces stacks of 4 servings of whatever you're cooking. Having a "leftover" food that you have to put somewhere to keep things nice and orderly is a pain.

Honestly, I considered changing it to 12, but that may a bit too storage-powercreep.

## Changelog
:cl:
tweak: Tray storage slots increased by one. (7 > 8)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
