### PR TITLE
Fix matter eater spamming chat when it can't cast

### DIFF
--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -391,7 +391,8 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if((C.head && (C.head.flags_cover & HEADCOVERSMOUTH)) || (C.wear_mask && (C.wear_mask.flags_cover & MASKCOVERSMOUTH) && !C.wear_mask.mask_adjusted))
-			to_chat(C, "<span class='warning'>Your mouth is covered, preventing you from eating!</span>")
+			if(show_message)
+				to_chat(C, "<span class='warning'>Your mouth is covered, preventing you from eating!</span>")
 			can_eat = FALSE
 	return can_eat
 


### PR DESCRIPTION
## What Does This PR Do
Fixes a mistake from the spell targeting refactor.

Fixes #17396

## Why It's Good For The Game
Bug fix

## Changelog
:cl:
fix: Matter eater now won't spam your chat when you are wearing a mask
/:cl: