### PR TITLE
Prevents Cult Harvesters from spawning at Observers current location

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -60,7 +60,8 @@
 				to_chat(cult_mind.current, "<span class='cult'>Current goal: Slaughter the heretics!</span>")
 	..()
 
-/obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user)
+/obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
+	user.forceMove(get_turf(src)) //make_new_construct spawns harvesters at observers locations, could be used to get into admin rooms/CC
 	make_new_construct(/mob/living/simple_animal/hostile/construct/harvester, user, cult_override = TRUE)
 	new /obj/effect/particle_effect/smoke/sleeping(user.loc)
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #16982 
Observers are now teleported directly to nar'sie before being made into a harvester construct upon clicking Nar'sie or the Nar'sie action button.

## Why It's Good For The Game
Exploits are bad. Harvesters should not be able to spawn in an admin room or central command and harass CC characters.

## Changelog
:cl:
fix: Prevents Cult Harvesters from spawning at Observers current location
/:cl:
