### PR TITLE
Maps in the RD hardsuit to delta and meta

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -79647,7 +79647,7 @@
 	},
 /area/toxins/mixing)
 "dvc" = (
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/rd/secure,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -62019,12 +62019,12 @@
 	},
 /area/crew_quarters/hor)
 "cDL" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/light,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = -32
 	},
+/obj/machinery/suit_storage_unit/rd/secure,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -75981,6 +75981,13 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"ffD" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/hor)
 "fga" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/door/window/northleft{
@@ -113789,7 +113796,7 @@ cwR
 bYY
 cBf
 czS
-cAN
+ffD
 cBT
 cDL
 cxU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Maps the RD hardsuit (in the secure suit storage) to the RD office on meta and delta. Moves the holopad in the meta office up 2 tiles.

Approved as a fix by @dearmochi 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Map consistency is good, RD has the hardsuit on cyberiad, but only an EVA suit on delta, and no suit at all on meta.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

Meta:
![image](https://user-images.githubusercontent.com/52090703/146656378-073cf496-95ef-453e-a4de-dd0c844d244e.png)

Delta:
![image](https://user-images.githubusercontent.com/52090703/146656384-d374859d-33c2-4c6e-a24f-0eac1ff7c8ff.png)


## Changelog
:cl:
fix: Adds the RD hardsuit secure storage to Delta and Meta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
