### PR TITLE
Fixes a rare bug where you can spawn as IPC cling

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -287,8 +287,6 @@ SUBSYSTEM_DEF(jobs)
 	for(var/mob/new_player/player in GLOB.player_list)
 		if(player.ready && player.has_valid_preferences() && player.mind && !player.mind.assigned_role)
 			unassigned += player
-			if(player.client.prefs.toggles2 & PREFTOGGLE_2_RANDOMSLOT)
-				player.client.prefs.load_random_character_slot(player.client)
 
 	Debug("DO, Len: [unassigned.len]")
 	if(unassigned.len == 0)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -180,6 +180,11 @@ SUBSYSTEM_DEF(ticker)
 		Master.SetRunLevel(RUNLEVEL_LOBBY)
 		return FALSE
 
+	// Randomise characters now. This avoids rare cases where a human is set as a changeling then they randomise to an IPC
+	for(var/mob/new_player/player in GLOB.player_list)
+		if(player.client.prefs.toggles2 & PREFTOGGLE_2_RANDOMSLOT)
+			player.client.prefs.load_random_character_slot(player.client)
+
 	//Configure mode and assign player to special mode stuff
 	mode.pre_pre_setup()
 	var/can_continue


### PR DESCRIPTION
## What Does This PR Do
Fixes a rare bug where you can spawn as an IPC cling.

If you have a human as your random character, then randomise to an IPC slot, you can end up as a changeling still. This is bad.

## Why It's Good For The Game
Bugs bad

## Changelog
:cl: AffectedArc07
fix: Fixed a rare bug where you could roll as an IPC changeling 
/:cl:
