### PR TITLE
Repair description of irish_cream and beepsky_smash

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -530,7 +530,6 @@
 	color = "#664300" // rgb: 102, 67, 0
 	alcohol_perc = 0.5
 	drink_icon = "beepskysmashglass"
-	description = "Whiskey-imbued cream, what else would you expect from the Irish."
 	drink_name = "Beepsky Smash"
 	drink_desc = "Heavy, hot and strong. Just like the Iron fist of the LAW."
 	taste_description = "THE LAW"
@@ -543,6 +542,7 @@
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"
 	id = "irishcream"
+	description = "Whiskey-imbued cream, what else would you expect from the Irish."
 	reagent_state = LIQUID
 	color = "#664300" // rgb: 102, 67, 0
 	alcohol_perc = 0.3


### PR DESCRIPTION
Beepsky had two descriptions.  Looks like the second one belongs to Irish_cream, which had no description

## What Does This PR Do
Adds a missing description to Irish_Cream which had been placed as a duplicate under beepsky_smash

## Why It's Good For The Game
Fixes drink descriptions


## Changelog
:cl:
fix: Adds a missing description to Irish_Cream which had been placed as a duplicate under beepsky_smash
/:cl:

