### PR TITLE
Death alarms now use signals, and properly trigger on gibbing / dusting

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implant_death_alarm.dm
@@ -18,20 +18,10 @@
 	return dat
 
 /obj/item/implant/death_alarm/Destroy()
-	STOP_PROCESSING(SSobj, src)
+	UnregisterSignal(imp_in, COMSIG_MOB_DEATH)
 	return ..()
 
-/obj/item/implant/death_alarm/process()
-	if(!implanted)
-		return
-	var/mob/M = imp_in
-
-	if(isnull(M)) // If the mob got gibbed
-		activate()
-	else if(M.stat == DEAD)
-		activate("death")
-
-/obj/item/implant/death_alarm/activate(cause)
+/obj/item/implant/death_alarm/activate(name, cause) // Death signal sends name followed by the gibbed / not gibbed check
 	var/mob/M = imp_in
 	var/area/t = get_area(M)
 
@@ -39,34 +29,34 @@
 	a.follow_target = M
 
 	switch(cause)
-		if("death")
-			if(is_type_in_typecache(t, stealth_areas))
-				//give the syndies a bit of stealth
-				a.autosay("[mobname] has died in Space!", "[mobname]'s Death Alarm")
-			else
-				a.autosay("[mobname] has died in [t.name]!", "[mobname]'s Death Alarm")
+		if(TRUE)
+			a.autosay("[name] has died-zzzzt in-in-in...", "[name]'s Death Alarm")
 			qdel(src)
 		if("emp")
-			var/name = prob(50) ? t.name : pick(SSmapping.teleportlocs)
-			a.autosay("[mobname] has died in [name]!", "[mobname]'s Death Alarm")
+			var/area_name = prob(50) ? t.name : pick(SSmapping.teleportlocs)
+			a.autosay("[name] has died in [area_name]!", "[name]'s Death Alarm")
 		else
-			a.autosay("[mobname] has died-zzzzt in-in-in...", "[mobname]'s Death Alarm")
+			if(is_type_in_typecache(t, stealth_areas))
+				//give the syndies a bit of stealth
+				a.autosay("[name] has died in Space!", "[name]'s Death Alarm")
+			else
+				a.autosay("[name] has died in [t.name]!", "[name]'s Death Alarm")
 			qdel(src)
 
 	qdel(a)
 
 /obj/item/implant/death_alarm/emp_act(severity)			//for some reason alarms stop going off in case they are emp'd, even without this
-	activate("emp")	//let's shout that this dude is dead
+	activate(mobname, "emp")	//let's shout that this dude is dead
 
 /obj/item/implant/death_alarm/implant(mob/target)
 	if(..())
 		mobname = target.real_name
-		START_PROCESSING(SSobj, src)
+		RegisterSignal(target, COMSIG_MOB_DEATH, /obj/item/implant/death_alarm/activate)
 		return 1
 	return 0
 
 /obj/item/implant/death_alarm/removed(mob/target)
 	if(..())
-		STOP_PROCESSING(SSobj, src)
+		UnregisterSignal(target, COMSIG_MOB_DEATH)
 		return 1
 	return 0

--- a/code/game/objects/items/weapons/implants/implant_death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implant_death_alarm.dm
@@ -51,7 +51,7 @@
 /obj/item/implant/death_alarm/implant(mob/target)
 	if(..())
 		mobname = target.real_name
-		RegisterSignal(target, COMSIG_MOB_DEATH, /obj/item/implant/death_alarm/activate)
+		RegisterSignal(target, COMSIG_MOB_DEATH, /obj/item/implant/death_alarm.proc/activate)
 		return 1
 	return 0
 

--- a/code/game/objects/items/weapons/implants/implant_death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implant_death_alarm.dm
@@ -29,7 +29,7 @@
 	a.follow_target = M
 
 	switch(cause)
-		if(TRUE)
+		if("gib")
 			a.autosay("[mobname] has died-zzzzt in-in-in...", "[mobname]'s Death Alarm")
 			qdel(src)
 		if("emp")
@@ -56,7 +56,10 @@
 	return 0
 
 /obj/item/implant/death_alarm/proc/check_gibbed_activate(datum/source, gibbed)
-	activate(gibbed)
+	if(gibbed)
+		activate("gib")
+	else
+		activate("death")
 
 /obj/item/implant/death_alarm/removed(mob/target)
 	if(..())

--- a/code/game/objects/items/weapons/implants/implant_death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implant_death_alarm.dm
@@ -21,7 +21,7 @@
 	UnregisterSignal(imp_in, COMSIG_MOB_DEATH)
 	return ..()
 
-/obj/item/implant/death_alarm/activate(name, cause) // Death signal sends name followed by the gibbed / not gibbed check
+/obj/item/implant/death_alarm/activate(cause) // Death signal sends name followed by the gibbed / not gibbed check
 	var/mob/M = imp_in
 	var/area/t = get_area(M)
 
@@ -30,30 +30,33 @@
 
 	switch(cause)
 		if(TRUE)
-			a.autosay("[name] has died-zzzzt in-in-in...", "[name]'s Death Alarm")
+			a.autosay("[mobname] has died-zzzzt in-in-in...", "[mobname]'s Death Alarm")
 			qdel(src)
 		if("emp")
-			var/area_name = prob(50) ? t.name : pick(SSmapping.teleportlocs)
-			a.autosay("[name] has died in [area_name]!", "[name]'s Death Alarm")
+			var/name = prob(50) ? t.name : pick(SSmapping.teleportlocs)
+			a.autosay("[mobname] has died in [name]!", "[mobname]'s Death Alarm")
 		else
 			if(is_type_in_typecache(t, stealth_areas))
 				//give the syndies a bit of stealth
-				a.autosay("[name] has died in Space!", "[name]'s Death Alarm")
+				a.autosay("[mobname] has died in Space!", "[mobname]'s Death Alarm")
 			else
-				a.autosay("[name] has died in [t.name]!", "[name]'s Death Alarm")
+				a.autosay("[mobname] has died in [t.name]!", "[mobname]'s Death Alarm")
 			qdel(src)
 
 	qdel(a)
 
 /obj/item/implant/death_alarm/emp_act(severity)			//for some reason alarms stop going off in case they are emp'd, even without this
-	activate(mobname, "emp")	//let's shout that this dude is dead
+	activate("emp")	//let's shout that this dude is dead
 
 /obj/item/implant/death_alarm/implant(mob/target)
 	if(..())
 		mobname = target.real_name
-		RegisterSignal(target, COMSIG_MOB_DEATH, /obj/item/implant/death_alarm.proc/activate)
+		RegisterSignal(target, COMSIG_MOB_DEATH, /obj/item/implant/death_alarm.proc/check_gibbed_activate)
 		return 1
 	return 0
+
+/obj/item/implant/death_alarm/proc/check_gibbed_activate(datum/source, gibbed)
+	activate(gibbed)
 
 /obj/item/implant/death_alarm/removed(mob/target)
 	if(..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Changes death alarms from using process to signals. 
Fixes death alarms not sending the cut out signal on gibbing / dusting.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad, sending at least an incomplete message of the captain getting gibbed / sacrificed is good. Gibbing / dusting does not say where the location is, so it is still an effective way to kill someone stealthily without security knowing where it was.

## Changelog
:cl:
fix: Fixed death alarms not sending an incomplete message when the user is gibbed / dusted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
