### PR TITLE
The return

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,10 @@
 /code/modules/unit_tests/ @AffectedArc07
 /tools/ci/ @AffectedArc07
 
+# Server Stuff
+/SQL/ @AffectedArc07
+/config/ @AffectedArc07
+
 # Executables that need to be security-cleared
 dreamchecker.exe @AffectedArc07
 rust_g.dll @AffectedArc07

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -673,6 +673,7 @@ pull requests/issues, and merging/closing pull requests.
 
 ### Maintainer List
 
+* [AffectedArc07](https://github.com/AffectedArc07)
 * [Ansari](https://github.com/variableundefined)
 * [Crazylemon](https://github.com/marlyn-x86)
 * [dearmochi](https://github.com/dearmochi)


### PR DESCRIPTION
## What Does This PR Do
Re-adds me to the list of maints.

Also adds me as a CODEOWNER for the SQL + config stuff since that is a hosting matter. Should I ever resign as host (I have no intention to), https://github.com/tgstation/tgstation/blob/master/.github/workflows/codeowner_reviews.yml can be used for codeowners without repository access (host does not get repository access in our staff structure, I only have it due to being a maintainer)

## Why It's Good For The Game
I am inevitable

## Changelog
N/A