### PR TITLE
Adds feedback to the Telegun's target setting, and applies it to the current shot

### DIFF
--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -35,6 +35,14 @@
 
 	var/desc = input("Please select a location to lock in.", "Telegun Target Interface") in L
 	teleport_target = L[desc]
+	to_chat(user, "<span class='notice'>The [src] is now set to [desc].</span>")
+	//Process the shot without draining the cell
+	if(chambered)
+		if(chambered.BB)
+			qdel(chambered.BB)
+			chambered.BB = null
+		chambered = null
+	newshot()
 
 /obj/item/gun/energy/telegun/newshot()
 	var/obj/item/ammo_casing/energy/teleport/T = ammo_type[select]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently, setting the telegun target will apply to the next shot rather than the current one, and also otherwise has no feedback of what's going on. The first would always be random. This tells the user what's going on, and also cycles the shot to set the target.

## Why It's Good For The Game
Makes the telegun less confusing.

## Images of changes
![Telegun](https://user-images.githubusercontent.com/80771500/138564291-ae493372-212d-496d-ac50-bf29157e0a1d.PNG)

https://user-images.githubusercontent.com/80771500/138564299-1e8ae385-4eca-4fb7-875d-fb890446be2a.mp4

## Changelog
:cl:
add: Selecting a target with the telegun displays feedback in the chat
fix: Setting the telegun target cycles the current charge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
