### PR TITLE
Mime finger gun description update

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -93,7 +93,7 @@
 
 /obj/effect/proc_holder/spell/targeted/mime/fingergun
 	name = "Finger Gun"
-	desc = "Shoot lethal, invisible bullets out of your fingers! 3 bullets available per cast. Use your fingers to holster them manually."
+	desc = "Shoot lethal, silencing bullets out of your fingers! 3 bullets available per cast. Use your fingers to holster them manually."
 	school = "mime"
 	panel = "Mime"
 	clothes_req = 0

--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -93,7 +93,7 @@
 
 /obj/effect/proc_holder/spell/targeted/mime/fingergun
 	name = "Finger Gun"
-	desc = "Shoot stunning, invisible bullets out of your fingers! 3 bullets available per cast. Use your fingers to holster them manually."
+	desc = "Shoot lethal, invisible bullets out of your fingers! 3 bullets available per cast. Use your fingers to holster them manually."
 	school = "mime"
 	panel = "Mime"
 	clothes_req = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes references to mime finger guns "stunning"
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Since the combat update PR, mime finger guns do not stun, but do 40 damage.
People have expressed that the outdated description is somewhat confusing. It was updated in the uplink, but not on the spell itself.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed mime finger guns saying they stun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
