### PR TITLE
[GBP: No Update] Fixes orbiting in vents and disposals

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -269,7 +269,7 @@
 	if(isturf(start))
 		return
 	var/atom/cur_atom = start
-	while(!isturf(cur_atom.loc) && !(cur_atom.loc in orbiter_list))
+	while(cur_atom.loc && !isturf(cur_atom.loc) && !(cur_atom.loc in orbiter_list))
 		RegisterSignal(cur_atom, COMSIG_MOVABLE_MOVED, .proc/on_intermediate_move, TRUE)
 		RegisterSignal(cur_atom, COMSIG_ATOM_EXITED, .proc/on_remove_child, TRUE)
 		cur_atom = cur_atom.loc

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -239,7 +239,7 @@
 /datum/component/orbiter/proc/orbiter_move_react(atom/movable/orbiter, atom/oldloc, direction)
 	SIGNAL_HANDLER	// COMSIG_MOVABLE_MOVED
 
-	if(get_turf(orbiter) == get_turf(parent) || get_turf(orbiter) == get_turf(oldloc) || get_turf(orbiter) == oldloc)
+	if(get_turf(orbiter) == get_turf(parent) || get_turf(orbiter) == get_turf(oldloc) || get_turf(orbiter) == oldloc || orbiter.loc == oldloc)
 		return
 
 	if(orbiter in orbiter_list)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -133,16 +133,6 @@
 /atom/movable/proc/setLoc(T, teleported=0)
 	loc = T
 
-/**
- * Meant for movement with zero side effects. only use for objects that are supposed to move "invisibly" (like camera mobs or ghosts).
- * If you want something to move onto a tile with a beartrap or recycler or tripmine or mouse without that object knowing about it at all, use this.
- * Most of the time you want forceMove(), but if you want to just set .loc then use this.
- */
-/atom/movable/proc/abstract_move(atom/new_loc)
-	var/atom/old_loc = loc
-	loc = new_loc
-	Moved(old_loc, get_dir(old_loc, new_loc))
-
 /atom/movable/Move(atom/newloc, direct = 0, movetime)
 	if(!loc || !newloc) return 0
 	var/atom/oldloc = loc

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -141,7 +141,7 @@
 /atom/movable/proc/abstract_move(atom/new_loc)
 	var/atom/old_loc = loc
 	loc = new_loc
-	Moved(old_loc, get_dir(old_loc, new_loc), FALSE)
+	Moved(old_loc, get_dir(old_loc, new_loc))
 
 /atom/movable/Move(atom/newloc, direct = 0, movetime)
 	if(!loc || !newloc) return 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -133,6 +133,16 @@
 /atom/movable/proc/setLoc(T, teleported=0)
 	loc = T
 
+/**
+ * Meant for movement with zero side effects. only use for objects that are supposed to move "invisibly" (like camera mobs or ghosts).
+ * If you want something to move onto a tile with a beartrap or recycler or tripmine or mouse without that object knowing about it at all, use this.
+ * Most of the time you want forceMove(), but if you want to just set .loc then use this.
+ */
+/atom/movable/proc/abstract_move(atom/new_loc)
+	var/atom/old_loc = loc
+	loc = new_loc
+	Moved(old_loc, get_dir(old_loc, new_loc), FALSE)
+
 /atom/movable/Move(atom/newloc, direct = 0, movetime)
 	if(!loc || !newloc) return 0
 	var/atom/oldloc = loc

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -79,7 +79,9 @@
 		climber = null
 		return FALSE
 
+	var/old_loc = usr.loc
 	usr.loc = get_turf(src)
+	Moved(old_loc, get_dir(old_loc, usr.loc), FALSE)
 	if(get_turf(user) == get_turf(src))
 		usr.visible_message("<span class='warning'>[user] climbs onto \the [src]!</span>")
 

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -298,8 +298,10 @@ Pipelines + Other Objects -> Pipe network
 		else if(target_move.can_crawl_through())
 			if(returnPipenet() != target_move.returnPipenet())
 				user.update_pipe_vision(target_move)
+			var/old_loc = user.loc
 			user.loc = target_move
-			user.client.eye = target_move //if we don't do this, Byond only updates the eye every tick - required for smooth movement
+			user.client.eye = target_move // if we don't do this, Byond only updates the eye every tick - required for smooth movement
+			SEND_SIGNAL(user, COMSIG_MOVABLE_MOVED, old_loc, target_move, get_dir(old_loc, target_move))
 			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
 				user.last_played_vent = world.time
 				playsound(src, 'sound/machines/ventcrawl.ogg', 50, 1, -3)

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -294,7 +294,7 @@ Pipelines + Other Objects -> Pipe network
 		if(is_type_in_list(target_move, GLOB.ventcrawl_machinery) && target_move.can_crawl_through())
 			user.remove_ventcrawl()
 			user.forceMove(target_move.loc) //handles entering and so on
-			user.visible_message("You hear something squeezing through the ducts.", "You climb out the ventilation system.")
+			user.visible_message("You hear something squeezing through the ducts.", "You climb out of the ventilation system.")
 		else if(target_move.can_crawl_through())
 			if(returnPipenet() != target_move.returnPipenet())
 				user.update_pipe_vision(target_move)
@@ -307,7 +307,7 @@ Pipelines + Other Objects -> Pipe network
 		if((direction & initialize_directions) || is_type_in_list(src, GLOB.ventcrawl_machinery)) //if we move in a way the pipe can connect, but doesn't - or we're in a vent
 			user.remove_ventcrawl()
 			user.forceMove(src.loc)
-			user.visible_message("You hear something squeezing through the pipes.", "You climb out the ventilation system.")
+			user.visible_message("You hear something squeezing through the pipes.", "You climb out of the ventilation system.")
 	user.canmove = 0
 	spawn(1)
 		user.canmove = 1

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -298,10 +298,8 @@ Pipelines + Other Objects -> Pipe network
 		else if(target_move.can_crawl_through())
 			if(returnPipenet() != target_move.returnPipenet())
 				user.update_pipe_vision(target_move)
-			var/old_loc = user.loc
-			user.loc = target_move
+			user.abstract_move(target_move)
 			user.client.eye = target_move // if we don't do this, Byond only updates the eye every tick - required for smooth movement
-			SEND_SIGNAL(user, COMSIG_MOVABLE_MOVED, old_loc, target_move, get_dir(old_loc, target_move))
 			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
 				user.last_played_vent = world.time
 				playsound(src, 'sound/machines/ventcrawl.ogg', 50, 1, -3)

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -290,6 +290,7 @@ Pipelines + Other Objects -> Pipe network
 		return
 
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction)
+	var/old_loc = user.loc
 	if(target_move)
 		if(is_type_in_list(target_move, GLOB.ventcrawl_machinery) && target_move.can_crawl_through())
 			user.remove_ventcrawl()
@@ -298,7 +299,8 @@ Pipelines + Other Objects -> Pipe network
 		else if(target_move.can_crawl_through())
 			if(returnPipenet() != target_move.returnPipenet())
 				user.update_pipe_vision(target_move)
-			user.forceMove(target_move)
+			user.loc = target_move
+			user.Moved(old_loc, get_dir(old_loc, user.loc), FALSE)
 			user.client.eye = target_move // if we don't do this, Byond only updates the eye every tick - required for smooth movement
 			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
 				user.last_played_vent = world.time
@@ -306,7 +308,8 @@ Pipelines + Other Objects -> Pipe network
 	else
 		if((direction & initialize_directions) || is_type_in_list(src, GLOB.ventcrawl_machinery)) //if we move in a way the pipe can connect, but doesn't - or we're in a vent
 			user.remove_ventcrawl()
-			user.forceMove(src.loc)
+			user.loc = target_move.loc
+			user.Moved(old_loc, get_dir(old_loc, user.loc), FALSE)
 			user.visible_message("You hear something squeezing through the pipes.", "You climb out of the ventilation system.")
 	user.canmove = 0
 	spawn(1)

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -298,7 +298,7 @@ Pipelines + Other Objects -> Pipe network
 		else if(target_move.can_crawl_through())
 			if(returnPipenet() != target_move.returnPipenet())
 				user.update_pipe_vision(target_move)
-			user.abstract_move(target_move)
+			user.forceMove(target_move)
 			user.client.eye = target_move // if we don't do this, Byond only updates the eye every tick - required for smooth movement
 			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
 				user.last_played_vent = world.time

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -752,7 +752,7 @@
 	var/list/slot_must_be_empty = list(slot_back,slot_handcuffed,slot_legcuffed,slot_l_hand,slot_r_hand,slot_belt,slot_head,slot_wear_suit)
 	for(var/slot_id in slot_must_be_empty)
 		if(user.get_item_by_slot(slot_id))
-			to_chat(user,"<span class='warning'>You can't fit inside while wearing that \the [user.get_item_by_slot(slot_id)].</span>")
+			to_chat(user,"<span class='warning'>You can't fit inside while wearing \the [user.get_item_by_slot(slot_id)].</span>")
 			return 0
 	return 1
 

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -108,8 +108,8 @@
 	UnregisterSignal(A, COMSIG_ATOM_ORBIT_BEGIN)
 
 /obj/item/melee/ghost_sword/proc/register_signals(atom/A)
-	RegisterSignal(A, COMSIG_ATOM_ORBIT_BEGIN, .proc/add_ghost)
-	RegisterSignal(A, COMSIG_ATOM_ORBIT_STOP, .proc/remove_ghost)
+	RegisterSignal(A, COMSIG_ATOM_ORBIT_BEGIN, .proc/add_ghost, override = TRUE)
+	RegisterSignal(A, COMSIG_ATOM_ORBIT_STOP, .proc/remove_ghost, override = TRUE)
 
 /**
  *  When moving into something's contents
@@ -123,11 +123,8 @@
 			remove_ghost(orbiter)
 	if(ismob(loc))
 		register_signals(loc)
-		for(var/mob/dead/observer/orbiter in old_loc.get_orbiters())
+		for(var/mob/dead/observer/orbiter in loc.get_orbiters())
 			add_ghost(orbiter)
-
-/obj/item/melee/ghost_sword/proc/on_leave_item()
-	SIGNAL_HANDLER // on move
 
 /obj/item/melee/ghost_sword/attack(mob/living/target, mob/living/carbon/human/user)
 	force = 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -497,7 +497,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 						return
 
 			visible_message("<b>[src] scrambles into the ventilation ducts!</b>", "You climb into the ventilation system.")
-			src.loc = vent_found
+			var/old_loc = loc
+			loc = vent_found
+			Moved(old_loc, get_dir(old_loc, loc), FALSE)
 			add_ventcrawl(vent_found)
 
 	else

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -406,7 +406,7 @@
 	flick("[icon_state]-flush", src)
 
 	var/wrapcheck = 0
-	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
+	var/obj/structure/disposalholder/H = new(src)	// virtual holder object which actually
 												// travels through the pipes.
 	//Hacky test to get drones to mail themselves through disposals.
 	for(var/mob/living/silicon/robot/drone/D in src)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -312,7 +312,7 @@
 	flushing = 1
 	flick("intake-closing", src)
 	var/deliveryCheck = 0
-	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
+	var/obj/structure/disposalholder/H = new(src)	// virtual holder object which actually
 													// travels through the pipes.
 	for(var/obj/structure/bigDelivery/O in src)
 		deliveryCheck = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some bugs introduced in #16718 where orbiting ghosts wouldn't properly follow things that were ventcrawling or in disposals.

This also includes a small bugfix to the spectral blade that should prevent runtimes from orbit signals, and fixes tableclimbing (of all things) breaking orbiting.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As a few users noted, this is pretty crucial for tracking mobs such as morphs or terror spiders where venting is part of their core gameplay.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Orbiting ghosts now follow mobs who are ventcrawling or in disposals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
