### PR TITLE
Makes blob spores/blobbers and mice GC properly

### DIFF
--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -24,6 +24,4 @@
 	spore_delay = world.time + 100 // 10 seconds
 	var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
 	if(overmind)
-		BS.color = overmind.blob_reagent_datum?.complementary_color
-		BS.overmind = overmind
-		overmind.blob_mobs.Add(BS)
+		overmind.add_mob_to_overmind(BS)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -77,6 +77,15 @@
 
 	blob_talk(message)
 
+/mob/camera/blob/proc/add_mob_to_overmind(mob/living/simple_animal/hostile/blob/B)
+	B.color = blob_reagent_datum?.complementary_color
+	B.overmind = src
+	blob_mobs += B
+	RegisterSignal(B, COMSIG_PARENT_QDELETING, .proc/on_blob_mob_death)
+
+/mob/camera/blob/proc/on_blob_mob_death(mob/living/simple_animal/hostile/blob/B)
+	blob_mobs -= B
+
 /mob/camera/blob/proc/blob_talk(message)
 	log_say("(BLOB) [message]", src)
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -231,9 +231,7 @@
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
 	if(blobber)
 		qdel(B)
-	blobber.color = blob_reagent_datum.complementary_color
-	blobber.overmind = src
-	blob_mobs.Add(blobber)
+	add_mob_to_overmind(blobber)
 	blobber.AIStatus = AI_OFF
 	blobber.LoseTarget()
 	spawn()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -212,9 +212,9 @@
 	var/datum/mind/blobmind = mind
 	var/client/C = client
 	if(istype(blobmind) && istype(C))
-		blobmind.special_role = SPECIAL_ROLE_BLOB
 		var/obj/structure/blob/core/core = new(T, C, 3)
 		core.lateblobtimer()
+		qdel(blobmind) // Delete the old mind. THe blob will make a new one
 	else
 		new /obj/structure/blob/core(T) // Ghosts will be prompted to control it.
 	if(ismob(loc)) // in case some taj/etc ate the mouse.


### PR DESCRIPTION
## What Does This PR Do
As the title suggests. Currently blob spores and blobbers never GC if they are made by a blob. That's bad since spores are known suicide bombers.
Blob mice also didn't GC because their mind never got cleaned up nor reused. Now the mind will just be deleted since the core will make a new one anyway.

```
[2021-12-16T20:11:09] Beginning search for references to a /mob/living/simple_animal/mouse/blobinfected.
[2021-12-16T20:11:09] Finished searching globals
[2021-12-16T20:13:40] Finished searching atoms
[2021-12-16T20:13:50] Found /mob/living/simple_animal/mouse/blobinfected [0x3000008] in /datum/mind's [0x21016f87] current var. World -> /datum/mind
[2021-12-16T20:13:54] Finished searching datums
[2021-12-16T20:13:54] Finished searching clients
[2021-12-16T20:13:54] Completed search for references to a /mob/living/simple_animal/mouse/blobinfected.
[2021-12-16T20:13:54] GC: -- [0x2100000c] | /mob/living/simple_animal/mouse/blobinfected was unable to be GC'd --
[2021-12-16T20:18:50] Beginning search for references to a /mob/living/simple_animal/hostile/blob/blobspore.
[2021-12-16T20:18:50] Finished searching globals
[2021-12-16T20:18:50] Found /mob/living/simple_animal/hostile/blob/blobspore [0x3000008] in list World -> /mob/camera/blob [0x30000a7] -> blob_mobs (list).
[2021-12-16T20:21:23] Finished searching atoms
[2021-12-16T20:21:37] Finished searching datums
[2021-12-16T20:21:37] Finished searching clients
[2021-12-16T20:21:37] Completed search for references to a /mob/living/simple_animal/hostile/blob/blobspore.
[2021-12-16T20:21:37] GC: -- [0x2100000c] | /mob/living/simple_animal/hostile/blob/blobspore was unable to be GC'd --
[2021-12-16T20:22:50] Beginning search for references to a /mob/living/simple_animal/mouse/blobinfected.
[2021-12-16T20:22:51] Finished searching globals
[2021-12-16T20:25:16] Finished searching atoms
[2021-12-16T20:25:24] Found /mob/living/simple_animal/mouse/blobinfected [0x30000ba] in /datum/mind's [0x2100ffab] current var. World -> /datum/mind
[2021-12-16T20:25:32] Finished searching datums
[2021-12-16T20:25:32] Finished searching clients
[2021-12-16T20:25:32] Completed search for references to a /mob/living/simple_animal/mouse/blobinfected.
```

## Why It's Good For The Game
Saves a lot of GC related lag

```
/mob/living/simple_animal/hostile/blob/blobspore
Failures: 129
qdel() Count: 133
Destroy() Cost: 72.706ms
Total Hard Deletes 124
Time Spent Hard Deleting: 21758.2ms
```

## Changelog
None