### PR TITLE
Improve organ damage feedback

### DIFF
--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -83,11 +83,11 @@
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
 			var/intensity = ""
 			if(I.damage <= 10)
-				intensity = "dull"
+				intensity = "a dull"
 			else if(I.damage <= 30)
-				intensity = "nagging"
+				intensity = "a nagging"
 			else if(I.damage <= 50)
-				intensity = "sharp"
+				intensity = "a sharp"
 			else
-				intensity = "stabbing"
-			custom_pain("You feel a [intensity] pain in your [parent.limb_name].")
+				intensity = "a stabbing"
+			custom_pain("You feel [intensity] pain in your [parent.limb_name]!")

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -79,6 +79,13 @@
 	for(var/obj/item/organ/internal/I in internal_organs)
 		if(I.hidden_pain)
 			continue
-		if(I.damage > 2 && prob(2))
+		if(prob(2) && I.damage > 2)
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
-			custom_pain("You feel a sharp pain in your [parent.limb_name]")
+			if(I.damage <= 10)
+				custom_pain("You feel a dull pain in your [parent.limb_name].")
+			else if(I.damage <= 30)
+				custom_pain("You feel a nagging pain in your [parent.limb_name], it's hard to ignore.")
+			else if(I.damage <= 50)
+				custom_pain("You feel a sharp pain in your [parent.limb_name]!")
+			else
+				custom_pain("You feel a stabbing pain in your [parent.limb_name]!")

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -81,13 +81,14 @@
 			continue
 		if(prob(2) && I.damage > 2)
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
-			var/intensity = ""
-			if(I.damage <= 10)
-				intensity = "a dull"
-			else if(I.damage <= 30)
-				intensity = "a nagging"
-			else if(I.damage <= 50)
-				intensity = "a sharp"
-			else
-				intensity = "a stabbing"
+			var/intensity
+			switch(I.damage)
+				if(0 to 10)
+					intensity = "a dull"
+				if(10 to 30)
+					intensity = "a nagging"
+				if(30 to 50)
+					intensity = "a sharp"
+				else
+					intensity = "a stabbing"
 			custom_pain("You feel [intensity] pain in your [parent.limb_name]!")

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -81,11 +81,13 @@
 			continue
 		if(prob(2) && I.damage > 2)
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
+			var/intensity = ""
 			if(I.damage <= 10)
-				custom_pain("You feel a dull pain in your [parent.limb_name].")
+				intensity = "dull"
 			else if(I.damage <= 30)
-				custom_pain("You feel a nagging pain in your [parent.limb_name], it's hard to ignore.")
+				intensity = "nagging"
 			else if(I.damage <= 50)
-				custom_pain("You feel a sharp pain in your [parent.limb_name]!")
+				intensity = "sharp"
 			else
-				custom_pain("You feel a stabbing pain in your [parent.limb_name]!")
+				intensity = "stabbing"
+			custom_pain("You feel a [intensity] pain in your [parent.limb_name].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reworks the messages for internal organ damage. Previously you'd get the sharp pain message (and only ever the sharp pain message) if you had more than 2 damage on a particular organ. There are now a few messages that scale to show the approximate magnitude of organ damage.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's kind of easy to get low-level organ damage, especially when welding without goggles (vulp mains know the pain), or getting flashbanged. It's currently really tough to tell the magnitude of your internal organ damage beyond "ow", and some better feedback might help players determine whether or not they need *immediate* medical attention.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![chest damage](https://i.imgur.com/rHYcj7P.png)
![appendix damage](https://i.imgur.com/O7uOxWs.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Improve pain messages from organ damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
