### PR TITLE
Fixes re-admin not working

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -704,8 +704,9 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 
 				if(istext(flags))
 					flags = text2num(flags)
+				var/client/check_client = GLOB.directory[ckey]
 				// Do a little check here
-				if(GLOB.configuration.system.is_production && (flags & R_ADMIN) && prefs._2fa_status == _2FA_DISABLED) // If they are an admin and their 2FA is disabled
+				if(GLOB.configuration.system.is_production && (flags & R_ADMIN) && check_client.prefs._2fa_status == _2FA_DISABLED) // If they are an admin and their 2FA is disabled
 					to_chat(src,"<span class='boldannounce'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.</big></span>") // Very fucking obvious
 					qdel(admin_read)
 					return


### PR DESCRIPTION
## What Does This PR Do
Fixes #16925 

This is caused by a BYOND bug. I have no idea how it happens but heres the fix.

## Why It's Good For The Game
Admins should be able to re-admin.

## Changelog
:cl: AffectedArc07
fix: Re-admin-self works again
/:cl:
