### PR TITLE
Prevents usage of martial arts with the passive trait

### DIFF
--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -68,6 +68,9 @@
 
 /datum/martial_art/krav_maga/teach(mob/living/carbon/human/H, make_temporary=0)
 	..()
+	if(HAS_TRAIT(H, TRAIT_PACIFISM))
+		to_chat(H, "<span class='warning'>The arts of Krav Maga echo uselessly in your head, the thought of their violence repulsive to you!</span>")
+		return
 	to_chat(H, "<span class = 'userdanger'>You know the arts of Krav Maga!</span>")
 	to_chat(H, "<span class = 'danger'>Place your cursor over a move at the top of the screen to see what it does.</span>")
 	neutral.Grant(H)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -49,7 +49,7 @@
 	return act(MARTIAL_COMBO_STEP_HELP, A, D)
 
 /datum/martial_art/proc/can_use(mob/living/carbon/human/H)
-	return TRUE
+	return !HAS_TRAIT(H, TRAIT_PACIFISM)
 
 /datum/martial_art/proc/act(step, mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(!can_use(user))
@@ -59,11 +59,7 @@
 	last_hit = world.time
 
 	if(HAS_COMBOS)
-		var/completed_combo = check_combos(step, user, target)
-		if(HAS_TRAIT(user, TRAIT_PACIFISM) && completed_combo)
-			to_chat(user, "<span class='warning'>Despite your knowledge of the martial art, your body refuses to execute the move!</span>")
-			return FALSE
-		return completed_combo
+		return check_combos(step, user, target)
 	return FALSE
 
 /datum/martial_art/proc/reset_combos()

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -49,6 +49,9 @@
 	return act(MARTIAL_COMBO_STEP_HELP, A, D)
 
 /datum/martial_art/proc/can_use(mob/living/carbon/human/H)
+	if(HAS_TRAIT(H, TRAIT_PACIFISM))
+		to_chat(H, "<span class='warning'>Despite your knowledge of the martial art, your body refuses to execute the move!</span>")
+		return FALSE
 	return TRUE
 
 /datum/martial_art/proc/act(step, mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -222,6 +225,9 @@
 		return
 	if(slot == slot_belt)
 		var/mob/living/carbon/human/H = user
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			to_chat("<span class='warning'>In spite of the grandiosity of the belt, you don't feel like getting into any fights.</span>")
+			return
 		style.teach(H,1)
 		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the Recall teaching verb in the wrestling tab.</span>")
 	return
@@ -265,12 +271,15 @@
 /obj/item/sleeping_carp_scroll/attack_self(mob/living/carbon/human/user as mob)
 	if(!istype(user) || !user)
 		return
-	if(user.mind && (user.mind.changeling || user.mind.vampire)) //Prevents changelings and vampires from being able to learn it
-		if(user.mind && user.mind.changeling) //Changelings
+	if(user.mind) //Prevents changelings and vampires from being able to learn it
+		if(user.mind.changeling) //Changelings
 			to_chat(user, "<span class ='warning'>We try multiple times, but we are not able to comprehend the contents of the scroll!</span>")
 			return
-		else //Vampires
+		else if(user.mind.vampire) //Vampires
 			to_chat(user, "<span class ='warning'>Your blood lust distracts you too much to be able to concentrate on the contents of the scroll!</span>")
+			return
+		else if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			to_chat(user, "<span class='warning'>The scroll's whispers of violence don't agree with you at all; you can't concentrate enough to understand what it truly means!</span>")
 			return
 
 	var/datum/martial_art/the_sleeping_carp/theSleepingCarp = new(null)
@@ -295,6 +304,9 @@
 			return
 		else if(user.mind.vampire) //Vampires
 			to_chat(user, "<span class='warning'>Your blood lust distracts you from the basics of CQC!</span>")
+			return
+		else if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			to_chat(user, "<span class='warning'>The mere thought of combat, let alone CQC, makes your head spin!</span>")
 			return
 
 	to_chat(user, "<span class='boldannounce'>You remember the basics of CQC.</span>")
@@ -342,12 +354,16 @@
 	if(C.stat)
 		to_chat(user, "<span class='warning'>It would be dishonorable to attack a foe while [C.p_they()] cannot retaliate.</span>")
 		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You feel violence is not the answer.</span>")
+		return
 	switch(user.a_intent)
 		if(INTENT_DISARM)
 			if(!wielded)
 				return ..()
 			if(!ishuman(target))
 				return ..()
+
 			var/mob/living/carbon/human/H = target
 			var/list/fluffmessages = list("[user] clubs [H] with [src]!", \
 										  "[user] smacks [H] with the butt of [src]!", \

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -49,9 +49,6 @@
 	return act(MARTIAL_COMBO_STEP_HELP, A, D)
 
 /datum/martial_art/proc/can_use(mob/living/carbon/human/H)
-	if(HAS_TRAIT(H, TRAIT_PACIFISM))
-		to_chat(H, "<span class='warning'>Despite your knowledge of the martial art, your body refuses to execute the move!</span>")
-		return FALSE
 	return TRUE
 
 /datum/martial_art/proc/act(step, mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -62,7 +59,11 @@
 	last_hit = world.time
 
 	if(HAS_COMBOS)
-		return check_combos(step, user, target)
+		var/completed_combo = check_combos(step, user, target)
+		if(HAS_TRAIT(user, TRAIT_PACIFISM) && completed_combo)
+			to_chat(user, "<span class='warning'>Despite your knowledge of the martial art, your body refuses to execute the move!</span>")
+			return FALSE
+		return completed_combo
 	return FALSE
 
 /datum/martial_art/proc/reset_combos()
@@ -277,9 +278,6 @@
 			return
 		else if(user.mind.vampire) //Vampires
 			to_chat(user, "<span class ='warning'>Your blood lust distracts you too much to be able to concentrate on the contents of the scroll!</span>")
-			return
-		else if(HAS_TRAIT(user, TRAIT_PACIFISM))
-			to_chat(user, "<span class='warning'>The scroll's whispers of violence don't agree with you at all; you can't concentrate enough to understand what it truly means!</span>")
 			return
 
 	var/datum/martial_art/the_sleeping_carp/theSleepingCarp = new(null)

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -36,7 +36,7 @@
 	to_chat(H, "<span class='sciradio'>You have learned the ancient martial art of the Sleeping Carp! \
 					Your hand-to-hand combat has become much more effective, and you are now able to deflect any projectiles directed toward you when in throw mode. \
 					However, you are also unable to use any ranged weaponry. \
-					You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
+					You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>")
 	if(HAS_TRAIT(H, TRAIT_PACIFISM))
 		to_chat(H, "<span class='warning'>You feel the knowledge of the scroll in your mind, yet reject its more violent teachings. \
 					You will instead deflect projectiles into the ground.")

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -36,7 +36,10 @@
 	to_chat(H, "<span class='sciradio'>You have learned the ancient martial art of the Sleeping Carp! \
 					Your hand-to-hand combat has become much more effective, and you are now able to deflect any projectiles directed toward you when in throw mode. \
 					However, you are also unable to use any ranged weaponry. \
-					You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>")
+					You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
+	if(HAS_TRAIT(H, TRAIT_PACIFISM))
+		to_chat(H, "<span class='warning'>You feel the knowledge of the scroll in your mind, yet reject its more violent teachings. \
+					You will instead deflect projectiles into the ground.")
 
 /datum/martial_art/the_sleeping_carp/remove(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -39,8 +39,17 @@ emp_act
 	if(mind?.martial_art?.deflection_chance) //Some martial arts users can deflect projectiles!
 		if(!lying && !HAS_TRAIT(src, TRAIT_HULK) && mind.martial_art.try_deflect(src)) //But only if they're not lying down, and hulks can't do it
 			add_attack_logs(P.firer, src, "hit by [P.type] but got deflected by martial arts '[mind.martial_art]'")
-			visible_message("<span class='danger'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 			playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+			if(HAS_TRAIT(src, TRAIT_PACIFISM))
+				// Pacifists can deflect projectiles, but not reflect them.
+				// Instead, they deflect them into the ground below them.
+				var/turf/T = get_turf(src)
+				P.firer = src
+				T.bullet_act(P)
+				visible_message("<span class='danger'>[src] deflects the projectile into the ground!</span>", "<span class='userdanger'>You deflect the projectile towards the ground beneath your feet!</span>")
+				return FALSE
+
+			visible_message("<span class='danger'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 			if(mind.martial_art.reroute_deflection)
 				P.firer = src
 				P.setAngle(rand(0, 360))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes how the pacifism (TRAIT_PACIFISM) trait interacts with martial arts. 
Pacifism wasn't being properly checked for in martial arts handling, despite some non-harm intent actions still dealing damage. Krav Maga gloves, for instance, could still kill by lung punching.

Also modifies the behavior of trying to learn some martial arts, making it so you flat out cannot use the CQC scroll if a pacifist. I know CQC is going to be nukie-only soon, so this probably shouldn't matter too much, but I'm adding this for consistency's sake.

For sleeping carp, I didn't want to entirely remove the ability to learn it while passive, since reflecting projectiles is a big reason for taking it, as well as a defensive technique more than anything. Instead, you can still use the sleeping carp scroll when passive, but instead of reflecting projectiles in another direction, you simply deflect them to the floor so they can't hurt anyone else.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Despite not seeing too much use of the passive trait in game, it doesn't make sense that someone who doesn't want to partake in violence can still beat someone to death because they found a fancy pair of gloves. This should hopefully help ensure that passive actually means passive.
For the reflection change, it seems like a fair way of removing the offensive abilities of Sleeping Carp without entirely removing its defensive capabilities.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

Sleeping Carp deflection
![img](https://i.imgur.com/MKIcnkD.gif)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Passive users of Sleeping Carp will now deflect oncoming projectiles into the floor.
fix: Ensure martial arts attacks don't work if the user is passive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
