### PR TITLE
Removes Russian Revolver from Bartender and Cyberiad Map

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -126,11 +126,11 @@
 	codes_txt = "patrol;next_patrol=Armory_South";
 	location = "Armory_North"
 	},
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/south,
 /mob/living/simple_animal/bot/secbot/armsky{
 	auto_patrol = 1
 	},
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -14725,7 +14725,6 @@
 /area/maintenance/fpmaint2)
 "aIR" = (
 /obj/structure/table,
-/obj/item/toy/russian_revolver,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aIS" = (
@@ -42760,11 +42759,11 @@
 	dir = 8;
 	location = "QM #1"
 	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #1";
 	suffix = "#1"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bRp" = (
@@ -43023,11 +43022,11 @@
 	dir = 8;
 	location = "QM #2"
 	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #2";
 	suffix = "#2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bRX" = (
@@ -53063,8 +53062,8 @@
 "clg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/mob/living/simple_animal/mouse/white,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/white,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "clh" = (
@@ -61988,8 +61987,8 @@
 /area/maintenance/incinerator)
 "cCB" = (
 /obj/machinery/hologram/holopad,
-/mob/living/simple_animal/mouse,
 /obj/effect/landmark/spawner/xeno,
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -62924,7 +62923,6 @@
 /area/toxins/misc_lab)
 "cEp" = (
 /obj/structure/closet,
-/obj/item/toy/russian_revolver,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -66015,8 +66013,8 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cLy" = (
-/mob/living/simple_animal/mouse,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
 "cLz" = (
@@ -66292,8 +66290,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cMg" = (
-/mob/living/simple_animal/slime,
 /obj/effect/landmark/spawner/rev,
+/mob/living/simple_animal/slime,
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "cMh" = (
@@ -74182,9 +74180,9 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dev" = (
-/mob/living/simple_animal/mouse,
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dew" = (

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -149,9 +149,6 @@
 	l_ear = /obj/item/radio/headset/headset_service
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	pda = /obj/item/pda/bar
-	backpack_contents = list(
-		/obj/item/toy/russian_revolver = 1
-	)
 
 /datum/outfit/job/bartender/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes the Russian Revolver from the Bartender and the two mapped on the Cyberiad Map
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The Russian Revolver seems to be very LowRP (that's not taking into account the potential excess medical attention/brain destroying chance it can have), along with it clearly being a noob trap.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl: Quantum-M
del: Removes Russian Revolver from Bartender
del: Removes Russian Revolver from Cyberiad Map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
