### PR TITLE
Ammo boxes now return materials properly.

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -117,14 +117,13 @@
 	var/caliber
 	var/multiload = 1
 	var/list/initial_mats //For calculating refund values.
+	var/mats_initialized=FALSE
 
 /obj/item/ammo_box/New()
 	..()
 	for(var/i in 1 to max_ammo)
 		stored_ammo += new ammo_type(src)
 	update_icon()
-	initial_mats = materials.Copy()
-	update_mat_value()
 
 /obj/item/ammo_box/Destroy()
 	QDEL_LIST(stored_ammo)
@@ -139,6 +138,10 @@
 		stored_ammo -= b
 		if(keep)
 			stored_ammo.Insert(1,b)
+		if(!mats_initialized){
+			initial_mats = materials.Copy()
+			mats_initialized=TRUE
+		}
 		update_mat_value()
 		update_icon()
 		return b

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -138,10 +138,9 @@
 		stored_ammo -= b
 		if(keep)
 			stored_ammo.Insert(1,b)
-		if(!mats_initialized){
+		if(!mats_initialized)
 			initial_mats = materials.Copy()
-			mats_initialized=TRUE
-		}
+			mats_initialized = TRUE
 		update_mat_value()
 		update_icon()
 		return b

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -137,7 +137,7 @@
 		stored_ammo -= b
 		if(keep)
 			stored_ammo.Insert(1,b)
-		if(initial_mats==null)
+		if(!initial_mats)
 			initial_mats = materials.Copy()
 		update_mat_value()
 		update_icon()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -117,7 +117,7 @@
 	var/caliber
 	var/multiload = 1
 	var/list/initial_mats //For calculating refund values.
-	var/mats_initialized=FALSE
+	var/mats_initialized = FALSE
 
 /obj/item/ammo_box/New()
 	..()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -117,7 +117,6 @@
 	var/caliber
 	var/multiload = 1
 	var/list/initial_mats //For calculating refund values.
-	var/mats_initialized = FALSE
 
 /obj/item/ammo_box/New()
 	..()
@@ -138,9 +137,8 @@
 		stored_ammo -= b
 		if(keep)
 			stored_ammo.Insert(1,b)
-		if(!mats_initialized)
+		if(initial_mats==null)
 			initial_mats = materials.Copy()
-			mats_initialized = TRUE
 		update_mat_value()
 		update_icon()
 		return b


### PR DESCRIPTION

## What Does This PR Do
Ammo boxes (and speedloaders) used to give more materials if a bullet was taken out, than it took to make the ammo box. This PR fixes that bug/exploit. Fixes #17388 

## Why It's Good For The Game
No more infinite metal from the autolathe.


## Changelog
:cl: Iwanabeu
fix: Autolathed ammo boxes/speedloaders give correct materials back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
