### PR TITLE
Fixes mech creation DB logging

### DIFF
--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -80,7 +80,7 @@
 	return 0
 
 
-/datum/construction/proc/spawn_result(mob/user as mob)
+/datum/construction/proc/spawn_result(mob/user, result_name)
 	if(result)
 		if(taskpath)
 			var/datum/job_objective/task = user.mind.findJobTask(taskpath)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -22,8 +22,8 @@
 	else
 		return ..()
 
-/datum/construction/mecha/spawn_result(name)
-	SSblackbox.record_feedback("tally", "mechas_created", 1, "[name]")
+/datum/construction/mecha/spawn_result(mob/user, result_name)
+	SSblackbox.record_feedback("tally", "mechas_created", 1, "[result_name]")
 
 /datum/construction/reversible/mecha/custom_action(index as num, diff as num, atom/used_atom, mob/user as mob)
 	if(istype(used_atom, /obj/item/stack/cable_coil))
@@ -65,8 +65,8 @@
 /datum/construction/mecha/ripley_chassis/action(atom/used_atom,mob/user as mob)
 	return check_all_steps(used_atom,user)
 
-/datum/construction/mecha/ripley_chassis/spawn_result()
-	..("Ripley")
+/datum/construction/mecha/ripley_chassis/spawn_result(mob/user, result_name)
+	..(user, "Ripley")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/ripley(const_holder)
 	const_holder.icon = 'icons/mecha/mech_construction.dmi'
@@ -270,8 +270,8 @@
 /datum/construction/mecha/gygax_chassis/action(atom/used_atom,mob/user as mob)
 	return check_all_steps(used_atom,user)
 
-/datum/construction/mecha/gygax_chassis/spawn_result()
-	..("Gygax")
+/datum/construction/mecha/gygax_chassis/spawn_result(mob/user, result_name)
+	..(user, "Gygax")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/gygax(const_holder)
 	const_holder.icon = 'icons/mecha/mech_construction.dmi'
@@ -545,8 +545,8 @@
 /datum/construction/mecha/firefighter_chassis/action(atom/used_atom,mob/user as mob)
 	return check_all_steps(used_atom,user)
 
-/datum/construction/mecha/firefighter_chassis/spawn_result()
-	..("Firefighter Ripley")
+/datum/construction/mecha/firefighter_chassis/spawn_result(mob/user, result_name)
+	..(user, "Firefighter Ripley")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/firefighter(const_holder)
 	const_holder.icon = 'icons/mecha/mech_construction.dmi'
@@ -764,8 +764,8 @@
 	qdel(used_atom)
 	return 1
 
-/datum/construction/mecha/honker_chassis/spawn_result()
-	..("Honker")
+/datum/construction/mecha/honker_chassis/spawn_result(mob/user, result_name)
+	..(user, "Honker")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/honker(const_holder)
 	const_holder.density = 1
@@ -836,8 +836,8 @@
 	qdel(used_atom)
 	return 1
 
-/datum/construction/mecha/reticence_chassis/spawn_result()
-	..("Reticence")
+/datum/construction/mecha/reticence_chassis/spawn_result(mob/user, result_name)
+	..(user, "Reticence")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/reticence(const_holder)
 	const_holder.density = 1
@@ -910,8 +910,8 @@
 /datum/construction/mecha/durand_chassis/action(atom/used_atom,mob/user as mob)
 	return check_all_steps(used_atom,user)
 
-/datum/construction/mecha/durand_chassis/spawn_result()
-	..("Durand")
+/datum/construction/mecha/durand_chassis/spawn_result(mob/user, result_name)
+	..(user, "Durand")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/durand(const_holder)
 	const_holder.icon = 'icons/mecha/mech_construction.dmi'
@@ -1188,8 +1188,8 @@
 /datum/construction/mecha/phazon_chassis/action(atom/used_atom,mob/user as mob)
 	return check_all_steps(used_atom,user)
 
-/datum/construction/mecha/phazon_chassis/spawn_result()
-	..("Phazon")
+/datum/construction/mecha/phazon_chassis/spawn_result(mob/user, result_name)
+	..(user, "Phazon")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/phazon(const_holder)
 	const_holder.icon = 'icons/mecha/mech_construction.dmi'
@@ -1507,8 +1507,8 @@
 /datum/construction/mecha/odysseus_chassis/action(atom/used_atom,mob/user as mob)
 	return check_all_steps(used_atom,user)
 
-/datum/construction/mecha/odysseus_chassis/spawn_result()
-	..("Odysseus")
+/datum/construction/mecha/odysseus_chassis/spawn_result(mob/user, result_name)
+	..(user, "Odysseus")
 	var/obj/item/mecha_parts/chassis/const_holder = holder
 	const_holder.construct = new /datum/construction/reversible/mecha/odysseus(const_holder)
 	const_holder.icon = 'icons/mecha/mech_construction.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Mech creation DB logging now properly records the name of the mech created, instead of the building user's name.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #17295
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mech creation database logging now properly records the name of the mech created, instead of the building user's name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
