### PR TITLE
Fixes the Rod of Asclepius dupe exploit

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -209,7 +209,6 @@
 	tick_interval = 25
 	examine_text = "<span class='notice'>They seem to have an aura of healing and helpfulness about them.</span>"
 	alert_type = null
-	var/hand
 	var/deathTick = 0
 	/// How many points the rod has to heal with, maxes at 50, or whatever heal_points_max is set to.
 	var/heal_points = 50
@@ -246,33 +245,6 @@
 	else
 		if(ishuman(owner))
 			var/mob/living/carbon/human/itemUser = owner
-			var/obj/item/heldItem = (hand ==  1 ? itemUser.l_hand : itemUser.r_hand)
-			if(!heldItem || !istype(heldItem, /obj/item/rod_of_asclepius)) //Checks to make sure the rod is still in their hand
-				var/obj/item/rod_of_asclepius/newRod = new(itemUser.loc)
-				newRod.activated()
-				if(hand)
-					itemUser.drop_l_hand()
-					if(itemUser.put_in_l_hand(newRod))
-						to_chat(itemUser, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
-					else
-						if(!itemUser.has_organ("l_arm"))
-							new /obj/item/organ/external/arm(itemUser)
-						new /obj/item/organ/external/hand(itemUser)
-						itemUser.update_body()
-						itemUser.put_in_l_hand(newRod)
-						to_chat(itemUser, "<span class='notice'>Your arm suddenly grows back with the Rod of Asclepius still attached!</span>")
-				else
-					itemUser.drop_r_hand()
-					if(itemUser.put_in_r_hand(newRod))
-						to_chat(itemUser, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
-					else
-						if(!itemUser.has_organ("r_arm"))
-							new /obj/item/organ/external/arm/right(itemUser)
-						new /obj/item/organ/external/hand/right(itemUser)
-						itemUser.update_body()
-						itemUser.put_in_r_hand(newRod)
-						to_chat(itemUser, "<span class='notice'>Your arm suddenly grows back with the Rod of Asclepius still attached!</span>")
-
 			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
 			if(itemUser.health < itemUser.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(itemUser), "#375637")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -158,6 +158,7 @@
 //Rod of Asclepius
 #define RIGHT_HAND 0
 #define LEFT_HAND 1
+
 /obj/item/rod_of_asclepius
 	name = "\improper Rod of Asclepius"
 	desc = "A wooden rod about the size of your forearm with a snake carved around it, winding its way up the sides of the rod. Something about it seems to inspire in you the responsibilty and duty to help others."
@@ -254,7 +255,7 @@
 	activated = TRUE
 
 	owner.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
-	RegisterSignal(owner, .proc/deactivate, COMSIG_PARENT_QDELETING)
+	RegisterSignal(owner, COMSIG_PARENT_QDELETING, .proc/deactivate)
 
 /obj/item/rod_of_asclepius/proc/deactivate()
 	if(owner)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -156,6 +156,8 @@
 //Spooky special loot
 
 //Rod of Asclepius
+#define RIGHT_HAND 0
+#define LEFT_HAND 1
 /obj/item/rod_of_asclepius
 	name = "\improper Rod of Asclepius"
 	desc = "A wooden rod about the size of your forearm with a snake carved around it, winding its way up the sides of the rod. Something about it seems to inspire in you the responsibilty and duty to help others."
@@ -163,6 +165,7 @@
 	icon_state = "asclepius_dormant"
 	var/activated = FALSE
 	var/usedHand
+	var/mob/living/carbon/owner
 
 /obj/item/rod_of_asclepius/attack_self(mob/user)
 	if(activated)
@@ -172,9 +175,9 @@
 		return
 	var/mob/living/carbon/itemUser = user
 	if(itemUser.l_hand == src)
-		usedHand = 1
+		usedHand = LEFT_HAND
 	if(itemUser.r_hand == src)
-		usedHand = 0
+		usedHand = RIGHT_HAND
 	if(itemUser.has_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH))
 		to_chat(user, "<span class='warning'>You can't possibly handle the responsibility of more than one rod!</span>")
 		return
@@ -201,12 +204,67 @@
 		to_chat(itemUser, failText)
 		return
 	to_chat(itemUser, "<span class='notice'>The snake, satisfied with your oath, attaches itself and the rod to your forearm with an inseparable grip. Your thoughts seem to only revolve around the core idea of helping others, and harm is nothing more than a distant, wicked memory...</span>")
-	var/datum/status_effect/hippocraticOath/effect = itemUser.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
-	effect.hand = usedHand
-	activated()
 
-/obj/item/rod_of_asclepius/proc/activated()
-	flags =  NODROP | DROPDEL
+	activated(itemUser)
+
+/obj/item/rod_of_asclepius/Destroy()
+	owner = null
+	return ..()
+
+/obj/item/rod_of_asclepius/dropped(mob/user, silent)
+	..()
+	if(!activated)
+		return
+	addtimer(CALLBACK(src, .proc/try_attach_to_owner), 0) // Do this once the drop call stack is done. The holding limb might be getting removed
+
+/obj/item/rod_of_asclepius/proc/try_attach_to_owner()
+	if(ishuman(owner) && !QDELETED(owner))
+		if(ishuman(loc))
+			var/mob/living/carbon/human/thief = loc
+			thief.unEquip(src, TRUE, TRUE) // You're not my owner!
+		if(owner.stat == DEAD)
+			qdel(src) // Oh no! Oh well a new rod will be made from the STATUS_EFFECT_HIPPOCRATIC_OATH
+			return
+		flags |= NODROP // Readd the nodrop
+		var/mob/living/carbon/human/H = owner
+		var/limb_regrown = FALSE
+		if(usedHand == LEFT_HAND)
+			limb_regrown = H.regrow_external_limb_if_missing("l_arm")
+			limb_regrown = H.regrow_external_limb_if_missing("l_hand") || limb_regrown
+			H.drop_l_hand(TRUE)
+			H.put_in_l_hand(src, TRUE)
+		else
+			limb_regrown = H.regrow_external_limb_if_missing("r_arm")
+			limb_regrown = H.regrow_external_limb_if_missing("r_hand") || limb_regrown
+			H.drop_r_hand(TRUE)
+			H.put_in_r_hand(src, TRUE)
+		if(!limb_regrown)
+			to_chat(H, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
+		else
+			H.update_body() // Update the limb sprites
+			to_chat(H, "<span class='notice'>Your arm suddenly grows back with the Rod of Asclepius still attached!</span>")
+	else
+		deactivate()
+
+/obj/item/rod_of_asclepius/proc/activated(mob/living/carbon/new_owner)
+	owner = new_owner
+	flags = NODROP
 	desc = "A short wooden rod with a mystical snake inseparably gripping itself and the rod to your forearm. It flows with a healing energy that disperses amongst yourself and those around you. "
 	icon_state = "asclepius_active"
 	activated = TRUE
+
+	owner.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
+	RegisterSignal(owner, .proc/deactivate, COMSIG_PARENT_QDELETING)
+
+/obj/item/rod_of_asclepius/proc/deactivate()
+	if(owner)
+		UnregisterSignal(owner, COMSIG_PARENT_QDELETING)
+		owner = null
+
+	flags = NONE
+	activated = FALSE
+	desc = initial(desc)
+	icon_state = initial(icon_state)
+
+#undef RIGHT_HAND
+#undef LEFT_HAND

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -40,8 +40,8 @@
 	return null
 
 //Puts the item into your l_hand if possible and calls all necessary triggers/updates. returns 1 on success.
-/mob/proc/put_in_l_hand(obj/item/W)
-	if(!put_in_hand_check(W))
+/mob/proc/put_in_l_hand(obj/item/W, skip_lying_check = FALSE)
+	if(!put_in_hand_check(W, skip_lying_check))
 		return 0
 	if(!l_hand && has_left_hand())
 		W.forceMove(src)		//TODO: move to equipped?
@@ -56,8 +56,8 @@
 	return 0
 
 //Puts the item into your r_hand if possible and calls all necessary triggers/updates. returns 1 on success.
-/mob/proc/put_in_r_hand(obj/item/W)
-	if(!put_in_hand_check(W))
+/mob/proc/put_in_r_hand(obj/item/W, skip_lying_check = FALSE)
+	if(!put_in_hand_check(W, skip_lying_check))
 		return 0
 	if(!r_hand && has_right_hand())
 		W.forceMove(src)
@@ -71,8 +71,8 @@
 		return 1
 	return 0
 
-/mob/proc/put_in_hand_check(obj/item/W)
-	if(lying && !(W.flags & ABSTRACT))	return 0
+/mob/proc/put_in_hand_check(obj/item/W, skip_lying_check)
+	if(!skip_lying_check && lying && !(W.flags & ABSTRACT))	return 0
 	if(!istype(W))	return 0
 	return 1
 
@@ -102,12 +102,12 @@
 	return 0
 
 //Drops the item in our left hand
-/mob/proc/drop_l_hand()
-	return unEquip(l_hand) //All needed checks are in unEquip
+/mob/proc/drop_l_hand(force = FALSE)
+	return unEquip(l_hand, force) //All needed checks are in unEquip
 
 //Drops the item in our right hand
-/mob/proc/drop_r_hand()
-	return unEquip(r_hand) //Why was this not calling unEquip in the first place jesus fuck.
+/mob/proc/drop_r_hand(force = FALSE)
+	return unEquip(r_hand, force) //Why was this not calling unEquip in the first place jesus fuck.
 
 //Drops the item in our active hand.
 /mob/proc/drop_item() //THIS. DOES. NOT. NEED. AN. ARGUMENT.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1102,6 +1102,21 @@
 				I = new organ(H) //Create the organ inside the player.
 				I.insert(H)
 
+/**
+ * Regrows a given external limb if it is missing. Does not add internal organs back in.
+ * Returns whether or not it regrew the limb
+ *
+ * * limb_name - The name of the limb being added. "l_arm" for example
+ */
+/mob/living/carbon/human/proc/regrow_external_limb_if_missing(limb_name)
+	if(has_organ(limb_name))
+		return FALSE// Already there
+
+	var/list/organ_data = dna.species.has_limbs[limb_name]
+	var/limb_path = organ_data["path"]
+	new limb_path(src)
+	return TRUE
+
 /mob/living/carbon/human/revive()
 	//Fix up all organs and replace lost ones.
 	restore_all_organs() //Rejuvenate and reset all existing organs.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1106,6 +1106,7 @@
  * Regrows a given external limb if it is missing. Does not add internal organs back in.
  * Returns whether or not it regrew the limb
  *
+ * Arguments:
  * * limb_name - The name of the limb being added. "l_arm" for example
  */
 /mob/living/carbon/human/proc/regrow_external_limb_if_missing(limb_name)


### PR DESCRIPTION
## What Does This PR Do
Makes the rod of Asclepius not dupe itself when you're laying down while it is removed.
Also stops it from adding new limbs to you when you removed it and somehow got a hold of a NODROP item in the old hand you used.

I moved some stuff around to make it less insane.

One side effect I found while testing. When you're gibbed it'll delete the rod as well due to line 226 in necropolis_chest.dm. If this is an issue then I can probably find a workaround for it. In the master branch it'll drop the rod while it is still "bound" to the gibbed person. So the next person to pick it up and won't have the benefit even though it is stuck in their hands.

Fixes #17109
Fixes: #12631

## Why It's Good For The Game
Exploit be gone

## Changelog
:cl:
fix: The Rod of Asclepius now no longer can be duped
/:cl: