### PR TITLE
[TM ONLY FFS] Enables GC debugging

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -11,9 +11,9 @@
 
 /***** All toggles for the GC ref finder *****/
 
-// #define REFERENCE_TRACKING		// Uncomment to enable ref finding
+#define REFERENCE_TRACKING		// Uncomment to enable ref finding
 
-// #define GC_FAILURE_HARD_LOOKUP	//makes paths that fail to GC call find_references before del'ing.
+#define GC_FAILURE_HARD_LOOKUP	//makes paths that fail to GC call find_references before del'ing.
 
 // #define FIND_REF_NO_CHECK_TICK	//Sets world.loop_checks to false and prevents find references from sleeping
 


### PR DESCRIPTION
## What Does This PR Do
Enables debugging and searching for references on types that fail to GC

# DO NOT MERGE THIS PR UNDER ANY CIRCUMSTANCES. IT IS FOR TESTMERGES ONLY.

## Why It's Good For The Game
Being able to nail down causes for GC fails is important

## Changelog
:cl: AffectedArc07
experiment: Someone merged a PR that should never have been merged. Please lampoon whoever merged this.
/:cl:
