### PR TITLE
Tweaks MC logic

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -90,7 +90,7 @@
 		queue_node_priority = queue_node.queued_priority
 		queue_node_flags = queue_node.flags
 
-		if(queue_node_flags & SS_TICKER)
+		if(queue_node_flags & (SS_TICKER|SS_BACKGROUND) == SS_TICKER)
 			if((SS_flags & (SS_TICKER|SS_BACKGROUND)) != SS_TICKER)
 				continue
 			if(queue_node_priority < SS_priority)


### PR DESCRIPTION
## What Does This PR Do

Ports tgstation/tgstation#64500

Paste from the original PR 

---
For maybe a week now we've been seeing very concerning behavior on live. Background subsystems like atmos processing at full tilt, while standard subsystems absolutely blow chunks

Requeued ss_ticker subsystems were breaking the mc's processing queue and tricking it into setting the background toggle while processing non background subsystems.

The MC tracks the total priority of a queue by increasing a number when a subsystem is queued, and decreasing it when it's processed. One for background subsystems and one for normal ones. They're reset when a queue is finished

A fucked up queue order will lead to these values getting desynced, and if we're unable to complete a full run, they'll never reset.

So the background priority will go to -INFINITY and the normal priority will go to INFINITY.

---

## Why It's Good For The Game
The MC crying bloody murder for no reason is bad

## Changelog
:cl: AffectedArc07 (Original PR by MSO)
tweak: Tweaked some logic on the MC
/:cl:
