### PR TITLE
Borg locker verb fix.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -295,11 +295,11 @@
 	if(ishuman(usr))
 		add_fingerprint(usr)
 		toggle(usr)
-	else
-		if(isrobot(usr))
-			toggle(usr)
-		else
-			to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		return
+	if(isrobot(usr))
+		toggle(usr)
+		return
+	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	if(!opened)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -295,10 +295,11 @@
 	if(ishuman(usr))
 		add_fingerprint(usr)
 		toggle(usr)
-	else if(isrobot(usr))
-		toggle(usr)
 	else
-		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		if(isrobot(usr))
+			toggle(usr)
+		else
+			to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	if(!opened)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -295,6 +295,8 @@
 	if(ishuman(usr))
 		add_fingerprint(usr)
 		toggle(usr)
+	else if(isrobot(usr))
+		toggle(usr)
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -292,11 +292,8 @@
 	if(usr.incapacitated())
 		return
 
-	if(ishuman(usr))
+	if(ishuman(usr) || isrobot(usr))
 		add_fingerprint(usr)
-		toggle(usr)
-		return
-	if(isrobot(usr))
 		toggle(usr)
 		return
 	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -90,11 +90,8 @@
 	if(usr.incapacitated()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
 		return
 
-	if(ishuman(usr))
+	if(ishuman(usr)||isrobot(usr))
 		add_fingerprint(usr)
-		togglelock(usr)
-		return
-	if(isrobot(usr))
 		togglelock(usr)
 		return
 	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -93,11 +93,11 @@
 	if(ishuman(usr))
 		add_fingerprint(usr)
 		togglelock(usr)
-	else
-		if(isrobot(usr))
-			togglelock(usr)
-		else
-			to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		return
+	if(isrobot(usr))
+		togglelock(usr)
+		return
+	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/secure_closet/update_overlays() //Putting the welded stuff in update_overlays() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	cut_overlays()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -93,10 +93,11 @@
 	if(ishuman(usr))
 		add_fingerprint(usr)
 		togglelock(usr)
-	else if(isrobot(usr))
-		togglelock(usr)
 	else
-		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		if(isrobot(usr))
+			togglelock(usr)
+		else
+			to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/secure_closet/update_overlays() //Putting the welded stuff in update_overlays() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	cut_overlays()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -93,6 +93,8 @@
 	if(ishuman(usr))
 		add_fingerprint(usr)
 		togglelock(usr)
+	else if(isrobot(usr))
+		togglelock(usr)
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -28,9 +28,9 @@
 	return TRUE
 
 /obj/structure/closet/crate/open(by_hand = FALSE)
-	if(src.opened)
+	if(opened)
 		return FALSE
-	if(!src.can_open())
+	if(!can_open())
 		return FALSE
 
 	if(by_hand)
@@ -54,7 +54,7 @@
 	for(var/mob/M in src) //Mobs
 		M.forceMove(loc)
 	icon_state = icon_opened
-	src.opened = TRUE
+	opened = TRUE
 
 	if(climbable)
 		structure_shaken()
@@ -62,9 +62,9 @@
 	return TRUE
 
 /obj/structure/closet/crate/close()
-	if(!src.opened)
+	if(!opened)
 		return FALSE
-	if(!src.can_close())
+	if(!can_close())
 		return FALSE
 
 	playsound(loc, close_sound, close_sound_volume, TRUE, -3)
@@ -82,7 +82,7 @@
 		itemcount++
 
 	icon_state = icon_closed
-	src.opened = FALSE
+	opened = FALSE
 	return TRUE
 
 /obj/structure/closet/crate/attackby(obj/item/W, mob/user, params)
@@ -133,7 +133,7 @@
 /obj/structure/closet/crate/attack_hand(mob/user)
 	if(manifest)
 		to_chat(user, "<span class='notice'>You tear the manifest off of the crate.</span>")
-		playsound(src.loc, 'sound/items/poster_ripped.ogg', 75, 1)
+		playsound(loc, 'sound/items/poster_ripped.ogg', 75, 1)
 		manifest.forceMove(loc)
 		if(ishuman(user))
 			user.put_in_hands(manifest)
@@ -147,15 +147,15 @@
 				if(L.electrocute_act(17, src))
 					do_sparks(5, 1, src)
 					return
-		src.add_fingerprint(user)
-		src.toggle(user, by_hand = TRUE)
+		add_fingerprint(user)
+		toggle(user, by_hand = TRUE)
 
 // Called when a crate is delivered by MULE at a location, for notifying purposes
 /obj/structure/closet/crate/proc/notifyRecipient(destination)
 	var/list/msg = list("[capitalize(name)] has arrived at [destination].")
 	if(destination in announce_beacons)
 		for(var/obj/machinery/requests_console/D in GLOB.allRequestConsoles)
-			if(D.department in src.announce_beacons[destination])
+			if(D.department in announce_beacons[destination])
 				D.createMessage(name, "Your Crate has Arrived!", msg, 1)
 
 /obj/structure/closet/crate/secure
@@ -208,14 +208,14 @@
 	return !locked
 
 /obj/structure/closet/crate/secure/proc/togglelock(mob/user)
-	if(src.opened)
+	if(opened)
 		to_chat(user, "<span class='notice'>Close the crate first.</span>")
 		return
-	if(src.broken)
+	if(broken)
 		to_chat(user, "<span class='warning'>The crate appears to be broken.</span>")
 		return
-	if(src.allowed(user))
-		src.locked = !src.locked
+	if(allowed(user))
+		locked = !locked
 		visible_message("<span class='notice'>The crate has been [locked ? null : "un"]locked by [user].</span>")
 		update_icon()
 	else
@@ -230,18 +230,18 @@
 		return
 
 	if(ishuman(usr))
-		src.add_fingerprint(usr)
-		src.togglelock(usr)
+		add_fingerprint(usr)
+		togglelock(usr)
 		return
 	if(isrobot(usr))
-		src.togglelock(usr)
+		togglelock(usr)
 		return
 	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/crate/secure/attack_hand(mob/user)
 	if(manifest)
 		to_chat(user, "<span class='notice'>You tear the manifest off of the crate.</span>")
-		playsound(src.loc, 'sound/items/poster_ripped.ogg', 75, 1)
+		playsound(loc, 'sound/items/poster_ripped.ogg', 75, 1)
 		manifest.forceMove(loc)
 		if(ishuman(user))
 			user.put_in_hands(manifest)
@@ -249,9 +249,9 @@
 		update_icon()
 		return
 	if(locked)
-		src.togglelock(user)
+		togglelock(user)
 	else
-		src.toggle(user, by_hand = TRUE)
+		toggle(user, by_hand = TRUE)
 
 /obj/structure/closet/crate/secure/closed_item_click(mob/user)
 	togglelock(user)
@@ -261,8 +261,8 @@
 		overlays += sparks
 		spawn(6) overlays -= sparks //Tried lots of stuff but nothing works right. so i have to use this *sadface*
 		playsound(src.loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		src.locked = 0
-		src.broken = 1
+		locked = 0
+		broken = 1
 		update_icon()
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
 
@@ -271,19 +271,19 @@
 		O.emp_act(severity)
 	if(!broken && !opened  && prob(50/severity))
 		if(!locked)
-			src.locked = 1
+			locked = 1
 		else
 			overlays += sparks
 			spawn(6) overlays -= sparks //Tried lots of stuff but nothing works right. so i have to use this *sadface*
 			playsound(src, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-			src.locked = 0
+			locked = 0
 		update_icon()
 	if(!opened && prob(20/severity))
 		if(!locked)
 			open()
 		else
-			src.req_access = list()
-			src.req_access += pick(get_all_accesses())
+			req_access = list()
+			req_access += pick(get_all_accesses())
 	..()
 
 /obj/structure/closet/crate/plastic
@@ -460,7 +460,7 @@
 	. = ..()
 	if(.)//we can hold up to one large item
 		var/found = 0
-		for(var/obj/structure/S in src.loc)
+		for(var/obj/structure/S in loc)
 			if(S == src)
 				continue
 			if(!S.anchored)
@@ -468,7 +468,7 @@
 				S.forceMove(src)
 				break
 		if(!found)
-			for(var/obj/machinery/M in src.loc)
+			for(var/obj/machinery/M in loc)
 				if(!M.anchored)
 					M.forceMove(src)
 					break
@@ -486,7 +486,7 @@
 	. = ..()
 	if(.)//we can hold up to one large item
 		var/found = 0
-		for(var/obj/structure/S in src.loc)
+		for(var/obj/structure/S in loc)
 			if(S == src)
 				continue
 			if(!S.anchored)
@@ -494,7 +494,7 @@
 				S.forceMove(src)
 				break
 		if(!found)
-			for(var/obj/machinery/M in src.loc)
+			for(var/obj/machinery/M in loc)
 				if(!M.anchored)
 					M.forceMove(src)
 					break

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -232,11 +232,11 @@
 	if(ishuman(usr))
 		src.add_fingerprint(usr)
 		src.togglelock(usr)
-	else
-		if(isrobot(usr))
-			src.togglelock(usr)
-		else
-			to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		return
+	if(isrobot(usr))
+		src.togglelock(usr)
+		return
+	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/crate/secure/attack_hand(mob/user)
 	if(manifest)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -232,10 +232,11 @@
 	if(ishuman(usr))
 		src.add_fingerprint(usr)
 		src.togglelock(usr)
-	else if(isrobot(usr))
-		src.togglelock(usr)
 	else
-		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		if(isrobot(usr))
+			src.togglelock(usr)
+		else
+			to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/crate/secure/attack_hand(mob/user)
 	if(manifest)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -133,7 +133,7 @@
 /obj/structure/closet/crate/attack_hand(mob/user)
 	if(manifest)
 		to_chat(user, "<span class='notice'>You tear the manifest off of the crate.</span>")
-		playsound(loc, 'sound/items/poster_ripped.ogg', 75, 1)
+		playsound(loc, 'sound/items/poster_ripped.ogg', 75, TRUE)
 		manifest.forceMove(loc)
 		if(ishuman(user))
 			user.put_in_hands(manifest)
@@ -229,11 +229,8 @@
 	if(!usr.canmove || usr.stat || usr.restrained()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
 		return
 
-	if(ishuman(usr))
+	if(ishuman(usr) || isrobot(usr))
 		add_fingerprint(usr)
-		togglelock(usr)
-		return
-	if(isrobot(usr))
 		togglelock(usr)
 		return
 	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
@@ -261,8 +258,8 @@
 		overlays += sparks
 		spawn(6) overlays -= sparks //Tried lots of stuff but nothing works right. so i have to use this *sadface*
 		playsound(src.loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		locked = 0
-		broken = 1
+		locked = FALSE
+		broken = TRUE
 		update_icon()
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
 
@@ -271,12 +268,12 @@
 		O.emp_act(severity)
 	if(!broken && !opened  && prob(50/severity))
 		if(!locked)
-			locked = 1
+			locked = TRUE
 		else
 			overlays += sparks
 			spawn(6) overlays -= sparks //Tried lots of stuff but nothing works right. so i have to use this *sadface*
 			playsound(src, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-			locked = 0
+			locked = FALSE
 		update_icon()
 	if(!opened && prob(20/severity))
 		if(!locked)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -232,6 +232,8 @@
 	if(ishuman(usr))
 		src.add_fingerprint(usr)
 		src.togglelock(usr)
+	else if(isrobot(usr))
+		src.togglelock(usr)
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 


### PR DESCRIPTION
## What Does This PR Do
Borgs can now use the locker/crate verbs via right click or object menu, to toggle and open lockers/crate, since they already can by clicking the locker. Fixes #17371.

## Why It's Good For The Game
The ability is already there, but now players can use the verb if they want to, or right click.

## Changelog
:cl: Iwanabeu
tweak: Borgs can use locker/crate verbs to open or lock.
/:cl:
