### PR TITLE
Fixes the "Tight and drawn" message from inspecting thralls, to not be hindered by non covering clothing

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -332,7 +332,7 @@
 				else if(!client)
 					msg += "[p_they(TRUE)] [p_have()] suddenly fallen asleep, suffering from Space Sleep Disorder. [p_they(TRUE)] may wake up soon.\n"
 
-	if(!(skipface || ( wear_mask && ( wear_mask.flags_inv & HIDEFACE || wear_mask.flags_cover & MASKCOVERSMOUTH) ) ) && is_thrall(src) && in_range(user,src))
+	if(!(skipface || ( wear_mask && ( wear_mask.flags_inv & HIDEFACE) ) ) && is_thrall(src) && in_range(user,src))
 		msg += "Their features seem unnaturally tight and drawn.\n"
 
 	if(decaylevel == 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes #16980, and changes a group of small items so they no longer inhibit seeing the "tight and drawn" inspection on thralls.

Items it affects: Muzzles (including tape), Surgical masks, Scarfes, Breathing masks (Including the vox one) and Facehuggers.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Different kinds of masks or gear which do not cover your whole face, nor even your whole mouth, or are see through, should not hinder inspecting the thralled and seeing the "Their features seem unnaturally tight and drawn." message. This is both for common sense, as the items listed do not cover much, and for voxxies not to have to take their mask of to show they are not tralls.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/65926304/146853137-1d8760f0-14d2-4509-a407-22d055304b52.png)
Breath masks and other items which dont cover much, obstruct viewing your tight and drawn face.

After
![image](https://user-images.githubusercontent.com/65926304/146853284-5f1fffa7-2fed-48fb-8f2a-9d8a987bdd95.png)
Breath masks and other items that dont cover much now dont hinder viewing your tight and drawn face.


![image](https://user-images.githubusercontent.com/65926304/146853387-8a6b9c9e-2029-465d-a089-ba55f9755561.png)
The same applies to vox masks, who now dont have to take their masks off to show they are not thralls.


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fixed non-facecovering clothing to not hinder seeing the "tight and drawn" face upon inspecting thralls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
