### PR TITLE
Goonchat Error Message Tweak

### DIFF
--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -31,9 +31,10 @@
 		<div>
 			Loading...<br><br>
 			If this takes longer than 10 seconds, it will automatically reload, multiple times if necessary.<br>
-			If it <b>still</b> doesn't work, do not adminhelp (F1), you will not see our responses.<br>
-			Please see <a href="https://paradisestation.org/wiki/index.php/Goonchat_Troubleshooting">This Guide</a> and seek help on our discord #helpchat
-
+			If it <b>still</b> does not reload, do not open an adminhelp, you will be unable to see our responses.<br>
+			Please instead click the wiki button in the top right of your screen and type "Goonchat Troubleshooting" <br>
+			This will provide possible solutions, furthermore please seek help on our discord #helpchat if this <br>
+			issue cannot be resolved on your own.
 		</div>
 	</div>
 	<div id="messages">


### PR DESCRIPTION
## What Does This PR Do
Edits the goonchat error message when it fails to load it properly.

## Why It's Good For The Game
Hyperlinks are not clickable when goonchat fails to load, this change instead directs the user to use a method to get to the goonchat troubleshooting guide that actually works.

## Changelog
:cl:
tweak: Tweaked Goonchat Error Message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
