### PR TITLE
fixes huds magically appearing when people go invisible from genes / reactive armor

### DIFF
--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -216,6 +216,7 @@
 	..()
 	M.alpha = 255
 	M.invisibility = 0
+	M.add_to_all_human_data_huds()
 
 // WAS: /datum/bioEffect/darkcloak
 /datum/mutation/stealth/darkcloak
@@ -240,9 +241,11 @@
 	else
 		M.alpha = 255
 		M.invisibility = 0
+		M.add_to_all_human_data_huds()
 	if(M.alpha == 0)
 		M.invisibility = INVISIBILITY_OBSERVER
 		M.alpha = 128
+		M.remove_from_all_data_huds()
 
 //WAS: /datum/bioEffect/chameleon
 /datum/mutation/stealth/chameleon
@@ -263,9 +266,11 @@
 	else
 		M.alpha = round(255 * 0.80)
 		M.invisibility = 0
+		M.add_to_all_human_data_huds()
 	if(M.alpha == 0)
 		M.invisibility = INVISIBILITY_OBSERVER
 		M.alpha = 128
+		M.remove_from_all_data_huds()
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -214,9 +214,7 @@
 
 /datum/mutation/stealth/deactivate(mob/living/M)
 	..()
-	M.alpha = 255
-	M.invisibility = 0
-	M.add_to_all_human_data_huds()
+	M.reset_visibility()
 
 // WAS: /datum/bioEffect/darkcloak
 /datum/mutation/stealth/darkcloak
@@ -239,13 +237,10 @@
 		if(M.invisibility != INVISIBILITY_OBSERVER)
 			M.alpha = round(M.alpha * 0.8)
 	else
-		M.alpha = 255
-		M.invisibility = 0
-		M.add_to_all_human_data_huds()
+		M.reset_visibility()
+		M.alpha = round(255 * 0.8)
 	if(M.alpha == 0)
-		M.invisibility = INVISIBILITY_OBSERVER
-		M.alpha = 128
-		M.remove_from_all_data_huds()
+		M.make_invisible()
 
 //WAS: /datum/bioEffect/chameleon
 /datum/mutation/stealth/chameleon
@@ -264,13 +259,10 @@
 		if(M.invisibility != INVISIBILITY_OBSERVER)
 			M.alpha -= 25
 	else
+		M.reset_visibility()
 		M.alpha = round(255 * 0.80)
-		M.invisibility = 0
-		M.add_to_all_human_data_huds()
 	if(M.alpha == 0)
-		M.invisibility = INVISIBILITY_OBSERVER
-		M.alpha = 128
-		M.remove_from_all_data_huds()
+		M.make_invisible()
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -393,12 +393,14 @@
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
 		owner.invisibility = INVISIBILITY_OBSERVER
 		owner.alpha = 128
+		owner.remove_from_all_data_huds()
 		addtimer(CALLBACK(owner, /mob/living/.proc/reset_visibility), 4 SECONDS)
 		return TRUE
 
 /mob/living/proc/reset_visibility(mob/living/carbon/human/owner)
 	invisibility = initial(invisibility)
 	alpha = initial(alpha)
+	add_to_all_human_data_huds()
 
 /obj/item/clothing/suit/armor/reactive/tesla
 	name = "reactive tesla armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -391,16 +391,9 @@
 		E.GiveTarget(owner) //so it starts running right away
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		owner.invisibility = INVISIBILITY_OBSERVER
-		owner.alpha = 128
-		owner.remove_from_all_data_huds()
+		owner.make_invisible()
 		addtimer(CALLBACK(owner, /mob/living/.proc/reset_visibility), 4 SECONDS)
 		return TRUE
-
-/mob/living/proc/reset_visibility(mob/living/carbon/human/owner)
-	invisibility = initial(invisibility)
-	alpha = initial(alpha)
-	add_to_all_human_data_huds()
 
 /obj/item/clothing/suit/armor/reactive/tesla
 	name = "reactive tesla armor"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1515,3 +1515,13 @@ GLOBAL_LIST_INIT(holy_areas, typecacheof(list(
 
 	to_chat(src, "<span class='warning'>Your powers are useless on this holy ground.</span>")
 	return TRUE
+
+/mob/proc/reset_visibility()
+	invisibility = initial(invisibility)
+	alpha = initial(alpha)
+	add_to_all_human_data_huds()
+
+/mob/proc/make_invisible()
+	invisibility = INVISIBILITY_OBSERVER
+	alpha = 128
+	remove_from_all_data_huds()


### PR DESCRIPTION
GBP no update again


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Removes huds when people go invisible from the previously done powers / stealth armor, and adds when they unstealth

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Their huds becoming fully visible when they go invisible is a bit silly.

## Changelog
:cl:
fix: Fixes huds appearing on invisible people from chameleon / shadow / stealth armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
