### PR TITLE
Fixes abstract items hiding in linen bins.

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -242,6 +242,12 @@ LINEN BINS
 	var/list/sheets = list()
 	var/obj/item/hidden = null
 
+/obj/structure/bedsheetbin/Destroy()
+	QDEL_LIST(sheets)
+	hidden.forceMove(get_turf(src))
+	hidden = null
+	return ..()
+
 
 /obj/structure/bedsheetbin/examine(mob/user)
 	. = ..()
@@ -255,9 +261,12 @@ LINEN BINS
 
 /obj/structure/bedsheetbin/update_icon()
 	switch(amount)
-		if(0)				icon_state = "linenbin-empty"
-		if(1 to amount / 2)	icon_state = "linenbin-half"
-		else				icon_state = "linenbin-full"
+		if(0)
+			icon_state = "linenbin-empty"
+		if(1 to amount / 2)
+			icon_state = "linenbin-half"
+		else
+			icon_state = "linenbin-full"
 
 
 /obj/structure/bedsheetbin/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
@@ -271,22 +280,24 @@ LINEN BINS
 	extinguish()
 	update_icon()
 
-/obj/structure/bedsheetbin/attackby(obj/item/I as obj, mob/user as mob, params)
+/obj/structure/bedsheetbin/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/bedsheet))
 		user.drop_item()
-		I.loc = src
+		I.forceMove(src)
 		sheets.Add(I)
 		amount++
 		to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 	else if(amount && !hidden && I.w_class < WEIGHT_CLASS_BULKY)	//make sure there's sheets to hide it among, make sure nothing else is hidden in there.
+		if(I.flags & ABSTRACT)
+			return
 		user.drop_item()
-		I.loc = src
+		I.forceMove(src)
 		hidden = I
 		to_chat(user, "<span class='notice'>You hide [I] among the sheets.</span>")
 
 
 
-/obj/structure/bedsheetbin/attack_hand(mob/user as mob)
+/obj/structure/bedsheetbin/attack_hand(mob/user)
 	if(amount >= 1)
 		amount--
 
@@ -311,7 +322,7 @@ LINEN BINS
 	add_fingerprint(user)
 
 
-/obj/structure/bedsheetbin/attack_tk(mob/user as mob)
+/obj/structure/bedsheetbin/attack_tk(mob/user)
 	if(amount >= 1)
 		amount--
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -282,7 +282,9 @@ LINEN BINS
 
 /obj/structure/bedsheetbin/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/bedsheet))
-		user.drop_item()
+		if(!user.drop_item())
+			to_chat(user, "<span class='notice'>[I] is stuck to your hand!</span>")
+			return
 		I.forceMove(src)
 		sheets.Add(I)
 		amount++
@@ -290,7 +292,9 @@ LINEN BINS
 	else if(amount && !hidden && I.w_class < WEIGHT_CLASS_BULKY)	//make sure there's sheets to hide it among, make sure nothing else is hidden in there.
 		if(I.flags & ABSTRACT)
 			return
-		user.drop_item()
+		if(!user.drop_item())
+			to_chat(user, "<span class='notice'>[I] is stuck to your hand!</span>")
+			return
 		I.forceMove(src)
 		hidden = I
 		to_chat(user, "<span class='notice'>You hide [I] among the sheets.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
title + some code improvements I made while I was at it.
removes some `as mob` and `as obj` and moves `loc =` to forcemove. 

Also makes hidden items fall out when the linen bin is destroyed. seemed to be missing some `destroy` stuff so I added that

## Why It's Good For The Game
bugs/bad code bad

## Changelog
:cl:
fix: linen bins now will not allow you to hide slaps inside.
tweak: linen bins drop their hidden items when they are destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
