### PR TITLE
Re-adds officer's cap to SecDrobe, alphabetizes the list

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1804,30 +1804,31 @@
 	icon_state = "secdrobe"
 	ads_list = list("Beat perps in style!", "It's red so you can't see the blood!", "You have the right to be fashionable!", "Now you can be the fashion police you always wanted to be!")
 	vend_reply = "Thank you for using the SecDrobe!"
-	products = list(/obj/item/clothing/under/rank/security = 4,
+	products = list(/obj/item/clothing/under/rank/security/corp = 4,
+					/obj/item/clothing/under/rank/dispatch = 4,
+					/obj/item/clothing/under/rank/security/skirt = 4,
+					/obj/item/clothing/under/rank/security = 4,
 					/obj/item/clothing/under/rank/security2 = 4,
 					/obj/item/clothing/under/rank/security/formal = 4,
-					/obj/item/clothing/under/rank/security/skirt = 4,
-					/obj/item/clothing/under/rank/security/corp = 4,
-					/obj/item/clothing/under/rank/dispatch = 4,
+					/obj/item/clothing/head/soft/sec/corp = 4,
+					/obj/item/clothing/head/officer = 4,
 					/obj/item/clothing/head/beret/sec = 4,
 					/obj/item/clothing/head/soft/sec = 4,
-					/obj/item/clothing/head/soft/sec/corp = 4,
-					/obj/item/clothing/suit/armor/secjacket = 4,
 					/obj/item/clothing/suit/jacket/secbomber = 2,
+					/obj/item/clothing/suit/armor/secjacket = 4,
 					/obj/item/clothing/suit/hooded/wintercoat/security = 4,
-					/obj/item/clothing/gloves/color/black = 4,
-					/obj/item/clothing/accessory/armband/sec = 6,
-					/obj/item/clothing/shoes/laceup = 4,
 					/obj/item/clothing/shoes/jackboots = 4,
 					/obj/item/clothing/shoes/jackboots/jacksandals = 4,
+					/obj/item/clothing/shoes/laceup = 4,
+					/obj/item/storage/backpack/duffel/security = 2,
 					/obj/item/storage/backpack/security = 2,
 					/obj/item/storage/backpack/satchel_sec = 2,
-					/obj/item/storage/backpack/duffel/security = 2)
-	premium = list(/obj/item/clothing/mask/gas/sechailer/swat = 2,
-				   /obj/item/clothing/mask/balaclava = 1)
-	contraband = list(/obj/item/toy/figure/crew/secofficer = 1,
-					  /obj/item/toy/figure/crew/hos = 1)
+					/obj/item/clothing/gloves/color/black = 4,
+					/obj/item/clothing/accessory/armband/sec = 6)
+	premium = list(/obj/item/clothing/mask/balaclava = 1,
+				   /obj/item/clothing/mask/gas/sechailer/swat = 2)
+	contraband = list(/obj/item/toy/figure/crew/hos = 1,
+					  /obj/item/toy/figure/crew/secofficer = 1)
 	refill_canister = /obj/item/vending_refill/secdrobe
 
 /obj/machinery/vending/detdrobe


### PR DESCRIPTION
## What Does This PR Do
Re-adds the missing officer's cap to SecDrobe. Alphabetizes the list of each category (uniforms, headwears, etc.)
Fixes #17013

## Why It's Good For The Game
According to the author of #17013, this item was present before in the lockers. Seems to be an oversight that it is missing from the SecDrobe.

## Images of changes
![image](https://user-images.githubusercontent.com/93430361/139531719-bbb1b785-6211-480a-8f96-3e94b156325d.png)

One was vended.

## Changelog
:cl:
add: Re-added the officer's cap to SecDrobe. Alphabetized the vendor's list of contents.
/:cl:
