### PR TITLE
Fixes IPC damage overlays not updating

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -103,6 +103,7 @@ emp_act
 			break
 		nrembrute = max(rembrute - E.brute_dam, 0)
 		E.heal_damage(rembrute,0,0,1)
+		UpdateDamageIcon()
 		rembrute = nrembrute
 		user.visible_message("<span class='alert'>[user] patches some dents on [src]'s [E.name] with [I].</span>")
 	if(bleed_rate && ismachineperson(src))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -568,7 +568,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 				use(1)
 				cable_used += 1
 				E.heal_damage(0, HEALPERCABLE, 0, TRUE)
-				H.UpdateDamageIcon()
+			H.UpdateDamageIcon()
 			user.visible_message("<span class='alert'>[user] repairs some burn damage on [M]'s [E.name] with [src].</span>")
 		return 1
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -567,8 +567,9 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 			while(cable_used <= MAXCABLEPERHEAL && E.burn_dam && amount >= 1)
 				use(1)
 				cable_used += 1
-				E.heal_damage(0, HEALPERCABLE, 0, 1)
-			user.visible_message("<span class='alert'>\The [user] repairs some burn damage on \the [M]'s [E.name] with \the [src].</span>")
+				E.heal_damage(0, HEALPERCABLE, 0, TRUE)
+				H.UpdateDamageIcon()
+			user.visible_message("<span class='alert'>[user] repairs some burn damage on [M]'s [E.name] with [src].</span>")
 		return 1
 
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes IPC damage overlays not being removed when healed with a cable coil or welding tool. (Fixes #16682)
This was caused by the healing procs updating the limb's `damage_state` via `heal_damage()`, but not calling `UpdateDamageIcon()` to apply it to the overlay.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Oversight/Inconsistency.

## Changelog
:cl:
fix: Fixed IPC damage overlays not updating when healed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
