### PR TITLE
Display container transfer amounts on examine.

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -84,3 +84,7 @@
 			to_chat(user, "<span class='notice'>You fill [src] from [source].</span>")
 			return
 	..()
+
+/obj/item/reagent_containers/examine(mob/user)
+	. = ..()
+	. += list("<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this > 1 ? "s" : ""] at a time.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR is a simple quality-of-life change which extends container descriptions to display their transfer amounts.

Whether this is a "feature" or otherwise with respect to the feature freeze I leave up to the headmins to decide.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Currently the only way to check the transfer amount of a container is to 1) pick it up, 2) right-click -> "Set Transfer Amount", then 3) close the dialog box that has opened. This provides a reasonable and straightforward shortcut.

## Images of changes

![transfer_amounts](https://user-images.githubusercontent.com/59303604/150861147-7ba43fe9-60ae-4026-8793-092eea5140cc.png)


## Changelog
:cl:
tweak: Examining containers now displays their current reagent transfer amount.
/:cl:
