### PR TITLE
Creates a "Off" Preset for Air Alarms

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -718,7 +718,7 @@
 		AALARM_PRESET_HUMAN		= list("name"="Human",     	 "desc"="Checks for oxygen and nitrogen", "id" = AALARM_PRESET_HUMAN),\
 		AALARM_PRESET_VOX 		= list("name"="Vox",       	 "desc"="Checks for nitrogen only", "id" = AALARM_PRESET_VOX),\
 		AALARM_PRESET_COLDROOM 	= list("name"="Coldroom", 	 "desc"="For freezers", "id" = AALARM_PRESET_COLDROOM),\
-		AALARM_PRESET_SERVER 	= list("name"="Server Room", "desc"="For server rooms", "id" = AALARM_PRESET_SERVER)
+		AALARM_PRESET_SERVER 	= list("name"="Server Room", "desc"="For server rooms", "id" = AALARM_PRESET_SERVER),\
 		AALARM_PRESET_DISABLED 	= list("name"="Disabled", "desc"="Disables all alarms", "id" = AALARM_PRESET_DISABLED)
 	)
 	data["preset"] = preset

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -719,6 +719,7 @@
 		AALARM_PRESET_VOX 		= list("name"="Vox",       	 "desc"="Checks for nitrogen only", "id" = AALARM_PRESET_VOX),\
 		AALARM_PRESET_COLDROOM 	= list("name"="Coldroom", 	 "desc"="For freezers", "id" = AALARM_PRESET_COLDROOM),\
 		AALARM_PRESET_SERVER 	= list("name"="Server Room", "desc"="For server rooms", "id" = AALARM_PRESET_SERVER)
+		AALARM_PRESET_DISABLED 	= list("name"="Disabled", "desc"="Disables all alarms", "id" = AALARM_PRESET_DISABLED)
 	)
 	data["preset"] = preset
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -43,6 +43,7 @@
 #define AALARM_PRESET_VOX       2 // Support Vox
 #define AALARM_PRESET_COLDROOM  3 // Kitchen coldroom
 #define AALARM_PRESET_SERVER    4 // Server coldroom
+#define AALARM_PRESET_DISABLED  5 // Disables all alarms
 
 #define AALARM_REPORT_TIMEOUT 100
 
@@ -147,6 +148,9 @@
 /obj/machinery/alarm/kitchen_cold_room
 	preset = AALARM_PRESET_COLDROOM
 
+/obj/machinery/alarm/disabled
+	preset = AALARM_PRESET_DISABLED
+
 /obj/machinery/alarm/proc/apply_preset(no_cycle_after=0)
 	// Propogate settings.
 	for(var/obj/machinery/alarm/AA in alarm_area)
@@ -194,8 +198,18 @@
 				"pressure"       = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), /* kpa */
 				"temperature"    = new/datum/tlv(0, 0, T20C + 5, T20C + 15), // K
 			)
+		if(AALARM_PRESET_DISABLED)
+			TLV = list(
+				"oxygen"         = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
+				"nitrogen"       = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
+				"carbon dioxide" = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
+				"plasma"         = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
+				"other"          = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
+				"pressure"       = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), /* kpa */
+				"temperature"    = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // K
+			)
 
-	if(!no_cycle_after)
+	if(!no_cycle_after && preset != AALARM_PRESET_DISABLED)
 		mode = AALARM_MODE_REPLACEMENT
 		apply_mode()
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -199,6 +199,7 @@
 				"temperature"    = new/datum/tlv(0, 0, T20C + 5, T20C + 15), // K
 			)
 		if(AALARM_PRESET_DISABLED)
+			no_cycle_after = TRUE
 			TLV = list(
 				"oxygen"         = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
 				"nitrogen"       = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -210,7 +210,7 @@
 				"temperature"    = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // K
 			)
 
-	if(!no_cycle_after && preset != AALARM_PRESET_DISABLED)
+	if(!no_cycle_after)
 		mode = AALARM_MODE_REPLACEMENT
 		apply_mode()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a System Preset for Air alarms, with all thresholds set to off. When this Preset is set, it does not affect vents or scrubbers connected to the air alarm, nor the System modes for those. If changed from "Disabled" the air alarm will cycle the air, as it would if you changed between Vox or Human.

## Why It's Good For The Game
Changing a air alarms thresholds to off, to not get constant alerts or firelocks is a pain, as there are a lot of them. This will make it easier to disable alarms, which will also make it easier for antagonists to utilise the air alarm settings, so the AI will not immidietly discover someone made a breach somewhere. Alternatively the AI could plasmaflood, with air alarms not triggering fire alerts, thereby not hindering the gas spreading. In essence this is a small quality of life change, which makes air alarms easier to use for antags mostly, but also for special engineering projects.

## Images of changes
![image](https://user-images.githubusercontent.com/65926304/146624955-69b6d363-72f6-40ce-8141-421309fb80a5.png)
The difference between setting all of these manually to -1

![image](https://user-images.githubusercontent.com/65926304/146624968-e1151e52-d11d-4e16-9117-c337918d5caf.png)
To clicking one button

## Changelog
:cl:
add: Added Disabled Air Alarm setting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
