### PR TITLE
Add radioactive message to health analyzer

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -268,7 +268,7 @@ REAGENT SCANNER
 		to_chat(user, "<span class='danger'>Subject is husked. Application of synthflesh is recommended.</span>")
 
 	if(H.radiation > RAD_MOB_SAFE)
-		to_char(user, "<span class='danger'>Subject is irradiated.</span>")
+		to_chat(user, "<span class='danger'>Subject is irradiated.</span>")
 
 /obj/item/healthanalyzer/attack_self(mob/user)
 	toggle_mode()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -267,6 +267,9 @@ REAGENT SCANNER
 	if(HAS_TRAIT(H, TRAIT_HUSK))
 		to_chat(user, "<span class='danger'>Subject is husked. Application of synthflesh is recommended.</span>")
 
+	if(H.radiation > RAD_MOB_SAFE)
+		to_char(user, "<span class='danger'>Subject is irradiated.</span>")
+
 /obj/item/healthanalyzer/attack_self(mob/user)
 	toggle_mode()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a small message noting `Subject is irradiated.` when scanning a patient that is indeed irradiated with the health analyzer. Inspired by /tg/.
I didn't add the amount of rads to this output so you'll still need to grab a geiger counter or use a body scanner to see exactly how many rads someone has. 
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Radiation has been a pretty hot topic lately, especially due to the two different types of radioactive contamination that can collect in people. While they won't be contaminating others if they aren't glowing, knowing that someone still has rads in them can be crucial to actually getting treated.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dgs](https://i.imgur.com/xZmqsJP.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Health scanner now tells if a subject is radioactive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
