### PR TITLE
Fix - Bodybag tags don't disappear when opening/closing the bags.

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -35,7 +35,7 @@
 			return
 		cut_overlays()
 		if(t)
-			add_overlay(image(icon, "bodybag_label"))
+			add_overlay("bodybag_label")
 		return
 	if(istype(I, /obj/item/wirecutters))
 		to_chat(user, "<span class='notice'>You cut the tag off the bodybag.</span>")
@@ -53,6 +53,10 @@
 		return TRUE
 	return FALSE
 
+/obj/structure/closet/body_bag/update_overlays()
+	..()
+	if(name != initial(name))
+		add_overlay("bodybag_label")
 
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes bodybags so the tags are retained when opening or closing the bag. As closets, they'd get removed with every other overlays when opened/closed and that'd be the end of it until a new tag or wirecutters are used on it.

## Why It's Good For The Game
#17163
Closets sure had issues, huh? Makes the tags not go the way of ghosts.

## Images of changes
https://user-images.githubusercontent.com/80771500/143625305-f87a900a-47b0-43e7-9ec1-5ec57ad3a55f.mp4

## Changelog
:cl:
fix: Tags on bodybags don't disappear when opening/closing the bag after applying one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
