### PR TITLE
Removes prison cubes

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -81,14 +81,12 @@
 	name = "puzzling chest"
 
 /obj/structure/closet/crate/necropolis/puzzle/populate_contents()
-	var/loot = rand(1,3)
+	var/loot = rand(1,2)
 	switch(loot)
 		if(1)
 			new /obj/item/soulstone/anybody(src)
 		if(2)
 			new /obj/item/wisp_lantern(src)
-		if(3)
-			new /obj/item/prisoncube(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
removes the prison cube from lavaland loot

Leaves it as admin stuffs.

Affected told me I could make this PR regardless of the feature freeze

## Why It's Good For The Game
the players cannot solve these for shit, they clog the hallways and they are annoying. they have never been used to NOT grief.


## Changelog
:cl:
del: prison cube from lavaland loot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
