### PR TITLE
Make SSinstancing no longer sleep, fixing client stuff

### DIFF
--- a/code/controllers/subsystem/instancing.dm
+++ b/code/controllers/subsystem/instancing.dm
@@ -43,17 +43,19 @@ SUBSYSTEM_DEF(instancing)
 	var/ckey_json = json_encode(ckeys)
 
 	// Yes I care about performance savings this much here to mass execute this shit
-	var/list/datum/db_query/queries = list()
-	queries += SSdbcore.NewQuery("UPDATE instance_data_cache SET key_value=:json WHERE key_name='playerlist' AND server_id=:sid", list(
+	var/datum/db_query/dbq = SSdbcore.NewQuery("UPDATE instance_data_cache SET key_value=:json WHERE key_name='playerlist' AND server_id=:sid", list(
 		"json" = ckey_json,
 		"sid" = GLOB.configuration.system.instance_id
 	))
-	queries += SSdbcore.NewQuery("UPDATE instance_data_cache SET key_value=:count WHERE key_name='playercount' AND server_id=:sid", list(
+	dbq.warn_execute(FALSE, FALSE)
+	qdel(dbq)
+
+	dbq = SSdbcore.NewQuery("UPDATE instance_data_cache SET key_value=:count WHERE key_name='playercount' AND server_id=:sid", list(
 		"count" = length(ckeys),
 		"sid" = GLOB.configuration.system.instance_id
 	))
-
-	SSdbcore.MassExecute(queries, TRUE, TRUE, FALSE, FALSE)
+	dbq.warn_execute(FALSE, FALSE)
+	qdel(dbq)
 
 /**
   * Heartbeat updater

--- a/code/controllers/subsystem/instancing.dm
+++ b/code/controllers/subsystem/instancing.dm
@@ -47,15 +47,15 @@ SUBSYSTEM_DEF(instancing)
 		"json" = ckey_json,
 		"sid" = GLOB.configuration.system.instance_id
 	))
-	dbq.warn_execute(FALSE, FALSE)
+	dbq.warn_execute(FALSE)
 	qdel(dbq)
 
-	dbq = SSdbcore.NewQuery("UPDATE instance_data_cache SET key_value=:count WHERE key_name='playercount' AND server_id=:sid", list(
+	var/datum/db_query/dbq2 = SSdbcore.NewQuery("UPDATE instance_data_cache SET key_value=:count WHERE key_name='playercount' AND server_id=:sid", list(
 		"count" = length(ckeys),
 		"sid" = GLOB.configuration.system.instance_id
 	))
-	dbq.warn_execute(FALSE, FALSE)
-	qdel(dbq)
+	dbq2.warn_execute(FALSE)
+	qdel(dbq2)
 
 /**
   * Heartbeat updater


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
- Replaces `SSinstancing.update_playercache()`'s call to `MassExecute` by separate, synchronous queries to prevent sleeping because it is called during `/client/New()` and `/client/Destroy()` and they shouldn't sleep ever

No CL, culls a fair amount of runtimes and issues plaguing us recently.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
