### PR TITLE
Remove commie vending machines

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -49423,7 +49423,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "chk" = (
-/obj/machinery/vending/coffee/free,
+/obj/machinery/vending/coffee,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -10626,7 +10626,7 @@
 	name = "Internal Affairs Privacy Shutters Control";
 	pixel_x = -25
 	},
-/obj/machinery/vending/coffee/free,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -14070,7 +14070,7 @@
 /turf/simulated/floor/carpet,
 /area/maintenance/fpmaint)
 "aGp" = (
-/obj/machinery/vending/coffee/free,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -14460,7 +14460,7 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/fpmaint2)
 "aHj" = (
-/obj/machinery/vending/cigarette/free,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/maintenance/fpmaint2)
 "aHk" = (
@@ -15277,7 +15277,7 @@
 	},
 /area/security/detectives_office)
 "aJl" = (
-/obj/machinery/vending/cigarette/free,
+/obj/machinery/vending/cigarette,
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_y = -24


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Fixes https://github.com/ParadiseSS13/Paradise/issues/17089

Some vending machines on box and a single one on delta were set to the /free subtype. This PR replaces them by the regular credit required type. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This subtype is AFAIK meant to be used for vendors in places that dont use the credit system like the syndicate researchers or for the permabrig, not for station machines.


## Changelog
:cl:
fix: Some vending machines on boxstation and delstation that were set to be free now cost credits to use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
