### PR TITLE
Fixes #9332

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -25,7 +25,9 @@
 /turf/simulated/floor/mineral/titanium/blue/airless,
 /area/ruin/powered)
 "i" = (
-/obj/machinery/computer/shuttle,
+/obj/machinery/computer{
+	name = "shuttle control console"
+	},
 /turf/simulated/floor/mineral/titanium/blue/airless,
 /area/ruin/powered)
 "j" = (
@@ -46,7 +48,9 @@
 /turf/simulated/floor/mineral/titanium/blue/airless,
 /area/ruin/powered)
 "n" = (
-/obj/machinery/computer/mecha,
+/obj/machinery/computer{
+	name = "exosuit control console"
+	},
 /turf/simulated/floor/mineral/titanium/blue/airless,
 /area/ruin/powered)
 "p" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Fixes #9332 by changing the consoles to be generic computer consoles with var edited names instead of being actually linked to the station mining shuttle/exosuit console.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Map fixes be fixey? Also noticed we had a map issue label, so was browsing the issues in that to fix.

## Changelog
:cl:
fix: Mech shuttle space ruin no longer controls station mining shuttle or exosuits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
