### PR TITLE
Fixes burst weapons not properly having weapon spread when dual wielded

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -37,7 +37,6 @@
 	var/list/restricted_species
 
 	var/spread = 0
-	var/randomspread = 1
 
 	var/unique_rename = TRUE //allows renaming with a pen
 	var/unique_reskin = FALSE //allows one-time reskinning
@@ -237,10 +236,7 @@
 				if( i>1 && !(src in get_both_hands(user))) //for burst firing
 					break
 			if(chambered)
-				if(randomspread)
-					sprd = round((rand() - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
-				else
-					sprd = round((i / burst_size - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
+				sprd = round((pick(0.5, -0.5)) * (randomized_gun_spread + randomized_bonus_spread))
 				if(!chambered.fire(target, user, params, ,suppressed, zone_override, sprd))
 					shoot_with_empty_chamber(user)
 					break

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -9,7 +9,6 @@
 	fire_sound = 'sound/weapons/blastcannon.ogg'
 	needs_permit = FALSE
 	clumsy_check = FALSE
-	randomspread = FALSE
 
 	var/obj/item/transfer_valve/bomb
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes burst weapons have spread when dual-wielded, currently they have no visible spread at all for some reason.
Removes a redundant var that is no longer needed.
Fixes https://github.com/ParadiseSS13/Paradise/issues/15998
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You are penalised for dual-wielding single-shot weapons, you should be penalised for doing the same with burst-fire weapons.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
https://user-images.githubusercontent.com/12197162/142913336-989ed403-4904-4e01-ba61-b756e3b1381b.mp4
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fixed burst weapons not having spread when dual wielding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
