### PR TITLE
[GBP: No Update] Fax Machines can no longer eat folders

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -90,6 +90,9 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 	else if(istype(item, /obj/item/paper) || istype(item, /obj/item/photo) || istype(item, /obj/item/paper_bundle))
 		..()
 		SStgui.update_uis(src)
+	else if(istype(item, /obj/item/folder))
+		to_chat(user, "<span class='warning'>The [src] can't accept folders!</span>")
+		return //early return so the parent proc doesn't suck up and items that a photocopier would take
 	else
 		return ..()
 


### PR DESCRIPTION
## What Does This PR Do
Parent proc of the Fax Machine's attackby proc accepted folders but the fax machine did not have an early return if a player used a folder on it. 

GBP Ignore b/c this is a bug introduced in one of my refactors.

## Why It's Good For The Game
Patching all the wonderful edge cases I never knew would trouble me months down the road so that the fax machine isn't buggy anymore.

## Changelog
:cl:
fix: Fixed Fax Machines eating folders
/:cl: