### PR TITLE
Fixes the morph ambush description

### DIFF
--- a/code/game/gamemodes/miniantags/morph/spells/ambush.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/ambush.dm
@@ -3,7 +3,7 @@
 /obj/effect/proc_holder/spell/morph_spell/ambush
 	name = "Prepare Ambush"
 	desc = "Prepare an ambush. Dealing significantly more damage on the first hit and you will weaken the target. Only works while morphed. If the target tries to use you with their hands then you will do even more damage. \
-	 		Keeping still for another 10 seconds will perfect your disguise."
+	 		Keeping still for another 15 seconds will perfect your disguise."
 	action_icon_state = "morph_ambush"
 	charge_max = 8 SECONDS
 


### PR DESCRIPTION
## What Does This PR Do
The morph ambush spell says it will go into perfect ambush mode after 10 seconds. This is incorrect and I forgot to change it after tweaking the value to 15 seconds.

## Why It's Good For The Game
Gives correct information to the user

## Changelog
:cl:
spellcheck: The morph ambush spell now has a correct number of seconds you have to wait for it to perfect. 10 was incorrect. 15 is correct
/:cl: