### PR TITLE
Adds attack logging to the revenant drain ability

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -85,6 +85,7 @@
 					target.visible_message("<span class='warning'>[target] slumps onto the ground.</span>", \
  										   "<span class='revenwarning'>Violets lights, dancing in your vision, getting clo--</span>")
 					drained_mobs.Add(target)
+					add_attack_logs(src, target, "revenant harvested soul")
 					target.death(0)
 				else
 					to_chat(src, "<span class='revenwarning'>[target ? "[target] has":"They have"] been drawn out of your grasp. The link has been broken.</span>")


### PR DESCRIPTION
## What Does This PR Do
Adds missing logging to the revenant drain ability.

## Why It's Good For The Game
An attack should be logged. Especially one that kills

## Changelog
:cl:
tweak: Revenant drains are now logged once they are successful
/:cl: