### PR TITLE
Automatic handling of majorly-colliding CIDs

### DIFF
--- a/code/controllers/configuration/sections/admin_configuration.dm
+++ b/code/controllers/configuration/sections/admin_configuration.dm
@@ -13,6 +13,8 @@
 	var/list/ckey_rank_map = list()
 	/// Assoc list of admin ranks and their colours. key: rank | value: rank colour
 	var/list/rank_colour_map = list()
+	/// Assoc list of CIDs which shouldnt be banned due to mass collisions
+	var/list/common_cid_map = list()
 
 /datum/configuration_section/admin_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
@@ -37,6 +39,12 @@
 		rank_colour_map.Cut()
 		for(var/list/kvset in data["admin_rank_colour_map"])
 			rank_colour_map[kvset["name"]] = kvset["colour"]
+
+	// Load common CIDs
+	if(islist(data["common_cid_map"]))
+		common_cid_map.Cut()
+		for(var/list/kvset in data["common_cid_map"])
+			common_cid_map[kvset["cid"]] = kvset["reason"]
 
 	// For the person who asks "Why not put admin datum generation in this step?", well I will tell you why
 	// Admins can be reloaded at runtime when DB edits are made and such, and I dont want an entire config reload to be part of this

--- a/code/modules/admin/db_ban/functions.dm
+++ b/code/modules/admin/db_ban/functions.dm
@@ -112,6 +112,12 @@
 			to_chat(usr, "<span class='danger'>You cannot apply this ban type on yourself.</span>")
 			return
 
+	// Check validity of the CID. Some have a lot of collisions due to bad industry practices (thanks walmart)
+	if(computerid && (computerid in GLOB.configuration.admin.common_cid_map))
+		to_chat(usr, "<span class='notice'>You attempted to apply a ban that includes the CID [computerid]. This CID has been ignored for the following reason: [GLOB.configuration.admin.common_cid_map[computerid]]</span>")
+		// Cancel it out. DO NOT USE NULL HERE. IT MAKES THE DB CRY. USE AN EMPTY STRING.
+		computerid = ""
+
 	var/who
 	for(var/client/C in GLOB.clients)
 		if(!who)

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -91,6 +91,10 @@ admin_rank_colour_map = [
 	{name = "PR Reviewer", colour = "#c27c0e"},
 	{name = "Mentor", colour = "#f1c40f"},
 ]
+# Map of common CIDs that should not be banned, plus their reasons
+common_cid_map = [
+	{cid = "3923664137", reason = "Mass-Match related to Walmart branded prebuilt PCs"}
+]
 
 
 ################################################################


### PR DESCRIPTION
## What Does This PR Do
Adds a config option for a list of CIDs and their collision reasons.

Non admins may not know this, but walmart makes our life hell, as all their prebuilts have the same windows image with no changes, causing issues within BYOND. Occasionally this CID gets accidentally banned, and we end up banning 160 people without realising. This PR puts in code that allows us to automatically cancel this out.

![image](https://user-images.githubusercontent.com/25063394/154262792-166168e9-5863-4b50-b78f-f675eb496f60.png)

![image](https://user-images.githubusercontent.com/25063394/154262806-c3681840-1fb6-4b39-9f63-c92ff7d3bca6.png)
*Note the blank CID field* 

## Why It's Good For The Game
Mass banning people because walmart cant make PCs isnt good

## Changelog
:cl: AffectedArc07
add: Added a safety net to avoid 160 people being mass banned because Walmart cant produce computers properly
/:cl:
