### PR TITLE
[GBP: no update] Fixes a runtime with vampire datums

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -365,7 +365,7 @@
 	else
 		bodytemperature += (BODYTEMP_HEATING_MAX + (fire_stacks * 12))
 		var/datum/antagonist/vampire/V = mind?.has_antag_datum(/datum/antagonist/vampire)
-		if(!V?.get_ability(/datum/vampire_passive/full) && stat != DEAD)
+		if(V && !V.get_ability(/datum/vampire_passive/full) && stat != DEAD)
 			V.bloodusable = max(V.bloodusable - 5, 0)
 
 /mob/living/carbon/human/proc/get_thermal_protection()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime occurring when a non-vampire is on fire due to their vamp datum being `null`. Partially reverts some code in #17351. Moral of the story is be *very* careful when you combine `!` with the `?.` operator.

![image](https://user-images.githubusercontent.com/42044220/151085532-cbb069d6-4491-4c90-ae28-66d7d328a2c9.png)

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Fixes a runtime occurring when a non-vampire is on fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
