### PR TITLE
Fixes Area discrepancy with onehalf ruin bridge area

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -768,7 +768,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "bR" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
@@ -779,7 +779,7 @@
 /area/ruin/onehalf/hallway)
 "bT" = (
 /turf/simulated/wall/r_wall,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "bU" = (
 /obj/item/stack/sheet/metal,
 /turf/template_noop,
@@ -818,22 +818,22 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cd" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "ce" = (
 /obj/structure/table,
 /obj/item/paper,
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cf" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cg" = (
 /obj/machinery/light{
 	dir = 1;
@@ -841,11 +841,11 @@
 	},
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "ch" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "ci" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -858,7 +858,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -905,7 +905,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -914,22 +914,22 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cq" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cr" = (
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cs" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "ct" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -945,7 +945,7 @@
 /obj/structure/table,
 /obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cu" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
@@ -968,7 +968,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cv" = (
 /obj/item/stack/rods,
 /turf/template_noop,
@@ -1004,19 +1004,19 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cB" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 7;
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cC" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cD" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
@@ -1030,7 +1030,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cE" = (
 /obj/item/stack/tile/wood,
 /turf/template_noop,
@@ -1062,11 +1062,11 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cJ" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cK" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "onehalf bridge";
@@ -1076,12 +1076,12 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cL" = (
 /obj/item/crowbar,
 /obj/item/multitool,
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cM" = (
 /obj/structure/safe/floor,
 /obj/item/tank/internals/oxygen/red,
@@ -1091,13 +1091,13 @@
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /obj/item/folder/syndicate/blue,
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cN" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cO" = (
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/cut{
@@ -1112,7 +1112,7 @@
 	},
 /obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cR" = (
 /obj/item/stack/sheet/plasteel,
 /turf/template_noop,
@@ -1135,11 +1135,11 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cW" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cX" = (
 /obj/structure/table,
 /obj/machinery/door_control{
@@ -1148,7 +1148,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cY" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
@@ -1162,7 +1162,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "cZ" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -1181,23 +1181,23 @@
 /obj/structure/table,
 /obj/item/flashlight,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "dc" = (
 /obj/structure/table,
 /obj/item/stack/ore/bluespace_crystal,
 /obj/item/coin/plasma,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "dd" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "de" = (
 /obj/machinery/light,
 /obj/structure/table,
 /obj/item/storage/firstaid,
 /turf/simulated/floor/plasteel,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "df" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -1238,7 +1238,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "dl" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
@@ -1253,7 +1253,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "dm" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
@@ -1274,7 +1274,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "dn" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
@@ -1291,7 +1291,7 @@
 	name = "bridge blast door"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/onehalf/bridge)
+/area/ruin/onehalf/abandonedbridge)
 "do" = (
 /obj/structure/lattice,
 /obj/structure/cable{

--- a/code/modules/ruins/ruin_areas.dm
+++ b/code/modules/ruins/ruin_areas.dm
@@ -42,8 +42,8 @@
 	name = "Crew Quarters"
 	icon_state = "Sleep"
 
-/area/ruin/onehalf/bridge
-	name = "Bridge"
+/area/ruin/onehalf/abandonedbridge
+	name = "Abandoned Bridge"
 	icon_state = "bridge"
 
 // Old tcommsat


### PR DESCRIPTION
## What Does This PR Do
Changes `/area/ruin/onehalf/bridge` to `/area/ruin/onehalf/abandonedbridge`
Fixes #17325
## Why It's Good For The Game
Now when you use the jump to area verb you no longer jump to a random ruin instead of the actual station bridge.

## Changelog
:cl:
fix: Fixed area discrepancy with station and onehalf ruin bridge area names
/:cl:
