### PR TITLE
fix(damage_converter): updates sprite when healed #16495

### DIFF
--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -49,6 +49,7 @@ Bonus
 			healed += min(E.brute_dam, get_damage) + min(E.burn_dam, get_damage)
 			E.heal_damage(get_damage, get_damage, 0, 0)
 		M.adjustToxLoss(healed)
+		M.UpdateAppearance()
 
 
 	else
@@ -56,6 +57,7 @@ Bonus
 			M.adjustFireLoss(-get_damage)
 			M.adjustBruteLoss(-get_damage)
 			M.adjustToxLoss(get_damage)
+			M.UpdateAppearance()
 		else
 			return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #16495 by updating the infected mob sprite every time the toxic compensation symptom proc ticks.

## Why It's Good For The Game
It fixes a bug.

## Images of changes
Because the relevant image would be a healed character, I'm choosing to not insert one here. But you can always picture a healthy space worker in your head if you wanted to.

## Changelog
:cl:
fix: Updates mob sprites when healed by Toxic Compensation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
