### PR TITLE
Fixes being able to enter sleepers illegally

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -485,7 +485,7 @@
 	add_fingerprint(usr)
 	return
 
-/obj/machinery/sleeper/MouseDrop_T(atom/movable/O as mob|obj, mob/user)
+/obj/machinery/sleeper/MouseDrop_T(atom/movable/O, mob/user)
 	if(!permitted_check(O, user))
 		return
 	var/mob/living/L = O
@@ -509,7 +509,7 @@
 		return
 	return
 
-/obj/machinery/sleeper/proc/permitted_check(atom/movable/O as mob|obj, mob/user)
+/obj/machinery/sleeper/proc/permitted_check(atom/movable/O, mob/user)
 	if(O.loc == user) //no you can't pull things out of your ass
 		return
 	if(user.incapacitated()) //are you cuffed, dying, lying, stunned or other

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -485,7 +485,31 @@
 	add_fingerprint(usr)
 	return
 
-/obj/machinery/sleeper/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/machinery/sleeper/MouseDrop_T(atom/movable/O as mob|obj, mob/user)
+	if(!permitted_check(O, user))
+		return
+	var/mob/living/L = O
+	if(L == user)
+		visible_message("[user] starts climbing into the sleeper.")
+	else
+		visible_message("[user] starts putting [L.name] into the sleeper.")
+	if(do_after(user, 20, target = L))
+		if(!permitted_check(O, user))
+			return
+		if(!L)
+			return
+		L.forceMove(src)
+		occupant = L
+		icon_state = "[base_icon]"
+		to_chat(L, "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
+		add_fingerprint(user)
+		if(user.pulling == L)
+			user.stop_pulling()
+		SStgui.update_uis(src)
+		return
+	return
+
+/obj/machinery/sleeper/proc/permitted_check(atom/movable/O as mob|obj, mob/user)
 	if(O.loc == user) //no you can't pull things out of your ass
 		return
 	if(user.incapacitated()) //are you cuffed, dying, lying, stunned or other
@@ -498,7 +522,7 @@
 		return
 	if(!ishuman(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 		return
-	if(user.loc==null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
+	if(!user.loc) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
 		return
 	if(!istype(user.loc, /turf) || !istype(O.loc, /turf)) // are you in a container/closet/pod/etc?
 		return
@@ -517,26 +541,7 @@
 	if(L.has_buckled_mobs()) //mob attached to us
 		to_chat(user, "<span class='warning'>[L] will not fit into [src] because [L.p_they()] [L.p_have()] a slime latched onto [L.p_their()] head.</span>")
 		return
-	if(L == user)
-		visible_message("[user] starts climbing into the sleeper.")
-	else
-		visible_message("[user] starts putting [L.name] into the sleeper.")
-
-	if(do_after(user, 20, target = L))
-		if(occupant)
-			to_chat(user, "<span class='boldnotice'>The sleeper is already occupied!</span>")
-			return
-		if(!L) return
-		L.forceMove(src)
-		occupant = L
-		icon_state = "[base_icon]"
-		to_chat(L, "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
-		add_fingerprint(user)
-		if(user.pulling == L)
-			user.stop_pulling()
-		SStgui.update_uis(src)
-		return
-	return
+	return TRUE
 
 /obj/machinery/sleeper/AllowDrop()
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/17105 and other sleeper issues due to checks only being performed once.
Now additionally checks for correct conditions after the timer for entering is completed.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mobs can no longer hold items or do weird things during the timer and still enter the sleeper.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed being able to enter sleepers with items in hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
