### PR TITLE
Fix - Clockwork walls have the proper icons, regular and brass windoors can be properly disassembled, fix a windoor runtime and text

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -342,8 +342,39 @@
 	base_state = "clockwork"
 	shards = 0
 	rods = 0
+	cable = 0
 	resistance_flags = ACID_PROOF | FIRE_PROOF
 	var/made_glow = FALSE
+
+/obj/machinery/door/window/clockwork/crowbar_act(mob/user, obj/item/I)
+	if(operating)
+		return
+	if(flags & NODECONSTRUCT)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	try_to_crowbar(user, I)
+
+/obj/machinery/door/window/clockwork/welder_act(mob/user, obj/item/I)
+	if(operating)
+		return
+	if(flags & NODECONSTRUCT)
+		return
+	if(!panel_open)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	WELDER_ATTEMPT_SLICING_MESSAGE
+	if(!I.use_tool(src, user, 40, volume = I.tool_volume))
+		return
+	if(!panel_open && operating && !loc)
+		return
+	WELDER_FLOOR_SLICE_SUCCESS_MESSAGE
+	var/obj/item/stack/tile/brass/B = new (get_turf(src), 2)
+	B.add_fingerprint(user)
+	qdel(src)
 
 /obj/machinery/door/window/clockwork/spawnDebris(location)
 	. = ..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -280,7 +280,10 @@
 				WA.setDir(dir)
 				WA.ini_dir = dir
 				WA.update_icon()
-				WA.created_name = name
+				if(WA.secure)
+					WA.name = "secure wired windoor assembly"
+				else
+					WA.name = "wired windoor assembly"
 
 				to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -213,15 +213,13 @@
 		windoor.close()
 
 /obj/structure/windoor_assembly/screwdriver_act(mob/user, obj/item/I)
-	if(state != "02" || electronics)
+	if(state != "02" || !electronics)
 		return
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	if(!electronics)
-		return
 	user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to uninstall electronics from the airlock assembly...")
-	if(!I.use_tool(src, user, 40, volume = I.tool_volume) || electronics)
+	if(!I.use_tool(src, user, 40, volume = I.tool_volume))
 		return
 	to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 	name = "wired windoor assembly"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -133,7 +133,7 @@
 			//Adding airlock electronics for access. Step 6 complete.
 			if(istype(W, /obj/item/airlock_electronics) && !istype(W, /obj/item/airlock_electronics/destroyed))
 				playsound(loc, W.usesound, 100, 1)
-				user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly...")
+				user.visible_message("[user] installs the electronics into the windoor assembly.", "You start to install electronics into the windoor assembly...")
 				user.drop_item()
 				W.forceMove(src)
 
@@ -141,7 +141,7 @@
 					if(!src || electronics)
 						W.forceMove(loc)
 						return
-					to_chat(user, "<span class='notice'>You install the airlock electronics.</span>")
+					to_chat(user, "<span class='notice'>You install the windoor electronics.</span>")
 					name = "near finished windoor assembly"
 					electronics = W
 				else
@@ -218,7 +218,7 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to uninstall electronics from the airlock assembly...")
+	user.visible_message("[user] removes the electronics from the windoor assembly.", "You start to uninstall the electronics from the windoor assembly...")
 	if(!I.use_tool(src, user, 40, volume = I.tool_volume))
 		return
 	to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
@@ -234,7 +234,7 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly...")
+	user.visible_message("[user] cuts the wires from the windoor assembly.", "You start to cut the wires from windoor assembly...")
 	if(!I.use_tool(src, user, 40, volume = I.tool_volume) || state != "02")
 		return
 	to_chat(user, "<span class='notice'>You cut the windoor wires.</span>")

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -218,6 +218,8 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+	if(!electronics)
+		return
 	user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to uninstall electronics from the airlock assembly...")
 	if(!I.use_tool(src, user, 40, volume = I.tool_volume) || electronics)
 		return

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -53,6 +53,9 @@
 /turf/simulated/wall/clockwork
 	name = "clockwork wall"
 	desc = "A huge chunk of warm metal. The clanging of machinery emanates from within."
+	icon = 'icons/turf/walls/clockwork_wall.dmi'
+	icon_state = "clockwork_wall-0"
+	base_icon_state = "clockwork_wall"
 	explosion_block = 2
 	hardness = 10
 	slicing_duration = 80


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The right icons are set to the clockwork wall, and also tweaks the brass windoor disassembly to only require opening the panel, and welding, as its only component is brass sheets. It also prevents the removal of nonexistent electronics, and will not yield a cable when destroyed.

At the same this, this also fixes some inconsistencies in the regular windoor, as disassembling one into an assembly and using a screwdriver afterwards causes a runtime to occur. Likewise in reverse, you couldn't remove the electronics from a partly built assembly. Half of its steps would also call it an airlock inconsistently, so those are corrected as well.

## Why It's Good For The Game
Fixes #17432. Also runtime. Someone didn't understand how `||`  or `!` worked.

## Images of changes
https://user-images.githubusercontent.com/80771500/155634394-a9aa7bea-dfed-402e-b8a9-158232e6b879.mp4

## Changelog
:cl:
fix: Clockwork walls use the right icon
fix: Brass windoors can be disassembled by opening the panel and cutting it with a welder
fix: Disassembled windoors into assemblies can't be spammed with a screwdriver in an attempt to remove nonexistent electronics
fix: Electronics can be properly removed from windoor assemblies with a screwdriver
fix: Windoors are consistently called windoors when tinkered with
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
