### PR TITLE
Move ashtray under /obj/item/storage.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -47832,7 +47832,7 @@
 /area/blueshield)
 "cdR" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = -4;
 	pixel_y = -4
 	},
@@ -91220,7 +91220,7 @@
 /area/medical/cmo)
 "dVx" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -45764,7 +45764,7 @@
 	})
 "bUX" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = -4;
 	pixel_y = -4
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -190,7 +190,7 @@
 /area/derelict/bridge)
 "aA" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -727,7 +727,7 @@
 /area/derelict/bridge)
 "bI" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = 6;
 	pixel_y = 3
 	},
@@ -853,7 +853,7 @@
 /area/derelict/bridge)
 "bY" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -909,7 +909,7 @@
 /area/derelict/bridge)
 "cg" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -1423,7 +1423,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -2889,7 +2889,7 @@
 	})
 "gg" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -2969,7 +2969,7 @@
 /area/derelict/crew_quarters)
 "gp" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -3125,7 +3125,7 @@
 	})
 "gE" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -6054,7 +6054,7 @@
 	})
 "mM" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -6088,7 +6088,7 @@
 	})
 "mP" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -6534,7 +6534,7 @@
 	name = "Derelict Annex"
 	})
 "nQ" = (
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -6611,7 +6611,7 @@
 /area/derelict/crew_quarters)
 "nX" = (
 /obj/structure/table,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -7891,7 +7891,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table,
-/obj/item/ashtray/plastic,
+/obj/item/storage/ashtray/plastic,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel,
 /area/derelict/arrival)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -3436,7 +3436,7 @@
 /area/security/brig)
 "alp" = (
 /obj/structure/table,
-/obj/item/ashtray/bronze{
+/obj/item/storage/ashtray/bronze{
 	pixel_x = -1;
 	pixel_y = 1
 	},
@@ -12803,7 +12803,7 @@
 /area/crew_quarters/courtroom)
 "aEm" = (
 /obj/structure/table/wood/poker,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -13424,7 +13424,7 @@
 	pixel_y = 8
 	},
 /obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /obj/item/radio/intercom/department/security{
 	pixel_x = 28
 	},
@@ -13559,7 +13559,7 @@
 "aFV" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes,
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -20721,7 +20721,7 @@
 /area/crew_quarters/dorms)
 "aWD" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze,
+/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/dorms)
 "aWE" = (
@@ -26987,7 +26987,7 @@
 /area/chapel/main)
 "bjK" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze{
+/obj/item/storage/ashtray/bronze{
 	pixel_x = -1;
 	pixel_y = 1
 	},
@@ -54670,7 +54670,7 @@
 /area/ntrep)
 "coX" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	pixel_x = -4;
 	pixel_y = -4
 	},
@@ -64401,7 +64401,7 @@
 /area/maintenance/aft)
 "cIo" = (
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze{
+/obj/item/storage/ashtray/bronze{
 	pixel_x = -1;
 	pixel_y = 1
 	},

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4249,7 +4249,7 @@
 /area/syndicate_mothership)
 "pB" = (
 /obj/structure/table/reinforced,
-/obj/item/ashtray/glass{
+/obj/item/storage/ashtray/glass{
 	icon_state = "ashtray_half_gl"
 	},
 /obj/item/cigbutt/cigarbutt{
@@ -10168,7 +10168,7 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/shuttle/vox)
 "NC" = (
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /obj/structure/table,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)

--- a/_maps/map_files/shuttles/admin_admin.dmm
+++ b/_maps/map_files/shuttles/admin_admin.dmm
@@ -140,7 +140,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "ay" = (
-/obj/item/ashtray/glass,
+/obj/item/storage/ashtray/glass,
 /obj/structure/table,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -1,17 +1,31 @@
-/obj/item/ashtray
+/obj/item/storage/ashtray
 	icon = 'icons/ashtray.dmi'
-	var/max_butts = 0
+	w_class = WEIGHT_CLASS_SMALL
+	can_hold = list(/obj/item/cigbutt, /obj/item/clothing/mask/cigarette)
+	allow_quick_empty = TRUE
+	allow_quick_gather = FALSE
+
+	// No generic container insertion messages/sounds.
+	silent = TRUE
+	use_sound = null
+
 	var/icon_half = ""
 	var/icon_full = ""
 
-/obj/item/ashtray/Initialize(mapload)
+/obj/item/storage/ashtray/Initialize(mapload)
 	. = ..()
 	pixel_y = rand(-5, 5)
 	pixel_x = rand(-6, 6)
 
-/obj/item/ashtray/attackby(obj/item/I, mob/user, params)
+/obj/item/storage/ashtray/attack_self(mob/user)
+	// We want allow_quick_empty to enable disposal dumping
+	// but don't want to accidentally dump ashtray contents
+	// on the floor.
+	return
+
+/obj/item/storage/ashtray/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/cigbutt) || istype(I, /obj/item/clothing/mask/cigarette) || istype(I, /obj/item/match))
-		if(contents.len >= max_butts)
+		if(contents.len >= storage_slots)
 			to_chat(user, "This ashtray is full.")
 			return
 		if(!user.unEquip(I))
@@ -34,61 +48,65 @@
 	else
 		return ..()
 
-/obj/item/ashtray/update_icon()
-	if(contents.len == max_butts)
+/obj/item/storage/ashtray/examine(mob/user)
+	. = ..()
+	if(contents.len == storage_slots)
+		. += " It's stuffed full."
+	else if(contents.len > storage_slots * 0.5)
+		. += " It's half-filled."
+
+/obj/item/storage/ashtray/update_icon()
+	if(contents.len == storage_slots)
 		icon_state = icon_full
-		desc = initial(desc) + " It's stuffed full."
-	else if(contents.len > max_butts * 0.5)
+	else if(contents.len > storage_slots * 0.5)
 		icon_state = icon_half
-		desc = initial(desc) + " It's half-filled."
 	else
 		icon_state = initial(icon_state)
-		desc = initial(desc)
 
-/obj/item/ashtray/deconstruct()
+/obj/item/storage/ashtray/deconstruct()
 	empty_tray()
 	qdel(src)
 
-/obj/item/ashtray/proc/empty_tray()
+/obj/item/storage/ashtray/proc/empty_tray()
 	for(var/obj/item/I in contents)
 		I.forceMove(loc)
 	update_icon()
 
-/obj/item/ashtray/throw_impact(atom/hit_atom)
+/obj/item/storage/ashtray/throw_impact(atom/hit_atom)
 	if(contents.len)
 		visible_message("<span class='warning'>[src] slams into [hit_atom] spilling its contents!</span>")
 	empty_tray()
 	return ..()
 
-/obj/item/ashtray/plastic
+/obj/item/storage/ashtray/plastic
 	name = "plastic ashtray"
 	desc = "Cheap plastic ashtray."
 	icon_state = "ashtray_bl"
 	icon_half  = "ashtray_half_bl"
 	icon_full  = "ashtray_full_bl"
-	max_butts = 8
+	storage_slots = 8
 	max_integrity = 8
 	materials = list(MAT_METAL=30, MAT_GLASS=30)
 	throwforce = 3
 
-/obj/item/ashtray/bronze
+/obj/item/storage/ashtray/bronze
 	name = "bronze ashtray"
 	desc = "Massive bronze ashtray."
 	icon_state = "ashtray_br"
 	icon_half  = "ashtray_half_br"
 	icon_full  = "ashtray_full_br"
-	max_butts = 16
+	storage_slots = 16
 	max_integrity = 16
 	materials = list(MAT_METAL=80)
 	throwforce = 10
 
-/obj/item/ashtray/glass
+/obj/item/storage/ashtray/glass
 	name = "glass ashtray"
 	desc = "Glass ashtray. Looks fragile."
 	icon_state = "ashtray_gl"
 	icon_half  = "ashtray_half_gl"
 	icon_full  = "ashtray_full_gl"
-	max_butts = 12
+	storage_slots = 12
 	max_integrity = 12
 	materials = list(MAT_GLASS=60)
 	throwforce = 6

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -488,7 +488,7 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/empty), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
 	new /datum/stack_recipe("plastic crate", /obj/structure/closet/crate/plastic, 10, one_per_turf = 1, on_floor = 1), \
-	new /datum/stack_recipe("plastic ashtray", /obj/item/ashtray/plastic, 2, one_per_turf = 1, on_floor = 1), \
+	new /datum/stack_recipe("plastic ashtray", /obj/item/storage/ashtray/plastic, 2, one_per_turf = 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic fork", /obj/item/kitchen/utensil/pfork, 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic spoon", /obj/item/kitchen/utensil/pspoon, 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic spork", /obj/item/kitchen/utensil/pspork, 1, on_floor = 1), \


### PR DESCRIPTION
## What Does This PR Do

The point of this PR was to allow ashtrays to be emptied by using them on disposal chutes. I decided to go with a type change here because 1) it means no snowflake casing for ashtrays in the disposal chutes code, and 2) because `/obj/item/storage` has the functionality needed to move items over without rewriting that implementation (notably `#remove_from_storage`).

So this PR:

1. Moves ashtrays under `/obj/item/storage`.
2. Uses `#examine` to return their changed description instead of mutating its original one (thanks @hal9000PR)

I tried to keep the behavior as close to as how ashtrays work right now. The only thing that's remarkably different is that the inventory of the ashtray can be examined like other containers, but I don't see any issue with that.

(aa said this would be considered a refactor so i'm opening it now instead of after the feature thaw)

## Why It's Good For The Game

Easier to empty ashtrays.

## Changelog
:cl:
tweak: Ashtrays can now be emptied in disposals chutes.
/:cl:
