### PR TITLE
Replaces unused key shortcut with the admin freeze button

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -39,7 +39,7 @@
 		if(modifiers["shift"] && modifiers["middle"])
 			M = get_mob_in_atom_with_warning(A)
 			if(M)
-				admin_mob_info(M)
+				client.freeze(M)
 			return
 	if(modifiers["middle"])
 		MiddleClickOn(A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Admin can now use shift+middle click to freeze or unfreeze someone, previously this combination of buttons was used for the purpose of displaying mob info which is something mentors get a button for when receieving a mhelp because they dont have AGHOST but pretty useless for an admin who can obtain more information by aghosting towards the player.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sometimes freezing is done in chaotic circumstances, sometimes you might misclick "Get mob" instead or you might be lagging, this pr should help with those issues.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Changelog
:cl:
tweak: administration: Replaced virtually unused key shortcut with the admin freeze button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
