### PR TITLE
Fixes basketball hoop double message.

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -513,25 +513,12 @@
 		visible_message("<span class='notice'>[user] dunks [W] into [src]!</span>")
 		return
 
-/obj/structure/holohoop/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover,/obj/item) && mover.throwing)
-		var/obj/item/I = mover
-		if(istype(I, /obj/item/projectile))
-			return
-		if(prob(50))
-			I.loc = src.loc
-			visible_message("<span class='notice'>Swish! \the [I] lands in \the [src].</span>")
-		else
-			visible_message("<span class='alert'>\The [I] bounces off of \the [src]'s rim!</span>")
-		return 0
-	else
-		return ..(mover, target, height)
 
 /obj/structure/holohoop/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	if(isitem(AM) && !istype(AM,/obj/item/projectile))
 		if(prob(50))
 			AM.forceMove(get_turf(src))
-			visible_message("<span class='warning'>Swish! [AM] lands in [src].</span>")
+			visible_message("<span class='notice'>Swish! [AM] lands in [src].</span>")
 			return
 		else
 			visible_message("<span class='danger'>[AM] bounces off of [src]'s rim!</span>")

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -519,7 +519,6 @@
 		if(prob(50))
 			AM.forceMove(get_turf(src))
 			visible_message("<span class='notice'>Swish! [AM] lands in [src].</span>")
-			return
 		else
 			visible_message("<span class='danger'>[AM] bounces off of [src]'s rim!</span>")
 			return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently, upon throwing something at the basketball hoop in holodeck, two messages appear, and they might not even say the same thing. This is very confusing for playing basketball, as one message can say swish while the other says miss.

## Why It's Good For The Game
Fixes weird double message.

## Changelog
:cl: Iwanabeu
fix: Fixes basketball hoop showing two messages when shooting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
