### PR TITLE
Fixes turfs using wrong icon_state

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -376,14 +376,12 @@
 	name = "ice sheet"
 	desc = "A sheet of solid ice. Looks slippery."
 	icon = 'icons/turf/floors/ice_turf.dmi'
-	icon_state = "unsmooth"
+	icon_state = "ice_turf-0"
 	oxygen = 22
 	nitrogen = 82
 	temperature = 180
 	baseturf = /turf/simulated/floor/plating/ice
 	slowdown = TRUE
-	smoothing_flags = SMOOTH_CORNERS
-	canSmoothWith = list(SMOOTH_GROUP_FLOOR_ICE)
 
 /turf/simulated/floor/plating/ice/Initialize(mapload)
 	. = ..()
@@ -393,9 +391,11 @@
 	return
 
 /turf/simulated/floor/plating/ice/smooth
-	icon_state = "smooth"
-	smoothing_flags = SMOOTH_CORNERS | SMOOTH_BORDER
-	canSmoothWith = list(SMOOTH_GROUP_FLOOR_ICE)
+	icon_state = "ice_turf-255"
+	base_icon_state = "ice_turf"
+	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
+	canSmoothWith = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_FLOOR_ICE)
+	smoothing_groups = list(SMOOTH_GROUP_FLOOR_ICE)
 
 /turf/simulated/floor/plating/nitrogen
 	oxygen = 0

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -227,11 +227,9 @@
 
 /turf/simulated/wall/mineral/titanium/nodiagonal
 	icon_state = "map-shuttle_nd"
-	base_icon_state = "plastinum_wall"
 	smoothing_flags = SMOOTH_BITMASK
 
 /turf/simulated/wall/mineral/titanium/nosmooth
-	icon_state = "plastinum_wall"
 	smoothing_flags = NONE
 
 /turf/simulated/wall/mineral/titanium/overspace
@@ -290,13 +288,12 @@
 	fixed_underlay = list("icon"='icons/turf/floors.dmi', "icon_state"="darkredfull")
 
 /turf/simulated/wall/mineral/titanium/nodecon/nodiagonal
-	smoothing_flags = SMOOTH_CORNERS
 	icon_state = "map-shuttle_nd"
+	smoothing_flags = SMOOTH_BITMASK
 
 /turf/simulated/wall/mineral/titanium/nodecon/nosmooth
+	icon_state = "plastinum_wall"
 	smoothing_flags = NONE
-	icon = 'icons/turf/shuttle.dmi'
-	icon_state = "wall"
 
 //properties for derelict sub-type to prevent said deconstruction/thermiting
 /turf/simulated/wall/mineral/titanium/nodecon/try_decon(obj/item/I, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes sure ice turfs are using the right icon states, there is a slight issue still with the smoothing for the smooth ice not being properly set up leading to some strange smoothing. But that smooth ice is only used in one lavaland ruin and looks good enough. A spriter will have to fix the issues with that at a later point.

EDIT:

Also fixes USSP walls using the wrong icon_state
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to see turfs is good!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

Before:
![image](https://user-images.githubusercontent.com/12197162/146640949-d65203a1-19d2-4aef-9082-5d653819a807.png)

After:
![image](https://user-images.githubusercontent.com/12197162/146640943-0531f333-ad8f-4464-b2ba-e472a0d0bebc.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fixed missing ice sprites
fix: Fixed USSP walls being weird
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
