### PR TITLE
Removes Force from Finger Gun

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -151,6 +151,7 @@
 	name = "\improper finger gun"
 	desc = "Bang bang bang!"
 	icon_state = "fingergun"
+	force = 0
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38/invisible
 	origin_tech = ""
 	flags = ABSTRACT | NODROP | DROPDEL


### PR DESCRIPTION
## What Does This PR Do
What it says on the tin. The mime's finger gun, fake and non-fake, no longer does five force when hitting something or someone. 
## Why It's Good For The Game

From a realism standpoint, I am aware that hitting someone with your hand should still do damage to them.  However. It's just being abused to be a shitter and damage brig cells/try to escape the brig. For traitor mimes, they can simply shoot the windows so this won't really affect them too much. For non-antags that get the fake finger gun ability from the arcade they will no longer be able to abuse it to be a pain in the ass.

This CAN be changed to only include the fake finger gun if wanted, however, I feel that both should be kept the same for consistencies sake, though I'll leave that up to management for the final decision.

## Changelog
:cl:
tweak: You can no longer damage people or objects with the 'Finger Gun' part of the Finger Gun. Traitor mime bullet functionality remains the same.
/:cl:
