### PR TITLE
Makes playable mobs GC better by reworking how GLOB.respawnable_list works

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -27,7 +27,7 @@
 		var/obj/vent = pick_n_take(vents)
 		var/mob/C = pick_n_take(candidates)
 		if(C)
-			GLOB.respawnable_list -= C.client
+			C.remove_from_respawnable_list()
 			var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
 			new_xeno.amount_grown += (0.75 * new_xeno.max_grown)	//event spawned larva start off almost ready to evolve.
 			new_xeno.key = C.key

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 		var/mob/C = pick_n_take(candidates)
 		spawn_count--
 		if(C)
-			GLOB.respawnable_list -= C.client
+			C.remove_from_respawnable_list()
 			var/mob/living/carbon/human/M = new /mob/living/carbon/human(picked_loc)
 			M.ckey = C.ckey // must be before equipOutfit, or that will runtime due to lack of mind
 			M.equipOutfit(/datum/outfit/admin/sol_trader)

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -6,4 +6,4 @@
 
 	if(GLOB.non_respawnable_keys[ckey])
 		can_reenter_corpse = 0
-		GLOB.respawnable_list -= src
+		remove_from_respawnable_list()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -164,9 +164,9 @@ Works together with spawning an observer, noted above.
 			flags &= ~GHOST_CAN_REENTER
 		var/mob/dead/observer/ghost = new(src, flags)	//Transfer safety to observer spawning proc.
 		ghost.timeofdeath = src.timeofdeath //BS12 EDIT
-		GLOB.respawnable_list -= src
+		remove_from_respawnable_list()
 		if(ghost.can_reenter_corpse)
-			GLOB.respawnable_list += ghost
+			ghost.add_to_respawnable_list()
 		else
 			GLOB.non_respawnable_keys[ckey] = 1
 		ghost.key = key

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -51,7 +51,7 @@
 			brainmob.forceMove(src)
 			brainmob.stat = CONSCIOUS
 			brainmob.see_invisible = initial(brainmob.see_invisible)
-			GLOB.respawnable_list -= brainmob
+			brainmob.remove_from_respawnable_list()
 			GLOB.dead_mob_list -= brainmob//Update dem lists
 			GLOB.alive_mob_list += brainmob
 
@@ -161,7 +161,7 @@
 
 	brainmob.container = null//Reset brainmob mmi var.
 	brainmob.forceMove(held_brain) //Throw mob into brain.
-	GLOB.respawnable_list += brainmob
+	brainmob.add_to_respawnable_list()
 	GLOB.alive_mob_list -= brainmob//Get outta here
 	held_brain.brainmob = brainmob//Set the brain to use the brainmob
 	held_brain.brainmob.cancel_camera()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -85,7 +85,7 @@
 	GLOB.dead_mob_list += src
 	if(mind)
 		mind.store_memory("Time of death: [station_time_timestamp("hh:mm:ss", timeofdeath)]", 0)
-		GLOB.respawnable_list += src
+		add_to_respawnable_list()
 
 		if(mind.name && !isbrain(src)) // !isbrain() is to stop it from being called twice
 			var/turf/T = get_turf(src)

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -54,7 +54,7 @@
 	GLOB.dead_mob_list -= src
 	GLOB.alive_mob_list += src
 	if(mind)
-		GLOB.respawnable_list -= src
+		remove_from_respawnable_list()
 	timeofdeath = null
 	if(updating)
 		update_canmove()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1095,6 +1095,14 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/activate_hand(selhand)
 	return
 
+/mob/proc/add_to_respawnable_list()
+	GLOB.respawnable_list += src
+	RegisterSignal(src, COMSIG_PARENT_QDELETING, .proc/remove_from_respawnable_list)
+
+/mob/proc/remove_from_respawnable_list()
+	GLOB.respawnable_list -= src
+	UnregisterSignal(src, COMSIG_PARENT_QDELETING)
+
 /mob/dead/observer/verb/respawn()
 	set name = "Respawn as NPC"
 	set category = "Ghost"
@@ -1115,17 +1123,13 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		var/picked = input("Please select an NPC to respawn as", "Respawn as NPC")  as null|anything in creatures
 		switch(picked)
 			if("Mouse")
-				GLOB.respawnable_list -= usr
+				remove_from_respawnable_list()
 				become_mouse()
-				spawn(5)
-					GLOB.respawnable_list += usr
 			else
 				var/mob/living/NPC = picked
 				if(istype(NPC) && !NPC.key)
-					GLOB.respawnable_list -= usr
+					remove_from_respawnable_list()
 					NPC.key = key
-					spawn(5)
-						GLOB.respawnable_list += usr
 	else
 		to_chat(usr, "You are not dead or you have given up your right to be respawned!")
 		return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -194,7 +194,7 @@
 			observer.name = observer.real_name
 			observer.key = key
 			QDEL_NULL(mind)
-			GLOB.respawnable_list += observer
+			observer.add_to_respawnable_list()
 			qdel(src)
 			return TRUE
 		return FALSE

--- a/code/modules/tgui/modules/ghost_hud_panel.dm
+++ b/code/modules/tgui/modules/ghost_hud_panel.dm
@@ -69,7 +69,7 @@ GLOBAL_DATUM_INIT(ghost_hud_panel, /datum/ui_module/ghost_hud_panel, new)
 
 				ghost.has_enabled_antagHUD = TRUE
 				ghost.can_reenter_corpse = FALSE
-				GLOB.respawnable_list -= ghost
+				ghost.remove_from_respawnable_list()
 
 			ghost.antagHUD = TRUE
 			for(var/datum/atom_hud/antag/H in GLOB.huds)


### PR DESCRIPTION
## What Does This PR Do
Most playable mobs get added to the `GLOB.respawnable_list` once they die. Ghosts also get added.
They ain't always properly removed which causes GC issues. This PR will ensure that when the mob is deleted it will at least be removed from this list.
Also makes the xeno and trader event properly remove the spawned mob from the list. Other events might still not properly do this but I limited this PRs scope to only fixing the GC issue.

```
[2021-12-12T15:17:04] Found /mob/living/carbon/human [0x30000a3] in list GLOB [0x21000082] -> respawnable_list (list).
```

## Why It's Good For The Game
It will help improve the GC of all playable mobs. The fix is not ideal but it has the least amount of impact on other code.


## Changelog
None