### PR TITLE
Fix - Simple mobs sleep properly

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -181,8 +181,11 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 		else
-			WakeUp()
-			create_debug_log("woke up, trigger reason: [reason]")
+			if(sleeping && (stat == CONSCIOUS))
+				KnockOut()
+			if(!sleeping)
+				WakeUp()
+				create_debug_log("woke up, trigger reason: [reason]")
 	med_hud_set_status()
 
 /mob/living/simple_animal/proc/handle_automated_action()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -153,7 +153,7 @@
 		. += "<span class='deadsay'>Upon closer examination, [p_they()] appear[p_s()] to be dead.</span>"
 		return
 	if(sleeping)
-		. += "<span class='deadsay'>Upon closer examination, [p_they()] appear[p_s()] to be asleep.</span>"
+		. += "<span class='notice'>Upon closer examination, [p_they()] appear[p_s()] to be asleep.</span>"
 
 /mob/living/simple_animal/updatehealth(reason = "none given")
 	..(reason)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -151,6 +151,9 @@
 	. = ..()
 	if(stat == DEAD)
 		. += "<span class='deadsay'>Upon closer examination, [p_they()] appear[p_s()] to be dead.</span>"
+		return
+	if(sleeping)
+		. += "<span class='deadsay'>Upon closer examination, [p_they()] appear[p_s()] to be asleep.</span>"
 
 /mob/living/simple_animal/updatehealth(reason = "none given")
 	..(reason)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Have simple mobs get knocked out or wake up properly based on `sleeping`, as right now it currently just renders them deaf.

An examine case is also added. No transformation is done to the sprite.

## Why It's Good For The Game
Fixes #17079

## Images of changes
![SimpleSleep](https://user-images.githubusercontent.com/80771500/147422634-8ab35d9e-d528-40f0-b002-2fd27daa57fc.png)

## Changelog
:cl:
fix: Simple mobs (e.g. Ian) will sleep properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
