### PR TITLE
Adds a cap to Xenobiology Mobs and Allows Sentient Giant Spider prompts to be disabled

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -184,6 +184,9 @@
 #define HOSTILE_SPAWN 1
 #define FRIENDLY_SPAWN 2
 
+///Max amount of living Xenobio mobs allowed at any given time (excluding slimes).
+#define MAX_GOLD_CORE_MOBS 45
+
 #define TINT_IMPAIR 2			//Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
 #define EYE_SHINE_THRESHOLD 6	//dark_view threshold past which a humanoid's eyes will 'shine' in the dark.

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -9,8 +9,10 @@ SUBSYSTEM_DEF(mobs)
 	var/static/list/clients_by_zlevel[][]
 	var/static/list/dead_players_by_zlevel[][] = list(list()) // Needs to support zlevel 1 here, MaxZChanged only happens when CC is created and new_players can login before that.
 	var/static/list/cubemonkeys = list()
-	/// The amount of giant spiders that exist in the world. Used for mob capping.
-	var/giant_spiders = 0
+	/// The amount of Xenobiology mobs (and their offspring) that exist in the world. Used for mob capping. Excludes Slimes
+	var/xenobiology_mobs = 0
+	/// The amount of Xenobiology slimes (and their offspring) that exist in the world. Used for mob capping. Excludes Slimes
+	var/xenobiology_slimes = 0
 
 /datum/controller/subsystem/mobs/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -11,8 +11,6 @@ SUBSYSTEM_DEF(mobs)
 	var/static/list/cubemonkeys = list()
 	/// The amount of Xenobiology mobs (and their offspring) that exist in the world. Used for mob capping. Excludes Slimes
 	var/xenobiology_mobs = 0
-	/// The amount of Xenobiology slimes (and their offspring) that exist in the world. Used for mob capping. Excludes Slimes
-	var/xenobiology_slimes = 0
 
 /datum/controller/subsystem/mobs/get_metrics()
 	. = ..()

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -1,4 +1,3 @@
-
 /obj/structure/spider
 	name = "web"
 	desc = "it's stringy and sticky"
@@ -183,11 +182,10 @@
 			if(!grow_as)
 				grow_as = pick(typesof(/mob/living/simple_animal/hostile/poison/giant_spider))
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(loc)
-			SSmobs.xenobiology_mobs++
 			S.faction = faction.Copy()
 			S.master_commander = master_commander
 			S.xenobiology_spawned = xenobiology_spawned
-			if (xenobiology_spawned)
+			if(xenobiology_spawned)
 				SSmobs.xenobiology_mobs++
 			if(player_spiders && !selecting_player)
 				selecting_player = 1

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -80,7 +80,7 @@
 			var/obj/structure/spider/spiderling/S = new /obj/structure/spider/spiderling(loc)
 			S.faction = faction.Copy()
 			S.master_commander = master_commander
-			S.xenobiology_spawned = S.xenobiology_spawned
+			S.xenobiology_spawned = xenobiology_spawned
 			if(player_spiders)
 				S.player_spiders = TRUE
 		qdel(src)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -1,6 +1,4 @@
-//generic procs copied from obj/effect/alien
-#define SPIDER_SOFT_CAP 30
-#define SPIDER_HARD_CAP 40
+
 /obj/structure/spider
 	name = "web"
 	desc = "it's stringy and sticky"
@@ -60,6 +58,8 @@
 	icon_state = "eggs"
 	var/amount_grown = 0
 	var/player_spiders = 0
+	///Was this egg laid by a xenobiology mob? Used for mob capping
+	var/xenobiology_spawned = FALSE
 	var/list/faction = list("spiders")
 
 /obj/structure/spider/eggcluster/Initialize(mapload)
@@ -69,7 +69,7 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/spider/eggcluster/process()
-	if(SSmobs.giant_spiders > SPIDER_SOFT_CAP) //eggs gonna chill out until there is less spiders
+	if(SSmobs.xenobiology_mobs > MAX_GOLD_CORE_MOBS - 10) //eggs gonna chill out until there is less spiders
 		return
 
 	amount_grown += rand(0, 2)
@@ -174,19 +174,20 @@
 	if(isturf(loc))
 		amount_grown += rand(0,2)
 		if(amount_grown >= 100)
-			if(SSmobs.giant_spiders > SPIDER_HARD_CAP)
+			if(SSmobs.xenobiology_mobs > MAX_GOLD_CORE_MOBS)
 				qdel(src)
 				return
 			if(!grow_as)
 				grow_as = pick(typesof(/mob/living/simple_animal/hostile/poison/giant_spider))
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(loc)
-			SSmobs.giant_spiders++
+			SSmobs.xenobiology_mobs++
 			S.faction = faction.Copy()
 			S.master_commander = master_commander
+			S.xenobiology_spawned = xenobiology_spawned
 			if(player_spiders && !selecting_player)
 				selecting_player = 1
 				spawn()
-					var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a giant spider?", ROLE_GSPIDER, TRUE, source = S)
+					var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a giant spider?", ROLE_SENTIENT, TRUE, source = S)
 
 					if(length(candidates) && !QDELETED(S))
 						var/mob/C = pick(candidates)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -80,6 +80,7 @@
 			var/obj/structure/spider/spiderling/S = new /obj/structure/spider/spiderling(loc)
 			S.faction = faction.Copy()
 			S.master_commander = master_commander
+			S.xenobiology_spawned = S.xenobiology_spawned
 			if(player_spiders)
 				S.player_spiders = TRUE
 		qdel(src)
@@ -98,6 +99,8 @@
 	var/player_spiders = 0
 	var/list/faction = list("spiders")
 	var/selecting_player = 0
+	///Is this spiderling created from a xenobiology mob?
+	var/xenobiology_spawned = FALSE
 
 /obj/structure/spider/spiderling/Initialize(mapload)
 	. = ..()
@@ -174,7 +177,7 @@
 	if(isturf(loc))
 		amount_grown += rand(0,2)
 		if(amount_grown >= 100)
-			if(SSmobs.xenobiology_mobs > MAX_GOLD_CORE_MOBS)
+			if(SSmobs.xenobiology_mobs > MAX_GOLD_CORE_MOBS && xenobiology_spawned)
 				qdel(src)
 				return
 			if(!grow_as)
@@ -184,6 +187,8 @@
 			S.faction = faction.Copy()
 			S.master_commander = master_commander
 			S.xenobiology_spawned = xenobiology_spawned
+			if (xenobiology_spawned)
+				SSmobs.xenobiology_mobs++
 			if(player_spiders && !selecting_player)
 				selecting_player = 1
 				spawn()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -257,6 +257,7 @@
 					var/obj/structure/spider/eggcluster/C = new /obj/structure/spider/eggcluster(src.loc)
 					C.faction = faction.Copy()
 					C.master_commander = master_commander
+					C.xenobiology_spawned = xenobiology_spawned
 					if(ckey)
 						C.player_spiders = 1
 					fed--

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -56,12 +56,6 @@
 		for(var/obj/structure/spider/S in range(1, get_turf(src)))
 			return S
 
-/mob/living/simple_animal/hostile/poison/giant_spider/death(gibbed)
-	. = ..()
-	if(!.)
-		return FALSE
-	SSmobs.giant_spiders--
-
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 	desc = "Furry and black, it makes you shudder to look at it. This one has brilliant green eyes."

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -80,6 +80,8 @@
 	var/max_offspring = DEFAULT_MAX_OFFSPRING
 
 	var/buffed = 0 //In the event that you want to have a buffing effect on the mob, but don't want it to stack with other effects, any outside force that applies a buff to a simple mob should at least set this to 1, so we have something to check against
+	///Was this mob spawned by xenobiology magic? Used for mobcapping.
+	var/xenobiology_spawned = FALSE
 	var/gold_core_spawnable = NO_SPAWN //If the mob can be spawned with a gold slime core. HOSTILE_SPAWN are spawned with plasma, FRIENDLY_SPAWN are spawned with blood
 
 	var/mob/living/carbon/human/master_commander = null //holding var for determining who own/controls a sentient simple animal (for sentience potions).
@@ -374,6 +376,8 @@
 			visible_message("<span class='danger'>\The [src] [deathmessage]</span>")
 		else if(!del_on_death)
 			visible_message("<span class='danger'>\The [src] stops moving...</span>")
+	if (xenobiology_spawned)
+		SSmobs.xenobiology_mobs--
 	if(del_on_death)
 		//Prevent infinite loops if the mob Destroy() is overridden in such
 		//a manner as to cause a call to death() again

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -376,7 +376,7 @@
 			visible_message("<span class='danger'>\The [src] [deathmessage]</span>")
 		else if(!del_on_death)
 			visible_message("<span class='danger'>\The [src] stops moving...</span>")
-	if (xenobiology_spawned)
+	if(xenobiology_spawned)
 		SSmobs.xenobiology_mobs--
 	if(del_on_death)
 		//Prevent infinite loops if the mob Destroy() is overridden in such

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -21,7 +21,7 @@
 	return
 
 
-/datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = "chemicalsummon", random = TRUE)
+/datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = "chemicalsummon", random = TRUE, gold_core_spawn = FALSE)
 	if(holder && holder.my_atom)
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
@@ -48,6 +48,8 @@
 				S = create_random_mob(get_turf(holder.my_atom), mob_class)
 			else
 				S = new mob_class(get_turf(holder.my_atom))//Spawn our specific mob_class
+			if (gold_core_spawn) //For tracking xenobiology mobs
+				S.xenobiology_spawned = TRUE
 			S.faction |= mob_faction
 			if(prob(50))
 				for(var/j = 1, j <= rand(1, 3), j++)

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -48,7 +48,7 @@
 				S = create_random_mob(get_turf(holder.my_atom), mob_class)
 			else
 				S = new mob_class(get_turf(holder.my_atom))//Spawn our specific mob_class
-			if (gold_core_spawn) //For tracking xenobiology mobs
+			if(gold_core_spawn) //For tracking xenobiology mobs
 				S.xenobiology_spawned = TRUE
 			S.faction |= mob_faction
 			if(prob(50))

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -103,7 +103,7 @@
 /datum/chemical_reaction/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
-		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN, , gold_core_spawn = TRUE), 50)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN, "chemicalsummon", TRUE, TRUE), 50)
 		SSmobs.xenobiology_mobs += 5
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
@@ -116,7 +116,7 @@
 /datum/chemical_reaction/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
-		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral", gold_core_spawn = TRUE), 50)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral", TRUE, TRUE), 50)
 		SSmobs.xenobiology_mobs += 3
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
@@ -129,7 +129,7 @@
 /datum/chemical_reaction/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
-		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral", gold_core_spawn = TRUE), 50)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral", TRUE, TRUE), 50)
 		SSmobs.xenobiology_mobs += 1
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -102,7 +102,11 @@
 
 /datum/chemical_reaction/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN), 50)
+	if(SS.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN), 50)
+		SS.xenobiology_mobs += 5
+	else
+		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
 
 /datum/chemical_reaction/slimemobspawn/lesser
 	name = "Slime Crit Lesser"
@@ -111,7 +115,11 @@
 
 /datum/chemical_reaction/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
+	if(SS.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
+		SS.xenobiology_mobs += 3
+	else
+		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
 
 /datum/chemical_reaction/slimemobspawn/friendly
 	name = "Slime Crit Friendly"
@@ -120,8 +128,11 @@
 
 /datum/chemical_reaction/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral"), 50)
-
+	if(SS.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral"), 50)
+		SS.xenobiology_mobs += 1
+	else
+		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
 //Silver
 /datum/chemical_reaction/slimebork
 	name = "Slime Bork"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -102,9 +102,9 @@
 
 /datum/chemical_reaction/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	if(SS.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
+	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
 		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN), 50)
-		SS.xenobiology_mobs += 5
+		SSmobs.xenobiology_mobs += 5
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
 
@@ -115,9 +115,9 @@
 
 /datum/chemical_reaction/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	if(SS.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
+	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
 		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
-		SS.xenobiology_mobs += 3
+		SSmobs.xenobiology_mobs += 3
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
 
@@ -128,9 +128,9 @@
 
 /datum/chemical_reaction/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
-	if(SS.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
+	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
 		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral"), 50)
-		SS.xenobiology_mobs += 1
+		SSmobs.xenobiology_mobs += 1
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
 //Silver

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -103,7 +103,7 @@
 /datum/chemical_reaction/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
-		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN), 50)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN, , gold_core_spawn = TRUE), 50)
 		SSmobs.xenobiology_mobs += 5
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
@@ -116,7 +116,7 @@
 /datum/chemical_reaction/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
-		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral", gold_core_spawn = TRUE), 50)
 		SSmobs.xenobiology_mobs += 3
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
@@ -129,7 +129,7 @@
 /datum/chemical_reaction/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	if(SSmobs.xenobiology_mobs < MAX_GOLD_CORE_MOBS)
-		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral"), 50)
+		addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral", gold_core_spawn = TRUE), 50)
 		SSmobs.xenobiology_mobs += 1
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -133,6 +133,7 @@
 		SSmobs.xenobiology_mobs += 1
 	else
 		T.visible_message("<span class='danger'>The slime extract sputters out, there's too many mobs to make any more!</span>")
+
 //Silver
 /datum/chemical_reaction/slimebork
 	name = "Slime Bork"


### PR DESCRIPTION
## What Does This PR Do
- Changes cap introduced in #15923 to xenobiology specific giant spiders only (Eggs stop growing when total mobs>cap-10 and spiderlings die instead of spawning spiders when total mobs=cap)
- Adds a mob cap to xenobiology mobs (Currently set at 45 & Does not include slimes). Spawning xenobio mobs from gold cores increases counter, said mobs dying decreases the counter.
- Sets giant spiders prompt flag to ROLE_SENTIENT instead of ROLE_GSPIDER so those who have sentient mobs disabled do not get prompted

## Why It's Good For The Game
Admins are tired of coming up with IC methods/reasoning to cleaning up xenobio mob explosions and it usually just ends with players being confused in dchat as to why we leveled xenobiology or deleted all of their mobs.

Sentient Giant spiders dchat prompts can now be disabled by disabling the Sentient Mobs preference in game preferences. Getting spammed with 40 dings and prompts over the course of 5-10 minutes is annoying and should be avoidable. In a future PR (or if someone wants to help me), the preference for giant spiders in game preferences should be labeled as `terror spider` since giant spiders only prompted naturally from xenobiology before and this flag only applies to Terrors now.

This PR will prevent significant loads being placed on SSmobs by xenobiology. I think 45 mobs is generous so feel free to weigh in your opinion if you think I should drop it down to 40 or even 30.


This was tested by spawning in xenobio mobs with gold slime cores. I don't have the skill to set up a two client local server so I'm not 100% sure how sentience potions will affect the `xenobiology_spawned` variable but it should be fine. Testing on local server produced no runtimes and as long as the initial nurse spider has the `xenobiology_spawned` var set to `TRUE` then all of it's children will also have the var set to true.
## Changelog
:cl:
add: Adds a 45 mob cap on spawning xenobiology mobs
tweak: Sentient Giant Spider dchat prompts now fall under the sentient mob preference
/:cl:

