### PR TITLE
Unable to remove solar panel assembly from a bag of holding #17021

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -191,9 +191,7 @@
 	var/glass_type = null
 
 /obj/item/solar_assembly/attack_hand(mob/user)
-	if(in_storage) // you can always pick it up if it is in storage
-		..()
-	if(!anchored && isturf(loc)) // You can't pick it up
+	if(in_storage || (!anchored && isturf(loc))) // You can't pick it up
 		..()
 
 // Give back the glass type we were supplied with

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -191,7 +191,7 @@
 	var/glass_type = null
 
 /obj/item/solar_assembly/attack_hand(mob/user)
-	if (in_storage) // you can always pick it up if it is in storage
+	if(in_storage) // you can always pick it up if it is in storage
 		..()
 	if(!anchored && isturf(loc)) // You can't pick it up
 		..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -191,7 +191,7 @@
 	var/glass_type = null
 
 /obj/item/solar_assembly/attack_hand(mob/user)
-	if(in_storage || (!anchored && isturf(loc))) // You can't pick it up
+	if(!anchored)
 		..()
 
 // Give back the glass type we were supplied with

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -191,6 +191,8 @@
 	var/glass_type = null
 
 /obj/item/solar_assembly/attack_hand(mob/user)
+	if (in_storage) // you can always pick it up if it is in storage
+		..()
 	if(!anchored && isturf(loc)) // You can't pick it up
 		..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds a check so if the solar assembly is in storage, it can always be picked up.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The solar assembly becomes unusable, as well as eats through the storage space.
Fixes #17021.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![2021-11-02-13-44-45](https://user-images.githubusercontent.com/48896572/139908945-5a02fa73-d3d6-469c-92f0-197518bbe6b2.gif)

## Changelog
:cl:
fix: Now you can pick up a sonal panel assembly from a bag of holding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
