### PR TITLE
Doomsday device detonation plays cinematic

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -312,6 +312,18 @@ SUBSYSTEM_DEF(ticker)
 		for(var/mob/M in GLOB.mob_list)
 			if(M.client)
 				M.client.screen += cinematic	//show every client the cinematic
+	else if(override == "AI malfunction")
+		for(var/mob/M in GLOB.mob_list)
+			var/turf/T = get_turf(M)
+			if(T && is_station_level(T.z) && !issilicon(M))
+				to_chat(M, "<span class='danger'><B>The blast wave from [src] tears you atom from atom!</B></span>")
+				var/mob/ghost = M.ghostize()
+				M.dust()
+				if(ghost && ghost.client)
+					ghost.client.screen += cinematic
+				CHECK_TICK
+			if(M && M.client)
+				M.client.screen += cinematic
 	else	//nuke kills everyone on z-level 1 to prevent "hurr-durr I survived"
 		for(var/mob/M in GLOB.mob_list)
 			if(M.stat != DEAD)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -312,23 +312,12 @@ SUBSYSTEM_DEF(ticker)
 		for(var/mob/M in GLOB.mob_list)
 			if(M.client)
 				M.client.screen += cinematic	//show every client the cinematic
-	else if(override == "AI malfunction")
-		for(var/mob/M in GLOB.mob_list)
-			var/turf/T = get_turf(M)
-			if(T && is_station_level(T.z) && !issilicon(M))
-				to_chat(M, "<span class='danger'><B>The blast wave from [src] tears you atom from atom!</B></span>")
-				var/mob/ghost = M.ghostize()
-				M.dust()
-				if(ghost && ghost.client)
-					ghost.client.screen += cinematic
-				CHECK_TICK
-			if(M && M.client)
-				M.client.screen += cinematic
 	else	//nuke kills everyone on z-level 1 to prevent "hurr-durr I survived"
 		for(var/mob/M in GLOB.mob_list)
 			if(M.stat != DEAD)
 				var/turf/T = get_turf(M)
-				if(T && is_station_level(T.z) && !istype(M.loc, /obj/structure/closet/secure_closet/freezer))
+				if(T && is_station_level(T.z) && !istype(M.loc, /obj/structure/closet/secure_closet/freezer) && !(issilicon(M) && override == "AI malfunction"))
+					to_chat(M, "<span class='danger'><B>The blast wave from [src] tears you atom from atom!</B></span>")
 					var/mob/ghost = M.ghostize()
 					M.dust() //no mercy
 					if(ghost && ghost.client) //Play the victims an uninterrupted cinematic.

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -322,16 +322,8 @@
 	for(var/explodee in GLOB.player_list)
 		SEND_SOUND(explodee, doomsday_alarm)
 	sleep(100)
-	for(var/mob/living/L in GLOB.mob_list)
-		var/turf/T = get_turf(L)
-		if(!T || T.z != z_level)
-			continue
-		if(issilicon(L))
-			continue
-		to_chat(L, "<span class='danger'><B>The blast wave from [src] tears you atom from atom!</B></span>")
-		L.dust()
+	SSticker.station_explosion_cinematic(null, "AI malfunction")
 	to_chat(world, "<B>The AI cleansed the station of life with the doomsday device!</B>")
-	SSticker.force_ending = TRUE
 	SSticker.mode.station_was_nuked = TRUE
 
 //AI Turret Upgrade: Increases the health and damage of all turrets.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
AI doomsday device now once again plays the AI doomsday device cinematic when dusting the organics.
Also moves the entire dust the organics part of the doomsday device to ssticker
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously when malf was still a separate gamemode, this cinematic would play when the doomsday device detonated, but since it has been moved into the traitor gamemode it no longer does this.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
https://user-images.githubusercontent.com/19361017/142297692-6b92e961-e5c4-448f-bac1-68307eed1df4.mp4
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: AI doomsday device now once again plays the AI doomsday device cinematic when detonating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
