### PR TITLE
fixes duping lights

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -627,6 +627,9 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
 
+	if(status == LIGHT_EMPTY)
+		return
+
 	// make it burn hands if not wearing fire-insulated gloves
 	if(on)
 		var/prot = 0
@@ -664,6 +667,9 @@
 // break the light and make sparks if was on
 
 /obj/machinery/light/proc/drop_light_tube(mob/user)
+	if(status == LIGHT_EMPTY)
+		return
+
 	var/obj/item/light/L = new light_type()
 	L.status = status
 	L.rigged = rigged


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can no longer dupe lights by clicking on lights that are empty
fixes #17191
## Why It's Good For The Game
bugs/exploits bad
sanity checks good

## Changelog
:cl:
fix: you can no longer dupe lights by removing phantom lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
