### PR TITLE
Improve defibrillator messaging

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -467,7 +467,6 @@
 							playsound(get_turf(src), 'sound/machines/defib_saftyoff.ogg', 50, 0)
 							user.visible_message("<span class='boldnotice'>[defib] chimes: Minimal brain activity detected, brain treatment recommended for full resuscitation.</span>")
 						else
-
 							playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
 						user.visible_message("<span class='boldnotice'>[defib] pings: Resuscitation successful.</span>")
 						H.update_revive()

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -467,8 +467,9 @@
 							playsound(get_turf(src), 'sound/machines/defib_saftyoff.ogg', 50, 0)
 							user.visible_message("<span class='boldnotice'>[defib] chimes: Minimal brain activity detected, brain treatment recommended for full resuscitation.</span>")
 						else
-							user.visible_message("<span class='boldnotice'>[defib] pings: Resuscitation successful.</span>")
+
 							playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
+						user.visible_message("<span class='boldnotice'>[defib] pings: Resuscitation successful.</span>")
 						H.update_revive()
 						H.KnockOut()
 						H.Paralyse(5)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -405,6 +405,11 @@
 			var/tloss = DEFIB_TIME_LOSS
 			var/total_burn	= 0
 			var/total_brute	= 0
+			if(ghost && ghost.can_reenter_corpse)
+				to_chat(ghost, "<span class='ghostalert'>Your heart is being defibrillated. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
+				window_flash(ghost.client)
+				notify_ghosts()
+				ghost << sound('sound/effects/genetics.ogg')
 			if(do_after(user, 20 * toolspeed, target = M)) //placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 				for(var/obj/item/carried_item in H.contents)
 					if(istype(carried_item, /obj/item/clothing/suit/space))
@@ -450,15 +455,20 @@
 					for(var/obj/item/organ/external/O in H.bodyparts)
 						total_brute	+= O.brute_dam
 						total_burn	+= O.burn_dam
-					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK)  && !HAS_TRAIT(H, TRAIT_BADDNA) && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
+					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK) && !HAS_TRAIT(H, TRAIT_BADDNA) && H.blood_volume > BLOOD_VOLUME_SURVIVE && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
 						tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 						tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 						H.adjustOxyLoss(tobehealed)
 						H.adjustToxLoss(tobehealed)
 						H.adjustFireLoss(tobehealed)
 						H.adjustBruteLoss(tobehealed)
-						user.visible_message("<span class='boldnotice'>[defib] pings: Resuscitation successful.</span>")
-						playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
+						if(H.get_int_organ(/obj/item/organ/internal/brain) && H.getBrainLoss() >= 100)
+							// If you want to treat this with mannitol, it'll have to metabolize while the patient is alive, so it's alright to bring them back up for a minute
+							playsound(get_turf(src), 'sound/machines/defib_saftyoff.ogg', 50, 0)
+							user.visible_message("<span class='boldnotice'>[defib] chimes: Minimal brain activity detected, brain treatment recommended for full resuscitation.</span>")
+						else
+							user.visible_message("<span class='boldnotice'>[defib] pings: Resuscitation successful.</span>")
+							playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
 						H.update_revive()
 						H.KnockOut()
 						H.Paralyse(5)
@@ -476,17 +486,16 @@
 						else if(total_burn >= 180 || total_brute >= 180)
 							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Severe tissue damage detected.</span>")
 						else if(HAS_TRAIT(H, TRAIT_HUSK))
-							user.visible_message("<span class='notice'>[defib] buzzes: Resucitation failed: Subject is husked.</span>")
+							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed: Subject is husked.</span>")
+						else if (H.blood_volume < BLOOD_VOLUME_SURVIVE)
+							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed: Patient blood volume critically low.</span>")
 						else if(ghost)
 							if(!ghost.can_reenter_corpse) // DNR or AntagHUD
-								user.visible_message("<span class='notice'>[defib] buzzes: Resucitation failed: No electrical brain activity detected.</span>")
+								user.visible_message("<span class='boldnotice'>[defib] buzzes: Resucitation failed: No electrical brain activity detected.</span>")
 							else
-								user.visible_message("<span class='notice'>[defib] buzzes: Resuscitation failed: Patient's brain is unresponsive. Further attempts may succeed.</span>")
-								to_chat(ghost, "<span class='ghostalert'>Your heart is being defibrillated. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
-								window_flash(ghost.client)
-								ghost << sound('sound/effects/genetics.ogg')
+								user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed: Patient's brain is unresponsive. Further attempts may succeed.</span>")
 						else
-							user.visible_message("<span class='notice'>[defib] buzzes: Resuscitation failed.</span>")
+							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed.</span>")
 						playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
 						defib.deductcharge(revivecost)
 					update_icon()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

I've added a check to prevent revival if the patient's blood level is below the crucial "instant death" threshold, and a message to the defib holder as to why said revival doesn't work, nudging them towards how to fix the problem.
If a player has too much brain damage, the target will be revived, but an alternate sound effect will play from the defib with a message noting that the user needs their brain fixed before they can be properly revived. This will still revive them, particularly so that mannitol can process in their system when applicable, but they will probably still die again in a few seconds due to said brain damage.
Lastly, as a little bonus, I've moved the ghost ping for your body being revived to when the paddles are first placed on your body, before the progress bar even pops up. If you're quick enough, you should be able to get revived on the first shock without a `patient's brain is unresponsive` message.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One thing I've seen over and over again is that a patient with no blood is revived ad nauseum while they die instantly on defibrillation. Same for brain dead patients. There really isn't any feedback specifying *why* the patient dies instantly unless the doc is privy to the situation or gets told what's happening (the sheer amount of times I've been *begging* to LOOC about this-). It's one of those things that's easy to diagnose once you know what to look for, but can otherwise be a huge noob trap or something that you need to be told.
If this information can be provided in-game, it seems like it would be a huge boon.
On that same note, I think giving ghosts the chance to make it into their bodies before the zap would accelerate the whole revival process a lot (saving at least 5 seconds, but in a busy medbay it can add up).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Re-enter body notification now shows up when paddles are first applied.
tweak: Patients with critical blood will now not be defibrillated until their blood levels are restored.
add: Defib will now tell the user when the patient has too much brain damage or insufficient blood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
