### PR TITLE
Wakes borgs up when they get their cell added. Fixes a bug from #17226

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -127,9 +127,9 @@
 	max_damage = 50
 
 /datum/robot_component/cell/install(obj/item/stock_parts/cell/C)
-	..()
 	external_type = C.type // Update the cell component's `external_type` to the path of new cell
 	owner.cell = C
+	..()
 
 /datum/robot_component/cell/uninstall()
 	..()


### PR DESCRIPTION
## What Does This PR Do
Bug fix introduced by #17226

## Why It's Good For The Game
No more sleeping mister borgy

## Changelog
:cl:
fix: Borgs now wake up properly when adding a cell to them
/:cl: