### PR TITLE
Shooting fuel tanks now is logged properly and objects that get qdeleted by bullets now only get hit once

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -276,6 +276,8 @@
 
 			speed = round(speed)
 			step_towards(src, locate(new_x, new_y, z))
+			if(QDELETED(src)) // It hit something during the move
+				return
 			if(speed <= 1)
 				pixel_x = pixel_x_offset
 				pixel_y = pixel_y_offset

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -107,13 +107,13 @@
 	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/bullet_act(obj/item/projectile/P)
+	var/will_explode = !QDELETED(src) && !P.nodamage && (P.damage_type == BURN || P.damage_type == BRUTE)
+
+	if(will_explode) // Log here while you have the information needed
+		add_attack_logs(P.firer, src, "shot with [P.name]", ATKLOG_FEW)
+		log_game("[key_name(P.firer)] triggered a fueltank explosion with [P.name] at [COORD(loc)]")
+		investigate_log("[key_name(P.firer)] triggered a fueltank explosion with [P.name] at [COORD(loc)]", INVESTIGATE_BOMB)
 	..()
-	if(!QDELETED(src)) //wasn't deleted by the projectile's effects.
-		if(!P.nodamage && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))
-			add_attack_logs(P.firer, src, "shot with [P.name]", ATKLOG_FEW)
-			log_game("[key_name(P.firer)] triggered a fueltank explosion with [P.name] at [COORD(loc)]")
-			investigate_log("[key_name(P.firer)] triggered a fueltank explosion with [P.name] at [COORD(loc)]", INVESTIGATE_BOMB)
-			boom()
 
 /obj/structure/reagent_dispensers/fueltank/do_boom(rigtrigger = FALSE, log_attack = FALSE) // Prevent case where someone who rigged the tank is blamed for the explosion when the rig isn't what triggered the explosion
 	if(rigtrigger) // If the explosion is triggered by an assembly holder


### PR DESCRIPTION
## What Does This PR Do
- Fuel tanks being shot now get fully logged as expected
- Objects that get qdeleted due to a bump in the `projectile/fire` move call now won't get hit again. This happened when you shoot an object which you clicked on that got qdeleted on the `turf/Enter()` call due to the `step_into` (I've not found any functional effects from this bug)

## Why It's Good For The Game
- Makes admins lives just a bit easier (not too much ofcourse).
- Mostly prevents weirdness and potential runtimes

## Changelog
:cl:
fix: Fuel tanks being fired on now get fully logged as expected
/:cl: