### PR TITLE
Fixes invisible lockers/crates on Boxstation AND z1 (so they're no longer invisible)

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -53743,14 +53743,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cmg" = (
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed"
-	},
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/structure/closet/cabinet,
 /turf/simulated/floor/wood,
 /area/blueshield)
 "cmh" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -26,6 +26,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"aae" = (
+/obj/structure/closet/crate{
+	icon_state = "crate_open";
+	name = "Gold Crate";
+	opened = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/storage/belt/fannypack/yellow,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
+"aaf" = (
+/obj/structure/closet/crate{
+	icon_state = "crate_open";
+	name = "Silver Crate";
+	opened = 1
+	},
+/obj/item/paper{
+	info = "I.O.U. some shinies - Mr V. Ox"
+	},
+/mob/living/simple_animal/hostile/scarybat,
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -81273,18 +81296,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"kXY" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	name = "Silver Crate";
-	opened = 1
-	},
-/obj/item/paper{
-	info = "I.O.U. some shinies - Mr V. Ox"
-	},
-/mob/living/simple_animal/hostile/scarybat,
-/turf/simulated/floor/plating,
-/area/maintenance/apmaint)
 "kYw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81890,17 +81901,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"pZQ" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	name = "Gold Crate";
-	opened = 1
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/storage/belt/fannypack/yellow,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/apmaint)
 "qcg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -103062,7 +103062,7 @@ cgQ
 ctV
 coL
 cvp
-pZQ
+aae
 cwz
 cBf
 oBH
@@ -104094,7 +104094,7 @@ sZe
 hvi
 lMw
 iui
-kXY
+aaf
 cvp
 cEJ
 cFM

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -19,6 +19,13 @@
 	icon_state = "white"
 	},
 /area/toxins/misc_lab)
+"aad" = (
+/obj/structure/closet/emcloset{
+	icon_state = "emergency";
+	opened = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -23556,13 +23563,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
-"bbS" = (
-/obj/structure/closet/emcloset{
-	icon_state = "emergencyopen";
-	opened = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bbT" = (
@@ -110464,7 +110464,7 @@ aPi
 aVD
 aQl
 aMA
-bbS
+aad
 aEN
 aRw
 biM

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4558,11 +4558,6 @@
 /obj/item/ammo_box/magazine/m45,
 /obj/item/ammo_box/magazine/m45,
 /obj/item/ammo_box/magazine/m45,
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed"
-	},
 /obj/item/clothing/head/helmet/space/deathsquad/beret,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/under/syndicate/combat,
@@ -4577,6 +4572,7 @@
 	pixel_x = 6;
 	pixel_y = -6
 	},
+/obj/structure/closet/cabinet,
 /turf/simulated/floor/plasteel/grimy,
 /area/centcom/specops)
 "ql" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the icon state of literally one locker in EVA maintenance in Boxstation so it's not longer invisible.
Fixes two invisible crates in the abandoned vault as per @S34NW's request
Fixes SOO office closet on Z1 as per @matttheficus's request

fix: #17056
fix: #17082
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because previously this was just a floating door that'd turn invisible upon closing.
Invisible things bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before, floating door, immersion entirely broken, literally unplayable
![image](https://user-images.githubusercontent.com/19361017/141095358-072b686a-8eeb-4715-869e-d9f3d413c92f.png)

After, beautiful RTX rendered locker, compliant with conventional physics, greatly enhancing my immersion
![image](https://user-images.githubusercontent.com/19361017/141095973-92c24228-a584-47e3-934f-b9359b5f4049.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Invisible crates/lockers on the Cyberiad are no longer invisible.
fix: SOO office closet no longer invisible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
