### PR TITLE
Prevents snow / snowclouds on walls, stopping runtimes

### DIFF
--- a/code/game/objects/effects/snowcloud.dm
+++ b/code/game/objects/effects/snowcloud.dm
@@ -21,7 +21,7 @@
 	if(QDELETED(parent_machine))
 		parent_machine = null
 	var/turf/T = get_turf(src)
-	if(isspaceturf(T))
+	if(isspaceturf(T) || T.density) // Don't want snowclouds or snow on walls
 		qdel(src)
 		return
 	var/turf_hotness
@@ -83,7 +83,7 @@
 
 /obj/effect/snow/process()
 	var/turf/T = get_turf(src)
-	if(isspaceturf(T))
+	if(isspaceturf(T) || T.density) // Don't want snowclouds or snow on walls
 		qdel(src)
 		return
 	else if(issimulatedturf(T))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Snowclouds / snow now check if the turf is dense, and deletes itself if the turf is dense.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Runtimes from snow(clouds) checking the turf air temperature on turfs that can't have air (walls) is bad.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Snow and Snowclouds no longer exist in walls and cause runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
