### PR TITLE
Moves CQC to Nukies Only, Adds Combat Gloves Minus

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -876,6 +876,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/CQC_manual
 	cost = 13
 	cant_discount = TRUE
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/cameraflash
 	name = "Camera Flash"
@@ -971,6 +972,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/gloves/color/black/krav_maga/combat
 	cost = 5
 	gamemodes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/stealthy_weapons/combat_minus
+	name = "Experimental Krav Gloves"
+	desc = "Experimental gloves with installed nanochips that teach you Krav Maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC. Do not look as fly as the Warden's"
+	reference = "CGM"
+	item = /obj/item/clothing/gloves/color/black/krav_maga
+	cost = 5
+	excludefrom = list(/datum/game_mode/nuclear)
 
 // GRENADES AND EXPLOSIVES
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -978,7 +978,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Experimental gloves with installed nanochips that teach you Krav Maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC. Do not look as fly as the Warden's"
 	reference = "CGM"
 	item = /obj/item/clothing/gloves/color/black/krav_maga
-	cost = 5
+	cost = 10
 	excludefrom = list(/datum/game_mode/nuclear)
 
 // GRENADES AND EXPLOSIVES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes CQC Nukies Only **(DO NOT MURDER ME, THIS WAS COMING ANYWAY)**

Adds Combat Gloves Minus, a pair of black gloves that act the same as the Warden's Gloves or Combat Plus Gloves.

## Why It's Good For The Game
I am the most fervent fanboy of CQC that exists on the planet.

That being said, after talking with Denth as well as discussing it with Fox before considering my CQC rework, its removal from the Basic Traitor kit was inevitable. This does not touch its inclusion in the Bond Bundle, as leaving it there was something that was discussed today.

That being said, I still want some sort of Close Combat item for traitors to use. In this case, you can now neck-punch and legsweep your way to victory with Combat Gloves Minus. They're the same as the Nukie version minus the shock-resist.


## Changelog
:cl:
tweak: makes CQC nukies only
add: adds Combat Gloves Minus to the uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
