### PR TITLE
Fixes Accidental O2 Canister Removal

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -73056,6 +73056,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "daT" = (


### PR DESCRIPTION
When space pods were removed, the O2 canister within the box pod-bay was removed as well.

It was a long established mapping condition that there was an O2 Canister just within escape maintenance, even prior to space pods being added to para, years ago.

This corrects that accidental removal. Easy thing to miss as few were around pre spacepods.

:cl: Fox McCloud
fix: Fixes boxstation lacking a maintenance O2 canister near escape
/:cl: