### PR TITLE
Disallows Alien resin wall/membrane stacking

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -118,6 +118,10 @@ Doesn't work on other aliens/AI.*/
 		var/choice = input("Choose what you wish to shape.","Resin building") as null|anything in list("resin wall","resin membrane","resin nest") //would do it through typesof but then the player choice would have the type path and we don't want the internal workings to be exposed ICly - Urist
 
 		if(!choice || !powerc(55))	return
+		var/obj/structure/alien/resin/T = locate() in get_turf(src)
+		if(T)
+			to_chat(src, "<span class='danger'>There is already a resin construction here.</span>")
+			return
 		adjustPlasma(-55)
 		for(var/mob/O in viewers(src, null))
 			O.show_message(text("<span class='alertalien'>[src] vomits up a thick purple substance and shapes it!</span>"), 1)


### PR DESCRIPTION
## What Does This PR Do
You can no longer stack resin/membrane walls on top of eachother infinitely
fixes #12517

## Changelog
:cl:
fix: Resin/membrane walls cannot be stacked ontop of eachother infinitely now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
