### PR TITLE
Ash Walker wasn't an offstation role #17016

### DIFF
--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -64,11 +64,13 @@
 	..()
 	lash = new
 	lash.Grant(H)
+	H.mind.offstation_role = TRUE
 
 /datum/species/unathi/on_species_loss(mob/living/carbon/human/H)
 	..()
 	if(lash)
 		lash.Remove(H)
+	H.mind.offstation_role = FALSE
 
 /datum/action/innate/tail_lash
 	name = "Tail lash"

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -64,13 +64,11 @@
 	..()
 	lash = new
 	lash.Grant(H)
-	H.mind.offstation_role = TRUE
 
 /datum/species/unathi/on_species_loss(mob/living/carbon/human/H)
 	..()
 	if(lash)
 		lash.Remove(H)
-	H.mind.offstation_role = FALSE
 
 /datum/action/innate/tail_lash
 	name = "Tail lash"

--- a/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
+++ b/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
@@ -76,6 +76,7 @@
 
 /obj/effect/mob_spawn/human/ash_walker/special(mob/living/carbon/human/new_spawn)
 	new_spawn.rename_character(new_spawn.real_name, new_spawn.dna.species.get_random_name(new_spawn.gender))
+	new_spawn.mind.offstation_role = TRUE
 
 	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
 	to_chat(new_spawn, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Ash_Walker)</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Sets ash walkers `mind.offstation_role` to `TRUE`.
Fixes #17016. Fixes other possible bugs too.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfix

## Changelog
:cl:
fix: Ash walkers can no longer be targeted by the cult
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
