### PR TITLE
Fixes some antag datum related issues

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1515,8 +1515,7 @@
 
 /datum/mind/proc/has_antag_datum(datum_type, check_subtypes = TRUE)
 	if(!datum_type)
-		return FALSE
-	. = FALSE
+		return
 	for(var/a in antag_datums)
 		var/datum/antagonist/A = a
 		if(check_subtypes && istype(A, datum_type))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -661,7 +661,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 		antag_list += "Shadowling Thrall"
 	if(M.mind.has_antag_datum(/datum/antagonist/traitor))
 		antag_list += "Traitor"
-	if(M.mind.has_antag_datum(/datum/antagonist/mindslave))
+	if(M.mind.has_antag_datum(/datum/antagonist/mindslave, FALSE))
 		antag_list += "Mindslave"
 	if(isrobot(M))
 		var/mob/living/silicon/robot/R = M

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -365,7 +365,7 @@
 	else
 		bodytemperature += (BODYTEMP_HEATING_MAX + (fire_stacks * 12))
 		var/datum/antagonist/vampire/V = mind?.has_antag_datum(/datum/antagonist/vampire)
-		if(V && !V.get_ability(/datum/vampire_passive/full) && stat != DEAD) // V?. doesn't work here because `has_antag_datum` return FALSE if there is no datum and ?. doesn't like that
+		if(!V?.get_ability(/datum/vampire_passive/full) && stat != DEAD)
 			V.bloodusable = max(V.bloodusable - 5, 0)
 
 /mob/living/carbon/human/proc/get_thermal_protection()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
* Makes `has_antag_datum` return `null` if it doesn't find a suitable antag datum to return, allowing the `?.` operator to work with this proc. For example:
```dm
var/datum/antagonist/traitor/T = has_antag_datum(/datum/antagonist/traitor)
T?.some_proc()
```
* Also fixes vampire thralls appearing in both the vampire thrall and mindslave category of the check antagonists panel
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
Fix: Fixes vampire thralls appearing in both the vampire thrall and mindslave category of the check antagonists panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
