### PR TITLE
Fixes some runtimes where mobs were spawned in nullspace

### DIFF
--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -18,10 +18,8 @@
 		for(var/mob/living/carbon/C in viewers(T, null))
 			C.flash_eyes()
 
-		for(var/i=1, i<=deliveryamt, i++)
-			var/atom/movable/x = new spawner_type
-			x.admin_spawned = admin_spawned
-			x.loc = T
+		for(var/i in 1 to deliveryamt)
+			var/atom/movable/x = new spawner_type(T)
 			if(prob(50))
 				for(var/j = 1, j <= rand(1, 3), j++)
 					step(x, pick(NORTH,SOUTH,EAST,WEST))

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -20,6 +20,7 @@
 
 		for(var/i in 1 to deliveryamt)
 			var/atom/movable/x = new spawner_type(T)
+			x.admin_spawned = admin_spawned
 			if(prob(50))
 				for(var/j = 1, j <= rand(1, 3), j++)
 					step(x, pick(NORTH,SOUTH,EAST,WEST))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes this
```[2021-11-24T16:32:04] Runtime in unsorted.dm,1992: Simple animal being instantiated in nullspace
[2021-11-24T16:32:04]   proc name: stack trace (/datum/proc/stack_trace)
[2021-11-24T16:32:04]   usr: The viscerator () (/mob/living/simple_animal/hostile/viscerator)
[2021-11-24T16:32:04] Runtime in unsorted.dm,1992: Simple animal being instantiated in nullspace
[2021-11-24T16:32:04]   proc name: stack trace (/datum/proc/stack_trace)
[2021-11-24T16:32:04]   usr: The viscerator () (/mob/living/simple_animal/hostile/viscerator)
[2021-11-24T16:32:04] Runtime in unsorted.dm,1992: Simple animal being instantiated in nullspace
[2021-11-24T16:32:04]   proc name: stack trace (/datum/proc/stack_trace)
[2021-11-24T16:32:04]   usr: The viscerator () (/mob/living/simple_animal/hostile/viscerator)
[2021-11-24T16:32:04] Runtime in unsorted.dm,1992: Simple animal being instantiated in nullspace
[2021-11-24T16:32:04]   proc name: stack trace (/datum/proc/stack_trace)
[2021-11-24T16:32:04]   usr: The viscerator () (/mob/living/simple_animal/hostile/viscerator)
[2021-11-24T16:32:04] Runtime in unsorted.dm,1992: Simple animal being instantiated in nullspace
```

## Why It's Good For The Game
runtimes bad

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
