### PR TITLE
Fixes a runtime from simple mobs walking on glass floors

### DIFF
--- a/code/__DEFINES/footstep.dm
+++ b/code/__DEFINES/footstep.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(clawfootstep, list(
 		'sound/effects/footstep/lava3.ogg'), 100, 0),
 	FOOTSTEP_MEAT = list(list(
 		'sound/effects/meatslap.ogg'), 100, 0),
-	FOOTSTEP_GLASS = list(list(
+	FOOTSTEP_GLASS_BAREFOOT = list(list(
 		'sound/effects/footstep/glassbarefoot1.ogg',
 		'sound/effects/footstep/glassbarefoot2.ogg',
 		'sound/effects/footstep/glassbarefoot3.ogg'), 100, 1),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes `Runtime in footstep.dm,98: cannot read from list`.
This was caused glass floors having `FOOTSTEP_GLASS_BAREFOOT` set as the `clawfootstep` sound, but the actual sounds being under just `FOOTSTEP_GLASS`:
https://github.com/ParadiseSS13/Paradise/blob/25c4275a16d76b7abd050887e21068b07d42a9cf/code/game/turfs/simulated/floor/transparent.dm#L1-L11
https://github.com/ParadiseSS13/Paradise/blob/25c4275a16d76b7abd050887e21068b07d42a9cf/code/__DEFINES/footstep.dm#L184-L187
https://github.com/ParadiseSS13/Paradise/blob/25c4275a16d76b7abd050887e21068b07d42a9cf/code/datums/components/footstep.dm#L87-L98

Mobs with `FOOTSTEP_MOB_CLAW` as their `footstep_type` (most simple mobs) would try to find `FOOTSTEP_GLASS_BAREFOOT` in the list and fail, causing the runtime.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I'm not sure how common this is since I only have the runtime logs I've saved of the past 3-4 rounds, but in the last two at least it's caused a total of 259 runtimes.

## Changelog
:cl:
fix: Fixed a runtime caused by simplemobs walking on glass floors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
