### PR TITLE
Fixes a runtime when you remove a fax too fast when sending it

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -315,10 +315,10 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 	flick(receive_anim, src)
 
 	playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
+	addtimer(CALLBACK(src, .proc/print_fax, incoming), 2 SECONDS)
+	return TRUE
 
-	// give the sprite some time to flick
-	sleep(20)
-
+/obj/machinery/photocopier/faxmachine/proc/print_fax(obj/item/incoming)
 	if(istype(incoming, /obj/item/paper))
 		papercopy(incoming)
 	else if(istype(incoming, /obj/item/photo))
@@ -326,10 +326,9 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 	else if(istype(incoming, /obj/item/paper_bundle))
 		bundlecopy(incoming)
 	else
-		return FALSE
+		return
 
 	use_power(active_power_usage)
-	return TRUE
 
 /obj/machinery/photocopier/faxmachine/proc/send_admin_fax(mob/sender, destination)
 	use_power(active_power_usage)


### PR DESCRIPTION
## What Does This PR Do
Bug happens when you send the fax and within 2 seconds remove the paper/bundle/photo you're sending
This also made the fax less easy to trace by admins since it failed to create a fax entry in the event tab.

Fixes
```
Runtime in faxmachine.dm,296: Cannot read "NT Representative\'T
  proc name: sendfax (/obj/machinery/photocopier/faxmachine/proc/sendfax)
  usr: Leeann Phan (farie82) (/mob/living/carbon/human)
  usr.loc: The floor (121,124,2) (/turf/simulated/floor/wood)
  src: the long range fax machine (/obj/machinery/photocopier/faxmachine/longrange)
  src.loc: the floor (120,124,2) (/turf/simulated/floor/wood)
  call stack:
  the long range fax machine (/obj/machinery/photocopier/faxmachine/longrange): sendfax("NT Representative\'s Office", Leeann Phan (/mob/living/carbon/human))
  the long range fax machine (/obj/machinery/photocopier/faxmachine/longrange): ui act("send", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/default (/datum/ui_state/default))
  /datum/tgui (/datum/tgui): Topic("src=%5B0x21017338%5D_656&actio...", /list (/list))
  Farie82 (/client): Topic("src=%5B0x21017338%5D_656&actio...", /list (/list), /datum/tgui (/datum/tgui))
```

## Why It's Good For The Game
Less runtimes more funtimes

## Changelog
:cl:
fix: A fax will properly display that you send it when you remove the paper too fast
/:cl: