### PR TITLE
Fix - Directional warning stripe decals initiate with the proper direction

### DIFF
--- a/code/game/objects/effects/decals/warning_stripes.dm
+++ b/code/game/objects/effects/decals/warning_stripes.dm
@@ -52,7 +52,8 @@
 
 /obj/effect/decal/warning_stripes/Initialize()
 	. = ..()
-	loc.overlays += src
+	var/image/I = image(icon, icon_state = icon_state, dir = dir)
+	loc.add_overlay(I)
 	qdel(src)
 
 // Credit to Neinhaus for making these into individual decals.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This makes sure that the directional warning decals are initiated properly, as simply using `src` as the turf overlay would yield erratic results, with tiles that had identical contents behave differently.

EDIT: Further investigation showed that the turfs have dirs, which currently affect the decals as well, which is insane.

## Why It's Good For The Game
Consistent behavior for the decals. They'd show properly in SDMM, but in-game was a potshot.

## Images of changes
![warning_yellow_old](https://user-images.githubusercontent.com/80771500/146626168-d53c5c5c-3462-485b-bca2-2559cf652df3.png)
![warning_yellow_new](https://user-images.githubusercontent.com/80771500/146626166-60ab7d0d-b5ea-460b-8f33-60129e7e8e08.png)

![warning_red_old](https://user-images.githubusercontent.com/80771500/146626176-9eecd595-3b6f-4d43-b73f-059f8779e724.png)
![warning_red_new](https://user-images.githubusercontent.com/80771500/146626180-11ace9ca-9efc-48fe-a947-9e04fd30aa93.png)

## Changelog
:cl:
fix: Warning stripes use their direction properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
