### PR TITLE
A little bit more GDPR compliance stuff

### DIFF
--- a/code/controllers/configuration/sections/system_configuration.dm
+++ b/code/controllers/configuration/sections/system_configuration.dm
@@ -24,11 +24,14 @@
 	var/instance_id = "paradise_main"
 	/// Server internal IP
 	var/internal_ip = "127.0.0.1"
+	/// Are we using an external handler for TOS
+	var/external_tos_handler = FALSE
 
 /datum/configuration_section/system_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
 	CONFIG_LOAD_BOOL(shutdown_on_reboot, data["shutdown_on_reboot"])
 	CONFIG_LOAD_BOOL(is_production, data["is_production"])
+	CONFIG_LOAD_BOOL(external_tos_handler, data["external_tos_handler"])
 
 	CONFIG_LOAD_STR(topic_key, data["communications_password"])
 	CONFIG_LOAD_STR(medal_hub_address, data["medal_hub_address"])

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -138,6 +138,22 @@
 	if(href_list["link_forum_account"])
 		link_forum_account()
 		return // prevents a recursive loop where the ..() 5 lines after this makes the proc endlessly re-call itself
+	if(href_list["withdraw_consent"])
+		var/choice = alert(usr, "Are you SURE you want to withdraw your consent to the Terms of Service?\nYou will be instantaneously removed from the server and will have to re-accept the Terms of Service.", "Warning", "Yes", "No")
+		if(choice == "Yes")
+			// Update the DB
+			var/datum/db_query/query = SSdbcore.NewQuery("REPLACE INTO privacy (ckey, datetime, consent) VALUES (:ckey, Now(), 0)", list(
+			"ckey" = ckey
+			))
+			if(!query.warn_execute())
+				to_chat(usr, "Well, this is embarassing. We tried to save your ToS withdrawal but the DB failed. Please contact the server host")
+				return
+
+			// I know its a very rare occurance, but I wouldnt doubt people using this to withdraw consent right when sec captures them
+			message_admins("[key_name_admin(usr)] was disconnected due to withdrawing their ToS consent.")
+			to_chat(usr, "<span class='boldannounce'>Your ToS consent has been withdrawn. You have been kicked from the server</span>")
+			del(src)
+
 	switch(href_list["action"])
 		if("openLink")
 			src << link(href_list["link"])
@@ -1025,6 +1041,22 @@
 		SSambience.ambience_listening_clients[src] = world.time + 10 SECONDS //Just wait 10 seconds before the next one aight mate? cheers.
 	else
 		SSambience.ambience_listening_clients -= src
+
+
+// Verb scoped to the client level so its ALWAYS available
+/client/verb/open_tos()
+	set category = "OOC"
+	set name = "Terms of Service"
+
+	var/output = GLOB.join_tos
+	output += "<hr><p>By withdrawing your consent, you acknowledge that you will be instantaneously kicked from the server and will have to re-accept the Terms of Service. If you do not wish to withdraw your consent at this moment, feel free to close this window.</p>"
+	output += "<p><a href='byond://?src=[UID()];withdraw_consent=1'>Withdraw consent</a></p>"
+	src << browse(output,"window=privacy_consent;size=600x500")
+	var/datum/browser/popup = new(src, "privacy_consent", "<div align='center'>Privacy Consent</div>", 500, 400)
+	popup.set_content(output)
+	popup.open(FALSE)
+	return
+
 
 #undef LIMITER_SIZE
 #undef CURRENT_SECOND

--- a/code/modules/client/login_processing/30-tos_consent.dm
+++ b/code/modules/client/login_processing/30-tos_consent.dm
@@ -13,9 +13,9 @@
 		C.tos_consent = TRUE
 		return
 
-	// If our query failed, just assume yes
+	// If our query failed dont just assume yes
 	if(Q.last_error)
-		C.tos_consent = TRUE
+		C.tos_consent = FALSE
 		return
 
 	// If we returned a row, they accepted

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -22,20 +22,24 @@
 /mob/new_player/verb/new_player_panel()
 	set src = usr
 
-	if(client.tos_consent)
+	if(client.tos_consent || GLOB.configuration.system.external_tos_handler)
 		new_player_panel_proc()
 	else
 		privacy_consent()
 
 
 /mob/new_player/proc/privacy_consent()
-	src << browse(null, "window=playersetup")
 	var/output = GLOB.join_tos
-	output += "<p><a href='byond://?src=[UID()];consent_signed=SIGNED'>I consent</A>"
-	output += "<p><a href='byond://?src=[UID()];consent_rejected=NOTSIGNED'>I DO NOT consent</A>"
+	// Dont blank out the other window. This one is read only.
+	if(!GLOB.configuration.system.external_tos_handler)
+		src << browse(null, "window=playersetup")
+		output += "<p><a href='byond://?src=[UID()];consent_signed=SIGNED'>I consent</A>"
+		output += "<p><a href='byond://?src=[UID()];consent_rejected=NOTSIGNED'>I DO NOT consent</A>"
 	src << browse(output,"window=privacy_consent;size=500x300")
 	var/datum/browser/popup = new(src, "privacy_consent", "<div align='center'>Privacy Consent</div>", 500, 400)
-	popup.set_window_options("can_close=0")
+	// Let them close it here, this is a read only pane
+	if(!GLOB.configuration.system.external_tos_handler)
+		popup.set_window_options("can_close=0")
 	popup.set_content(output)
 	popup.open(0)
 	return

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -741,6 +741,8 @@ instance_id = "paradise_main"
 # Server internal IP. Used if you are splitting instances over multiple internal IPs.
 # In most cases this is just 127.0.0.1
 internal_ip = "127.0.0.1"
+# Are we handling TOS consents on an external service?
+external_tos_handler = false
 
 
 ################################################################


### PR DESCRIPTION
## What Does This PR Do
This PR allows the game server to handle TOS consent on an external server before you are routed to the main server. It also adds a simple way to withdraw your consent ingame. Note that withdrawal of consent and requesting erasure of data are different things.

Currently, we already log information about users before they accept the TOS. **This is bad**, as we would be storing data about users without their consent. This also ties in with a TOS update that Shadey is working on for us. Expect an update to that soon. 

## Why It's Good For The Game
Complying with scary european law stuff is important.

## Changelog
:cl: AffectedArc07
tweak: Reworked server ToS to be a bit more compliant. 
/:cl:
