### PR TITLE
Fix full ashtray icon/descriptions.

### DIFF
--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -38,7 +38,7 @@
 	if(contents.len == max_butts)
 		icon_state = icon_full
 		desc = initial(desc) + " It's stuffed full."
-	if(contents.len > max_butts * 0.5)
+	else if(contents.len > max_butts * 0.5)
 		icon_state = icon_half
 		desc = initial(desc) + " It's half-filled."
 	else


### PR DESCRIPTION
## What Does This PR Do

Fixes a small logic error in updating ashtray icons.

## Why It's Good For The Game

No more confusion examining a full ashtray to be told it's half-full.

## Images of changes

## Changelog
:cl:
fix: Full ashtrays now have the correct icon/description.
/:cl:
