### PR TITLE
Adds z level checks for pride mirror

### DIFF
--- a/code/modules/ruins/lavalandruin_code/sin_ruins.dm
+++ b/code/modules/ruins/lavalandruin_code/sin_ruins.dm
@@ -116,12 +116,12 @@
 		if(!is_teleport_allowed(level))
 			levels -= level
 	if(user.z != 3) //if you somehow manage to bloody get out of lavaland without closing the UI
-		var/turf/naughty_naughty = locate(user.x, user.y, 3) //return to sender
+		var/turf/return_turf = locate(user.x, user.y, 3) //return to sender
 		var/mob/living/carbon/human/fool = user
-		if(naughty_naughty && fool)
+		if(return_turf && fool)
 			to_chat(fool, "<span class='danger'><B>You dare try to play me for a fool?</B></span>")
 			fool.monkeyize()
-			fool.forceMove(naughty_naughty)
+			fool.forceMove(return_turf)
 			return
 	T.ChangeTurf(/turf/simulated/floor/chasm)
 	var/turf/simulated/floor/chasm/C = T

--- a/code/modules/ruins/lavalandruin_code/sin_ruins.dm
+++ b/code/modules/ruins/lavalandruin_code/sin_ruins.dm
@@ -115,7 +115,14 @@
 	for(var/level in levels)
 		if(!is_teleport_allowed(level))
 			levels -= level
-
+	if(user.z != 3) //if you somehow manage to bloody get out of lavaland without closing the UI
+		var/turf/naughty_naughty = locate(user.x, user.y, 3) //return to sender
+		var/mob/living/carbon/human/fool = user
+		if(naughty_naughty && fool)
+			to_chat(fool, "<span class='danger'><B>You dare try to play me for a fool?</B></span>")
+			fool.monkeyize()
+			fool.forceMove(naughty_naughty)
+			return
 	T.ChangeTurf(/turf/simulated/floor/chasm)
 	var/turf/simulated/floor/chasm/C = T
 	C.drop_x = T.x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds custom logic for the pride mirror if the user somehow manages to leave the z-level.
If the pride curse is activated on a z that is not lavaland, the user is monkeyd and transported back to lavaland.
This means some users will gib outright, but a monkey does not have much of a chance anyway.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If a player teleports to station with pride mirror still open, they can "avoid" the curse long enough to create a chasm on-station before being spaced.
This PR adds custom logic so they get sent back to lavaland, either as a monkey or as gibs.
Don't try to trick pride.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked pride mirror so it can no longer create chasms on station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
