### PR TITLE
Adds a privacy warning for ban appeal screenshots

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -645,6 +645,7 @@
 	if(fromban)
 		url += "&fwd=appeal"
 		to_chat(src, {"Now opening a window to verify your information with the forums, so that you can appeal your ban. If the window does not load, please copy/paste this link: <a href="[url]">[url]</a>"})
+		to_chat(src, "<span class='boldannounce'>If you are screenshotting this screen for your ban appeal, please blur/draw over the token in the above link.</span>")
 	else
 		to_chat(src, {"Now opening a window to verify your information with the forums. If the window does not load, please go to: <a href="[url]">[url]</a>"})
 	src << link(url)


### PR DESCRIPTION
## What Does This PR Do
Adds a warning for people who screenshot their ban reasons, as it can end up showing a forum auth token.

![image](https://user-images.githubusercontent.com/25063394/145807505-502c9683-eaa6-4539-b1b1-fe24e7d6f1d9.png)

Behind that blur is a token thats used to link game accounts. Even though they are one use, its better for sanity to put a blur warning.

## Why It's Good For The Game
Exposing bad

## Changelog
N/A