### PR TITLE
Fix - Disassembled solar consoles don't turn into invisible computer frames, and disassemble in logical order

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -433,11 +433,11 @@
 		C.forceMove(loc)
 	if(stat & BROKEN)
 		to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-		A.state = 4
+		A.state = 4	// STATE_WIRES
 		new /obj/item/shard(drop_location())
 	else
 		to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-		A.state = 5
+		A.state = 5	// STATE_GLASS
 	A.dir = dir
 	A.circuit = M
 	A.update_icon()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -421,35 +421,27 @@
 				connected_tracker.modify_angle(SSsun.angle)
 			set_panels(cdir)
 
-/obj/machinery/power/solar_control/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/screwdriver))
-		playsound(src.loc, I.usesound, 50, 1)
-		if(do_after(user, 20 * I.toolspeed, target = src))
-			if(src.stat & BROKEN)
-				to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-				var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-				new /obj/item/shard( src.loc )
-				var/obj/item/circuitboard/solar_control/M = new /obj/item/circuitboard/solar_control( A )
-				for(var/obj/C in src)
-					C.loc = src.loc
-				A.circuit = M
-				A.state = 3
-				A.icon_state = "3"
-				A.anchored = 1
-				qdel(src)
-			else
-				to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-				var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-				var/obj/item/circuitboard/solar_control/M = new /obj/item/circuitboard/solar_control( A )
-				for(var/obj/C in src)
-					C.loc = src.loc
-				A.circuit = M
-				A.state = 4
-				A.icon_state = "4"
-				A.anchored = 1
-				qdel(src)
+/obj/machinery/power/solar_control/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	if(!I.use_tool(src, user, 20, volume = I.tool_volume))
+		return
+	var/obj/structure/computerframe/A = new /obj/structure/computerframe(loc)
+	var/obj/item/circuitboard/solar_control/M = new /obj/item/circuitboard/solar_control(A)
+	for(var/obj/C in src)
+		C.loc = loc
+	if(stat & BROKEN)
+		to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
+		A.state = 4
 	else
-		return ..()
+		to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
+		A.state = 5
+	A.dir = dir
+	A.circuit = M
+	A.update_icon()
+	A.anchored = 1
+	qdel(src)
 
 /obj/machinery/power/solar_control/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -434,6 +434,7 @@
 	if(stat & BROKEN)
 		to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
 		A.state = 4
+		new /obj/item/shard(drop_location())
 	else
 		to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
 		A.state = 5

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -430,7 +430,7 @@
 	var/obj/structure/computerframe/A = new /obj/structure/computerframe(loc)
 	var/obj/item/circuitboard/solar_control/M = new /obj/item/circuitboard/solar_control(A)
 	for(var/obj/C in src)
-		C.loc = loc
+		C.forceMove(loc)
 	if(stat & BROKEN)
 		to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
 		A.state = 4
@@ -440,7 +440,7 @@
 	A.dir = dir
 	A.circuit = M
 	A.update_icon()
-	A.anchored = 1
+	A.anchored = TRUE
 	qdel(src)
 
 /obj/machinery/power/solar_control/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -433,11 +433,11 @@
 		C.forceMove(loc)
 	if(stat & BROKEN)
 		to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-		A.state = 4
+		A.state = STATE_WIRES
 		new /obj/item/shard(drop_location())
 	else
 		to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-		A.state = 5
+		A.state = STATE_GLASS
 	A.dir = dir
 	A.circuit = M
 	A.update_icon()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -433,11 +433,11 @@
 		C.forceMove(loc)
 	if(stat & BROKEN)
 		to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-		A.state = STATE_WIRES
+		A.state = 4
 		new /obj/item/shard(drop_location())
 	else
 		to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-		A.state = STATE_GLASS
+		A.state = 5
 	A.dir = dir
 	A.circuit = M
 	A.update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Issue was a little vague, turns out that destroyed solar consoles are fine, however if someone takes a shot at fixing them, then they'll get an invisible frame.

This cleans up the code a bit, and makes it so the `icon state` is set properly. Or rather, handle it automatically off `state`. `state` was also wrong, as merely taking a screwdriver to an intact console would put it into a wired, but missing glass state.

## Why It's Good For The Game
Fixes #17203

## Images of changes
![solar](https://user-images.githubusercontent.com/80771500/147023914-58ac3643-926e-477b-bbc8-6846d0bd10e5.png)

## Changelog
:cl:
fix: Disassembled solar consoles don't become invisible
fix: Using a screwdriver on an intact solar console only removes the monitor, and does not require new glass to put back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
