### PR TITLE
Make kitchen machines show all contents on examine.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -350,9 +350,7 @@
 			found += A.search_contents_for(path, filter_path)
 	return found
 
-
-//All atoms
-/atom/proc/examine(mob/user, infix = "", suffix = "")
+/atom/proc/build_base_description(infix = "", suffix = "")
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
 	var/f_name = "\a [src][infix]."
 	if(src.blood_DNA && !istype(src, /obj/effect/decal))
@@ -368,6 +366,8 @@
 	if(desc)
 		. += desc
 
+/atom/proc/build_reagent_description(mob/user)
+	. = list()
 	if(reagents)
 		if(container_type & TRANSPARENT)
 			. += "<span class='notice'>It contains:</span>"
@@ -386,6 +386,10 @@
 				. += "<span class='notice'>It has [reagents.total_volume] unit\s left.</span>"
 			else
 				. += "<span class='danger'>It's empty.</span>"
+
+/atom/proc/examine(mob/user, infix = "", suffix = "")
+	. = build_base_description(infix, suffix)
+	. += build_reagent_description(user)
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -161,6 +161,51 @@
 *   Machine Menu	*
 ********************/
 
+/obj/machinery/kitchen_machine/proc/format_content_descs()
+	. = ""
+	var/list/items_counts = new
+	var/list/items_measures = new
+	var/list/items_measures_p = new
+	for(var/obj/O in contents)
+		var/display_name = O.name
+		if(istype(O,/obj/item/reagent_containers/food/snacks/egg))
+			items_measures[display_name] = "egg"
+			items_measures_p[display_name] = "eggs"
+		if(istype(O,/obj/item/reagent_containers/food/snacks/tofu))
+			items_measures[display_name] = "tofu chunk"
+			items_measures_p[display_name] = "tofu chunks"
+		if(istype(O,/obj/item/reagent_containers/food/snacks/meat)) //any meat
+			items_measures[display_name] = "slab of meat"
+			items_measures_p[display_name] = "slabs of meat"
+		if(istype(O,/obj/item/reagent_containers/food/snacks/donkpocket))
+			display_name = "Turnovers"
+			items_measures[display_name] = "turnover"
+			items_measures_p[display_name] = "turnovers"
+		if(istype(O,/obj/item/reagent_containers/food/snacks/carpmeat))
+			items_measures[display_name] = "fillet of meat"
+			items_measures_p[display_name] = "fillets of meat"
+		items_counts[display_name]++
+
+	for(var/O in items_counts)
+		var/N = items_counts[O]
+		if(!(O in items_measures))
+			. += {"<B>[capitalize(O)]:</B> [N] [lowertext(O)]\s<BR>"}
+		else
+			if(N==1)
+				. += {"<B>[capitalize(O)]:</B> [N] [items_measures[O]]<BR>"}
+			else
+				. += {"<B>[capitalize(O)]:</B> [N] [items_measures_p[O]]<BR>"}
+
+	for(var/datum/reagent/R in reagents.reagent_list)
+		var/display_name = R.name
+		if(R.id == "capsaicin")
+			display_name = "Hotsauce"
+		if(R.id == "frostoil")
+			display_name = "Coldsauce"
+
+		. += {"<B>[display_name]:</B> [R.volume] unit\s<BR>"}
+
+
 /obj/machinery/kitchen_machine/interact(mob/user) // The microwave Menu
 	if(panel_open || !anchored)
 		return
@@ -172,50 +217,12 @@
 	else if(dirty==100)
 		dat = {"<code>This [src] is dirty!<BR>Please clean it before use!</code>"}
 	else
-		var/list/items_counts = new
-		var/list/items_measures = new
-		var/list/items_measures_p = new
-		for(var/obj/O in contents)
-			var/display_name = O.name
-			if(istype(O,/obj/item/reagent_containers/food/snacks/egg))
-				items_measures[display_name] = "egg"
-				items_measures_p[display_name] = "eggs"
-			if(istype(O,/obj/item/reagent_containers/food/snacks/tofu))
-				items_measures[display_name] = "tofu chunk"
-				items_measures_p[display_name] = "tofu chunks"
-			if(istype(O,/obj/item/reagent_containers/food/snacks/meat)) //any meat
-				items_measures[display_name] = "slab of meat"
-				items_measures_p[display_name] = "slabs of meat"
-			if(istype(O,/obj/item/reagent_containers/food/snacks/donkpocket))
-				display_name = "Turnovers"
-				items_measures[display_name] = "turnover"
-				items_measures_p[display_name] = "turnovers"
-			if(istype(O,/obj/item/reagent_containers/food/snacks/carpmeat))
-				items_measures[display_name] = "fillet of meat"
-				items_measures_p[display_name] = "fillets of meat"
-			items_counts[display_name]++
-		for(var/O in items_counts)
-			var/N = items_counts[O]
-			if(!(O in items_measures))
-				dat += {"<B>[capitalize(O)]:</B> [N] [lowertext(O)]\s<BR>"}
-			else
-				if(N==1)
-					dat += {"<B>[capitalize(O)]:</B> [N] [items_measures[O]]<BR>"}
-				else
-					dat += {"<B>[capitalize(O)]:</B> [N] [items_measures_p[O]]<BR>"}
-
-		for(var/datum/reagent/R in reagents.reagent_list)
-			var/display_name = R.name
-			if(R.id == "capsaicin")
-				display_name = "Hotsauce"
-			if(R.id == "frostoil")
-				display_name = "Coldsauce"
-			dat += {"<B>[display_name]:</B> [R.volume] unit\s<BR>"}
-
-		if(items_counts.len==0 && reagents.reagent_list.len==0)
-			dat = {"<B>[src] is empty</B><BR>"}
-		else
+		dat += format_content_descs()
+		if(dat)
 			dat = {"<b>Ingredients:</b><br>[dat]"}
+		else
+			dat = {"<B>[src] is empty</B><BR>"}
+
 		dat += {"<HR><BR>\
 <A href='?src=[UID()];action=cook'>Turn on!</A><BR>\
 <A href='?src=[UID()];action=dispose'>Eject ingredients!</A><BR>\
@@ -439,3 +446,20 @@
 		if("dispose")
 			dispose()
 	return
+
+/obj/machinery/kitchen_machine/proc/build_ingredient_description()
+	if(contents)
+		var/list/contents_strings
+		var/list/item_counts
+		for(var/datum/I in contents)
+			item_counts[I.type] += 1
+		for(var/T in item_counts)
+			contents_strings += ""
+
+/obj/machinery/kitchen_machine/examine(mob/user, infix = "", suffix = "")
+	. = build_base_description(infix, suffix)
+	var/dat = format_content_descs()
+	if(dat)
+		. += "It contains: <BR>[dat]"
+
+	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -447,19 +447,11 @@
 			dispose()
 	return
 
-/obj/machinery/kitchen_machine/proc/build_ingredient_description()
-	if(contents)
-		var/list/contents_strings
-		var/list/item_counts
-		for(var/datum/I in contents)
-			item_counts[I.type] += 1
-		for(var/T in item_counts)
-			contents_strings += ""
+/obj/machinery/kitchen_machine/build_reagent_description(mob/user)
+	return
 
 /obj/machinery/kitchen_machine/examine(mob/user, infix = "", suffix = "")
-	. = build_base_description(infix, suffix)
+	. = ..()
 	var/dat = format_content_descs()
 	if(dat)
 		. += "It contains: <BR>[dat]"
-
-	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)


### PR DESCRIPTION
## What Does This PR Do

This PR subclasses `/atom/proc/examine` for kitchen machines.

`/atom/proc/examine` only has an awareness of reagents for the purposes of examining atoms. Kitchen machines have both reagents and non-reagent contents, but there's no implementation for displaying both sets of ingredients on examine.

The code that builds these descriptions was refactored into separate procs, which are used in the new examine override on kitchen machines. This should ensure that the actual content of these messages remains the same whether you're using the dialog box or the examine.

## Why It's Good For The Game

Kitchen machine UI and interaction models are a random jumble in general, and putting this information in an examine allows for one less necessary dialog box interaction.

## Images of changes

**Before**

With just ingredients:

![before_ingredients](https://user-images.githubusercontent.com/59303604/150826404-60453ab2-c661-4335-9be1-33c02b3ca340.png)

With ingredients and reagents:

![before_ingredients_and_reagents](https://user-images.githubusercontent.com/59303604/150826410-05351755-1bd4-4ff0-803d-203225bf5d67.png)

**After**

With just ingredients: 

![after_ingredients](https://user-images.githubusercontent.com/59303604/150826747-a1cae51b-fdcb-4d40-826a-623615ab3162.png)

With just reagents:

![after_reagents](https://user-images.githubusercontent.com/59303604/150826851-818cf39c-b66d-4a4a-a0d6-1c73f63d0303.png)

With ingredients and reagents:

![after_ingredients_and_reagents](https://user-images.githubusercontent.com/59303604/150826866-f1c7eb35-ab64-4615-89fd-776d36e24553.png)

## Changelog
:cl:
add: Examining kitchen machines now displays all of their contents, not just reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
