### PR TITLE
Fixes fire extinguishers (sometimes) failing to GC

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -26,9 +26,9 @@
 		if(NO_EXTINGUISHER)
 			return
 		if(MINI_EXTINGUISHER)
-			has_extinguisher = new/obj/item/extinguisher/mini
+			has_extinguisher = new /obj/item/extinguisher/mini(src)
 		else
-			has_extinguisher = new/obj/item/extinguisher
+			has_extinguisher = new /obj/item/extinguisher(src)
 
 /obj/structure/extinguisher_cabinet/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes fire extinguishers failing to GC when their cabinet is blown up.
This was caused by the extinguisher having no `loc` when first spawned inside the cabinet, and consequently failing to call `loc.handle_atom_del(src)`.
<details>
<summary><b>Explanation:</b></summary>
<hr>

Any explosions on the extinguisher cabinet get passed to the fire extinguisher inside:
https://github.com/ParadiseSS13/Paradise/blob/1d8b4aca030bd275b2926613bc91d1b7624de27e/code/game/objects/structures/extinguisher.dm#L53-L56
If the extinguisher is deleted by a severity 1 explosion, it's meant to call `loc.handle_atom_del(src)` (`loc` being the cabinet) and clean up its own reference:
https://github.com/ParadiseSS13/Paradise/blob/1d8b4aca030bd275b2926613bc91d1b7624de27e/code/game/atoms_movable.dm#L42-L47
https://github.com/ParadiseSS13/Paradise/blob/1d8b4aca030bd275b2926613bc91d1b7624de27e/code/game/objects/structures/extinguisher.dm#L58-L61
However, when the extinguisher is initially spawned inside the cabinet, no location is given to it so it just spawns in nullspace:
https://github.com/ParadiseSS13/Paradise/blob/1d8b4aca030bd275b2926613bc91d1b7624de27e/code/game/objects/structures/extinguisher.dm#L25-L31
![image](https://user-images.githubusercontent.com/57483089/137628963-9419e010-2999-4d72-a20c-2ffe464de514.png)
This meant that the `if(loc)` check in `/atom/movable/Destroy()` failed, and the reference to the extinguisher never got removed.
<hr>
</details>

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fire extinguishers only having deletion issues if their cabinet gets blown up is very much an edge case, but since the fix is only a small tweak on a couple of lines there's no real downsides to making it work properly.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
(Both screenshots taken 5 minutes after blowing up the extinguisher cabinet.)
**Before:**
![Before 5m](https://user-images.githubusercontent.com/57483089/137628372-c760a55b-7667-4c10-bdb7-5df0970d2dd7.png)

**After:**
![After 5m](https://user-images.githubusercontent.com/57483089/137628380-085302cc-ae74-47dc-ad19-99a5c821d682.png)


## Changelog
:cl:
fix: Fixed fire extinguishers not deleting properly if their cabinet gets blown up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
