### PR TITLE
Fixes decks vanishing into bluespace

### DIFF
--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -215,28 +215,57 @@
 		playsound(user, 'sound/items/cardshuffle.ogg', 50, 1)
 		cooldown = world.time
 
+/**
+  * Occurs when the deck is click-dragged onto something
+  * 
+  *
+  * This is overridden to be a method to pick up the deck.
+  * It is overridden because the normal method of picking up (attack_hand) is overridden to draw a card.
+  * Current behaviour is:
+  *  	Drag onto self when it's not in your inventory to put it in your hands
+  *  	Drag onto self when it's in your inventory to drop it
+  *  	Drag onto hands to put it into your hands from anywhere
+  *  	If none of the above, call parent since we might want the deck to interact with a MouseDrop_T object
+  *
+  * Arguments:
+  * * over_object - The atom the deck was dragged onto
+  */
+/obj/item/deck/MouseDrop(atom/over_object) //Code duplicated in paper bin and /obj/item/toy/cards/deck
+	//This is code from atom/MouseDrop, we're not calling parent after because if we fail here, we'd fail there. This probably isn't the best
+	if(!usr || !over_object)
+		return
+	if(!(istype(over_object, /obj/screen) || (loc && loc == over_object.loc)))
+		if(!Adjacent(usr) || !over_object.Adjacent(usr)) // should stop you from dragging through windows
+			return
 
-/obj/item/deck/MouseDrop(atom/over_object) // Code from Paper bin, so you can still pick up the deck
 	var/mob/M = usr
-	if(M.incapacitated() || !Adjacent(M))
-		return
-	if(!ishuman(M))
+	if(M.incapacitated() || !ishuman(M))
+		..() 
 		return
 
-	if(over_object == M || istype(over_object, /obj/screen))
-		if(!remove_item_from_storage(M))
+	if(over_object == M)
+		if(src in M.get_contents())
 			M.unEquip(src)
-		if(over_object != M)
-			switch(over_object.name)
-				if("r_hand")
-					M.put_in_r_hand(src)
-				if("l_hand")
-					M.put_in_l_hand(src)
+			usr.visible_message("<span class='notice'>[M] drops [src].</span>")
 		else
 			M.put_in_hands(src)
-
+			usr.visible_message("<span class='notice'>[M] picks up [src].</span>")
 		add_fingerprint(M)
-		usr.visible_message("<span class='notice'>[usr] picks up the deck.</span>")
+		return
+
+	if(istype(over_object, /obj/screen/inventory/hand))
+		switch(over_object.name)
+			if("r_hand")
+				M.put_in_r_hand(src)
+			if("l_hand")
+				M.put_in_l_hand(src)
+		usr.visible_message("<span class='notice'>[M] picks up [src].</span>")
+		add_fingerprint(M)
+		return
+
+	..() //If it isn't a deck specific action, call parent
+	return
+
 
 /obj/item/pack
 	name = "card pack"


### PR DESCRIPTION
## What Does This PR Do
This PR reworks MouseDrop on decks and Paper bins to fix a few bugs.
Specifically, fixes a bug where pulling a deck from an inventory onto a UI element that isn't your hands sends the deck into the user. Also fixes being able to pick up decks through glass panes. 

Closes #17401
Closes #12774
Closes #12193

Closes #11326
This was not intentional, but dragging a deck from a storage implant into your hands works now. 
## Why It's Good For The Game
Things dissapearing into bluespace is bad, as being able to pull things through glass.

## Changelog
:cl:
fix: Fixed decks and paper bins vanishing into bluespace
fix: Fixed decks and paper bins being able to be pulled through glass
/:cl:
