### PR TITLE
Fix - Tranquillite airlock uses the proper door assembly

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -227,6 +227,7 @@
 /obj/machinery/door/airlock/tranquillite
 	name = "tranquillite airlock"
 	icon = 'icons/obj/doors/airlocks/station/freezer.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_tranquillite
 	doorOpen = null // it's silent!
 	doorClose = null
 	doorDeni = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This assigns the tranquillite door assembly to the tranquillite airlock.

## Why It's Good For The Game
Fixes the general behavior of tranquillite airlock. Dissassembling, or severely damaging it will not cause it to turn into a default airlock assembly, and in turn will give back tranquillite ore as the assembly being taken apart uses more than metal.

## Images of changes
![MimeDoor1](https://user-images.githubusercontent.com/80771500/152664453-ee07f888-0872-42d9-a938-9ea7a1482881.png)

## Changelog
:cl:
fix: Tranquillite airlocks can be disassembled or destroyed into their core components properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
