### PR TITLE
add a notification when replying to fax

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2485,7 +2485,6 @@
 		var/obj/item/paper/P
 
 		if(sender)
-			log_admin("[key_name(src.owner)] has started replying to a fax message from [key_name(sender)]")
 			message_admins("[key_name_admin(src.owner)] has started replying to a fax message from [key_name_admin(sender)]")
 
 		var/use_letterheard = alert("Use letterhead? If so, do not add your own header or a footer. Type and format only your actual message.",,"Nanotrasen","Syndicate", "No")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2485,7 +2485,7 @@
 		var/obj/item/paper/P
 
 		if(sender)
-			message_admins("[key_name_admin(src.owner)] has started replying to a fax message from [key_name_admin(sender)]")
+			message_admins("[key_name_admin(owner)] has started replying to a fax message from [key_name_admin(sender)]")
 
 		var/use_letterheard = alert("Use letterhead? If so, do not add your own header or a footer. Type and format only your actual message.",,"Nanotrasen","Syndicate", "No")
 		switch(use_letterheard)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2483,6 +2483,11 @@
 		var/destination
 		var/notify
 		var/obj/item/paper/P
+
+		if(sender)
+			log_admin("[key_name(src.owner)] has started replying to a fax message from [key_name(sender)]")
+			message_admins("[key_name_admin(src.owner)] has started replying to a fax message from [key_name_admin(sender)]")
+
 		var/use_letterheard = alert("Use letterhead? If so, do not add your own header or a footer. Type and format only your actual message.",,"Nanotrasen","Syndicate", "No")
 		switch(use_letterheard)
 			if("Nanotrasen")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds a notification for admins when another admin starts replying to a fax.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier to know if someone is already writing up a fax response so that you don't start writing one yourself if they are.  This type of notification already exists if you start responding using a headset response so it just adds the same convenience to faxes.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/90358236/138537406-b9314f8c-04e7-4672-95bc-4ed713fc2f18.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Added a log message when an admin starts replying to a fax
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
