### PR TITLE
Fixes a Grey runechat runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -91,4 +91,6 @@
 
 /datum/species/grey/get_species_runechat_color(mob/living/carbon/human/H)
 	var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
-	return E.eye_color
+	if(E)
+		return E.eye_color
+	return flesh_color


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes `Runtime in grey.dm,94: Cannot read null.eye_color`.
This was caused by there not being a check to make sure that the eyes exist in `/datum/species/grey/get_species_runechat_color()`.
Now if a Grey player has their eyes removed, the runechat colour will default to the species' `flesh_color` of `#a598ad`.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtime fix.
![image](https://user-images.githubusercontent.com/57483089/137478158-f01cc795-e2e7-49ea-b9d0-35b1cd0df5b4.png)

## Changelog
:cl:
fix: Fixed a runtime caused by Grey players losing their eyes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
