### PR TITLE
Prevents mentors speaking in deadchat when deadchat is muted

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -46,7 +46,7 @@
 
 /mob/proc/say_dead(message)
 	if(client)
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			if(!GLOB.dsay_enabled)
 				to_chat(src, "<span class='danger'>Deadchat is globally muted.</span>")
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
prevents mentors from speaking in deadchat when deadchat is muted

## Why It's Good For The Game
its probably not intended to let mentors bypass admin intervention.

## Changelog
:cl:
fix: mentors can no longer talk in deadchat when deadchat is muted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
