### PR TITLE
Soulstone runtime fix

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -83,6 +83,10 @@
 	if(!ishuman(M)) //If target is not a human
 		return ..()
 
+	if(!M.mind)
+		to_chat(user, "<span class='warning'>This being has no soul!</span>")
+		return ..()
+
 	if(M.has_brain_worms()) //Borer stuff - RR
 		to_chat(user, "<span class='warning'>This being is corrupted by an alien intelligence and cannot be soul trapped.</span>")
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes `Runtime in soulstone.dm,98: Cannot read null.offstation_role`.
This was caused by there being no `mind` check in `/obj/item/soulstone/attack()` before the `mind.offstation_role` check.

Player mobs will always have a `mind` datum even if they've disconnected, so this shouldn't have any ingame effects. (The runtime already prevents it from being used.)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtimes are bad.

## Changelog
:cl:
fix: Fixed a runtime caused by using a soulstone on a NPC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
