### PR TITLE
Makes mindslaves lose their mindslave status when their owner cryos

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 
 /datum/objective/protect/mindslave/on_target_cryo()
 	if(owner?.current)
-		to_chat(owner.current, "<BR><span class='userdanger'>You notice that your master has cryo'd, and revert to your normal self, until they return again. You are no longer a mindslave!</span>")
+		to_chat(owner.current, "<BR><span class='userdanger'>You notice that your master has entered cryogenic storage, and revert to your normal self, until they return again. You are no longer a mindslave!</span>")
 		SEND_SOUND(owner.current, sound('sound/ambience/alarm4.ogg'))
 		owner.remove_antag_datum(/datum/antagonist/mindslave)
 		SSticker.mode.implanted.Remove(owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Overrides on_target_cryo() for mindslave project objectives. When the mindslave master cryos, instead of the mindslaved getting their objective rerolled to a random person, they are de-mindslaved, have their objective removed, and removed from the mindslave list.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

People getting mindslaved to a random person when there master cryo's is a bit silly. Instead, they just get de-mindslaved instead.
Fixes #16946 

## Changelog
:cl:
fix: Fixes mindslaved people being mindslaved to a random person when their owner cryos.
tweak: Mindslaved people are now d-emindslaved when their owner cryos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
