### PR TITLE
Fix gravgen airlock cycling on deltastation

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -33129,8 +33129,8 @@
 "bzM" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1331;
-	id_tag = "atmo_tank_vent"
+	frequency = 1379;
+	id_tag = "atmo_tank_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "atmo_tank_airlock";
@@ -33869,7 +33869,7 @@
 "bBs" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	id_tag = "atmos_tank_inner";
+	id_tag = "atmo_tank_inner";
 	locked = 1;
 	name = "Atmos External Access";
 	req_access_txt = "32"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the airlock cycling of the airlock at the gravity generator on deltastation, previously it was impossible to cycle it, and the inner airlock buttons didn't work at all

![image](https://user-images.githubusercontent.com/19361017/146546141-83abdc63-6051-45ed-bf5c-2687873c49c6.png)

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Gravity generator airlock on DeltaStation can now cycle properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
