### PR TITLE
Tweaks sling ascension message

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -173,7 +173,7 @@ Made by Xhuis
 			replace_jobbanned_player(new_thrall_mind.current, ROLE_SHADOWLING)
 		if(!victory_warning_announced && (length(shadowling_thralls) >= warning_threshold))//are the slings very close to winning?
 			victory_warning_announced = TRUE	//then let's give the station a warning
-			GLOB.command_announcement.Announce("Large concentration of psychic bluespace energy detected by long-ranged scanners. Shadowling ascension event imminent. Prevent it at all costs!", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
+			GLOB.command_announcement.Announce("Large concentration of psychic bluespace energy detected by long-ranged scanners. Shadowling ascension event is at least two-thirds of the way to completion. Disrupt the process at all costs, before the station is consumed! Space law and SOP are suspended. The entire crew must kill shadowlings and their thralls on sight.", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
 		return 1
 
 /datum/game_mode/proc/remove_thrall(datum/mind/thrall_mind, kill = 0)

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -173,7 +173,7 @@ Made by Xhuis
 			replace_jobbanned_player(new_thrall_mind.current, ROLE_SHADOWLING)
 		if(!victory_warning_announced && (length(shadowling_thralls) >= warning_threshold))//are the slings very close to winning?
 			victory_warning_announced = TRUE	//then let's give the station a warning
-			GLOB.command_announcement.Announce("Large concentration of psychic bluespace energy detected by long-ranged scanners. Shadowling ascension event is at least two-thirds of the way to completion. Disrupt the process at all costs, before the station is consumed! Space law and SOP are suspended. The entire crew must kill shadowlings and their thralls on sight.", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
+			GLOB.command_announcement.Announce("Hostile bluespace entities are attempting to transcend existence aboard [station_name()]. Disrupt the ascension at all costs, before the station is destroyed! Space law and SOP are suspended. The entire crew must kill shadowlings and their thralls on sight.", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
 		return 1
 
 /datum/game_mode/proc/remove_thrall(datum/mind/thrall_mind, kill = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some more detail to the shadowling ascension message.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->


## Why It's Good For The Game
Currently, the message is a bit vague:
![2022-01-12 20_32_31-Paradise Station 13](https://user-images.githubusercontent.com/12197162/149217781-eb5f05dd-2c82-432d-b517-4c5c06055923.png)

We get a fair few people unsure of what this means or what they can do.
After asking in staff chat, headmins ruled that slings and thralls at this stage are totally valid, like a summoning cult.

As such, I decided to clarify this ingame. I did ask about tweaking the message when I asked about the above, but the conversation drifted away. Since it was a simple change, I thought they might as well just use github to approve or object.

It would read:

> Large concentration of psychic bluespace energy detected by long-ranged scanners. Shadowling ascension event is at least two-thirds of the way to completion. Disrupt the process at all costs, before the station is consumed! Space law and SOP are suspended. The entire crew must kill shadowlings and their thralls on sight.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Changelog
:cl:
tweak: Tweaked sling ascension message to be clearer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
