### PR TITLE
Fix: timers not removing from second queue on init

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -463,7 +463,7 @@ SUBSYSTEM_DEF(timer)
 	if(buckethead == src)
 		bucket_list[bucket_pos] = next
 		SStimer.bucket_count--
-	else if(timeToRun < TIMER_MAX)
+	else if(bucket_joined)
 		SStimer.bucket_count--
 	else
 		var/l = length(second_queue)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/56292

## Why It's Good For The Game

Increases chances of smooth experience

## Changelog

:cl: Semoro
fix: timers not removing from second queue on init
/:cl:

