### PR TITLE
Fixes carpet crafting

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -28,7 +28,6 @@
 
 /obj/item/toy/crayon/New()
 	..()
-	name = "[colourName] crayon" //Makes crayons identifiable in things like grinders
 	drawtype = pick(pick(graffiti), pick(letters), "rune[rand(1, 8)]")
 
 /obj/item/toy/crayon/attack_self(mob/living/user as mob)
@@ -122,31 +121,37 @@
 
 
 /obj/item/toy/crayon/red
+	name = "red crayon"
 	icon_state = "crayonred"
 	colour = COLOR_RED
 	colourName = "red"
 
 /obj/item/toy/crayon/orange
+	name = "orange crayon"
 	icon_state = "crayonorange"
 	colour = COLOR_ORANGE
 	colourName = "orange"
 
 /obj/item/toy/crayon/yellow
+	name = "yellow crayon"
 	icon_state = "crayonyellow"
 	colour = COLOR_YELLOW
 	colourName = "yellow"
 
 /obj/item/toy/crayon/green
+	name = "green crayon"
 	icon_state = "crayongreen"
 	colour = COLOR_GREEN
 	colourName = "green"
 
 /obj/item/toy/crayon/blue
+	name = "blue crayon"
 	icon_state = "crayonblue"
 	colour = COLOR_BLUE
 	colourName = "blue"
 
 /obj/item/toy/crayon/purple
+	name = "purple crayon"
 	icon_state = "crayonpurple"
 	colour = COLOR_PURPLE
 	colourName = "purple"
@@ -155,38 +160,47 @@
 	icon_state = pick(list("crayonred", "crayonorange", "crayonyellow", "crayongreen", "crayonblue", "crayonpurple"))
 	switch(icon_state)
 		if("crayonred")
+			name = "red crayon"
 			colour = COLOR_RED
 			colourName = "red"
 		if("crayonorange")
+			name = "orange crayon"
 			colour = COLOR_ORANGE
 			colourName = "orange"
 		if("crayonyellow")
+			name = "yellow crayon"
 			colour = COLOR_YELLOW
 			colourName = "yellow"
 		if("crayongreen")
+			name = "green crayon"
 			colour =COLOR_GREEN
 			colourName = "green"
 		if("crayonblue")
+			name = "blue crayon"
 			colour = COLOR_BLUE
 			colourName = "blue"
 		if("crayonpurple")
+			name = "purple crayon"
 			colour = COLOR_PURPLE
 			colourName = "purple"
 	..()
 
 /obj/item/toy/crayon/black
+	name = "black crayon"
 	icon_state = "crayonblack"
 	colour = "#000000"
 	colourName = "black"
 
 /obj/item/toy/crayon/white
+	name = "white crayon"
 	icon_state = "crayonwhite"
 	colour = "#FFFFFF"
 	colourName = "white"
 
 /obj/item/toy/crayon/mime
-	icon_state = "crayonmime"
+	name = "mime crayon"
 	desc = "A very sad-looking crayon."
+	icon_state = "crayonmime"
 	colour = "#FFFFFF"
 	colourName = "mime"
 	uses = 0
@@ -211,6 +225,7 @@
 		..()
 
 /obj/item/toy/crayon/rainbow
+	name = "rainbow crayon"
 	icon_state = "crayonrainbow"
 	colour = "#FFF000"
 	colourName = "rainbow"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -377,7 +377,7 @@
 	category = CAT_MISC
 
 /datum/crafting_recipe/bluecarpet
-	name = "Black Carpet"
+	name = "Blue Carpet"
 	result = list(/obj/item/stack/tile/carpet/blue)
 	time = 20
 	reqs = list(/obj/item/stack/tile/carpet = 1)
@@ -386,7 +386,7 @@
 
 /datum/crafting_recipe/cyancarpet
 	name = "Cyan Carpet"
-	result = list(/obj/item/stack/tile/carpet/blue)
+	result = list(/obj/item/stack/tile/carpet/cyan)
 	time = 20
 	reqs = list(/obj/item/stack/tile/carpet = 1)
 	pathtools = list(/obj/item/toy/crayon/blue, /obj/item/toy/crayon/green)
@@ -418,7 +418,7 @@
 
 /datum/crafting_recipe/redcarpet
 	name = "Red Carpet"
-	result = list(/obj/item/stack/tile/carpet/purple)
+	result = list(/obj/item/stack/tile/carpet/red)
 	time = 20
 	reqs = list(/obj/item/stack/tile/carpet = 1)
 	pathtools = list(/obj/item/toy/crayon/red)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes #16968

It is now possible to craft all carpets properly.
Crayon names now properly show in the crafting menu.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Not getting what you expected is not good game design. Also good to see what you need to get what you want. _(this sentence hurts my eyes and I'm not sure why)_

## Changelog
:cl:
fix: Fixed carpet crafting.
fix: Fixed crayon names not appearing in the crafting menu.
/:cl:
_Remember to always test your PRs._

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
