### PR TITLE
Safes Can No Longer Hold `ABSTRACT` Things

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -175,6 +175,8 @@ GLOBAL_LIST_EMPTY(safes)
 
 /obj/structure/safe/attackby(obj/item/I, mob/user, params)
 	if(open)
+		if(I.flags && ABSTRACT)
+			return
 		if(broken && istype(I, /obj/item/safe_internals) && do_after(user, 2 SECONDS, target = src))
 			to_chat(user, "<span class='notice'>You replace the broken mechanism.</span>")
 			qdel(I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents safes from holding `ABSTRACT` items.

## Why It's Good For The Game
I shouldn't be able to store a grab or slapper.

Fixes #16963

## Changelog
:cl:
fix: fixes abstract items in safes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
