### PR TITLE
Adds seclite to the HoS' and the blueshield's lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -103,6 +103,7 @@
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/holosign_creator/security(src)
 	new /obj/item/shield/riot/tele(src)
+	new /obj/item/flashlight/seclite(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/gun/energy/gun/hos(src)
 	new /obj/item/door_remote/head_of_security(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -175,6 +175,7 @@
 	new /obj/item/storage/briefcase(src)
 	new	/obj/item/storage/firstaid/adv(src)
 	new /obj/item/pinpointer/crew(src)
+	new /obj/item/flashlight/seclite(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/read_only(src)


### PR DESCRIPTION
## What Does This PR Do
Adds a seclite to the HoS' and the blueshield's lockers.

## Why It's Good For The Game
The blueshield's seclite was apparently there before but it was removed with the security belt's rework. (#17389)
The HoS' one was reported on the chat by @hal9000PR.

This PR only adds the seclite to their lockers, not their loadouts, as security officers don't get to spawn with seclites either. (Tried to keep consistency.)

## Images of changes
![image](https://user-images.githubusercontent.com/33333517/154071089-1f9bc549-5bea-48e5-88a8-1763bedbd65d.png)
![image](https://user-images.githubusercontent.com/33333517/154087578-e39274eb-7585-4618-833a-f36ca3d23ec0.png)

## Changelog
:cl:
add: Re-added the seclite to the Blueshield's and the Head of Security's lockers.
/:cl:
