### PR TITLE
Fixes swarmers initialising multiple times

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -111,9 +111,6 @@
 
 /obj/effect/mob_spawn/proc/create(ckey, flavour = TRUE, name)
 	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
-	var/mob/living/carbon/human/H = M
-	if(H && !H.dna)
-		H.Initialize(null)
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
 		if(!mob_gender)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes `Runtime in unsorted.dm,1992: Warning: Swarmer 204-gamma(/mob/living/simple_animal/hostile/swarmer) initialized multiple times!`.
The runtime was caused by this code in corpse.dm:
https://github.com/ParadiseSS13/Paradise/blob/25c4275a16d76b7abd050887e21068b07d42a9cf/code/modules/awaymissions/corpse.dm#L112-L116
Because swarmers and other simple mobs have no DNA, they get initialised multiple times whenever a player uses the spawner.
I've gone through every `/obj/effect/mob_spawn` subtype with some breakpoints, and the only ones which ever get to line 116 are the simple mobs (causing the runtime).
![Paradise Test NSS Cyberiad 2021-10-15 150732](https://user-images.githubusercontent.com/57483089/137503918-d755318f-2229-4af2-8961-b9589b2d758c.png)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This code was needed when #9806 was merged as evidenced by the screenshots in that, but it seems that since then whatever the underlying issue was has been fixed.

## Runtime Logs
(Same test on each version, see the above screenshot)
<details>
<summary><b>Before:</b></summary>

```
Runtime in corpse.dm,113: Cannot create objects of type null.
  proc name: create (/obj/effect/mob_spawn/proc/create)
  usr: Zikuzi Querrl-xrim (sabreml) (/mob/dead/observer)
  usr.loc: The floor (161,31,1) (/turf/simulated/floor/plasteel)
  src: Unknown (/obj/effect/mob_spawn)
  src.loc: the floor (161,31,1) (/turf/simulated/floor/plasteel)
  call stack:
  Unknown (/obj/effect/mob_spawn): create(null, 1, null)
  Unknown (/obj/effect/mob_spawn): Initialize(0)
  Atoms (/datum/controller/subsystem/atoms): InitAtom(Unknown (/obj/effect/mob_spawn), /list (/list))
  Unknown (/obj/effect/mob_spawn): attempt init(0)
  Unknown (/obj/effect/mob_spawn): attempt init(the floor (161,31,1) (/turf/simulated/floor/plasteel))
  Unknown (/obj/effect/mob_spawn): New(the floor (161,31,1) (/turf/simulated/floor/plasteel))
  Unknown (/obj/effect/mob_spawn): New(the floor (161,31,1) (/turf/simulated/floor/plasteel))
  /datum/admins (/datum/admins): Topic("src=%5B0x21003b66%5D_668&filte...", /list (/list))
  SabreML (/client): Topic("src=%5B0x21003b66%5D_668&filte...", /list (/list), /datum/admins (/datum/admins))
Runtime in unsorted.dm,1992: Warning: Swarmer 554-beta(/mob/living/simple_animal/hostile/swarmer) initialized multiple times!
  proc name: stack trace (/datum/proc/stack_trace)
  usr: Zikuzi Querrl-xrim (sabreml) (/mob/dead/observer)
  usr.loc: The floor (155,34,1) (/turf/simulated/floor/plasteel)
  src: Swarmer 554-beta (/mob/living/simple_animal/hostile/swarmer)
  src.loc: the floor (151,35,1) (/turf/simulated/floor/plasteel)
  call stack:
  Swarmer 554-beta (/mob/living/simple_animal/hostile/swarmer): stack trace("Warning: Swarmer 554-beta(/mob...")
  Swarmer 554-beta (/mob/living/simple_animal/hostile/swarmer): Initialize(null)
  Swarmer 554-beta (/mob/living/simple_animal/hostile/swarmer): Initialize(null)
  Swarmer 554-beta (/mob/living/simple_animal/hostile/swarmer): Initialize(null)
  Swarmer 554-beta (/mob/living/simple_animal/hostile/swarmer): Initialize(null)
  Swarmer 554-beta (/mob/living/simple_animal/hostile/swarmer): Initialize(null)
  the unactivated swarmer (/obj/effect/mob_spawn/swarmer): create("sabreml", 1, null)
  the unactivated swarmer (/obj/effect/mob_spawn/swarmer): attack ghost(Zikuzi Querrl-xrim (/mob/dead/observer))
  Zikuzi Querrl-xrim (/mob/dead/observer): ClickOn(the unactivated swarmer (/obj/effect/mob_spawn/swarmer), "icon-x=18;icon-y=17;left=1;but...")
  the unactivated swarmer (/obj/effect/mob_spawn/swarmer): Click(the floor (151,35,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=18;icon-y=17;left=1;
Runtime in unsorted.dm,1992: Warning: the mouse(/mob/living/simple_animal/mouse) initialized multiple times!
  proc name: stack trace (/datum/proc/stack_trace)
  usr: Juniper (sabreml) (/mob/dead/observer)
  usr.loc: The floor (157,31,1) (/turf/simulated/floor/plasteel)
  src: the mouse (/mob/living/simple_animal/mouse)
  src.loc: the floor (159,31,1) (/turf/simulated/floor/plasteel)
  call stack:
  the mouse (/mob/living/simple_animal/mouse): stack trace("Warning: the mouse(/mob/living...")
  the mouse (/mob/living/simple_animal/mouse): Initialize(null)
  the mouse (/mob/living/simple_animal/mouse): Initialize(null)
  the mouse (/mob/living/simple_animal/mouse): Initialize(null)
  the mouse (/mob/living/simple_animal/mouse): Initialize(null)
  the mouse (/mob/living/simple_animal/mouse): Initialize(null)
  the sleeper (/obj/effect/mob_spawn/mouse): create("sabreml", 1, null)
  the sleeper (/obj/effect/mob_spawn/mouse): attack ghost(Juniper (/mob/dead/observer))
  Juniper (/mob/dead/observer): ClickOn(the sleeper (/obj/effect/mob_spawn/mouse), "icon-x=17;icon-y=10;left=1;but...")
  the sleeper (/obj/effect/mob_spawn/mouse): Click(the floor (159,31,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=17;icon-y=10;left=1;but...")
Runtime in unsorted.dm,1992: Warning: the cow(/mob/living/simple_animal/cow) initialized multiple times!
  proc name: stack trace (/datum/proc/stack_trace)
  usr: The space mouse (sabreml) (/mob/dead/observer)
  usr.loc: The floor (159,31,1) (/turf/simulated/floor/plasteel)
  src: the cow (/mob/living/simple_animal/cow)
  src.loc: the floor (160,31,1) (/turf/simulated/floor/plasteel)
  call stack:
  the cow (/mob/living/simple_animal/cow): stack trace("Warning: the cow(/mob/living/s...")
  the cow (/mob/living/simple_animal/cow): Initialize(null)
  the cow (/mob/living/simple_animal/cow): Initialize(null)
  the cow (/mob/living/simple_animal/cow): Initialize(null)
  the cow (/mob/living/simple_animal/cow): Initialize(null)
  the cow (/mob/living/simple_animal/cow): Initialize(null)
  the sleeper (/obj/effect/mob_spawn/cow): create("sabreml", 1, null)
  the sleeper (/obj/effect/mob_spawn/cow): attack ghost(the space mouse (/mob/dead/observer))
  the space mouse (/mob/dead/observer): ClickOn(the sleeper (/obj/effect/mob_spawn/cow), "icon-x=24;icon-y=14;left=1;but...")
  the sleeper (/obj/effect/mob_spawn/cow): Click(the floor (160,31,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=24;icon-y=14;left=1;but...")
```
</details>

<details>
<summary><b>After:</b></summary>

```
Runtime in corpse.dm,113: Cannot create objects of type null.
  proc name: create (/obj/effect/mob_spawn/proc/create)
  usr: Zikuzi Querrl-xrim (sabreml) (/mob/dead/observer)
  usr.loc: The floor (161,31,1) (/turf/simulated/floor/plasteel)
  src: Unknown (/obj/effect/mob_spawn)
  src.loc: the floor (161,31,1) (/turf/simulated/floor/plasteel)
  call stack:
  Unknown (/obj/effect/mob_spawn): create(null, 1, null)
  Unknown (/obj/effect/mob_spawn): Initialize(0)
  Atoms (/datum/controller/subsystem/atoms): InitAtom(Unknown (/obj/effect/mob_spawn), /list (/list))
  Unknown (/obj/effect/mob_spawn): attempt init(0)
  Unknown (/obj/effect/mob_spawn): attempt init(the floor (161,31,1) (/turf/simulated/floor/plasteel))
  Unknown (/obj/effect/mob_spawn): New(the floor (161,31,1) (/turf/simulated/floor/plasteel))
  Unknown (/obj/effect/mob_spawn): New(the floor (161,31,1) (/turf/simulated/floor/plasteel))
  /datum/admins (/datum/admins): Topic("src=%5B0x21003b5a%5D_664&filte...", /list (/list))
  SabreML (/client): Topic("src=%5B0x21003b5a%5D_664&filte...", /list (/list), /datum/admins (/datum/admins))
```
</details>


## Changelog
:cl:
fix: Fixed simple mob ghost spawners causing a runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
