### PR TITLE
Fixes Security Closets Not Having Seclites

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -160,6 +160,7 @@
 	new /obj/item/holosign_creator/security(src)
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/flashlight/seclite(src)
 	new /obj/item/clothing/head/helmet(src)
 	new /obj/item/clothing/suit/armor/secjacket(src)
 


### PR DESCRIPTION
unintentional removal.

Sec officers are meant to start with seclites in their lockers

:cl: Fox McCloud
fix: Fixes security officers not having access to seclites in their lockers
/:cl: