### PR TITLE
Fix runtime with patches and lava

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -202,6 +202,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		if((T.intact && level == 1) || T.transparent_floor) //fire can't damage things hidden below the floor.
 			return
 	..()
+	if(QDELETED(src))  // Some items, like patches, might get qdeled in the parent call
+		return
 	if(exposed_temperature && !(resistance_flags & FIRE_PROOF))
 		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, FIRE, 0)
 	if(!(resistance_flags & ON_FIRE) && (resistance_flags & FLAMMABLE) && !(resistance_flags & FIRE_PROOF))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a small runtime that occurs when a patch gets used up in lava (or gets destroyed by some other means, like admin rejuv), and then gets burn damage applied to it after it's processed its chems and been set to qdelete.
<details>
<summary>Sample runtime I'm fixing</summary>

```
[2021-12-12T19:53:05] Runtime in unsorted.dm,1994: The burn patch taking damage after deletion
[2021-12-12T19:53:05]   proc name: stack trace (/datum/proc/stack_trace)
[2021-12-12T19:53:05]   src: the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf)
[2021-12-12T19:53:05]   src.loc: the lava (70,146,3) (/turf/simulated/floor/plating/lava/smooth/lava_land_surface)
[2021-12-12T19:53:05]   call stack:
[2021-12-12T19:53:05]   the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf): stack trace("The burn patch taking damage a...")
[2021-12-12T19:53:05]   the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf): take damage(20, "fire", "fire", 0, null, 0)
[2021-12-12T19:53:05]   the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf): fire act(10000, 1000, null, 1)
[2021-12-12T19:53:05]   the lava (70,146,3) (/turf/simulated/floor/plating/lava/smooth/lava_land_surface): burn stuff(the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf))
[2021-12-12T19:53:05]   the lava (70,146,3) (/turf/simulated/floor/plating/lava/smooth/lava_land_surface): Entered(the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf))
[2021-12-12T19:53:05]   the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf): forceMove(the lava (70,146,3) (/turf/simulated/floor/plating/lava/smooth/lava_land_surface))
[2021-12-12T19:53:05]   Unknown (as [[hyperlink blocked]]) (/mob/living/carbon/human): unEquip(the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf), 1, 0)
[2021-12-12T19:53:05]   Unknown (as [[hyperlink blocked]]) (/mob/living/carbon/human): unEquip(the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf), 1, 0)
[2021-12-12T19:53:05]   Unknown (as [[hyperlink blocked]]) (/mob/living/carbon/human): unEquip(the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf), 1, 0)
[2021-12-12T19:53:05]   the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf): Destroy(0)
[2021-12-12T19:53:05]   the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf): Destroy(0)
[2021-12-12T19:53:05]   qdel(the burn patch (/obj/item/reagent_containers/food/pill/patch/silver_sulf), 0)
[2021-12-12T19:53:05]   Unknown (as [[hyperlink blocked]]) (/mob/living/carbon/human): handle patches()
[2021-12-12T19:53:05]   Unknown (as [[hyperlink blocked]]) (/mob/living/carbon/human): Life(2, 980)
[2021-12-12T19:53:05]   Unknown (as [[hyperlink blocked]]) (/mob/living/carbon/human): Life(2, 980)
[2021-12-12T19:53:05]   Mobs (/datum/controller/subsystem/mobs): fire(0)
[2021-12-12T19:53:05]   Mobs (/datum/controller/subsystem/mobs): ignite(0)
[2021-12-12T19:53:05]   Master (/datum/controller/master): RunQueue()
[2021-12-12T19:53:05]   Master (/datum/controller/master): Loop()
[2021-12-12T19:53:05]   Master (/datum/controller/master): StartProcessing(0)
```
</details>

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Generally, runtimes bad!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
