### PR TITLE
Limit the number of possible simple mob offspring.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -158,6 +158,9 @@
 #define ENVIRONMENT_SMASH_WALLS 2   //walls
 #define ENVIRONMENT_SMASH_RWALLS 4  //rwalls
 
+// Reproduction
+#define DEFAULT_MAX_OFFSPRING 8
+
 ///Flags used by the flags parameter of electrocute act.
 
 ///Makes it so that the shock doesn't take gloves into account.

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -652,7 +652,6 @@
 	response_disarm = "bops"
 	response_harm   = "kicks"
 	var/turns_since_scan = 0
-	var/puppies = 0
 
 //Lisa already has a cute bow!
 /mob/living/simple_animal/pet/dog/corgi/Lisa/Topic(href, href_list)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -469,9 +469,8 @@
 		var/childspawn = pickweight(childtype)
 		var/turf/target = get_turf(loc)
 		if(target)
-			new childspawn(target)
 			current_offspring += 1
-			return
+			return new childspawn(target)
 
 /mob/living/simple_animal/show_inv(mob/user as mob)
 	if(!can_collar)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -76,6 +76,8 @@
 	var/list/childtype = null
 	var/next_scan_time = 0
 	var/animal_species //Sorry, no spider+corgi buttbabies.
+	var/current_offspring = 0
+	var/max_offspring = DEFAULT_MAX_OFFSPRING
 
 	var/buffed = 0 //In the event that you want to have a buffing effect on the mob, but don't want it to stack with other effects, any outside force that applies a buff to a simple mob should at least set this to 1, so we have something to check against
 	var/gold_core_spawnable = NO_SPAWN //If the mob can be spawned with a gold slime core. HOSTILE_SPAWN are spawned with plasma, FRIENDLY_SPAWN are spawned with blood
@@ -438,11 +440,12 @@
 		regenerate_icons()
 
 /mob/living/simple_animal/proc/make_babies() // <3 <3 <3
+	if(current_offspring >= max_offspring)
+		return FALSE
 	if(gender != FEMALE || stat || next_scan_time > world.time || !childtype || !animal_species || !SSticker.IsRoundInProgress())
 		return FALSE
 	next_scan_time = world.time + 400
 
-	var/alone = TRUE
 	var/mob/living/simple_animal/partner
 	var/children = 0
 
@@ -459,11 +462,16 @@
 		else if(isliving(M) && !faction_check_mob(M)) //shyness check. we're not shy in front of things that share a faction with us.
 			return //we never mate when not alone, so just abort early
 
-	if(alone && partner && children < 3)
+	// The children check here isn't the total number of offspring, but the
+	// number of offspring within a visible 7-tile radius. It doesn't seem very
+	// effective at preventing population explosions but there you go.
+	if(partner && children < 3)
 		var/childspawn = pickweight(childtype)
 		var/turf/target = get_turf(loc)
 		if(target)
-			return new childspawn(target)
+			new childspawn(target)
+			current_offspring += 1
+			return
 
 /mob/living/simple_animal/show_inv(mob/user as mob)
 	if(!can_collar)


### PR DESCRIPTION
## What Does This PR Do

Limits the number of offspring a simple mob may create.
Also removes some unused variables.

## Why It's Good For The Game

1. Puppies/kittens are cute but can quickly get out of hand and be annoying.
2. Lots of simple mobs have a performance impact on the server.
3. Given the slightest fragment of a chance, crew will happily wander the halls bludgeoning innocent animals to death, which kind of brushes up against the Rule 2 precedent that "Employees should be reasonably able to pass a psych eval."

## Changelog
:cl:
tweak: Simple mobs may only reproduce eight times.
/:cl: