### PR TITLE
Fixes ToS decline issues

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -58,7 +58,7 @@
 		// If there is no row, they didnt accept
 		if(!check_query.NextRow())
 			qdel(check_query)
-			return list("reason"="tos", "desc"="\nReason: You are trying to connect without accepting server ToS. If this error persists, please contact the server host.")
+			return list("reason"="tos", "desc"="\nReason: You are trying to connect without accepting server ToS. If you did not get a ToS popup, please go to paradise13.org/fixtos")
 
 		qdel(check_query)
 		// As per my comment 8 or so lines above, we do NOT log failed connections here


### PR DESCRIPTION
## What Does This PR Do
Adds a link to the ToS denied message that will forcefully route the players next connection to the ToS server first, fixing the issues if they had previously logged in with a guest account or if they are on a multi-user connection. 

## Why It's Good For The Game
Less time spent dealing with support tickets

## Changelog
N/A 