### PR TITLE
QOL tweaks for supermatter sliver objective

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -743,25 +743,19 @@
 
 				var/obj/item/nuke_core/supermatter_sliver/S = new /obj/item/nuke_core/supermatter_sliver(drop_location())
 
-				var/obj/item/retractor/supermatter/tongs
-
-				if(istype(user.get_item_by_slot(slot_l_hand), /obj/item/retractor/supermatter))
-					tongs = user.get_item_by_slot(slot_l_hand)
-				else if(istype(user.get_item_by_slot(slot_r_hand), /obj/item/retractor/supermatter))
-					tongs = user.get_item_by_slot(slot_r_hand)
+				var/obj/item/retractor/supermatter/tongs = user.is_in_hands(/obj/item/retractor/supermatter)
 
 				if(tongs && !tongs.sliver)
 					tongs.sliver = S
 					S.forceMove(tongs)
 					tongs.icon_state = "supermatter_tongs_loaded"
 					tongs.item_state = "supermatter_tongs_loaded"
-					tongs.update_icon()
-					to_chat(user,"<span class='notice'> You pick up [S] with [tongs]!</span>")
+					to_chat(user, "<span class='notice'>You pick up [S] with [tongs]!</span>")
 			else
 				to_chat(user, "<span class='warning'>You fail to extract a sliver from [src]! [I] isn't sharp enough anymore.</span>")
 		return
 	if(istype(I, /obj/item/retractor/supermatter))
-		to_chat(user, "<span class='notice'>[I] bounces off the supermatter crystal, you need to cut a sliver off first!</span>")
+		to_chat(user, "<span class='notice'>[I] bounces off [src], you need to cut a sliver off first!</span>")
 	else if(user.drop_item())
 		user.visible_message("<span class='danger'>As [user] touches [src] with \a [I], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch [src] with [I], and everything suddenly goes silent.</span>\n<span class='notice'>[I] flashes into dust as you flinch away from [src].</span>",\

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -736,13 +736,32 @@
 		if(I.use_tool(src, user, 10 SECONDS, volume = 100))
 			if(scalpel.uses_left)
 				to_chat(user, "<span class='danger'>You extract a sliver from [src], and it begins to react violently!</span>")
-				new /obj/item/nuke_core/supermatter_sliver(drop_location())
 				matter_power += 800
 				scalpel.uses_left--
 				if(!scalpel.uses_left)
 					to_chat(user, "<span class='boldwarning'>A tiny piece of [I] falls off, rendering it useless!</span>")
+
+				var/obj/item/nuke_core/supermatter_sliver/S = new /obj/item/nuke_core/supermatter_sliver(drop_location())
+
+				var/obj/item/retractor/supermatter/tongs
+
+				if(istype(user.get_item_by_slot(slot_l_hand), /obj/item/retractor/supermatter))
+					tongs = user.get_item_by_slot(slot_l_hand)
+				else if(istype(user.get_item_by_slot(slot_r_hand), /obj/item/retractor/supermatter))
+					tongs = user.get_item_by_slot(slot_r_hand)
+
+				if(tongs && !tongs.sliver)
+					tongs.sliver = S
+					S.forceMove(tongs)
+					tongs.icon_state = "supermatter_tongs_loaded"
+					tongs.item_state = "supermatter_tongs_loaded"
+					tongs.update_icon()
+					to_chat(user,"<span class='notice'> You pick up [S] with [tongs]!</span>")
 			else
 				to_chat(user, "<span class='warning'>You fail to extract a sliver from [src]! [I] isn't sharp enough anymore.</span>")
+		return
+	if(istype(I, /obj/item/retractor/supermatter))
+		to_chat(user, "<span class='notice'>Your [I] bounces off the supermatter crystal, you need to cut a sliver off first!</span>")
 	else if(user.drop_item())
 		user.visible_message("<span class='danger'>As [user] touches [src] with \a [I], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch [src] with [I], and everything suddenly goes silent.</span>\n<span class='notice'>[I] flashes into dust as you flinch away from [src].</span>",\

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -731,28 +731,30 @@
 	if(moveable && default_unfasten_wrench(user, I, time = 20))
 		return
 	if(istype(I, /obj/item/scalpel/supermatter))
-		var/obj/item/scalpel/supermatter/scalpel = I
-		to_chat(user, "<span class='notice'>You carefully begin to scrape [src] with [I]...</span>")
-		if(I.use_tool(src, user, 10 SECONDS, volume = 100))
-			if(scalpel.uses_left)
-				to_chat(user, "<span class='danger'>You extract a sliver from [src], and it begins to react violently!</span>")
-				matter_power += 800
-				scalpel.uses_left--
-				if(!scalpel.uses_left)
-					to_chat(user, "<span class='boldwarning'>A tiny piece of [I] falls off, rendering it useless!</span>")
+		if(ishuman(user))
+			var/mob/living/carbon/human/M = user
+			var/obj/item/scalpel/supermatter/scalpel = I
+			to_chat(M, "<span class='notice'>You carefully begin to scrape [src] with [I]...</span>")
+			if(I.use_tool(src, M, 10 SECONDS, volume = 100))
+				if(scalpel.uses_left)
+					to_chat(M, "<span class='danger'>You extract a sliver from [src], and it begins to react violently!</span>")
+					matter_power += 800
+					scalpel.uses_left--
+					if(!scalpel.uses_left)
+						to_chat(M, "<span class='boldwarning'>A tiny piece of [I] falls off, rendering it useless!</span>")
 
-				var/obj/item/nuke_core/supermatter_sliver/S = new /obj/item/nuke_core/supermatter_sliver(drop_location())
+					var/obj/item/nuke_core/supermatter_sliver/S = new /obj/item/nuke_core/supermatter_sliver(drop_location())
 
-				var/obj/item/retractor/supermatter/tongs = user.is_in_hands(/obj/item/retractor/supermatter)
+					var/obj/item/retractor/supermatter/tongs = M.is_in_hands(/obj/item/retractor/supermatter)
 
-				if(tongs && !tongs.sliver)
-					tongs.sliver = S
-					S.forceMove(tongs)
-					tongs.icon_state = "supermatter_tongs_loaded"
-					tongs.item_state = "supermatter_tongs_loaded"
-					to_chat(user, "<span class='notice'>You pick up [S] with [tongs]!</span>")
-			else
-				to_chat(user, "<span class='warning'>You fail to extract a sliver from [src]! [I] isn't sharp enough anymore.</span>")
+					if(tongs && !tongs.sliver)
+						tongs.sliver = S
+						S.forceMove(tongs)
+						tongs.icon_state = "supermatter_tongs_loaded"
+						tongs.item_state = "supermatter_tongs_loaded"
+						to_chat(M, "<span class='notice'>You pick up [S] with [tongs]!</span>")
+				else
+					to_chat(user, "<span class='warning'>You fail to extract a sliver from [src]! [I] isn't sharp enough anymore.</span>")
 		return
 	if(istype(I, /obj/item/retractor/supermatter))
 		to_chat(user, "<span class='notice'>[I] bounces off [src], you need to cut a sliver off first!</span>")

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -761,7 +761,7 @@
 				to_chat(user, "<span class='warning'>You fail to extract a sliver from [src]! [I] isn't sharp enough anymore.</span>")
 		return
 	if(istype(I, /obj/item/retractor/supermatter))
-		to_chat(user, "<span class='notice'>Your [I] bounces off the supermatter crystal, you need to cut a sliver off first!</span>")
+		to_chat(user, "<span class='notice'>[I] bounces off the supermatter crystal, you need to cut a sliver off first!</span>")
 	else if(user.drop_item())
 		user.visible_message("<span class='danger'>As [user] touches [src] with \a [I], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch [src] with [I], and everything suddenly goes silent.</span>\n<span class='notice'>[I] flashes into dust as you flinch away from [src].</span>",\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

The supermatter sliver tongs no longer dust when clicking on the supermatter crystal with them, to help with missclicks, as the sprite blends in a little.

If you are holding the tongs in hand when extracting the sliver, you will automatically put the sliver in the tongs.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Dusting your one way to complete the objective as you slightly missclick is a little harsh. Plus, did not make sense, since why does the crystal dust the tongs, if the tongs are supposed to be able to pick up the crystal without dusting. Also, having the tongs automaticaly be able to pick up the sliver is nice.


## Changelog
:cl:
tweak: Supermatter extraction tongs no longer get dusted if you click on the supermatter with them
tweak: The supermatter sliver is automatically placed in the tongs, if you have it in your other hand when removing the sliver from the main crystal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
