### PR TITLE
Refactors revenants. makes them use UIDS, less istyping

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -52,8 +52,9 @@
 	var/unstun_time = 0 //How long the revenant is stunned for, is about 2 seconds times this var.
 	var/inhibited = 0 //If the revenant's abilities are blocked by a chaplain's power.
 	var/essence_drained = 0 //How much essence the revenant has drained.
-	var/draining = 0 //If the revenant is draining someone.
-	var/list/drained_mobs = list() //Cannot harvest the same mob twice
+	var/draining = FALSE //If the revenant is draining someone.
+	/// contains a list of UIDs of mobs who have been drained. cannot drain the same mob twice.
+	var/list/drained_mobs = list()
 	var/perfectsouls = 0 //How many perfect, regen-cap increasing souls the revenant has.
 
 
@@ -232,25 +233,21 @@
 	..()
 
 /mob/living/simple_animal/revenant/proc/castcheck(essence_cost)
-	if(!src)
-		return
 	if(holy_check(src))
 		return
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/simulated/wall))
 		to_chat(src, "<span class='revenwarning'>You cannot use abilities from inside of a wall.</span>")
 		return 0
-	if(src.inhibited)
+	if(inhibited)
 		to_chat(src, "<span class='revenwarning'>Your powers have been suppressed by nulling energy!</span>")
 		return 0
-	if(!src.change_essence_amount(essence_cost, 1))
+	if(!change_essence_amount(essence_cost, 1))
 		to_chat(src, "<span class='revenwarning'>You lack the essence to use that ability.</span>")
 		return 0
 	return 1
 
 /mob/living/simple_animal/revenant/proc/change_essence_amount(essence_amt, silent = 0, source = null)
-	if(!src)
-		return
 	if(essence + essence_amt <= 0)
 		return
 	essence = max(0, essence+essence_amt)
@@ -264,8 +261,6 @@
 	return 1
 
 /mob/living/simple_animal/revenant/proc/reveal(time)
-	if(!src)
-		return
 	if(time <= 0)
 		return
 	revealed = 1
@@ -280,8 +275,6 @@
 	update_spooky_icon()
 
 /mob/living/simple_animal/revenant/proc/stun(time)
-	if(!src)
-		return
 	if(time <= 0)
 		return
 	notransform = 1

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -42,20 +42,32 @@
 	speed = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 
-	var/essence = 75 //The resource of revenants. Max health is equal to three times this amount
-	var/essence_regen_cap = 75 //The regeneration cap of essence (go figure); regenerates every Life() tick up to this amount.
-	var/essence_regenerating = 1 //If the revenant regenerates essence or not; 1 for yes, 0 for no
-	var/essence_regen_amount = 5 //How much essence regenerates
-	var/essence_accumulated = 0 //How much essence the revenant has stolen
-	var/revealed = 0 //If the revenant can take damage from normal sources.
-	var/unreveal_time = 0 //How long the revenant is revealed for, is about 2 seconds times this var.
-	var/unstun_time = 0 //How long the revenant is stunned for, is about 2 seconds times this var.
-	var/inhibited = 0 //If the revenant's abilities are blocked by a chaplain's power.
-	var/essence_drained = 0 //How much essence the revenant has drained.
-	var/draining = FALSE //If the revenant is draining someone.
+	///The resource of revenants. Max health is equal to three times this amount
+	var/essence = 75
+	///The regeneration cap of essence (go figure); regenerates every Life() tick up to this amount.
+	var/essence_regen_cap = 75
+	///If the revenant regenerates essence or not; 1 for yes, 0 for no
+	var/essence_regenerating = 1
+	///How much essence regenerates
+	var/essence_regen_amount = 5
+	///How much essence the revenant has stolen
+	var/essence_accumulated = 0
+	///If the revenant can take damage from normal sources.
+	var/revealed = 0
+	///How long the revenant is revealed for, is about 2 seconds times this var.
+	var/unreveal_time = 0
+	///How long the revenant is stunned for, is about 2 seconds times this var.
+	var/unstun_time = 0
+	///If the revenant's abilities are blocked by a chaplain's power.
+	var/inhibited = 0
+	///How much essence the revenant has drained.
+	var/essence_drained = 0
+	///If the revenant is draining someone.
+	var/draining = FALSE
 	/// contains a list of UIDs of mobs who have been drained. cannot drain the same mob twice.
 	var/list/drained_mobs = list()
-	var/perfectsouls = 0 //How many perfect, regen-cap increasing souls the revenant has.
+	//How many perfect, regen-cap increasing souls the revenant has.
+	var/perfectsouls = 0
 
 
 /mob/living/simple_animal/revenant/Life(seconds, times_fired)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -47,26 +47,26 @@
 	///The regeneration cap of essence (go figure); regenerates every Life() tick up to this amount.
 	var/essence_regen_cap = 75
 	///If the revenant regenerates essence or not; 1 for yes, 0 for no
-	var/essence_regenerating = 1
+	var/essence_regenerating = TRUE
 	///How much essence regenerates
 	var/essence_regen_amount = 5
 	///How much essence the revenant has stolen
 	var/essence_accumulated = 0
 	///If the revenant can take damage from normal sources.
-	var/revealed = 0
+	var/revealed = FALSE
 	///How long the revenant is revealed for, is about 2 seconds times this var.
 	var/unreveal_time = 0
 	///How long the revenant is stunned for, is about 2 seconds times this var.
 	var/unstun_time = 0
 	///If the revenant's abilities are blocked by a chaplain's power.
-	var/inhibited = 0
+	var/inhibited = TRUE
 	///How much essence the revenant has drained.
 	var/essence_drained = 0
 	///If the revenant is draining someone.
 	var/draining = FALSE
 	/// contains a list of UIDs of mobs who have been drained. cannot drain the same mob twice.
 	var/list/drained_mobs = list()
-	//How many perfect, regen-cap increasing souls the revenant has.
+	///How many perfect, regen-cap increasing souls the revenant has.
 	var/perfectsouls = 0
 
 

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -259,7 +259,7 @@
 		for(var/turf/T in targets)
 			INVOKE_ASYNC(src, .proc/effect, user, T)
 
-/obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/proc/effect(mob/living/simple_animal/revenant/user, var/turf/T)
+/obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/proc/effect(mob/living/simple_animal/revenant/user, turf/T)
 	T.rev_malfunction()
 	for(var/atom/A in T.contents)
 		A.rev_malfunction()

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -31,8 +31,7 @@
 	if(draining)
 		to_chat(src, "<span class='revenwarning'>You are already siphoning the essence of a soul!</span>")
 		return
-	var/mob_UID = target.UID()
-	if(mob_UID in drained_mobs)
+	if(target.UID() in drained_mobs)
 		to_chat(src, "<span class='revenwarning'>[target]'s soul is dead and empty.</span>")
 		return
 	if(!target.stat)
@@ -219,14 +218,13 @@
 	if(!L.on) //wait, wait, don't shock me
 		return
 	flick("[L.base_state]2", L)
-	var/sound_cashe = 'sound/machines/defib_zap.ogg'
 	for(var/mob/living/M in view(shock_range, L))
 		if(M == user)
 			continue
-		M.Beam(L, icon_state = "purple_lightning" , icon = 'icons/effects/effects.dmi' , time = 0.5 SECONDS)
+		M.Beam(L, icon_state = "purple_lightning", icon = 'icons/effects/effects.dmi', time = 0.5 SECONDS)
 		M.electrocute_act(shock_damage, L, flags = SHOCK_NOGLOVES)
 		do_sparks(4, 0, M)
-		playsound(M, sound_cashe, 50, 1, -1)
+		playsound(M, 'sound/machines/defib_zap.ogg', 50, TRUE, -1)
 
 //Defile: Corrupts nearby stuff, unblesses floor tiles.
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -31,7 +31,8 @@
 	if(draining)
 		to_chat(src, "<span class='revenwarning'>You are already siphoning the essence of a soul!</span>")
 		return
-	if(target in drained_mobs)
+	var/mob_UID = target.UID()
+	if(mob_UID in drained_mobs)
 		to_chat(src, "<span class='revenwarning'>[target]'s soul is dead and empty.</span>")
 		return
 	if(!target.stat)
@@ -39,7 +40,7 @@
 		if(prob(10))
 			to_chat(target, "You feel as if you are being watched.")
 		return
-	draining = 1
+	draining = TRUE
 	essence_drained = rand(15, 20)
 	to_chat(src, "<span class='revennotice'>You search for the soul of [target].</span>")
 	if(do_after(src, 10, 0, target = target)) //did they get deleted in that second?
@@ -65,7 +66,7 @@
 				if(!target.stat)
 					to_chat(src, "<span class='revenwarning'>They are now powerful enough to fight off your draining.</span>")
 					to_chat(target, "<span class='boldannounce'>You feel something tugging across your body before subsiding.</span>")
-					draining = 0
+					draining = FALSE
 					return //hey, wait a minute...
 				to_chat(src, "<span class='revenminor'>You begin siphoning essence from [target]'s soul.</span>")
 				if(target.stat != DEAD)
@@ -84,7 +85,7 @@
 					to_chat(src, "<span class='revennotice'>[target]'s soul has been considerably weakened and will yield no more essence for the time being.</span>")
 					target.visible_message("<span class='warning'>[target] slumps onto the ground.</span>", \
  										   "<span class='revenwarning'>Violets lights, dancing in your vision, getting clo--</span>")
-					drained_mobs.Add(target)
+					drained_mobs.Add(mob_UID)
 					add_attack_logs(src, target, "revenant harvested soul")
 					target.death(0)
 				else
@@ -97,10 +98,10 @@
 					return
 			else
 				to_chat(src, "<span class='revenwarning'>You are not close enough to siphon [target ? "[target]'s":"their"] soul. The link has been broken.</span>")
-				draining = 0
+				draining = FALSE
 				essence_drained = 0
 				return
-	draining = 0
+	draining = FALSE
 	essence_drained = 0
 	return
 
@@ -199,20 +200,20 @@
 	var/shock_damage = 20
 	action_icon_state = "overload_lights"
 
-/obj/effect/proc_holder/spell/aoe_turf/revenant/overload/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
+/obj/effect/proc_holder/spell/aoe_turf/revenant/overload/cast(list/targets, mob/living/simple_animal/revenant/user = usr) // todo: make this not as gross
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
 			spawn(0)
 				for(var/obj/machinery/light/L in T.contents)
 					spawn(0)
 						if(!L.on)
-							return
+							continue
 						L.visible_message("<span class='warning'><b>\The [L] suddenly flares brightly and begins to spark!</span>")
 						do_sparks(4, 0, L)
 						new/obj/effect/temp_visual/revenant(L.loc)
-						sleep(20)
+						sleep(2 SECONDS)
 						if(!L.on) //wait, wait, don't shock me
-							return
+							continue
 						flick("[L.base_state]2", L)
 						for(var/mob/living/M in view(shock_range, L))
 							if(M == user)
@@ -233,46 +234,14 @@
 	unlock_amount = 75
 	cast_amount = 30
 	action_icon_state = "defile"
-	var/stamdamage= 25
-	var/toxdamage = 5
-	var/confusion = 20
-	var/maxconfusion = 30
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
-	if(attempt_cast(user))
-		for(var/turf/T in targets)
-			spawn(0)
-				if(T.flags & NOJAUNT)
-					T.flags -= NOJAUNT
-					new/obj/effect/temp_visual/revenant(T)
-				for(var/mob/living/carbon/human/human in T.contents)
-					to_chat(human, "<span class='warning'>You suddenly feel [pick("sick and tired", "tired and confused", "nauseated", "dizzy")].</span>")
-					human.adjustStaminaLoss(stamdamage)
-					human.adjustToxLoss(toxdamage)
-					human.AdjustConfused(confusion, bound_lower = 0, bound_upper = maxconfusion)
-					new/obj/effect/temp_visual/revenant(human.loc)
-				if(!istype(T, /turf/simulated/wall/indestructible) && !istype(T, /turf/simulated/wall/rust) && !istype(T, /turf/simulated/wall/r_wall) && istype(T, /turf/simulated/wall) && prob(15))
-					new/obj/effect/temp_visual/revenant(T)
-					T.ChangeTurf(/turf/simulated/wall/rust)
-				if(!istype(T, /turf/simulated/wall/r_wall/rust) && istype(T, /turf/simulated/wall/r_wall) && prob(15))
-					new/obj/effect/temp_visual/revenant(T)
-					T.ChangeTurf(/turf/simulated/wall/r_wall/rust)
-				for(var/obj/structure/window/window in T.contents)
-					window.take_damage(rand(30,80))
-					if(window && window.fulltile)
-						new/obj/effect/temp_visual/revenant/cracks(window.loc)
-				for(var/obj/structure/closet/closet in T.contents)
-					closet.open()
-
-				if(!istype(T, /turf/simulated/floor/plating) && !istype(T, /turf/simulated/floor/engine/cult) && istype(T, /turf/simulated/floor) && prob(15))
-					var/turf/simulated/floor/floor = T
-					if(floor.intact && floor.floor_tile)
-						new floor.floor_tile(floor)
-					floor.broken = 0
-					floor.burnt = 0
-					floor.make_plating(1)
-				for(var/obj/machinery/light/light in T.contents)
-					light.flicker(30) //spooky
+	if(!attempt_cast(user))
+		return
+	for(var/turf/T in targets)
+		T.defile()
+		for(var/atom/A in T.contents)
+			A.defile()
 
 //Malfunction: Makes bad stuff happen to robots and machines.
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction
@@ -288,29 +257,107 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			spawn(0)
-				for(var/mob/living/simple_animal/bot/bot in T.contents)
-					if(!bot.emagged)
-						new/obj/effect/temp_visual/revenant(bot.loc)
-						bot.locked = 0
-						bot.open = 1
-						bot.emag_act(null)
-				for(var/mob/living/carbon/human/human in T.contents)
-					to_chat(human, "<span class='warning'>You feel [pick("your sense of direction flicker out", "a stabbing pain in your head", "your mind fill with static")].</span>")
-					new/obj/effect/temp_visual/revenant(human.loc)
-					human.emp_act(1)
-				for(var/obj/thing in T.contents)
-					if(istype(thing, /obj/machinery/power/apc) || istype(thing, /obj/machinery/power/smes)) //Doesn't work on dominators, SMES and APCs, to prevent kekkery
-						continue
-					if(prob(20))
-						if(prob(50))
-							new/obj/effect/temp_visual/revenant(thing.loc)
-						thing.emag_act(null)
-					else
-						if(!istype(thing, /obj/machinery/clonepod)) //I hate everything but mostly the fact there's no better way to do this without just not affecting it at all
-							thing.emp_act(1)
-				for(var/mob/living/silicon/robot/S in T.contents) //Only works on cyborgs, not AI
-					playsound(S, 'sound/machines/warning-buzzer.ogg', 50, 1)
-					new/obj/effect/temp_visual/revenant(S.loc)
-					S.spark_system.start()
-					S.emp_act(1)
+			INVOKE_ASYNC(src, .proc/effect, user, T)
+
+/obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/proc/effect(mob/living/simple_animal/revenant/user, var/turf/T)
+	T.rev_malfunction()
+	for(var/atom/A in T.contents)
+		A.rev_malfunction()
+
+
+/atom/proc/defile()
+	return
+
+/atom/proc/rev_malfunction()
+	return
+
+/mob/living/carbon/human/rev_malfunction()
+	to_chat(src, "<span class='warning'>You feel [pick("your sense of direction flicker out", "a stabbing pain in your head", "your mind fill with static")].</span>")
+	new /obj/effect/temp_visual/revenant(loc)
+	emp_act(1)
+
+/mob/living/simple_animal/bot/rev_malfunction()
+	if(!emagged)
+		new /obj/effect/temp_visual/revenant(loc)
+		locked = 0
+		open = 1
+		emag_act(null)
+
+/obj/rev_malfunction()
+	if(prob(20))
+		if(prob(50))
+			new /obj/effect/temp_visual/revenant(loc)
+		emag_act(null)
+
+/obj/machinery/clonepod/rev_malfunction()
+	emag_act(null)
+
+/obj/machinery/power/apc/rev_malfunction()
+	return
+
+/obj/machinery/power/smes/rev_malfunction()
+	return
+
+/mob/living/silicon/robot/rev_malfunction()
+	playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 1)
+	new /obj/effect/temp_visual/revenant(loc)
+	spark_system.start()
+	emp_act(1)
+
+/turf/defile()
+	if(flags & NOJAUNT)
+		flags &= ~NOJAUNT
+		new /obj/effect/temp_visual/revenant(loc)
+
+/turf/simulated/wall/defile()
+	..()
+	if(prob(15))
+		new/obj/effect/temp_visual/revenant(loc)
+		ChangeTurf(/turf/simulated/wall/rust)
+
+/turf/simulated/wall/indestructible/defile()
+	return
+
+/turf/simulated/wall/r_wall/defile()
+	..()
+	if(prob(15))
+		new/obj/effect/temp_visual/revenant(loc)
+		ChangeTurf(/turf/simulated/wall/r_wall/rust)
+
+/mob/living/carbon/human/defile()
+	to_chat(src, "<span class='warning'>You suddenly feel [pick("sick and tired", "tired and confused", "nauseated", "dizzy")].</span>")
+	adjustStaminaLoss(25)
+	adjustToxLoss(5)
+	AdjustConfused(20, bound_lower = 0, bound_upper = 30)
+	new /obj/effect/temp_visual/revenant(loc)
+
+/obj/structure/window/defile()
+	take_damage(rand(30,80))
+	if(fulltile)
+		new /obj/effect/temp_visual/revenant/cracks(loc)
+
+/obj/structure/closet/defile()
+	open()
+
+/turf/simulated/floor/defile()
+	..()
+	if(prob(15))
+		if(intact && floor_tile)
+			new floor_tile(src)
+		broken = 0
+		burnt = 0
+		make_plating(1)
+
+/turf/simulated/floor/plating/defile()
+	if(flags & NOJAUNT)
+		flags &= ~NOJAUNT
+		new /obj/effect/temp_visual/revenant(loc)
+
+/turf/simulated/floor/engine/cult/defile()
+	if(flags & NOJAUNT)
+		flags &= ~NOJAUNT
+		new /obj/effect/temp_visual/revenant(loc)
+
+/obj/machinery/light/defile()
+	flicker(30)
+

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -144,7 +144,7 @@
 	name = "Report this to a coder"
 	var/reveal = 80 //How long it reveals the revenant in deciseconds
 	var/stun = 20 //How long it stuns the revenant in deciseconds
-	var/locked = 1 //If it's locked and needs to be unlocked before use
+	var/locked = TRUE //If it's locked and needs to be unlocked before use
 	var/unlock_amount = 100 //How much essence it costs to unlock
 	var/cast_amount = 50 //How much essence it costs to use
 
@@ -157,36 +157,36 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/can_cast(mob/living/simple_animal/revenant/user = usr, charge_check = TRUE, show_message = FALSE)
 	if(user.inhibited)
-		return 0
+		return FALSE
 	if(charge_counter < charge_max)
-		return 0
+		return FALSE
 	if(locked)
 		if(user.essence <= unlock_amount)
-			return 0
+			return FALSE
 	if(user.essence <= cast_amount)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/proc/attempt_cast(mob/living/simple_animal/revenant/user = usr)
 	if(locked)
 		if(!user.castcheck(-unlock_amount))
 			charge_counter = charge_max
-			return 0
+			return FALSE
 		name = "[initial(name)] ([cast_amount]E)"
 		to_chat(user, "<span class='revennotice'>You have unlocked [initial(name)]!</span>")
 		panel = "Revenant Abilities"
-		locked = 0
+		locked = FALSE
 		charge_counter = charge_max
-		return 0
+		return FALSE
 	if(!user.castcheck(-cast_amount))
 		charge_counter = charge_max
-		return 0
+		return FALSE
 	name = "[initial(name)] ([cast_amount]E)"
 	user.reveal(reveal)
 	user.stun(stun)
 	if(action)
 		action.UpdateButtonIcon()
-	return 1
+	return TRUE
 
 //Overload Light: Breaks a light that's online and sends out lightning bolts to all nearby people.
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload
@@ -284,8 +284,8 @@
 /mob/living/simple_animal/bot/rev_malfunction()
 	if(!emagged)
 		new /obj/effect/temp_visual/revenant(loc)
-		locked = 0
-		open = 1
+		locked = FALSE
+		open = TRUE
 		emag_act(null)
 
 /obj/rev_malfunction()

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -31,7 +31,8 @@
 	if(draining)
 		to_chat(src, "<span class='revenwarning'>You are already siphoning the essence of a soul!</span>")
 		return
-	if(target.UID() in drained_mobs)
+	var/mob_UID = target.UID()
+	if(mob_UID in drained_mobs)
 		to_chat(src, "<span class='revenwarning'>[target]'s soul is dead and empty.</span>")
 		return
 	if(!target.stat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
makes revs use UIDs, so they don't have a list of hard refs to mobs.

removes the awful mess of istypes that were their spells.

I still gotta get the zappy lights spell to be not awful, but I will do that later.

fixes zappy lights stopping completely if there was a disabled light on screen.

## Why It's Good For The Game
good code is good

bugs are bad

## Changelog
:cl:
fix: revenant's overload lights spell now functions properly with disabled lights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
