### PR TITLE
Ensure Alt Title Sanity

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -1661,9 +1661,10 @@
 	popup.open(0)
 
 /datum/character_save/proc/GetPlayerAltTitle(datum/job/job)
-	return player_alt_titles.Find(job.title) > 0 \
-		? player_alt_titles[job.title] \
-		: job.title
+    if(player_alt_titles.Find(job.title) > 0) // Does it exist in the list
+        if(player_alt_titles[job.title] in job.alt_titles) // Is it valid
+            return player_alt_titles[job.title]
+    return job.title // Use default
 
 /datum/character_save/proc/SetPlayerAltTitle(datum/job/job, new_title)
 	// remove existing entry


### PR DESCRIPTION
Credit to @AffectedArc07 

Adds sanity to alt-titles to prevent situations like this:

![img](https://cdn.discordapp.com/attachments/488080380415705098/909569196860518410/unknown.png)