### PR TITLE
Fix - Add logs to power gloves

### DIFF
--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -71,8 +71,10 @@
 		if(isliving(target_atom))
 			var/mob/living/L = target_atom
 			if(user.a_intent == INTENT_DISARM)
+				add_attack_logs(user, L, "shocked and weakened")
 				L.Weaken(3)
 			else
+				add_attack_logs(user, L, "electrocuted[P.unlimited_power ? " with unlimited power" : null]")
 				if(P.unlimited_power)
 					L.electrocute_act(1000, P, flags = SHOCK_NOGLOVES) //Just kill them
 				else

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -71,10 +71,10 @@
 		if(isliving(target_atom))
 			var/mob/living/L = target_atom
 			if(user.a_intent == INTENT_DISARM)
-				add_attack_logs(user, L, "shocked and weakened")
+				add_attack_logs(user, L, "shocked and weakened with power gloves")
 				L.Weaken(3)
 			else
-				add_attack_logs(user, L, "electrocuted[P.unlimited_power ? " with unlimited power" : null]")
+				add_attack_logs(user, L, "electrocuted with[P.unlimited_power ? " unlimited" : null] power gloves")
 				if(P.unlimited_power)
 					L.electrocute_act(1000, P, flags = SHOCK_NOGLOVES) //Just kill them
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Using the power gloves' alt-click now logs when it shocks a living target.

## Why It's Good For The Game
Fixes #17152

## Images of changes
![Power_Glove](https://user-images.githubusercontent.com/80771500/144121209-247305d6-da63-46d1-8600-ef10dab965f9.PNG)

## Changelog
:cl:
fix: Power gloves shocks are logged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
