### PR TITLE
Various Fixes to DeltaStation

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -9866,6 +9866,10 @@
 	location = "QM #3"
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/camera{
+	c_tag = "Cargo Dock West";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aFq" = (
@@ -20684,6 +20688,9 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/toy/figure/crew/cargotech,
+/obj/machinery/computer/guestpass{
+	pixel_y = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -20977,6 +20984,9 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Supply Lobby"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21455,6 +21465,9 @@
 /area/quartermaster/miningdock)
 "bcH" = (
 /obj/structure/table/reinforced,
+/obj/machinery/camera{
+	c_tag = "Mining Access"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -35685,6 +35698,9 @@
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/machinery/computer/guestpass{
+	pixel_y = 30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
@@ -38796,7 +38812,7 @@
 /area/security/detectives_office)
 "bLo" = (
 /obj/machinery/camera{
-	c_tag = "Research Toxins Storage Room";
+	c_tag = "Detective's Office";
 	dir = 4;
 	network = list("Research","SS13");
 	pixel_y = -22
@@ -46404,7 +46420,7 @@
 	pixel_x = -24;
 	pixel_y = 8
 	},
-/obj/machinery/computer/med_data/laptop,
+/obj/machinery/computer/guestpass/hop,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark"
@@ -46475,7 +46491,7 @@
 /area/tcommsat/chamber)
 "caY" = (
 /obj/machinery/camera/motion{
-	c_tag = "MiniSat AI Upload";
+	c_tag = "MiniSat Telecomms";
 	network = list("SS13","Minisat");
 	start_active = 1
 	},
@@ -67416,6 +67432,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/computer/guestpass{
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -67681,6 +67700,9 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitebluecorner"
@@ -67786,12 +67808,19 @@
 	},
 /area/medical/medbay3)
 "cWa" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplefull"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/assembly/robotics)
+/obj/machinery/camera{
+	c_tag = "Port Hallway South"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port)
 "cWb" = (
 /obj/machinery/light{
 	dir = 1
@@ -78369,11 +78398,6 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
@@ -78385,6 +78409,26 @@
 	dir = 4;
 	name = "west bump";
 	pixel_x = -24
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -131151,7 +131195,7 @@ bxh
 bxh
 bxh
 bxh
-bSy
+cWa
 bUI
 bWH
 ctU
@@ -133241,12 +133285,12 @@ vYC
 mzQ
 viE
 nbz
-cYA
+dvf
 cTI
 mhT
 vVf
 vFq
-cYA
+dvf
 dau
 dbP
 cPn
@@ -133498,7 +133542,7 @@ cLX
 cNx
 cPg
 cTJ
-cYA
+dvf
 cMl
 dni
 vrp
@@ -133760,7 +133804,7 @@ cVj
 cVj
 cPh
 cYo
-cYA
+dvf
 daB
 mLW
 tMu
@@ -134274,7 +134318,7 @@ cTJ
 cVj
 cWN
 cVj
-cYA
+dvf
 dau
 dbP
 cPn
@@ -134526,7 +134570,7 @@ cMb
 cVj
 cPk
 cTJ
-cYA
+dvf
 vrF
 fMg
 dmd
@@ -134783,12 +134827,12 @@ cMc
 hAi
 tsN
 cRb
-cYA
+dvf
 cTL
 cVl
 cWP
 jbq
-cYA
+dvf
 dau
 dbP
 cPn
@@ -135040,12 +135084,12 @@ cYz
 cYz
 cYz
 jLB
-cYA
-cYA
-cYA
-cYA
-cYA
-cYA
+dvf
+dvf
+dvf
+dvf
+dvf
+dvf
 dtS
 dbP
 cPn
@@ -138659,7 +138703,7 @@ dqp
 drK
 dce
 dce
-cWa
+ddJ
 dql
 dql
 dql

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -46868,7 +46868,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Library North";
+	c_tag = "Library Fore";
 	dir = 8
 	},
 /obj/machinery/newscaster{
@@ -56893,6 +56893,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Library Aft";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -60858,7 +60862,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j2s";
@@ -60876,7 +60882,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66767,7 +66775,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Chemistry";
 	dir = 8;
-	network = list("Research","SS13","Security")
+	network = list("Research","SS13")
 	},
 /obj/machinery/chem_dispenser,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -67401,10 +67409,10 @@
 /turf/simulated/floor/plasteel,
 /area/medical/research)
 "cUZ" = (
-/obj/machinery/light/small{
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/medical/research)
 "cVb" = (
@@ -68745,8 +68753,8 @@
 	},
 /area/toxins/xenobiology)
 "cYj" = (
-/obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/south,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/medical/research)
 "cYk" = (
@@ -72078,10 +72086,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
-"dfh" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/hor)
 "dfi" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -73306,6 +73310,12 @@
 	},
 /obj/structure/displaycase/labcage,
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the RD's goons from the safety of his office.";
+	name = "Research Monitor";
+	network = list("Research","MiniSat","RD");
+	pixel_y = 30
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dhO" = (
@@ -80506,8 +80516,8 @@
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
 /obj/machinery/camera{
-	c_tag = "Research Outpost Temporary Storage";
-	network = list("Research Outpost")
+	c_tag = "Research Toxins Launch";
+	network = list("Research","SS13")
 	},
 /obj/structure/disaster_counter/toxins{
 	pixel_y = 32
@@ -134580,7 +134590,7 @@ cYz
 dau
 dbP
 cPn
-dfh
+dff
 dhN
 djp
 djH

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -23668,6 +23668,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "bhC" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> Properly names some security cameras, adds a few to some blind spots, adds guest pass terminals to each department, gives robotics more metal (and adds some plasteel) to bring it to parity with round start BoxStation, gives botany a disk compartmentalizer, gives the RD the Research Monitor, and reinforces science chemistry's walls.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Good to fix oversights and improper camera names

## Changelog
:cl:
Fix: Renames some security cameras, fills blinds spots, adds guess pass terminals, disk compartmentalizer for botany, research monitoring camera, and stocks robotics more on DeltaStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
