### PR TITLE
Hides the contents of the PDA slot in the strip menu

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -396,7 +396,7 @@
 				dat += "<font color=grey>Right (Empty)</font>"
 			dat += "</A></td></tr>"
 			dat += "<tr><td>&nbsp;&#8627;<B>ID:</B></td><td><A href='?src=[UID()];item=[slot_wear_id]'>[(wear_id && !(wear_id.flags&ABSTRACT)) ? html_encode(wear_id) : "<font color=grey>Empty</font>"]</A></td></tr>"
-			dat += "<tr><td>&nbsp;&#8627;<B>PDA:</B></td><td><A href='?src=[UID()];item=[slot_wear_pda]'>[(wear_pda && !(wear_pda.flags&ABSTRACT)) ? html_encode(wear_pda) : "<font color=grey>Empty</font>"]</A></td></tr>"
+			dat += "<tr><td>&nbsp;&#8627;<B>PDA:</B></td><td><A href='?src=[UID()];item=[slot_wear_pda]'>[(wear_pda && !(wear_pda.flags&ABSTRACT)) ? "Full" : "<font color=grey>Empty</font>"]</A></td></tr>"
 
 			if(istype(w_uniform, /obj/item/clothing/under))
 				var/obj/item/clothing/under/U = w_uniform

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -770,15 +770,24 @@
 
 /mob/living/proc/check_ear_prot()
 
+/**
+ * Returns the name override, if any, for the slot somebody is trying to strip
+ */
+/mob/living/proc/get_strip_slot_name_override(slot)
+	switch(slot)
+		if(slot_wear_pda)
+			return "PDA"
+
 // The src mob is trying to strip an item from someone
 // Override if a certain type of mob should be behave differently when stripping items (can't, for example)
 /mob/living/stripPanelUnequip(obj/item/what, mob/who, where, silent = 0)
+	var/item_name = get_strip_slot_name_override(where) || what.name
 	if(what.flags & NODROP)
-		to_chat(src, "<span class='warning'>You can't remove \the [what.name], it appears to be stuck!</span>")
+		to_chat(src, "<span class='warning'>You can't remove \the [item_name], it appears to be stuck!</span>")
 		return
 	if(!silent)
-		who.visible_message("<span class='danger'>[src] tries to remove [who]'s [what.name].</span>", \
-						"<span class='userdanger'>[src] tries to remove [who]'s [what.name].</span>")
+		who.visible_message("<span class='danger'>[src] tries to remove [who]'s [item_name].</span>", \
+						"<span class='userdanger'>[src] tries to remove [who]'s [item_name].</span>")
 	what.add_fingerprint(src)
 	if(do_mob(src, who, what.strip_delay))
 		if(what && what == who.get_item_by_slot(where) && Adjacent(who))


### PR DESCRIPTION
## What Does This PR Do
Makes it so that you can't view the contents of the PDA slot using the strip menu.

I ain't fully sure about the solution. But it was the best I could come up with quickly without reworking more parts of inventory code.

## Why It's Good For The Game
Makes the behaviour the same as with examining somebody. Also fixes an exploit where you can see the identity of somebody by opening the strip menu while stunned or cuffed.
An alternative to fix this exploit was to make the menu close when stunned. TGUIifying this screen would fix that.

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/152178359-95927503-a273-48c7-b27c-944c153bd010.png)

![image](https://user-images.githubusercontent.com/15887760/152178347-8faae79f-c603-47cc-9f73-39f73bd7e870.png)
When removing an item from the PDA slot. Also shown when you have a pinpointer or such in that slot.

## Changelog
:cl:
tweak: You can't see the contents of the PDA slot in the strip menu now
/:cl: