### PR TITLE
Refactors the mind.original variable into non reference variables. Improving player mob GC

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -93,7 +93,7 @@
 
 
 /mob/living/silicon/proc/sync_zeroth(datum/ai_law/zeroth_law, datum/ai_law/zeroth_law_borg)
-	if(!is_special_character(src) || mind.original != src)
+	if(!is_special_character(src) || !mind.is_original_mob(src))
 		if(zeroth_law_borg)
 			laws.set_zeroth_law(zeroth_law_borg.law)
 		else if(zeroth_law)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -23,7 +23,8 @@
 	var/key
 	var/name				//replaces mob/var/original_name
 	var/mob/living/current
-	var/mob/living/original	//TODO: remove.not used in any meaningful way ~Carn. First I'll need to tweak the way silicon-mobs handle minds.
+	var/original_mob_UID
+	var/original_mob_name
 	var/active = 0
 
 	var/memory
@@ -82,8 +83,14 @@
 				qdel(i)
 		antag_datums = null
 	current = null
-	original = null
 	return ..()
+
+/datum/mind/proc/set_original_mob(mob/original)
+	original_mob_name = original.real_name
+	original_mob_UID = original.UID()
+
+/datum/mind/proc/is_original_mob(mob/M)
+	return original_mob_UID == M.UID()
 
 /datum/mind/proc/get_display_key()
 	var/clientKey = current?.client?.get_display_key()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -23,7 +23,9 @@
 	var/key
 	var/name				//replaces mob/var/original_name
 	var/mob/living/current
+	/// The original mob's UID. Used for example to see if a silicon with antag status is actually malf. Or just an antag put in a borg
 	var/original_mob_UID
+	/// The original mob's name. Used in Dchat messages
 	var/original_mob_name
 	var/active = 0
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -384,7 +384,7 @@
 
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)
-			if(D.mind && (D.mind.original == L || D.mind.current == L))
+			if(D.mind && (D.mind.is_original_mob(L) || D.mind.current == L))
 				if(L.stat == DEAD)
 					if(L.suiciding)	//Suicider
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<font color='red'><b>Suicide</b></font>)\n"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -356,7 +356,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/die/check_completion()
 	if(!owner.current || owner.current.stat == DEAD || isbrain(owner.current))
 		return 1
-	if(issilicon(owner.current) && owner.current != owner.original)
+	if(issilicon(owner.current) && !owner.is_original_mob(owner.current))
 		return 1
 	return 0
 
@@ -368,7 +368,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/survive/check_completion()
 	if(!owner.current || owner.current.stat == DEAD || isbrain(owner.current))
 		return 0		//Brains no longer win survive objectives. --NEO
-	if(issilicon(owner.current) && owner.current != owner.original)
+	if(issilicon(owner.current) && !owner.is_original_mob(owner.current))
 		return 0
 	return 1
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -29,7 +29,7 @@
 	modePlayer += wizard
 	wizard.assigned_role = SPECIAL_ROLE_WIZARD //So they aren't chosen for other jobs.
 	wizard.special_role = SPECIAL_ROLE_WIZARD
-	wizard.original = wizard.current
+	wizard.set_original_mob(wizard.current)
 	if(GLOB.wizardstart.len == 0)
 		to_chat(wizard.current, "<span class='danger'>A starting location for you could not be found, please report this bug!</span>")
 		return 0

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -135,7 +135,7 @@
 			else
 				for(var/n = ++i; n <= optioncount; n++)
 					dat += "<dd><font color='blue'>&#09;[n]. ---------------</font><br></dd>"
-			if((istype(user, /mob/living/silicon/ai) || istype(user, /mob/living/silicon/robot)) && (user.mind.special_role && user.mind.original == user))
+			if((istype(user, /mob/living/silicon/ai) || istype(user, /mob/living/silicon/robot)) && (user.mind.special_role && user.mind.is_original_mob(user)))
 				//Malf/Traitor AIs can bruteforce into the system to gain the Key.
 				dat += "<dd><A href='?src=[UID()];hack=1'><i><font color='Red'>*&@#. Bruteforce Key</font></i></font></a><br></dd>"
 			else
@@ -355,7 +355,7 @@
 
 		//Hack the Console to get the password
 		if(href_list["hack"])
-			if((istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot)) && (usr.mind.special_role && usr.mind.original == usr))
+			if((istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot)) && (usr.mind.special_role && usr.mind.is_original_mob(usr)))
 				src.hacking = 1
 				src.screen = 2
 				src.icon_screen = hack_icon

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -92,7 +92,7 @@
 		return TRUE
 	if(!isAI(user))
 		return FALSE
-	return (user.mind.special_role && user.mind.original == user)
+	return (user.mind.special_role && user.mind.is_original_mob(user))
 
 /**
   * Check if the user is allowed to hack a specific borg

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -84,7 +84,7 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 				R.real_name = R.name
 				R.mind = new
 				R.mind.current = R
-				R.mind.original = R
+				R.mind.set_original_mob(R)
 				R.mind.assigned_role = SPECIAL_ROLE_DEATHSQUAD
 				R.mind.special_role = SPECIAL_ROLE_DEATHSQUAD
 				R.mind.offstation_role = TRUE

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -21,7 +21,7 @@
 				photosync()
 				to_chat(src, "<b>Laws synced with AI, be sure to note any changes.</b>")
 				// TODO: Update to new antagonist system.
-				if(mind && mind.special_role == SPECIAL_ROLE_TRAITOR && mind.original == src)
+				if(mind && mind.special_role == SPECIAL_ROLE_TRAITOR && mind.is_original_mob(src))
 					to_chat(src, "<b>Remember, your AI does NOT share or know about your law 0.")
 		else
 			to_chat(src, "<b>No AI selected to sync laws with, disabling lawsync protocol.</b>")
@@ -30,7 +30,7 @@
 	to_chat(who, "<b>Obey these laws:</b>")
 	laws.show_laws(who)
 	// TODO: Update to new antagonist system.
-	if(mind && (mind.special_role == SPECIAL_ROLE_TRAITOR && mind.original == src) && connected_ai)
+	if(mind && (mind.special_role == SPECIAL_ROLE_TRAITOR && mind.is_original_mob(src)) && connected_ai)
 		to_chat(who, "<b>Remember, [connected_ai.name] is technically your master, but your objective comes first.</b>")
 	else if(connected_ai)
 		to_chat(who, "<b>Remember, [connected_ai.name] is your master, other AIs can be ignored.</b>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	..()
 
 	add_robot_verbs()
-	
+
 	// Remove inherited verbs that effectively do nothing for cyborgs, or lead to unintended behaviour.
 	verbs -= /mob/living/verb/lay_down
 	verbs -= /mob/living/verb/mob_sleep
@@ -1362,7 +1362,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	real_name = name
 	mind = new
 	mind.current = src
-	mind.original = src
+	mind.set_original_mob(src)
 	mind.assigned_role = SPECIAL_ROLE_ERT
 	mind.special_role = SPECIAL_ROLE_ERT
 	if(!(mind in SSticker.minds))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -457,8 +457,8 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 			var/realname = C.mob.real_name
 			if(C.mob.mind)
 				mindname = C.mob.mind.name
-				if(C.mob.mind.original && C.mob.mind.original.real_name)
-					realname = C.mob.mind.original.real_name
+				if(C.mob.mind.original_mob_name)
+					realname = C.mob.mind.original_mob_name
 			if(mindname && mindname != realname)
 				name = "[realname] died as [mindname]"
 			else

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -558,7 +558,7 @@
 		else if(mind.assigned_role == "Mime")
 			new_character.real_name = pick(GLOB.mime_names)
 			new_character.rename_self("mime")
-		mind.original = new_character
+		mind.set_original_mob(new_character)
 		mind.transfer_to(new_character)					//won't transfer key since the mind is not active
 
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -28,7 +28,7 @@
 
 	if(mind)
 		mind.transfer_to(O)
-		O.mind.original = O
+		O.mind.set_original_mob(O)
 	else
 		O.key = key
 
@@ -81,7 +81,7 @@
 	if(mind)		//TODO
 		mind.transfer_to(O)
 		if(O.mind.assigned_role == "Cyborg")
-			O.mind.original = O
+			O.mind.set_original_mob(O)
 		else if(mind && mind.special_role)
 			O.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
 	else

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -174,7 +174,7 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 	//Creates mind stuff.
 	M.mind = new
 	M.mind.current = M
-	M.mind.original = M
+	M.mind.set_original_mob(M)
 	M.mind.assigned_role = SPECIAL_ROLE_ERT
 	M.mind.special_role = SPECIAL_ROLE_ERT
 	M.mind.offstation_role = TRUE


### PR DESCRIPTION
## What Does This PR Do
Refactors the `mind.original` var into two separate variables which hold the UID and the original name.
This reference meant that player characters who got deleted could never properly GC.
As extra, this fixes the weird instance where your body got gibbed and after a while your dchat name changes to `Name died as other_name`. Now it stays like it normally is
```
[2021-12-12T20:28:55] Found /mob/living/carbon/human [0x300009c] in /datum/mind's [0x21003b00] original var. World -> /datum/mind
```

I tested this briefly to see if all borg/AI antag related stuff still worked and I found no issues. Malf AIs could still hack while borged agents could not.

## Why It's Good For The Game
GC gut

## Changelog
fix: Being gibbed (or otherwise deleted) no longer changes your Dchat messages header