### PR TITLE
Removes Parallax Animate

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -192,17 +192,12 @@
 		if(L.view_sized != C.view)
 			L.update_o(C.view)
 
-		var/change_x
-		var/change_y
-
 		if(L.absolute)
 			L.offset_x = -(posobj.x - SSparallax.planet_x_offset) * L.speed
 			L.offset_y = -(posobj.y - SSparallax.planet_y_offset) * L.speed
 		else
-			change_x = offset_x * L.speed
-			L.offset_x -= change_x
-			change_y = offset_y * L.speed
-			L.offset_y -= change_y
+			L.offset_x -= offset_x * L.speed
+			L.offset_y -= offset_y * L.speed
 
 			if(L.offset_x > 240)
 				L.offset_x -= 480
@@ -212,10 +207,6 @@
 				L.offset_y -= 480
 			if(L.offset_y < -240)
 				L.offset_y += 480
-
-		if(!(areaobj.parallax_movedir && areaobj.moving) && C.dont_animate_parallax <= world.time && (offset_x || offset_y) && abs(offset_x) <= max(C.parallax_throttle/world.tick_lag+1,1) && abs(offset_y) <= max(C.parallax_throttle/world.tick_lag+1,1) && (round(abs(change_x)) > 1 || round(abs(change_y)) > 1))
-			L.transform = matrix(1, 0, offset_x*L.speed, 0, 1, offset_y*L.speed)
-			animate(L, transform=matrix(), time = last_delay)
 
 		L.screen_loc = "CENTER-7:[round(L.offset_x,1)],CENTER-7:[round(L.offset_y,1)]"
 


### PR DESCRIPTION
TG did this as well.

You can't even notice the difference as it's literally 1-2 pixel.

`animate` however incurs proc call overhead and forces the server to do the heavy lifting for what *should* be something the client does (why BYOND, why). No sense in having this around for something you don't even notice.