### PR TITLE
Fixes cyborg brains dying during an ashstorm

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -287,5 +287,16 @@
 	return user.shared_living_ui_distance()
 
 /obj/item/mmi/forceMove(atom/destination)
+	if(!brainmob)
+		return ..()
+
+	var/atom/old_loc = loc
+	if(issilicon(old_loc) && !issilicon(destination))
+		var/mob/living/silicon/S = old_loc
+		brainmob.weather_immunities -= S.weather_immunities
+	else if(issilicon(destination))
+		var/mob/living/silicon/S = destination
+		brainmob.weather_immunities |= S.weather_immunities
+
 	. = ..()
-	brainmob?.update_runechat_msg_location()
+	brainmob.update_runechat_msg_location()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -277,7 +277,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	SStgui.close_uis(wires)
 	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
 		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
-		if(T)	mmi.loc = T
+		if(T)
+			mmi.forceMove(T)
 		if(mmi.brainmob)
 			mind.transfer_to(mmi.brainmob)
 			mmi.update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the cyborg MMI's `brainmob` the same `weather_immunities` that the cyborg itself has, when the MMI is inside of the cyborg. Prevents their brain from dying to ash storms, or any other form of harmful weather.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cyborgs are immune to ash storms by default and so their brains should be protected as well.

Fixes #17042
Fixes #13926
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes cyborg brains dying during an ashstorm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
