### PR TITLE
Fixes Diona Being Immune to Brain Damage

### DIFF
--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -10,7 +10,6 @@
 
 	burn_mod = 1.25
 	heatmod = 1.5
-	brain_mod = 0
 	var/pod = FALSE //did they come from a pod? If so, they're stronger than normal Diona.
 
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \


### PR DESCRIPTION
Diona aren't meant to be immune to brain damage---they never were.

A major aspect of the updated medical system, a couple years back, was ensuring far more species fit within it, having them be immune to brain damage was a bug---deliberately giving them `brain_mod = 0` is not within the design space intended.

:cl: Fox McCloud
fix: Fixes Diona being immune to brain damage
/:cl: