### PR TITLE
Fix - Necropolis walls use the right icon

### DIFF
--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -50,7 +50,11 @@
 	desc = "A seemingly impenetrable wall."
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "necro"
+	base_icon_state = "necro"
 	baseturf = /turf/simulated/wall/indestructible/necropolis
+	smoothing_flags = null
+	smoothing_groups = null
+	canSmoothWith = null
 
 /turf/simulated/wall/indestructible/boss
 	name = "necropolis wall"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Necropolis walls are assigned the right icon, and also will not smooth with other turfs in the process.

## Why It's Good For The Game
Fixes #17352.

## Images of changes
![Necro](https://user-images.githubusercontent.com/80771500/155814004-9934277c-67ea-4ef0-a781-6922a5e81152.png)


## Changelog
:cl:
fix: Necropolis walls don't display as metal walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
