### PR TITLE
Removes Mech Wormhole Generator

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -1,4 +1,4 @@
-// Teleporter, Wormhole generator, Gravitational catapult, Armor booster modules,
+// Teleporter, Gravitational catapult, Armor booster modules,
 // Repair droid, Tesla Energy relay, Generators
 
 ////////////////////////////////////////////// TELEPORTER ///////////////////////////////////////////////
@@ -28,53 +28,6 @@
 	origin_tech = "bluespace=7"
 	energy_drain = 1000
 	tele_precision = 1
-
-
-////////////////////////////////////////////// WORMHOLE GENERATOR //////////////////////////////////////////
-
-/obj/item/mecha_parts/mecha_equipment/wormhole_generator
-	name = "mounted wormhole generator"
-	desc = "An exosuit module that allows generating of small quasi-stable wormholes."
-	icon_state = "mecha_wholegen"
-	origin_tech = "bluespace=4;magnets=4;plasmatech=2"
-	equip_cooldown = 50
-	energy_drain = 300
-	range = MECHA_RANGED
-
-/obj/item/mecha_parts/mecha_equipment/wormhole_generator/action(atom/target)
-	if(!action_checks(target) || !is_teleport_allowed(loc.z))
-		return
-	var/list/theareas = get_areas_in_range(100, chassis)
-	if(!theareas.len)
-		return
-	var/area/thearea = pick(theareas)
-	var/list/L = list()
-	var/turf/pos = get_turf(src)
-	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!T.density && pos.z == T.z)
-			var/clear = 1
-			for(var/obj/O in T)
-				if(O.density)
-					clear = 0
-					break
-			if(clear)
-				L+=T
-	if(!L.len)
-		return
-	var/turf/target_turf = pick(L)
-	if(!target_turf)
-		return
-	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(target), target_turf)
-	P.icon = 'icons/obj/objects.dmi'
-	P.failchance = 0
-	P.icon_state = "anom"
-	P.name = "wormhole"
-	message_admins("[key_name_admin(chassis.occupant, chassis.occupant.client)]([ADMIN_QUE(chassis.occupant,"?")]) ([ADMIN_FLW(chassis.occupant,"FLW")]) used a Wormhole Generator in ([loc.x],[loc.y],[loc.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>JMP</a>)",0,1)
-	log_game("[key_name(chassis.occupant)] used a Wormhole Generator in ([loc.x],[loc.y],[loc.z])")
-	src = null
-	spawn(rand(150,300))
-		qdel(P)
-	return 1
 
 /////////////////////////////////////// GRAVITATIONAL CATAPULT ///////////////////////////////////////////
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -781,17 +781,6 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
-/datum/design/mech_wormhole_gen
-	name = "Exosuit Module (Localized Wormhole Generator)"
-	desc = "An exosuit module that allows generating of small quasi-stable wormholes."
-	id = "mech_wormhole_gen"
-	build_type = MECHFAB
-	req_tech = list("bluespace" = 4, "magnets" = 4, "plasmatech" = 3)
-	build_path = /obj/item/mecha_parts/mecha_equipment/wormhole_generator
-	materials = list(MAT_METAL=10000)
-	construction_time = 100
-	category = list("Exosuit Equipment")
-
 /datum/design/mech_rcd
 	name = "Exosuit Module (RCD Module)"
 	desc = "An exosuit-mounted Rapid Construction Device."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the Exosuit Wormhole Generator outright.

## Why It's Good For The Game
I have quite literally never seen this used for anything other than annoying spam that is impossible to contain.

It also spams the living hell out of admin logs and causes more bwoinks than is worth having (I know I personally have spoken to a number of people about it).

This was moved to a SoP requirement to avoid obnoxious use, but once youre in the mech there's really no sane way to catch them and deal with it without becoming a self-antag issue anyway. I've never seen someone get fired for it and Security has better things to do than chase a tider in an exosuit that can teleport randomly, including space.

## Image of Changes
Pain and suffering

![image](https://user-images.githubusercontent.com/57759731/137807458-2ce1c3a3-ccbc-41e1-b077-25233b9499c8.png)


## Changelog
:cl:
del: removes Exosuit Wormhole Generator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
