### PR TITLE
Photocopier TGUI Fix

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -390,28 +390,33 @@
 /obj/machinery/photocopier/ui_act(action, list/params)
 	if(..())
 		return
+	. = FALSE
 	add_fingerprint(usr)
 	switch(action)
 		if("copy")
 			copy(copyitem)
 		if("removedocument")
 			remove_document()
+			. = TRUE
 		if("removefolder")
 			remove_folder()
+			. = TRUE
 		if("add")
 			if(copies < maxcopies)
 				copies++
+				. = TRUE
 		if("minus")
 			if(copies > 0)
 				copies--
+				. = TRUE
 		if("scandocument")
 			scan_document()
 		if("filecopy")
 			file_copy(params["uid"])
 		if("deletefile")
 			delete_file(params["uid"])
+			. = TRUE
 	update_icon()
-	return TRUE
 
 /obj/machinery/photocopier/proc/aipic()
 	if(!issilicon(usr))


### PR DESCRIPTION
Please apply the ignore GBP tag, this is my fault.

## What Does This PR Do
Fixes #17115 
Was informed that always returning `TRUE` for ui_act made things more snappy. Was correct but this also fucks over any subtypes that do a `. = ..()` check. 

## Why It's Good For The Game
I can go back to bed
less angry admins
less bugs

## Changelog
:cl:
fix: Fixed Fax Machine UI
/:cl:
