### PR TITLE
Borgs and drones can now replace glass floors.

### DIFF
--- a/code/game/turfs/simulated/floor/transparent.dm
+++ b/code/game/turfs/simulated/floor/transparent.dm
@@ -44,8 +44,18 @@
 /turf/simulated/floor/transparent/glass/crowbar_act(mob/user, obj/item/I)
 	if(!I || !user)
 		return
-	var/obj/item/stack/R = user.get_inactive_hand()
-	if(istype(R, /obj/item/stack/sheet/metal))
+	var/obj/item/stack/R
+	if(ishuman(user))
+		R = user.get_inactive_hand()
+	if(isrobot(user))
+		var mob/living/silicon/robot/robouser = user
+		if(istype(robouser.module_state_1,/obj/item/stack/sheet/metal))
+			R=robouser.module_state_1
+		if(istype(robouser.module_state_2,/obj/item/stack/sheet/metal))
+			R=robouser.module_state_2
+		if(istype(robouser.module_state_3,/obj/item/stack/sheet/metal))
+			R=robouser.module_state_3
+	if(istype(R,/obj/item/stack/sheet/metal))
 		if(R.get_amount() < 2) //not enough metal in the stack
 			to_chat(user, "<span class='danger'>You also need to hold two sheets of metal to dismantle [src]!</span>")
 			return

--- a/code/game/turfs/simulated/floor/transparent.dm
+++ b/code/game/turfs/simulated/floor/transparent.dm
@@ -47,15 +47,16 @@
 	var/obj/item/stack/R
 	if(ishuman(user))
 		R = user.get_inactive_hand()
-	if(isrobot(user))
-		var mob/living/silicon/robot/robouser = user
-		if(istype(robouser.module_state_1,/obj/item/stack/sheet/metal))
-			R=robouser.module_state_1
-		if(istype(robouser.module_state_2,/obj/item/stack/sheet/metal))
-			R=robouser.module_state_2
-		if(istype(robouser.module_state_3,/obj/item/stack/sheet/metal))
-			R=robouser.module_state_3
-	if(istype(R,/obj/item/stack/sheet/metal))
+	else if(isrobot(user))
+		var/mob/living/silicon/robot/robouser = user
+		if(istype(robouser.module_state_1, /obj/item/stack/sheet/metal))
+			R = robouser.module_state_1
+		else if(istype(robouser.module_state_2, /obj/item/stack/sheet/metal))
+			R = robouser.module_state_2
+		else if(istype(robouser.module_state_3, /obj/item/stack/sheet/metal))
+			R = robouser.module_state_3
+
+	if(istype(R, /obj/item/stack/sheet/metal))
 		if(R.get_amount() < 2) //not enough metal in the stack
 			to_chat(user, "<span class='danger'>You also need to hold two sheets of metal to dismantle [src]!</span>")
 			return


### PR DESCRIPTION
## What Does This PR Do
Cyborgs and maintenance drones can now replace glass doors like normal, with crowbar in one module and metal in any other. Fixes #17366, Fixes #17286.

## Why It's Good For The Game
Since glass floors can be used in construction, makes sense for robots to be able to remove them.

## Changelog
:cl: Iwanabeu
fix:Borgs and drones can now replace glass floors with metal.
/:cl: