### PR TITLE
Fixes an exploit relating to syndicate turrets.

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -999,6 +999,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 
 	faction = "syndicate"
 	emp_vulnerable = FALSE
+	density = TRUE
 
 	lethal = TRUE
 	lethal_is_configurable = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents cheesing syndicate turrets by standing on them.

Normal turrets are dense when deployed, syndie turrets are always deployed so they never become dense. this fixes that.

## Why It's Good For The Game
exploits are bad. 

## Changelog
:cl:
fix: you can no longer cheese syndicate turrets by standing on them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
