### PR TITLE
Fixes inflatable barrier boxes infinite storage exploit

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -217,7 +217,7 @@
 	icon_state = "inf_box"
 	item_state = "syringe_kit"
 	w_class = WEIGHT_CLASS_NORMAL
-	can_hold = list(/obj/item/inflatable, /obj/item/inflatable/door)
+	can_hold = list(/obj/item/inflatable)
 
 /obj/item/storage/briefcase/inflatable/New()
 	..()

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -216,8 +216,8 @@
 	desc = "Contains inflatable walls and doors."
 	icon_state = "inf_box"
 	item_state = "syringe_kit"
-	max_combined_w_class = 21
 	w_class = WEIGHT_CLASS_NORMAL
+	can_hold = list(/obj/item/inflatable, /obj/item/inflatable/door)
 
 /obj/item/storage/briefcase/inflatable/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This makes inflatable barrier boxes only accept inflatable barriers and doors.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Apparently, people have been abusing these boxes to store loads of items in their bags, because the box itself fits in a backpack and has as much space as a normal bag. 
It also fits inside itself, allowing _infinite_ storage nesting inside a backpack.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed an infinite storage exploit using the inflatable barrier box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
