### PR TITLE
Adds video camera to protolathe designs

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -61,7 +61,7 @@
 	build_path = /obj/item/camera/digital
 	category = list("Miscellaneous")
 
-/datum/design/digital_camera
+/datum/design/video_camera
 	name = "Video Camera"
 	desc = "Produce a video camera that can send live feed to the entertainment network."
 	id = "videocamera"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -61,6 +61,16 @@
 	build_path = /obj/item/camera/digital
 	category = list("Miscellaneous")
 
+/datum/design/digital_camera
+	name = "Video Camera"
+	desc = "Produce a video camera that can send live feed to the entertainment network."
+	id = "videocamera"
+	req_tech = list("programming" = 3, "materials" = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
+	build_path = /obj/item/videocam
+	category = list("Miscellaneous")
+
 /datum/design/safety_muzzle
 	name = "Safety Muzzle"
 	desc = "Produce a lockable muzzle keyed to security ID cards"


### PR DESCRIPTION
## What Does This PR Do
Adds the entertainment monitor video camera to the R&D protolathe

## Why It's Good For The Game
There is no other way to get the Video Camera except spawning in as the librarian. Otherwise you have to ahelp to get one. There's no reason why players shouldn't be able to get this item

## Changelog
:cl:
add: Video Camera can now be acquired in the protolathe
/:cl: