### PR TITLE
The dawn of a new era

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -673,7 +673,8 @@ pull requests/issues, and merging/closing pull requests.
 ### Maintainer List
 
 * [Ansari](https://github.com/variableundefined)
-* [Crazy Lemon](https://github.com/Crazylemon64)
+* [Crazylemon](https://github.com/marlyn-x86)
+* [dearmochi](https://github.com/dearmochi)
 * [Fox P McCloud](https://github.com/Fox-McCloud)
 
 ### Maintainer instructions


### PR DESCRIPTION
## What Does This PR Do
- Puts mochi on the maint list
- Fixes the link to CL's github profile

## Why It's Good For The Repo
Up to date doc good