### PR TITLE
Standardize ghost follow

### DIFF
--- a/code/game/gamemodes/cult/cult_actions.dm
+++ b/code/game/gamemodes/cult/cult_actions.dm
@@ -53,7 +53,7 @@
 		if(iscultist(M))
 			to_chat(M, my_message)
 		else if((M in GLOB.dead_mob_list) && !isnewplayer(M))
-			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(user, ghost=M)]) [my_message] </span>")
+			to_chat(M, "<span class='cultspeech'>([ghost_follow_link(user, ghost=M)]) [my_message] </span>")
 
 	log_say("(CULT) [message]", user)
 
@@ -73,7 +73,7 @@
 		if(iscultist(M))
 			to_chat(M, my_message)
 		else if((M in GLOB.dead_mob_list) && !isnewplayer(M))
-			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(user, ghost=M)]) [my_message] </span>")
+			to_chat(M, "<span class='cultspeech'>([ghost_follow_link(user, ghost=M)]) [my_message] </span>")
 
 
 //Objectives

--- a/code/game/gamemodes/cult/cult_actions.dm
+++ b/code/game/gamemodes/cult/cult_actions.dm
@@ -53,7 +53,7 @@
 		if(iscultist(M))
 			to_chat(M, my_message)
 		else if((M in GLOB.dead_mob_list) && !isnewplayer(M))
-			to_chat(M, "<span class='cultspeech'> <a href='?src=[M.UID()];follow=[user.UID()]'>(F)</a> [my_message] </span>")
+			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(user, M)]) [my_message] </span>")
 
 	log_say("(CULT) [message]", user)
 
@@ -73,7 +73,7 @@
 		if(iscultist(M))
 			to_chat(M, my_message)
 		else if((M in GLOB.dead_mob_list) && !isnewplayer(M))
-			to_chat(M, "<span class='cultspeech'> <a href='?src=[M.UID()];follow=[user.UID()]'>(F)</a> [my_message] </span>")
+			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(player, M)]) [my_message] </span>")
 
 
 //Objectives

--- a/code/game/gamemodes/cult/cult_actions.dm
+++ b/code/game/gamemodes/cult/cult_actions.dm
@@ -53,7 +53,7 @@
 		if(iscultist(M))
 			to_chat(M, my_message)
 		else if((M in GLOB.dead_mob_list) && !isnewplayer(M))
-			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(user, M)]) [my_message] </span>")
+			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(user, ghost=M)]) [my_message] </span>")
 
 	log_say("(CULT) [message]", user)
 
@@ -73,7 +73,7 @@
 		if(iscultist(M))
 			to_chat(M, my_message)
 		else if((M in GLOB.dead_mob_list) && !isnewplayer(M))
-			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(player, M)]) [my_message] </span>")
+			to_chat(M, "<span class='cultspeech'> ([ghost_follow_link(user, ghost=M)]) [my_message] </span>")
 
 
 //Objectives

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -120,7 +120,7 @@
 		if(istype(M, /mob/living/simple_animal/revenant))
 			to_chat(M, rendered)
 		if(isobserver(M))
-			to_chat(M, "<a href='?src=[M.UID()];follow=[UID()]'>(F)</a> [rendered]")
+			to_chat(M, "([ghost_follow_link(src, M)]) [rendered]")
 	return
 
 /mob/living/simple_animal/revenant/Stat()

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -120,7 +120,7 @@
 		if(istype(M, /mob/living/simple_animal/revenant))
 			to_chat(M, rendered)
 		if(isobserver(M))
-			to_chat(M, "([ghost_follow_link(src, M)]) [rendered]")
+			to_chat(M, "([ghost_follow_link(src, ghost=M)]) [rendered]")
 	return
 
 /mob/living/simple_animal/revenant/Stat()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Standardizes some older links used for ghosts to follow some speaking mobs (revs, cult). Basically, anywhere there used to be an `(F)` to follow in chat, you'll now see the standard `(follow)`.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The old (F) method is annoying and it sometimes feels like it doesn't even work right. On top of that, it stands out like a sore thumb. We have better code for this, we should be using it.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cult- and revenant-speech in chat now uses the normal (follow) link.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
