### PR TITLE
DeltaStation mapfixes: Medbay

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -14714,12 +14714,12 @@
 	},
 /area/security/permabrig)
 "aPb" = (
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -15332,6 +15332,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "aQk" = (
@@ -15372,9 +15377,6 @@
 "aQo" = (
 /obj/structure/chair/comfy/lime{
 	dir = 4
-	},
-/obj/machinery/computer/med_data/laptop{
-	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
@@ -69674,7 +69676,7 @@
 	dir = 9
 	},
 /obj/machinery/hologram/holopad{
-	pixel_y = -16
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -77644,6 +77646,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -78359,6 +78366,7 @@
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
 	name = "Surgery Cleaner"
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -80580,9 +80588,9 @@
 /area/medical/cmo)
 "duw" = (
 /obj/machinery/camera{
-	c_tag = "Mini Satellite Access";
+	c_tag = "Medbay Southeast Hallway";
 	dir = 4;
-	network = list("SS13","MiniSat")
+	network = list("Medical","SS13")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -88182,8 +88190,9 @@
 	pixel_x = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Mining Dock External";
-	dir = 8
+	c_tag = "Virology Hallway";
+	dir = 8;
+	network = list("Medical","SS13")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -89802,16 +89811,17 @@
 	},
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/obj/machinery/camera{
-	c_tag = "Mining Dock External";
-	dir = 8
-	},
 /obj/item/storage/box/monkeycubes,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Virology Observation Room";
+	dir = 8;
+	network = list("Medical","SS13")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -98910,6 +98920,9 @@
 /area/security/permabrig)
 "sak" = (
 /obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
+	dir = 2
+	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "scA" = (


### PR DESCRIPTION
## What Does This PR Do
Fixes some reported issues with DeltaStation's Medbay.
See the screenshots for the list of fixes.

P.S.: The mouse was, in fact, not edited by me. That line was modified by `mapmerger.bat`.

## Why It's Good For The Game
Having less bugs will hopefully make DeltaStation more popular.

## Images of changes
These cameras were mislabelled and were in the wrong network ([reported by Christasmurf](https://github.com/ParadiseSS13/Paradise/issues/16515#issuecomment-927279189)):
![cam_viro1](https://user-images.githubusercontent.com/93430361/139532962-56d80e1c-6b80-4d68-a496-fca42384cbbf.gif)
![cam_viro2](https://user-images.githubusercontent.com/93430361/139532963-e72e9ed7-d612-429c-93b8-1869c45b06a0.gif)
![cam_med1](https://user-images.githubusercontent.com/93430361/139532966-a8ce8ef4-8c84-47a5-bb93-231e0da27685.gif)

This AI holopad was pixel-shifted, glitching into the vent south of it ([reported by Sikroth](https://github.com/ParadiseSS13/Paradise/issues/16515#issuecomment-932421080)):
![ai_holopad](https://user-images.githubusercontent.com/93430361/139532964-4a9a3b88-0677-47db-919e-0314672bb092.gif)

The psych office was not connected to the main powergrid ([reported by TopTheWorst](https://github.com/ParadiseSS13/Paradise/issues/16515#issuecomment-942362201)) and the laptop spawned below the chair ([reported by LordShekelstein](https://github.com/ParadiseSS13/Paradise/issues/16515#issuecomment-952367043)):
![psychoffice](https://user-images.githubusercontent.com/93430361/139532965-212a00d9-e243-431c-b7cc-1729efff655d.gif)

The surgery corridor was not connected to the main powergrid ([reported by TopTheWorst](https://github.com/ParadiseSS13/Paradise/issues/16515#issuecomment-942362201)):
![surgery_corridor](https://user-images.githubusercontent.com/93430361/139532967-5c24c0ac-5f6c-494a-a293-9e257ad5e966.gif)

## Changelog
:cl:
fix: DeltaStation - The following issues were fixed in the Medbay area:
fix: DeltaStation - The surgery corridor's APC was connected to the main powergrid.
fix: DeltaStation - The psych office's APC was connected to the main powergrid.
fix: DeltaStation - Fixed a pixel-shifted AI holopad in the sleeper room, glitching into a vent.
fix: DeltaStation - Fixed three misnamed cameras and added them to the Medical network.
fix: DeltaStation - The psychologist's laptop no longer spawns below their chair.
/:cl:
