### PR TITLE
Fixes cloning and genetics consoles pointing to the machines

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -359,17 +359,21 @@
 	else
 		return ..()
 
-/obj/machinery/computer/scan_consolenew/New()
+/obj/machinery/computer/scan_consolenew/Initialize()
 	..()
 	for(var/i=0;i<3;i++)
 		buffers[i+1]=new /datum/dna2/record
-	spawn(5)
-		for(dir in list(NORTH,EAST,SOUTH,WEST))
-			connected = locate(/obj/machinery/dna_scannernew, get_step(src, dir))
-			if(!isnull(connected))
-				break
-		spawn(250)
-			injector_ready = TRUE
+	addtimer(CALLBACK(src, .proc/find_machine), 1 SECONDS)
+	addtimer(CALLBACK(src, .proc/ready), 25 SECONDS)
+
+/obj/machinery/computer/scan_consolenew/proc/find_machine()
+	for(var/turf/t in orange(1, src))
+		connected = locate(/obj/machinery/dna_scannernew, t)
+		if(connected)
+			return
+
+/obj/machinery/computer/scan_consolenew/proc/ready()
+	injector_ready = TRUE
 
 /obj/machinery/computer/scan_consolenew/proc/all_dna_blocks(list/buffer)
 	var/list/arr = list()

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -359,8 +359,8 @@
 	else
 		return ..()
 
-/obj/machinery/computer/scan_consolenew/Initialize()
-	..()
+/obj/machinery/computer/scan_consolenew/Initialize(mapload)
+	. = ..()
 	for(var/i=0;i<3;i++)
 		buffers[i+1]=new /datum/dna2/record
 	addtimer(CALLBACK(src, .proc/find_machine), 1 SECONDS)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -367,10 +367,9 @@
 	addtimer(CALLBACK(src, .proc/ready), 25 SECONDS)
 
 /obj/machinery/computer/scan_consolenew/proc/find_machine()
-	for(var/turf/t in orange(1, src))
-		connected = locate(/obj/machinery/dna_scannernew, t)
-		if(connected)
-			return
+	for(var/obj/machinery/dna_scannernew/scanner in orange(1, src))
+		connected = scanner
+		return
 
 /obj/machinery/computer/scan_consolenew/proc/ready()
 	injector_ready = TRUE

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -61,18 +61,13 @@
 		selected_pod = pods[1]
 
 /obj/machinery/computer/cloning/proc/findscanner()
-	var/obj/machinery/dna_scannernew/scannerf = null
-
 	//Try to find scanner on adjacent tiles first
-	for(var/turf/t in orange(1, src))
-		scannerf = locate(/obj/machinery/dna_scannernew, t)
-		if(scannerf)
-			return scannerf
+	for(var/obj/machinery/dna_scannernew/scanner in orange(1, src))
+		return scanner
 
 	//Then look for a free one in the area
-	if(!scannerf)
-		for(var/obj/machinery/dna_scannernew/S in get_area(src))
-			return S
+	for(var/obj/machinery/dna_scannernew/S in get_area(src))
+		return S
 
 	return FALSE
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -64,8 +64,8 @@
 	var/obj/machinery/dna_scannernew/scannerf = null
 
 	//Try to find scanner on adjacent tiles first
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
-		scannerf = locate(/obj/machinery/dna_scannernew, get_step(src, dir))
+	for(var/turf/t in orange(1, src))
+		scannerf = locate(/obj/machinery/dna_scannernew, t)
 		if(scannerf)
 			return scannerf
 
@@ -74,7 +74,7 @@
 		for(var/obj/machinery/dna_scannernew/S in get_area(src))
 			return S
 
-	return 0
+	return FALSE
 
 /obj/machinery/computer/cloning/proc/releasecloner()
 	for(var/obj/machinery/clonepod/P in pods)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -25,8 +25,8 @@
 
 	light_color = LIGHT_COLOR_DARKBLUE
 
-/obj/machinery/computer/cloning/Initialize()
-	..()
+/obj/machinery/computer/cloning/Initialize(mapload)
+	. = ..()
 	pods = list()
 	records = list()
 	set_scan_temp("Scanner ready.", "good")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes the linking code for Genetics and Cloner consoles that causes them to obtain an unintended dir and face their linked machines. This happens when get_step is used (because it actually tries to move the consoles, go figure.)
I also slightly cleaned up cloner machine initialisation code because it was old and crap. (Also why the hell are they called scan_consolenew?)
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Computers facing the correct direction and not a large peice machinery is good for making the game appear somewhat sane.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Fixed genetics and cloning computers pointing in random directions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
