### PR TITLE
Converts items / abilities that set alpha to zero, to use invisibility

### DIFF
--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -235,13 +235,13 @@
 		return
 	var/light_available = T.get_lumcount() * 10
 	if(light_available <= 2)
-		if(M.invisibility != 60)
+		if(M.invisibility != INVISIBILITY_OBSERVER)
 			M.alpha = round(M.alpha * 0.8)
 	else
 		M.alpha = 255
 		M.invisibility = 0
 	if(M.alpha == 0)
-		M.invisibility = 60
+		M.invisibility = INVISIBILITY_OBSERVER
 		M.alpha = 128
 
 //WAS: /datum/bioEffect/chameleon
@@ -258,13 +258,13 @@
 
 /datum/mutation/stealth/chameleon/on_life(mob/M)
 	if((world.time - M.last_movement) >= 30 && !M.stat && M.canmove && !M.restrained())
-		if(M.invisibility != 60)
+		if(M.invisibility != INVISIBILITY_OBSERVER)
 			M.alpha -= 25
 	else
 		M.alpha = round(255 * 0.80)
 		M.invisibility = 0
 	if(M.alpha == 0)
-		M.invisibility = 60
+		M.invisibility = INVISIBILITY_OBSERVER
 		M.alpha = 128
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -215,6 +215,7 @@
 /datum/mutation/stealth/deactivate(mob/living/M)
 	..()
 	M.alpha = 255
+	M.invisibility = 0
 
 // WAS: /datum/bioEffect/darkcloak
 /datum/mutation/stealth/darkcloak
@@ -237,6 +238,9 @@
 		M.alpha = round(M.alpha * 0.8)
 	else
 		M.alpha = 255
+		M.invisibility = 0
+	if(M.alpha == 0)
+		M.invisibility = 90
 
 //WAS: /datum/bioEffect/chameleon
 /datum/mutation/stealth/chameleon
@@ -255,6 +259,9 @@
 		M.alpha -= 25
 	else
 		M.alpha = round(255 * 0.80)
+		M.invisibility = 0
+	if(M.alpha == 0)
+		M.invisibility = 90
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -235,12 +235,14 @@
 		return
 	var/light_available = T.get_lumcount() * 10
 	if(light_available <= 2)
-		M.alpha = round(M.alpha * 0.8)
+		if(M.invisibility != 60)
+			M.alpha = round(M.alpha * 0.8)
 	else
 		M.alpha = 255
 		M.invisibility = 0
 	if(M.alpha == 0)
-		M.invisibility = 90
+		M.invisibility = 60
+		M.alpha = 128
 
 //WAS: /datum/bioEffect/chameleon
 /datum/mutation/stealth/chameleon
@@ -256,12 +258,14 @@
 
 /datum/mutation/stealth/chameleon/on_life(mob/M)
 	if((world.time - M.last_movement) >= 30 && !M.stat && M.canmove && !M.restrained())
-		M.alpha -= 25
+		if(M.invisibility != 60)
+			M.alpha -= 25
 	else
 		M.alpha = round(255 * 0.80)
 		M.invisibility = 0
 	if(M.alpha == 0)
-		M.invisibility = 90
+		M.invisibility = 60
+		M.alpha = 128
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -390,13 +390,13 @@
 		E.Copy_Parent(owner, 50)
 		E.GiveTarget(owner) //so it starts running right away
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
-		owner.alpha = 0
+		owner.invisibility = 90
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		addtimer(CALLBACK(owner, /mob/living/.proc/reset_alpha), 4 SECONDS)
+		addtimer(CALLBACK(owner, /mob/living/.proc/reset_visibility), 4 SECONDS)
 		return TRUE
 
-/mob/living/proc/reset_alpha(mob/living/carbon/human/owner)
-	alpha = initial(alpha)
+/mob/living/proc/reset_visibility(mob/living/carbon/human/owner)
+	invisibility  = initial(invisibility)
 
 /obj/item/clothing/suit/armor/reactive/tesla
 	name = "reactive tesla armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -390,13 +390,15 @@
 		E.Copy_Parent(owner, 50)
 		E.GiveTarget(owner) //so it starts running right away
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
-		owner.invisibility = 90
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
+		owner.invisibility = 60
+		owner.alpha = 128
 		addtimer(CALLBACK(owner, /mob/living/.proc/reset_visibility), 4 SECONDS)
 		return TRUE
 
 /mob/living/proc/reset_visibility(mob/living/carbon/human/owner)
-	invisibility  = initial(invisibility)
+	invisibility = initial(invisibility)
+	alpha = initial(alpha)
 
 /obj/item/clothing/suit/armor/reactive/tesla
 	name = "reactive tesla armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -391,7 +391,7 @@
 		E.GiveTarget(owner) //so it starts running right away
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		owner.invisibility = 60
+		owner.invisibility = INVISIBILITY_OBSERVER
 		owner.alpha = 128
 		addtimer(CALLBACK(owner, /mob/living/.proc/reset_visibility), 4 SECONDS)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Changes reactive stealth armor to use invisibility instead of alpha.

Changes abilities that after a while convert alpha to zero, to set invisibility to 90 after alpha reaches zero.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to see people with zero alpha by rightclick / screentips is bad. As such, using invisibility to prevent this is good.

## Changelog
:cl:
tweak: Reactive stealth armor, darkness based stealth, and the chameleon gene now are fully invisible when fully active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
