### PR TITLE
Fix - Lava and chasms with footing are safe to walk on

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -74,7 +74,7 @@
 
 /turf/simulated/floor/chasm/proc/drop_stuff(AM)
 	. = 0
-	if(is_safe())
+	if(find_safeties())
 		return FALSE
 	var/thing_to_check = src
 	if(AM)

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -58,7 +58,7 @@
 /turf/simulated/floor/plating/lava/proc/burn_stuff(AM)
 	. = 0
 
-	if(is_safe())
+	if(find_safeties())
 		return FALSE
 
 	var/thing_to_check = src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Make the lava and chasm `burn_stuff` and `drop_stuff` check for footing specifically. They'd call `is_safe`, which checks both footing and atmospheric safety, with footing being a single `check_safeties` proc now.

## Why It's Good For The Game
Fixes #17187

## Images of changes
![Lava](https://user-images.githubusercontent.com/80771500/144752856-718da451-b970-4d95-affc-2857af939f71.png)

## Changelog
:cl:
fix: Lava and chasms with footing are safe to walk on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
