### PR TITLE
Checks contents of storage items for restrictions

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -358,7 +358,7 @@
 		for(var/obj/A in S.return_inv())
 			if(is_type_in_typecache(A, cant_hold))
 				if(!stop_messages)
-					to_chat(usr, "<span class='warning'>[src] rejects [I] because of it's contents.</span>")
+					to_chat(usr, "<span class='warning'>[src] rejects [I] because of its contents.</span>")
 				return FALSE
 
 	if(I.w_class > max_w_class)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -43,7 +43,7 @@
 	var/foldable_amt = 0
 
 	/// Lazy list of mobs which are currently viewing the storage inventory.
-	var/list/mobs_viewing 
+	var/list/mobs_viewing
 
 /obj/item/storage/Initialize(mapload)
 	. = ..()
@@ -352,6 +352,14 @@
 		if(!stop_messages)
 			to_chat(usr, "<span class='warning'>[src] cannot hold [I].</span>")
 		return FALSE
+
+	if(istype(I, /obj/item/storage)) //Checks nested storage contents for restricted objects, we don't want people sneaking the NAD in via boxes now, do we?
+		var/obj/item/storage/S = I
+		for(var/obj/A in S.return_inv())
+			if(is_type_in_typecache(A, cant_hold))
+				if(!stop_messages)
+					to_chat(usr, "<span class='warning'>[src] rejects [I] because of it's contents.</span>")
+				return FALSE
 
 	if(I.w_class > max_w_class)
 		if(!stop_messages)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -353,7 +353,7 @@
 			to_chat(usr, "<span class='warning'>[src] cannot hold [I].</span>")
 		return FALSE
 
-	if(istype(I, /obj/item/storage)) //Checks nested storage contents for restricted objects, we don't want people sneaking the NAD in via boxes now, do we?
+	if(length(cant_hold) && istype(I, /obj/item/storage)) //Checks nested storage contents for restricted objects, we don't want people sneaking the NAD in via boxes now, do we?
 		var/obj/item/storage/S = I
 		for(var/obj/A in S.return_inv())
 			if(is_type_in_typecache(A, cant_hold))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR ensures that the contents of storage items are also checked for restricted items when putting something into something else.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Putting the NAD into a storage implant using boxes is a nasty exploit that causes a few issues. This solves it on a broader scale by adding a check for all storage objects that are inserted into other storage objects.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed an exploit letting you bypass storage restrictions using nested storage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
