### PR TITLE
GitHub Balance Points

### DIFF
--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -1,0 +1,17 @@
+no_balance_label = "GBP: No Update"
+reset_label = "GBP: Reset"
+
+[points]
+"Administration" = 2
+"Balance" = -8
+"Code Improvement" = 1
+"Feature" = -9
+"Fix" = 3
+"GC Related" = 12
+"Grammar and Formatting" = 1
+"High Priority" = 20
+"Infrastructure" = 5
+"Performance" = 12
+"Refactor" = 3
+"Sound" = 3
+"Sprites" = 3

--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -1,0 +1,47 @@
+# This generates GBP balances
+name: GBP
+on:
+  pull_request_target:
+    types: [closed, opened]
+
+jobs:
+  gbp:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
+      id: value_holder
+      env:
+        ENABLER_SECRET: ${{ secrets.ACTION_ENABLER }}
+      run: |
+        unset SECRET_EXISTS
+        if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
+        echo "::set-output name=ACTIONS_ENABLED::$SECRET_EXISTS"
+
+    - name: Checkout
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      uses: actions/checkout@v2
+
+    - name: Setup git
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      run: |
+        git config --global user.name "gbp-action"
+        git config --global user.email "<>"
+
+    - name: Checkout alternate branch
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      uses: actions/checkout@v2
+      with:
+        ref: "gbp-balances" # The branch name
+        path: gbp-balances
+    # This is to ensure we keep the gbp.toml from master
+    # without having to update our separate branch.
+    - name: Copy configuration
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      run: cp ./.github/gbp.toml ./gbp-balances/.github/gbp.toml
+    - name: GBP action
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      uses: tgstation/gbp-action@master
+      with:
+        branch: "gbp-balances"
+        directory: ./gbp-balances
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gbp_collect.yml
+++ b/.github/workflows/gbp_collect.yml
@@ -1,0 +1,51 @@
+# This collects balances to one merged file
+name: GBP Collection
+# Every hour at the :20 minute mark. GitHub tells us to pick odd hours, instead of just using the start.
+on:
+  schedule:
+  - cron: "20 * * * *"
+  workflow_dispatch:
+
+jobs:
+  gbp_collection:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
+      id: value_holder
+      env:
+        ENABLER_SECRET: ${{ secrets.ACTION_ENABLER }}
+      run: |
+        unset SECRET_EXISTS
+        if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
+        echo "::set-output name=ACTIONS_ENABLED::$SECRET_EXISTS"
+
+    - name: Checkout
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      uses: actions/checkout@v2
+
+    - name: Setup git
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Checkout alternate branch
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      uses: actions/checkout@v2
+      with:
+        ref: "gbp-balances" # The branch name
+        path: gbp-balances
+
+    # This is to ensure we keep the gbp.toml from master
+    # without having to update our separate branch.
+    - name: Copy configuration
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      run: cp ./.github/gbp.toml ./gbp-balances/.github/gbp.toml
+
+    - name: GBP action
+      if: steps.value_holder.outputs.ACTIONS_ENABLED
+      uses: tgstation/gbp-action@master
+      with:
+        collect: "true"
+        directory: ./gbp-balances
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What Does This PR Do
This PR adds the GitHub balance points (GBP from herein) system to the repo. This will automatically track user point values from pull requests based on labels and is a way of automating "Fix tokens" as per the feature freeze in #17040 

@Fox-McCloud 

## Why It's Good For The Repo
Automating this is good. It also means we can have values for other labels other than `Fix`
