### PR TITLE
Fixes cyborg special role runtime

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -629,7 +629,6 @@ GLOBAL_VAR_INIT(nologevent, 0)
   *
   * Arguments:
   * * M - the mob you're checking
-  * *
   */
 /proc/is_special_character(mob/M)
 	if(!SSticker.mode)
@@ -640,7 +639,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 		var/mob/living/silicon/robot/R = M
 		if(R.emagged)
 			return TRUE
-	if(M.mind.special_role)//If they have a mind and special role, they are some type of traitor or antagonist.
+	if(M.mind?.special_role)//If they have a mind and special role, they are some type of traitor or antagonist.
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes `Runtime in admin.dm,643: Cannot read null.special_role`.
This was caused by cyborgs calling `is_special_character()` and running into `if(M.mind.special_role)` before a mind had actually been created.

**Full runtime:**
```
[2021-10-14T11:53:53] Runtime in admin.dm,643: Cannot read null.special_role
[2021-10-14T11:53:53]   proc name: is special character (/proc/is_special_character)
[2021-10-14T11:53:53]   usr: Default Robot-903 () (/mob/living/silicon/robot)
[2021-10-14T11:53:53]   usr.loc: The floor (172,122,2) (/turf/simulated/floor/plasteel)
[2021-10-14T11:53:53]   src: null
[2021-10-14T11:53:53]   call stack:
[2021-10-14T11:53:53]   is special character(Default Robot-903 (/mob/living/silicon/robot))
[2021-10-14T11:53:53]   Default Robot-903 (/mob/living/silicon/robot): sync zeroth(/datum/ai_law/zero (/datum/ai_law/zero), /datum/ai_law/zero (/datum/ai_law/zero))
[2021-10-14T11:53:53]   Corporate (/datum/ai_laws/corporate): sync(Default Robot-903 (/mob/living/silicon/robot), 1)
[2021-10-14T11:53:53]   Default Robot-903 (/mob/living/silicon/robot): lawsync()
[2021-10-14T11:53:53]   Default Robot-903 (/mob/living/silicon/robot): sync()
[2021-10-14T11:53:53]   Default Robot-903 (/mob/living/silicon/robot): connect to ai(RELIC (/mob/living/silicon/ai))
[2021-10-14T11:53:53]   Default Robot-903 (/mob/living/silicon/robot): init(0, 1, RELIC (/mob/living/silicon/ai))
[2021-10-14T11:53:53]   Default Robot-903 (/mob/living/silicon/robot): New(the floor (172,122,2) (/turf/simulated/floor/plasteel), 0, 1, 0, 1, RELIC (/mob/living/silicon/ai))
[2021-10-14T11:53:53]   the robot endoskeleton (/obj/item/robot_parts/robot_suit): attackby(Man-Machine Interface: Danni M... (/obj/item/mmi), Kana Kisume (/mob/living/carbon/human), "icon-x=15;icon-y=15;left=1;scr...")
[2021-10-14T11:53:53]   Man-Machine Interface: Danni M... (/obj/item/mmi): melee attack chain(Kana Kisume (/mob/living/carbon/human), the robot endoskeleton (/obj/item/robot_parts/robot_suit), "icon-x=15;icon-y=15;left=1;scr...")
[2021-10-14T11:53:53]   Kana Kisume (/mob/living/carbon/human): ClickOn(the robot endoskeleton (/obj/item/robot_parts/robot_suit), "icon-x=15;icon-y=15;left=1;scr...")
[2021-10-14T11:53:53]   the robot endoskeleton (/obj/item/robot_parts/robot_suit): Click(the floor (172,122,2) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=15;icon-y=15;left=1;scr...")
```

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently this is causing a runtime whenever a cyborg is spawned in with an active AI on the station, which seems to be around 4 times per round.

## Changelog
:cl:
fix: Fixed a runtime caused by cyborgs trying to sync laws with an AI before their mind had been created.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
