### PR TITLE
Fixes survival capsules being permitted in holodeck

### DIFF
--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -9,7 +9,7 @@
 	. = ..()
 	blacklisted_turfs = typecacheof(list(/turf/simulated/wall, /turf/simulated/mineral))
 	whitelisted_turfs = list()
-	banned_areas = typecacheof(/area/shuttle)
+	banned_areas = typecacheof(list(/area/shuttle, /area/holodeck/alphadeck))
 
 /datum/map_template/shelter/proc/check_deploy(turf/deploy_location)
 	var/affected = get_affected_turfs(deploy_location, centered=TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds the stationside holodeck area to the list of banned survival capsule areas, preventing you from spawning one in the holodeck. I think this is a fix because this is totally unintended behaviour, but if it's a tweak just let me know and I'll change my CL.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Survival capsules break the holodeck because they overwrite the area with their own, meaning only admin intervention can restore the holodeck to a normal working state.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Changelog
:cl:
fix: Fixed being able to break the holodeck with survival capsules
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
