### PR TITLE
Fix - Cigarette machines create the right circuit board when disassembled, and added or tweaked remaining vendors so they can be built properly

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -232,6 +232,7 @@ to destroy them and players will be able to make replacements.
 	req_components = list(/obj/item/vending_refill/boozeomat = 1)
 
 	var/static/list/vending_names_paths = list(
+		"ArtVend" =								/obj/machinery/vending/artvend,
 		"Booze-O-Mat" =							/obj/machinery/vending/boozeomat,
 		"Solar's Best Hot Drinks" =				/obj/machinery/vending/coffee,
 		"Getmore Chocolate Corp" =				/obj/machinery/vending/snack,
@@ -239,6 +240,7 @@ to destroy them and players will be able to make replacements.
 		"Robust Softdrinks" =					/obj/machinery/vending/cola,
 		"ShadyCigs Deluxe" =					/obj/machinery/vending/cigarette,
 		"ShadyCigs Ultra" =						/obj/machinery/vending/cigarette/beach,
+		"Suspicious Cigarette Machine" =		/obj/machinery/vending/syndicigs,
 		"Hatlord 9000" =						/obj/machinery/vending/hatdispenser,
 		"Suitlord 9000" =						/obj/machinery/vending/suitdispenser,
 		"Shoelord 9000" =						/obj/machinery/vending/shoedispenser,
@@ -249,6 +251,7 @@ to destroy them and players will be able to make replacements.
 		"Vendomat" =							/obj/machinery/vending/assist,
 		"YouTool" =								/obj/machinery/vending/tool,
 		"Engi-Vend" =							/obj/machinery/vending/engivend,
+		"Toximate 3000" =						/obj/machinery/vending/plasmaresearch,
 		"NutriMax" =							/obj/machinery/vending/hydronutrients,
 		"MegaSeed Servitor" =					/obj/machinery/vending/hydroseeds,
 		"Sustenance Vendor" =					/obj/machinery/vending/sustenance,
@@ -257,6 +260,7 @@ to destroy them and players will be able to make replacements.
 		"Robotech Deluxe" =						/obj/machinery/vending/robotics,
 		"Robco Tool Maker" =					/obj/machinery/vending/engineering,
 		"BODA" =								/obj/machinery/vending/sovietsoda,
+		"Syndicate Donksoft Toy Vendor" =		/obj/machinery/vending/toyliberationstation,
 		"SecTech" =								/obj/machinery/vending/security,
 		"CritterCare" =							/obj/machinery/vending/crittercare,
 		"SecDrobe" =							/obj/machinery/vending/secdrobe,

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -238,6 +238,7 @@ to destroy them and players will be able to make replacements.
 		"Mr. Chang" =							/obj/machinery/vending/chinese,
 		"Robust Softdrinks" =					/obj/machinery/vending/cola,
 		"ShadyCigs Deluxe" =					/obj/machinery/vending/cigarette,
+		"ShadyCigs Ultra" =						/obj/machinery/vending/cigarette/beach,
 		"Hatlord 9000" =						/obj/machinery/vending/hatdispenser,
 		"Suitlord 9000" =						/obj/machinery/vending/suitdispenser,
 		"Shoelord 9000" =						/obj/machinery/vending/shoedispenser,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1117,7 +1117,7 @@
 	resistance_flags = FIRE_PROOF
 
 /obj/machinery/vending/cigarette
-	name = "cigarette machine"
+	name = "\improper ShadyCigs Deluxe"
 	desc = "If you want to get cancer, might as well do it in style."
 	slogan_list = list("Space cigs taste good like a cigarette should.","I'd rather toolbox than switch.","Smoke!","Don't believe the reports - smoke today!")
 	ads_list = list("Probably not bad for you!","Don't believe the scientists!","It's good for you!","Don't quit, buy more!","Smoke!","Nicotine heaven.","Best cigarettes since 2150.","Award-winning cigs.")

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -942,7 +942,7 @@
 
 
 /obj/machinery/vending/coffee
-	name = "\improper Hot Drinks machine"
+	name = "\improper Solar's Best Hot Drinks"
 	desc = "A vending machine which dispenses hot drinks."
 	ads_list = list("Have a drink!","Drink up!","It's good for you!","Would you like a hot joe?","I'd kill for some coffee!","The best beans in the galaxy.","Only the finest brew for you.","Mmmm. Nothing like a coffee.","I like coffee, don't you?","Coffee helps you work!","Try some tea.","We hope you like the best!","Try our new chocolate!","Admin conspiracies")
 	icon_state = "coffee"
@@ -1542,7 +1542,7 @@
 	resistance_flags = FIRE_PROOF
 
 /obj/machinery/vending/engivend
-	name = "\improper Engi-vend"
+	name = "\improper Engi-Vend"
 	desc = "Spare tool vending. What? Did you expect some witty description?"
 	icon_state = "engivend"
 	icon_deny = "engivend_deny"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Due to the way machine frames handle circuit boards, using their names, the cigarette machines would runtime if you used the boards from their disassembly as they were plainly called "cigarette machine" instead of "ShadyCigs Deluxe".

Construction could use a refactor, but for now this simply renames a few machines, and adds the missing mapped in vendors to the list of circuit boards.

- "cigarette machine" > "ShadyCigs Deluxe"
- "Hot Drinks machine" > "Solar's Best Hot Drinks"
- ArtVend, Syndi cigarette machine, Toximate, and the Donksoft Toy Vendor are added to the board list as they're either mapped into the stations, or in ruins.

## Why It's Good For The Game
Fixes #17375. In general, makes it so vendors can be consistently taken apart and rebuilt.

## Images of changes
https://user-images.githubusercontent.com/80771500/151641063-5ced245a-fde2-4c3d-8ded-ff712353eb57.mp4

## Changelog
:cl:
tweak: Cigarette machine renamed to ShadyCigs Deluxe
tweak: Hot drinks machine renamed to Solar's Best Hot Drinks
fix: The following machines can be disassembled and rebuilt properly: Cigarette machines, hot drinks machines, ArtVend, Toximate, Donksoft Toy Vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
