### PR TITLE
Adds a new Nuclear Agent Detomax Subtype

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1056,6 +1056,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "DEPC"
 	item = /obj/item/cartridge/syndicate
 	cost = 6
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/explosives/detomatix/nuclear
+	desc = "When inserted into a personal digital assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA. This version comes with a program to toggle your nuclear shuttle blast doors remotely."
+	item = /obj/item/cartridge/syndicate/nuclear
+	excludefrom = list()
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"

--- a/code/modules/pda/cart.dm
+++ b/code/modules/pda/cart.dm
@@ -276,12 +276,16 @@
 /obj/item/cartridge/syndicate
 	name = "Detomatix Cartridge"
 	icon_state = "cart"
-	var/initial_remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
 	charges = 4
-	programs = list(new/datum/data/pda/utility/toggle_door)
 	messenger_plugins = list(new/datum/data/pda/messenger_plugin/virus/detonate)
 
-/obj/item/cartridge/syndicate/Initialize(mapload)
+/obj/item/cartridge/syndicate/nuclear //needed subtype so regular traitors can't open and close nuclear shuttle doors
+	name = "Nuclear Agent Detomatix Cartridge"
+	desc = "The same reliable Detomatix program except with the added ability of remotely toggling your nuclear shuttle airlock from your PDA"
+	var/initial_remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
+	programs = list(new/datum/data/pda/utility/toggle_door)
+
+/obj/item/cartridge/syndicate/nuclear/Initialize(mapload)
 	. = ..()
 	var/datum/data/pda/utility/toggle_door/D = programs[1]
 	if(istype(D))

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -113,7 +113,7 @@
 	icon_state = "pda-miner"
 
 /obj/item/pda/syndicate
-	default_cartridge = /obj/item/cartridge/syndicate
+	default_cartridge = /obj/item/cartridge/syndicate/nuclear
 	icon_state = "pda-syndi"
 	name = "Military PDA"
 	owner = "John Doe"


### PR DESCRIPTION
## What Does This PR Do
fixes #7611
- Creates the subtype of the `cartridge/syndicate/nuclear` which is a carbon copy of the old detomax cartridge only available to nuclear operatives in their uplink or in Military PDAs
- Removes the nuclear shuttle toggle-door program from `cartridge/syndicate` which is now only available in traitor uplinks

## Why It's Good For The Game
Removes a completely useless button given to on-station traitors from the Detomax cartridge. New cartridge description informs nukies of their cool PDA program so they might use it more often.

## Changelog
:cl:
add: Added subtype of detomax cartridge only for nuclear agents
tweak: Traitor detomax cartridges can no longer remotely open the nuclear shuttle blast door
/:cl: