### PR TITLE
Make ghost notification for blob mouse follow the mob instead of just jumping to it

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -32,5 +32,5 @@
 
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
 	to_chat(B, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Blob)</span>")
-	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B)
+	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = src, action = NOTIFY_FOLLOW)
 	successSpawn = TRUE

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -32,5 +32,5 @@
 
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
 	to_chat(B, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Blob)</span>")
-	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = src, action = NOTIFY_FOLLOW)
+	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B, action = NOTIFY_FOLLOW)
 	successSpawn = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the infected mouse ghost notification to make ghosts orbit the mouse instead of just jumping to it.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most of the time, when an infected mouse currently spawns, it almost instantly starts to ventcrawl, and observers have to follow other ghosts to find where it's going. It seems like a bit of an inconsistency.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Clicking the event notification for an infected mouse now orbits the mouse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
