### PR TITLE
Adds mining shelters as a Radstorm protected area

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -18,7 +18,8 @@
 	var/pre_maint_all_access
 	area_type = /area
 	protected_areas = list(/area/maintenance, /area/turret_protected/ai_upload, /area/turret_protected/ai_upload_foyer,
-	/area/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2, /area/crew_quarters/sleep, /area/security/brig, /area/shuttle)
+	/area/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2, /area/crew_quarters/sleep, /area/security/brig,
+	/area/shuttle, /area/survivalpod) //although survivalpods are off-station, creating one on station no longer protects pods on station from the rad storm
 	target_trait = STATION_LEVEL
 
 	immunity_type = "rad"


### PR DESCRIPTION
## What Does This PR Do
Adds the mining shelter area as an area protected from radstorms. Normally radstorm doesn't effect non `STATION_LEVEL` areas, however the `area/survivalpod` becomes a station_level area when a pod capsule is used on the station-z which then effects all the pods in lavaland.

Also, unable to replicate bug so closes #14533

## Why It's Good For The Game
This does mean that mining shelters on-station are protected from rad-storms, however it's heavily looked down upon to throw one down on-station. It's much easier to just run into maints so I don't think this will pose any future issues.

## Changelog
:cl:
tweak: Adds mining shelters as a Radstorm protected area
/:cl: