### PR TITLE
Remove duplicate tracking implants

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_track.dm
+++ b/code/game/objects/items/weapons/implants/implant_track.dm
@@ -30,11 +30,3 @@
 				circuitry. As a result neurotoxins can cause massive damage.<HR>
 				Implant Specifics:<BR>"}
 	return dat
-
-/obj/item/implantcase/track
-	name = "implant case - 'Tracking'"
-	desc = "A glass case containing a tracking implant."
-
-/obj/item/implantcase/track/New()
-	imp = new /obj/item/implant/tracking(src)
-	..()

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -560,7 +560,7 @@
 	req_tech = list("materials" = 2, "biotech" = 3, "magnets" = 3, "programming" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
-	build_path = /obj/item/implantcase/track
+	build_path = /obj/item/implantcase/tracking
 	category = list("Medical")
 
 //Cybernetic organs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Removes /obj/item/implantcase/track, and replaces the buildpath for tracking implants from protolathe with 
/obj/item/implantcase/tracking

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Having 2 paths for the exact same thing is silly.

## Changelog
:cl:
tweak: Removed /obj/item/implantcase/track as /obj/item/implantcase/tracking exists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
