### PR TITLE
Fixes the teleport spell not saying where the wizard is going

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -202,7 +202,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	if(action)
 		action.UpdateButtonIcon()
 
-/obj/effect/proc_holder/spell/proc/invocation(mob/user = usr) //spelling the spell out and setting it on recharge/reducing charges amount
+/obj/effect/proc_holder/spell/proc/invocation(mob/user) //spelling the spell out and setting it on recharge/reducing charges amount
 	switch(invocation_type)
 		if("shout")
 			if(!user.IsVocal())
@@ -343,7 +343,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
 	SHOULD_NOT_OVERRIDE(TRUE)
 	before_cast(targets, user)
-	invocation()
+	invocation(user)
 	if(user && user.ckey)
 		if(create_custom_logs)
 			write_custom_logs(targets, user)

--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -76,18 +76,17 @@
 
 	return
 
-/obj/effect/proc_holder/spell/area_teleport/invocation(area/chosenarea = null)
-	if(!invocation_area || !chosenarea)
+/obj/effect/proc_holder/spell/area_teleport/invocation(mob/user)
+	if(!invocation_area || !selected_area)
 		..()
 	else
 		switch(invocation_type)
 			if("shout")
-				usr.say("[invocation] [uppertext(chosenarea.name)]")
-				if(usr.gender==MALE)
-					playsound(usr.loc, pick('sound/misc/null.ogg','sound/misc/null.ogg'), 100, 1)
+				user.say("[invocation] [uppertext(selected_area.name)]")
+				if(user.gender==MALE)
+					playsound(user.loc, pick('sound/misc/null.ogg','sound/misc/null.ogg'), 100, 1)
 				else
-					playsound(usr.loc, pick('sound/misc/null.ogg','sound/misc/null.ogg'), 100, 1)
+					playsound(user.loc, pick('sound/misc/null.ogg','sound/misc/null.ogg'), 100, 1)
 			if("whisper")
-				usr.whisper("[invocation] [uppertext(chosenarea.name)]")
+				user.whisper("[invocation] [uppertext(selected_area.name)]")
 
-	return


### PR DESCRIPTION
## What Does This PR Do
Left over from the spell refactor

## Why It's Good For The Game
Bugs bad yo

## Changelog
:cl:
fix: The wizard teleport spell now makes the user yell their teleport location again
/:cl: