### PR TITLE
Fixes ashwalkers being permanently in a state of heart attack

### DIFF
--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -117,4 +117,14 @@
 	default_language = "Sinta'unathi"
 
 	speed_mod = -0.80
-	inherent_traits = list(TRAIT_CHUNKYFINGERS, TRAIT_NOBREATH)
+	inherent_traits = list(TRAIT_CHUNKYFINGERS)
+
+	has_organ = list( // same as unathi's organs, aside for the lungs as they need to be able to breathe on lavaland.
+		"heart" =    /obj/item/organ/internal/heart/unathi,
+		"lungs" =    /obj/item/organ/internal/lungs/unathi/ash_walker,
+		"liver" =    /obj/item/organ/internal/liver/unathi,
+		"kidneys" =  /obj/item/organ/internal/kidneys/unathi,
+		"brain" =    /obj/item/organ/internal/brain/unathi,
+		"appendix" = /obj/item/organ/internal/appendix,
+		"eyes" =     /obj/item/organ/internal/eyes/unathi
+		)

--- a/code/modules/surgery/organs/subtypes/unathi.dm
+++ b/code/modules/surgery/organs/subtypes/unathi.dm
@@ -28,3 +28,6 @@
 /obj/item/organ/internal/kidneys/unathi
 	name = "unathi kidneys"
 	icon = 'icons/obj/species_organs/unathi.dmi'
+
+/obj/item/organ/internal/lungs/unathi/ash_walker
+	safe_oxygen_min = 0 // can breathe on lavaland


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #17156 
ashwalkers can now die of a heart attack, instead of being permanently stunned.

## Why It's Good For The Game
bugs are bad

## Images of changes
![image](https://user-images.githubusercontent.com/69320440/154952866-677fc595-cb98-46c1-8798-3d9aefdc5997.png)
ash walker happily dying :)

## Changelog
:cl:
fix: ash walkers can actually die of a heart attack now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
