### PR TITLE
Fixes the 'Toggle Runechat Colour Forcing' chat message

### DIFF
--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -347,7 +347,7 @@
 	set desc = "Toggles forcing your runechat colour to white"
 	prefs.toggles2 ^= PREFTOGGLE_2_FORCE_WHITE_RUNECHAT
 	prefs.save_preferences(src)
-	to_chat(src, "Your runechats will [(prefs.toggles2 & PREFTOGGLE_2_FORCE_WHITE_RUNECHAT) ? "no longer" : "now"] be forced to be white.")
+	to_chat(src, "Your runechats will [(prefs.toggles2 & PREFTOGGLE_2_FORCE_WHITE_RUNECHAT) ? "now" : "no longer"] be forced to be white.")
 
 /client/verb/toggle_simple_stat_panel()
 	set name = "Toggle Simple Status Panel"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Flips the 'Toggle Runechat Colour Forcing' chat message, since currently it's the wrong way around.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Well, it's backwards.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
### Before:
**Enabling:**
![1](https://user-images.githubusercontent.com/57483089/137484845-bc961bfc-fa30-4e10-9438-792d1a55f608.png)

**Disabling:**
![2](https://user-images.githubusercontent.com/57483089/137484862-bba4df36-a0a8-493c-b0d5-e94abac33ef4.png)
<hr>

### After:
**Enabling:**
![3](https://user-images.githubusercontent.com/57483089/137484925-6cb6d95d-0f11-4e9d-87eb-cb31b7b818cb.png)

**Disabling:**
![4](https://user-images.githubusercontent.com/57483089/137484935-da1bf64c-f52e-413f-a3a8-ad493dbda0e7.png)

## Changelog
:cl:
fix: Fixed the 'Toggle Runechat Colour Forcing' chat message being backwards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
