### PR TITLE
Borg broken component remove fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -839,7 +839,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	if(module)
 		removable_components += module.custom_removals
 	var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
-	if(!remove)
+	if(!remove || !Adjacent(user))
 		return
 
 	var/datum/robot_component/C = components[remove]

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -841,20 +841,24 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
 	if(!remove)
 		return
+
+	var/datum/robot_component/C = components[remove]
+	if(C.is_missing()) // Somebody else removed it during the input
+		return
+
 	if(module && module.handle_custom_removal(remove, user, I))
 		return
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	var/datum/robot_component/C = components[remove]
 	var/obj/item/robot_parts/robot_component/thing = C.wrapped
 	to_chat(user, "You remove \the [thing].")
 	if(istype(thing))
 		thing.brute = C.brute_damage
 		thing.burn = C.electronics_damage
 
+	C.uninstall()
 	thing.loc = loc
-	if(C.installed)
-		C.uninstall()
+
 
 
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -839,7 +839,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	if(module)
 		removable_components += module.custom_removals
 	var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
-	if(!remove || !Adjacent(user))
+	if(!remove || !Adjacent(user) || !opened)
 		return
 
 	var/datum/robot_component/C = components[remove]


### PR DESCRIPTION
## What Does This PR Do
Fuckup on my part in the recent borg PR. I overlooked some old logic.
Also fixed a bug where you could teleport borg parts that just got removed if you keep the input window open after they already got removed.
And one where you could remove parts from borgs from a long distance as long as you kept the input window open.
And another where you could remove borg parts from a borg that already got their hatched closed again

## Why It's Good For The Game
Bug fixes

## Changelog
:cl:
fix: Removing borg parts now functions properly again
fix: Can't teleport borg parts that just got removed
fix: Can't remove parts from borgs that are no longer next to you
fix: Can't remove borg parts from borgs that got their hatched closed again
/:cl: