### PR TITLE
Passes ID var from window spawners to electrochromic windows

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -74,6 +74,14 @@
 /obj/effect/spawner
 	name = "object spawner"
 
+/**
+ * Used when we want to pass vars from a spawner to a spawned object
+ *
+ * o - The spawned object we want to pass a var to
+ */
+/obj/effect/spawner/proc/synchronize_variables(atom/a)
+	return
+
 /obj/effect/list_container
 	name = "list container"
 

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -77,7 +77,7 @@
 /**
  * Used when we want to pass vars from a spawner to a spawned object
  *
- * o - The spawned object we want to pass a var to
+ * a - The spawned object we want to pass a var to
  */
 /obj/effect/spawner/proc/synchronize_variables(atom/a)
 	return

--- a/code/game/objects/effects/spawners/windowspawner.dm
+++ b/code/game/objects/effects/spawners/windowspawner.dm
@@ -27,12 +27,12 @@
 				continue
 			var/obj/structure/window/WI = new window_to_spawn_regular(get_turf(src))
 			WI.dir = cdir
-			if(id)
+			if(istype(src, /obj/effect/spawner/window/reinforced/polarized) && id)
 				var/obj/structure/window/reinforced/polarized/WIP = WI
 				WIP.id = id
 	else
 		var/obj/structure/window/WI = new window_to_spawn_full(get_turf(src))
-		if(id)
+		if(istype(src, /obj/effect/spawner/window/reinforced/polarized) && id)
 			var/obj/structure/window/full/reinforced/polarized/WIP = WI
 			WIP.id = id
 

--- a/code/game/objects/effects/spawners/windowspawner.dm
+++ b/code/game/objects/effects/spawners/windowspawner.dm
@@ -7,6 +7,8 @@
 	var/window_to_spawn_regular = /obj/structure/window/basic
 	var/window_to_spawn_full = /obj/structure/window/full/basic
 	anchored = TRUE // No sliding out while you prime
+	/// Used to link electrochromic windows to buttons
+	var/id
 
 /obj/effect/spawner/window/Initialize(mapload)
 	. = ..()
@@ -25,8 +27,14 @@
 				continue
 			var/obj/structure/window/WI = new window_to_spawn_regular(get_turf(src))
 			WI.dir = cdir
+			if(id)
+				var/obj/structure/window/reinforced/polarized/WIP = WI
+				WIP.id = id
 	else
-		new window_to_spawn_full(get_turf(src))
+		var/obj/structure/window/WI = new window_to_spawn_full(get_turf(src))
+		if(id)
+			var/obj/structure/window/full/reinforced/polarized/WIP = WI
+			WIP.id = id
 
 	if(useGrille)
 		new /obj/structure/grille(get_turf(src))

--- a/code/game/objects/effects/spawners/windowspawner.dm
+++ b/code/game/objects/effects/spawners/windowspawner.dm
@@ -7,12 +7,11 @@
 	var/window_to_spawn_regular = /obj/structure/window/basic
 	var/window_to_spawn_full = /obj/structure/window/full/basic
 	anchored = TRUE // No sliding out while you prime
-	/// Used to link electrochromic windows to buttons
-	var/id
 
 /obj/effect/spawner/window/Initialize(mapload)
 	. = ..()
 	var/turf/T = get_turf(src)
+	var/obj/structure/window/WI
 	for(var/obj/structure/grille/G in get_turf(src))
 		// Complain noisily
 		log_runtime(EXCEPTION("Extra grille on turf: ([T.x],[T.y],[T.z])"), src)
@@ -25,23 +24,17 @@
 				break
 			if(!cdir)
 				continue
-			var/obj/structure/window/WI = new window_to_spawn_regular(get_turf(src))
+			WI = new window_to_spawn_regular(get_turf(src))
 			WI.dir = cdir
-			if(istype(src, /obj/effect/spawner/window/reinforced/polarized) && id)
-				var/obj/structure/window/reinforced/polarized/WIP = WI
-				WIP.id = id
 	else
-		var/obj/structure/window/WI = new window_to_spawn_full(get_turf(src))
-		if(istype(src, /obj/effect/spawner/window/reinforced/polarized) && id)
-			var/obj/structure/window/full/reinforced/polarized/WIP = WI
-			WIP.id = id
+		WI = new window_to_spawn_full(get_turf(src))
+	synchronize_variables(WI)
 
 	if(useGrille)
 		new /obj/structure/grille(get_turf(src))
 
 	air_update_turf(TRUE) //atmos can pass otherwise
 	return INITIALIZE_HINT_QDEL
-
 
 /obj/effect/spawner/window/reinforced
 	name = "reinforced window spawner"
@@ -72,6 +65,16 @@
 	icon_state = "ewindow_spawner"
 	window_to_spawn_regular = /obj/structure/window/reinforced/polarized
 	window_to_spawn_full = /obj/structure/window/full/reinforced/polarized
+	/// Used to link electrochromic windows to buttons
+	var/id
+
+/obj/effect/spawner/window/reinforced/polarized/synchronize_variables(atom/a)
+	if(useFull)
+		var/obj/structure/window/full/reinforced/polarized/p = a
+		p.id = id
+	else
+		var/obj/structure/window/reinforced/polarized/p = a
+		p.id = id
 
 /obj/effect/spawner/window/shuttle
 	name = "shuttle window spawner"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR lets you give window spawners the ID var and pass them to the spawned windows.
This is essential to making electrochromic windows work using spawners.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Using spawners is better than directly placing windows, but that was not feasible for electrochromic windows before now. Since ID var is critical to separating tightly packed windows.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed electrochromic window spawners not setting window ID var
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
