### PR TITLE
Optimizes Organ Processing

### DIFF
--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -96,15 +96,12 @@
 	if(status & ORGAN_DEAD)
 		return
 
-	if(is_preserved())
-		return
-
 	//Process infections
 	if(is_robotic() || sterile || (owner && HAS_TRAIT(owner, TRAIT_NOGERMS)))
 		germ_level = 0
 		return
 
-	if(!owner)
+	if(!owner && !is_preserved())
 		// Maybe scale it down a bit, have it REALLY kick in once past the basic infection threshold
 		// Another mercy for surgeons preparing transplant organs
 		germ_level++


### PR DESCRIPTION
checking for if an organ is preserved while it's in someone's body is stupid and just incurs lots of extra CPU overhead.

before:
```
Proc Name                                Self CPU    Total CPU    Real Time     Overtime        Calls
 /mob/living/carbon/human/handle_organs 1.298       11.791       11.802        1.298       100049

after:

/mob/living/carbon/human/handle_organs  1.302        9.008        9.022        1.300       100063
```


This saves 23.6% of CPU for `handle_organs` by just only doing the preservation check when an organ is no longer attached to a body.