### PR TITLE
Removes CE Items from Engineering and Atmospheric Clothes Vendor

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2016,7 +2016,6 @@
 					/obj/item/clothing/suit/storage/hazardvest = 3,
 					/obj/item/clothing/head/beret/eng = 3,
 					/obj/item/clothing/head/hardhat = 2,
-					/obj/item/clothing/head/hardhat/white = 2,
 					/obj/item/clothing/head/hardhat/orange = 2,
 					/obj/item/clothing/head/hardhat/dblue = 2,
 					/obj/item/clothing/accessory/armband/engine = 6,
@@ -2026,8 +2025,7 @@
 					/obj/item/storage/backpack/satchel_eng = 2,
 					/obj/item/storage/backpack/duffel/engineering = 2,
 					/obj/item/storage/belt/utility = 2)
-	premium = list(/obj/item/storage/belt/utility/chief = 2,
-					/obj/item/clothing/gloves/color/yellow = 2)
+	premium = list(/obj/item/clothing/gloves/color/yellow = 2)
 	contraband = list(/obj/item/toy/figure/crew/ce = 1,
 				      /obj/item/toy/figure/crew/engineer = 1)
 	refill_canister = /obj/item/vending_refill/engidrobe
@@ -2047,7 +2045,6 @@
 					/obj/item/clothing/head/beret/atmos = 3,
 					/obj/item/clothing/head/hardhat = 2,
 					/obj/item/clothing/head/hardhat/red = 2,
-					/obj/item/clothing/head/hardhat/white = 2,
 					/obj/item/clothing/head/hardhat/orange = 2,
 					/obj/item/clothing/head/hardhat/dblue = 2,
 					/obj/item/clothing/gloves/color/black = 3,
@@ -2058,7 +2055,6 @@
 					/obj/item/storage/backpack/satchel_eng = 2,
 					/obj/item/storage/backpack/duffel/atmos = 2,
 					/obj/item/storage/belt/utility = 2)
-	premium = list(/obj/item/storage/belt/utility/chief = 2)
 	contraband = list(/obj/item/toy/figure/crew/atmos = 1)
 	refill_canister = /obj/item/vending_refill/atmosdrobe
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes the White Hardhat and Chief Engineer Belt from the Engineering and Atmospheric Clothes Vendors.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Keeps Chief Engineer unique items to the Chief Engineer, as it seems odd their department could acquire a white hardhat (associated with the Chief Engineer) or a Chief Engineer Toolbelt.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl: Quantum-M
del: Removes Chief Engineer items from the Engineering and Atmospheric Clothes Vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
