### PR TITLE
Removes some inherited verbs from AIs and cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -172,6 +172,14 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	if(isturf(loc))
 		add_ai_verbs(src)
+	
+	// Remove inherited verbs that effectively do nothing for AIs, or lead to unintended behaviour.
+	verbs -= /mob/living/verb/lay_down
+	verbs -= /mob/living/verb/mob_sleep
+	verbs -= /mob/living/verb/resist
+	verbs -= /mob/living/verb/stop_pulling1
+	verbs -= /mob/living/silicon/verb/pose
+	verbs -= /mob/living/silicon/verb/set_flavor
 
 	//Languages
 	add_language("Robot Talk", 1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -169,7 +169,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	// Remove inherited verbs that effectively do nothing for cyborgs, or lead to unintended behaviour.
 	verbs -= /mob/living/verb/lay_down
 	verbs -= /mob/living/verb/mob_sleep
-	verbs -= /mob/living/verb/resist
 
 	if(cell)
 		var/datum/robot_component/cell_component = components["power cell"]

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -165,6 +165,11 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	..()
 
 	add_robot_verbs()
+	
+	// Remove inherited verbs that effectively do nothing for cyborgs, or lead to unintended behaviour.
+	verbs -= /mob/living/verb/lay_down
+	verbs -= /mob/living/verb/mob_sleep
+	verbs -= /mob/living/verb/resist
 
 	if(cell)
 		var/datum/robot_component/cell_component = components["power cell"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
- Removes the following verbs from AI:
  - **Rest**: All it effectively does is prevent you from moving your eye.
  - **Sleep**: This one was the most problematic. AIs **do not** process the "sleep" status effect and if they were put to sleep, they would end up never waking up.
  - **Resist**: Mostly intended for cuffs and buckling.
  - **Stop Pulling**: I'm not even sure AIs can pull and if they could, it would be very strange.
  - **Set Pose**: Does not show up on AI examination.
  - **Set Flavor Text**: DItto.
- Also removes the following from cyborgs:
  - **Rest**: `update_stat` on a resting cyborg causes them to go unconscious for... reasons?
  - **Sleep**: No real use.
  - **Resist**: Same.

## Changelog
:cl:
del: AIs can no longer rest, sleep, resist, stop pulling or set pose/flavor text
del: Cyborgs can no longer rest or sleep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
