### PR TITLE
Fix - Skrell headpockets are checked when processed as a contractor target

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -373,11 +373,10 @@
 
 	// Skrell headpocket. They already have a check in place to limit what's placed in them.
 	var/obj/item/organ/internal/headpocket/C = H.get_int_organ(/obj/item/organ/internal/headpocket)
-	if(C)
-		if(C.held_item)
-			GLOB.prisoner_belongings.give_item(C.held_item)
-			victim_belongings += C.held_item
-			C.held_item = null
+	if(C?.held_item)
+		GLOB.prisoner_belongings.give_item(C.held_item)
+		victim_belongings += C.held_item
+		C.held_item = null
 
 	// Regular items get removed in second
 	for(var/obj/item/I in M)

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -371,6 +371,14 @@
 		if(I)
 			stuff_to_transfer += I
 
+	// Skrell headpocket. They already have a check in place to limit what's placed in them.
+	var/obj/item/organ/internal/headpocket/C = H.get_int_organ(/obj/item/organ/internal/headpocket)
+	if(C)
+		if(C.held_item)
+			GLOB.prisoner_belongings.give_item(C.held_item)
+			victim_belongings += C.held_item
+			C.held_item = null
+
 	// Regular items get removed in second
 	for(var/obj/item/I in M)
 		// Any items we don't want to take from them?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds a check to contractor target processing for skrell headpockets.

## Why It's Good For The Game
Fixes #17270

## Images of changes
![Contractor_1](https://user-images.githubusercontent.com/80771500/147395813-d6df28cb-f2af-4686-b0e6-562afcadbc8f.PNG)

## Changelog
:cl:
fix: Skrell headpocket contents are moved to closet when processed as a contractor target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
