### PR TITLE
Wall-locker fixes

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -7135,14 +7135,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/derelict/crew_quarters)
-"pg" = (
-/obj/structure/closet/walllocker{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "orangefull"
-	},
-/area/derelict/crew_quarters)
 "ph" = (
 /obj/structure/holohoop{
 	dir = 1
@@ -14333,7 +14325,7 @@ ok
 oB
 ok
 pb
-pg
+nV
 bm
 py
 dJ

--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -20,7 +20,7 @@
 	desc = "A wall mounted locker with emergency supplies"
 	icon_state = "emerg"
 	icon_closed = "emerg"
-	icon_opened = "emergopen"
+	icon_opened = "emerg_open"
 
 /obj/structure/closet/walllocker/emerglocker/populate_contents()
 	new /obj/item/tank/internals/emergency_oxygen(src)


### PR DESCRIPTION
## What Does This PR Do
- Removes an invisible wall locker in the space USSP ruin
- Fixes the open emergency wall locker sprite to not be invisible

## Why It's Good For The Game
Bugs bad, this is what we do to bugs.

## Changelog
:cl:
fix: Open emergency wall-lockers are no longer invisible.
fix: There is no longer an invisible wall-locker in the USSP ruin.
/:cl: