### PR TITLE
Add xenomorph section to orbit menu

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -112,7 +112,7 @@
 						antag_serialized["antag"] = antag_name
 						antagonists += list(antag_serialized)
 
-				// Player terror spiders have their own category to help see how much there are.
+				// Player terror spiders (and other hostile player-controlled event mobs) have their own category to help see how much there are.
 				// Not in the above block because terrors can be known whether AHUD is on or not.
 				if(isterrorspider(M))
 					var/list/antag_serialized = serialized.Copy()
@@ -121,6 +121,10 @@
 				else if(istype(M, /mob/living/simple_animal/revenant))
 					var/list/antag_serialized = serialized.Copy()
 					antag_serialized["antag"] = "Revenant"
+					antagonists += list(antag_serialized)
+				else if(isalien(M))
+					var/list/antag_serialized = serialized.Copy()
+					antag_serialized["antag"] = "Xenomorph"
 					antagonists += list(antag_serialized)
 		else
 			misc += list(serialized)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds xenomorphs to the orbit menu, much like terror spiders or revs.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's useful to be able to see who the xenos are/how many there are, since it isn't really clear from a glance.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![img](https://i.imgur.com/AnX4ZIY.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Xenomorphs now show up in orbit menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
