### PR TITLE
Removes "name" design datums. Adds logging for null design error.

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -93,56 +93,57 @@
 	name = "\improper KA mod disk"
 	desc = "A design disk containing the design for a unique kinetic accelerator modkit. It's compatible with a research console."
 	icon_state = "datadisk1"
-	var/modkit_design = /datum/design/unique_modkit
+	var/modkit_design
 
 /obj/item/disk/design_disk/modkit_disk/New()
 	. = ..()
-	blueprint = new modkit_design
+	if(modkit_design)
+		blueprint = new modkit_design
 
 /obj/item/disk/design_disk/modkit_disk/mob_and_turf_aoe
 	name = "\improper KA mod disk (Offensive mining explosion)"
-	modkit_design = /datum/design/unique_modkit/offensive_turf_aoe
+	modkit_design = /datum/design/offensive_turf_aoe_modkit
 
 /obj/item/disk/design_disk/modkit_disk/rapid_repeater
 	name = "\improper KA mod disk (Rapid repeater)"
-	modkit_design = /datum/design/unique_modkit/rapid_repeater
+	modkit_design = /datum/design/rapid_repeater_modkit
 
 /obj/item/disk/design_disk/modkit_disk/resonator_blast
 	name = "\improper KA mod disk (Resonator blast)"
-	modkit_design = /datum/design/unique_modkit/resonator_blast
+	modkit_design = /datum/design/resonator_blast_modkit
 
 /obj/item/disk/design_disk/modkit_disk/bounty
 	name = "\improper KA mod disk (Death syphon)"
-	modkit_design = /datum/design/unique_modkit/bounty
+	modkit_design = /datum/design/bounty_modkit
 
-/datum/design/unique_modkit
-	build_type = PROTOLATHE | MECHFAB
-
-/datum/design/unique_modkit/offensive_turf_aoe
+/datum/design/offensive_turf_aoe_modkit
 	name = "Kinetic Accelerator Offensive Mining Explosion Mod"
 	desc = "A device which causes kinetic accelerators to fire AoE blasts that destroy rock and damage creatures."
 	id = "hyperaoemod"
 	materials = list(MAT_METAL = 7000, MAT_GLASS = 3000, MAT_SILVER= 3000, MAT_GOLD = 3000, MAT_DIAMOND = 4000)
 	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs/andmobs
 	category = list("Mining", "Cyborg Upgrade Modules")
+	build_type = PROTOLATHE | MECHFAB
 
-/datum/design/unique_modkit/rapid_repeater
+/datum/design/rapid_repeater_modkit
 	name = "Kinetic Accelerator Rapid Repeater Mod"
 	desc = "A device which greatly reduces a kinetic accelerator's cooldown on striking a living target or rock, but greatly increases its base cooldown."
 	id = "repeatermod"
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 5000, MAT_URANIUM = 8000, MAT_BLUESPACE = 2000)
 	build_path = /obj/item/borg/upgrade/modkit/cooldown/repeater
 	category = list("Mining", "Cyborg Upgrade Modules")
+	build_type = PROTOLATHE | MECHFAB
 
-/datum/design/unique_modkit/resonator_blast
+/datum/design/resonator_blast_modkit
 	name = "Kinetic Accelerator Resonator Blast Mod"
 	desc = "A device which causes kinetic accelerators to fire shots that leave and detonate resonator blasts."
 	id = "resonatormod"
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 5000, MAT_SILVER= 5000, MAT_URANIUM = 5000)
 	build_path = /obj/item/borg/upgrade/modkit/resonator_blasts
 	category = list("Mining", "Cyborg Upgrade Modules")
+	build_type = PROTOLATHE | MECHFAB
 
-/datum/design/unique_modkit/bounty
+/datum/design/bounty_modkit
 	name = "Kinetic Accelerator Death Syphon Mod"
 	desc = "A device which causes kinetic accelerators to permanently gain damage against creature types killed with it."
 	id = "bountymod"
@@ -150,6 +151,7 @@
 	reagents_list = list("blood" = 40)
 	build_path = /obj/item/borg/upgrade/modkit/bounty
 	category = list("Mining", "Cyborg Upgrade Modules")
+	build_type = PROTOLATHE | MECHFAB
 
 //Spooky special loot
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -155,7 +155,7 @@
 	build_path = /obj/item/reagent_scanner
 	category = list("Medical")
 
-/datum/design/item/scalpel_laser1
+/datum/design/scalpel_laser1
 	name = "Basic Laser Scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks basic and could be improved."
 	id = "scalpel_laser1"
@@ -165,7 +165,7 @@
 	build_path = /obj/item/scalpel/laser/laser1
 	category = list("Medical")
 
-/datum/design/item/scalpel_laser2
+/datum/design/scalpel_laser2
 	name = "Improved Laser Scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks somewhat advanced."
 	id = "scalpel_laser2"
@@ -175,7 +175,7 @@
 	build_path = /obj/item/scalpel/laser/laser2
 	category = list("Medical")
 
-/datum/design/item/scalpel_laser3
+/datum/design/scalpel_laser3
 	name = "Advanced Laser Scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks to be the pinnacle of precision energy cutlery!"
 	id = "scalpel_laser3"
@@ -185,7 +185,7 @@
 	build_path = /obj/item/scalpel/laser/laser3
 	category = list("Medical")
 
-/datum/design/item/scalpel_manager
+/datum/design/scalpel_manager
 	name = "Incision Management System"
 	desc = "A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps."
 	id = "scalpel_manager"

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -109,7 +109,7 @@ research holder datum.
 	if(!D)
 		return FALSE
 	if(!CanAddDesign2Known(D))
-		return FALSE
+		return TRUE
 	// Global datums make me nervous
 	known_designs[D.id] = D
 	return TRUE

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -106,10 +106,13 @@ research holder datum.
 	return TRUE
 
 /datum/research/proc/AddDesign2Known(datum/design/D)
+	if(!D)
+		return FALSE
 	if(!CanAddDesign2Known(D))
-		return
+		return FALSE
 	// Global datums make me nervous
 	known_designs[D.id] = D
+	return TRUE
 
 //Refreshes known_tech and known_designs list.
 //Input/Output: n/a
@@ -119,7 +122,8 @@ research holder datum.
 			AddTech2Known(PT)
 	for(var/datum/design/PD in possible_designs)
 		if(DesignHasReqs(PD))
-			AddDesign2Known(PD)
+			if(!AddDesign2Known(PD))
+				log_runtime(EXCEPTION("Game attempted to add a null design to list of known designs! Design: [PD] with ID: [PD.id]"), src)
 	for(var/v in known_tech)
 		var/datum/tech/T = known_tech[v]
 		T.level = clamp(T.level, 0, 20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes instances of blank design datums that result in "name" designs, namely:  `/datum/design/item` and `/datum/design/unique_modkit` (Thanks @SabreML for pointing me in the direction of these).
This PR also adds logging to the weird error we have been getting lately where RND completely breaks due to null designs being added to the `known_designs` list. It adds a null check to prevent the error from breaking RND consoles.

Fixes https://github.com/ParadiseSS13/Paradise/issues/16954
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I am not sure why the null design issue happens, during one round where I had the chance to investigate, two random designs that _do_ exist did not get properly referenced in the `known_designs` list, causing the bug.
From what I can see, all the code around `possible_designs` and `known_designs` should work, so I figured adding logging while preventing the error's effects is a step in the right direction.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Removed blank RND designs with the name "name"
fix: Remedied an error that occasionally broke all of RND
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
