### PR TITLE
Serialize/deserialize uniform accessories.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -699,6 +699,26 @@ BLIND     // can't see anything
 
 	. = ..()
 
+/obj/item/clothing/under/serialize()
+	var/data = ..()
+	var/list/accessories_list = list()
+	data["accessories"] = accessories_list
+	for(var/obj/item/clothing/accessory/A in accessories)
+		accessories_list.len++
+		accessories_list[accessories_list.len] = A.serialize()
+
+	return data
+
+/obj/item/clothing/under/deserialize(list/data)
+	for(var/thing in accessories)
+		remove_accessory(src, thing)
+	for(var/thing in data["accessories"])
+		if(islist(thing))
+			var/obj/item/clothing/accessory/A = list_to_object(thing, src)
+			A.has_suit = src
+			accessories += A
+	..()
+
 /obj/item/clothing/under/proc/attach_accessory(obj/item/clothing/accessory/A, mob/user, unequip = FALSE)
 	if(can_attach_accessory(A))
 		if(unequip && !user.unEquip(A)) // Make absolutely sure this accessory is removed from hands


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds uniform accessories to the list of items serialized to JSON, and the analogous deserialization.

Accessory attachment is tightly coupled with the user that is attaching it or who it is being attached to, so the deserializer attempts manual attachment (`A.has_suit = src` etc). There's probably a much better way to do this.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Crew datums will be more accurate.

## Images of changes

Diff of the serialized JSON before and after this change:

![WinMerge -  before json - after json -11_23_08](https://user-images.githubusercontent.com/59303604/155174586-3a43039f-1f58-4747-a750-f36c6fffea29.png)

Result of deserializing the resultant JSON:

![Paradise Station 13-11_24_10](https://user-images.githubusercontent.com/59303604/155174794-2c711311-4025-42d2-989c-46e66de180c7.png)

![Paradise Station 13-11_24_02](https://user-images.githubusercontent.com/59303604/155174815-fcb08eae-e269-476d-aceb-19362c17e00f.png)

(Changelog section removed due to this changes lack of effect on non-admin players).