### PR TITLE
Fixes floorbot construction

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -211,17 +211,10 @@
 	icon_state = "toolbox_tiles_sensor"
 
 /obj/item/storage/toolbox/attackby(obj/item/stack/tile/plasteel/T, mob/user, params)
-	var/list/allowed_toolbox = list(/obj/item/storage/toolbox/emergency,	//which toolboxes can be made into floorbots
-								/obj/item/storage/toolbox/electrical,
-								/obj/item/storage/toolbox/mechanical,
-								/obj/item/storage/toolbox/artistic,
-								/obj/item/storage/toolbox/syndicate,
-								/obj/item/storage/toolbox/fakesyndi)
-
 	if(!istype(T, /obj/item/stack/tile/plasteel))
 		..()
 		return
-	if(!is_type_in_list(src, allowed_toolbox))
+	if(!istype(src, /obj/item/storage/toolbox))
 		return
 	if(contents.len >= 1)
 		to_chat(user, "<span class='warning'>They won't fit in, as there is already stuff inside.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/17150
Any toolbox can now be made into a floorbot (his grace is not a toolbox, code-wise).
Since there is no floorbot sprite with a while colour, white toolboxes become standard blue floorbots.
Credit to @BeebBeebBoob for showing how the Russians fixed this.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Floorbots can't be made from autolathe toolboxes currently, this would change that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed autolathe toolboxes being incompatible with floorbots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
