### PR TITLE
Cult veil-torn text appears to lobby players  #17009

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -29,8 +29,11 @@
 	. = ..()
 	icon_state = SSticker.cultdat?.entity_icon_state
 	name = SSticker.cultdat?.entity_name
-	to_chat(world, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")
-	SEND_SOUND(world, sound(pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg')))
+
+	for (var/mob/living/player in GLOB.player_list)
+		if (!isnewplayer(player))
+			to_chat(player, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")
+			SEND_SOUND(player, sound(pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg')))
 
 	var/datum/game_mode/gamemode = SSticker.mode
 	if(gamemode)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -30,8 +30,8 @@
 	icon_state = SSticker.cultdat?.entity_icon_state
 	name = SSticker.cultdat?.entity_name
 
-	for (var/mob/living/player in GLOB.player_list)
-		if (!isnewplayer(player))
+	for(var/mob/living/player in GLOB.player_list)
+		if(!isnewplayer(player))
 			to_chat(player, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")
 			SEND_SOUND(player, sound(pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg')))
 

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -30,10 +30,14 @@
 	icon_state = SSticker.cultdat?.entity_icon_state
 	name = SSticker.cultdat?.entity_name
 
-	for(var/mob/living/player in GLOB.player_list)
-		if(!isnewplayer(player))
-			to_chat(player, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")
-			SEND_SOUND(player, sound(pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg')))
+	var/sound/cry = sound(pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg'))
+
+	for (var/mob/living/player in GLOB.player_list)
+		if (isnewplayer(player))
+			continue
+
+		to_chat(player, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")
+		SEND_SOUND(player, cry)
 
 	var/datum/game_mode/gamemode = SSticker.mode
 	if(gamemode)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -32,8 +32,8 @@
 
 	var/sound/cry = sound(pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg'))
 
-	for (var/mob/living/player in GLOB.player_list)
-		if (isnewplayer(player))
+	for(var/mob/living/player in GLOB.player_list)
+		if(isnewplayer(player))
 			continue
 
 		to_chat(player, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Prevents lobby players from being notified that Nar'Sie was spawned.
Fixes  #17009

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

From the original issue: "Players in the lobby should only know basic job stats, the alert code, crew manifest, etc. Having an entire lobby/a lobby player know the round antag is bad."

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

N/A.

## Changelog
:cl:
fix: Lobby players can no longer be notified that Nar'Sie was spawned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
