### PR TITLE
Fixes the end of round antag list not showing disconnected player's keys.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -86,7 +86,7 @@
 	return ..()
 
 /datum/mind/proc/get_display_key()
-	var/clientKey = current?.client.get_display_key()
+	var/clientKey = current?.client?.get_display_key()
 	return clientKey ? clientKey : key
 
 /datum/mind/proc/transfer_to(mob/living/new_character)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes `Runtime in mind.dm,89: Cannot execute null.get display key().`.
This was caused by the end of round "The antagonists were:" list not checking if the antag player was still connected to the server.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently the only effect it has ingame is the player's key not showing, but obivously it shouldn't be happening.
![image](https://user-images.githubusercontent.com/57483089/137489400-9633317e-40df-4ab6-b7fc-8e3850d79e8d.png)

## Changelog
:cl:
fix: Fixed player's ckeys not showing in the end of round antag list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
