### PR TITLE
Fixes bad documentation

### DIFF
--- a/.github/DOWNLOADING.md
+++ b/.github/DOWNLOADING.md
@@ -98,7 +98,6 @@ When you have done this, you'll need to recompile the code, but then it should w
 The SQL backend is required for storing character saves, preferences, administrative data, and many other things.
 We recommend running a database if your server is going to be used as more than just a local test server.
 Your SQL server details go in the `database_configuration` section of `config.toml`,
-and the SQL schema is in `SQL/paradise_schema.sql` or `SQL/paradise_schema_prefix.sql`,
-depending on if you want table prefixes.
+and the SQL schema can be found in `SQL/paradise_schema.sql`.
 More detailed setup instructions are located on our wiki:
 https://www.paradisestation.org/wiki/index.php/Setting_up_the_Database


### PR DESCRIPTION
## What Does This PR Do
Fixes some bad documentation in `DOWNLOADING.md`

We haven't had table prefixes in a while, and we're never adding them again.

## Why It's Good For The Repo
Documentation should be accurate.
