### PR TITLE
Profiler results are now sent to Redis

### DIFF
--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -8,9 +8,13 @@ SUBSYSTEM_DEF(profiler)
 	var/fetch_cost = 0
 	/// Time it took to write the file (ms)
 	var/write_cost = 0
+	/// Time it took to encode the data for redis (ms)
+	var/send_encode_cost = 0
+	/// Time it took to send the stuff down FFI for redis (ms)
+	var/send_ffi_cost = 0
 
 /datum/controller/subsystem/profiler/stat_entry()
-	..("F:[round(fetch_cost, 1)]ms | W:[round(write_cost, 1)]ms")
+	..("F:[round(fetch_cost, 1)]ms | W:[round(write_cost, 1)]ms | SE:[round(send_encode_cost, 1)]ms | SF:[round(send_ffi_cost, 1)]ms")
 
 /datum/controller/subsystem/profiler/Initialize()
 	if(!GLOB.configuration.general.enable_auto_profiler)
@@ -37,14 +41,34 @@ SUBSYSTEM_DEF(profiler)
 // Write the file while also cost tracking
 /datum/controller/subsystem/profiler/proc/DumpFile()
 	var/timer = TICK_USAGE_REAL
+	// Fetch info
 	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")
 	fetch_cost = MC_AVERAGE(fetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 	CHECK_TICK
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
 	var/json_file = file("[GLOB.log_directory]/profile.json")
+	// Put it in a file
 	if(fexists(json_file))
 		fdel(json_file)
 	timer = TICK_USAGE_REAL
 	WRITE_FILE(json_file, current_profile_data)
 	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+
+	// Send it down redis
+	if(SSredis.connected)
+		// Encode
+		timer = TICK_USAGE_REAL
+
+		var/list/ffi_data = list()
+		ffi_data["round_id"] = GLOB.round_id
+		// We dont have to JSON decode here. The other end can worry about a 2-layer decode.
+		// Performance matters on this end. It doesnt on the other end
+		ffi_data["profile_data"] = current_profile_data
+		var/ffi_string = json_encode(ffi_data)
+		send_encode_cost = MC_AVERAGE(send_encode_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+
+		// Now actually fire it off
+		timer = TICK_USAGE_REAL
+		SSredis.publish("profilerdaemon.input", ffi_string)
+		send_ffi_cost = MC_AVERAGE(send_ffi_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))


### PR DESCRIPTION
## What Does This PR Do
Adds functionality for throwing profiler data at Redis every time SSprofiler fires

## Why It's Good For The Game
By sending the profiler data to something that isn't byond, we can do more things with it, such as track time changes between procs, measure specific procs over time with profiler snapshots, and more.

I plan to have this data received by a Java application encompassing a frontend, redis backend for this, database management and more, but that is still WIP. 

As for the performance impact of this, it results at taking this much time to encode and send.
![image](https://user-images.githubusercontent.com/25063394/155904943-0b518acf-beea-430a-9871-d4f892700bce.png)

I know this may seem higher than good (especially since FFI blocks), but you have to remember that this SS fires every 5 minutes, which is a pretty long delay. On top of that, I noticed no delay while walking around the station and having this fire every **5 seconds**, and thats with 0 latency. Most of the delay is on encoding, which is non-tick-blocking [FFI calls halt the entire tick]. My Redis server is also not on the same machine and is 2 switch hops away, whereas on prod it is simulated inside the same RAM as the game server since its all virtualised, not to mention prod having a much beefier CPU.


## Changelog
:cl: AffectedArc07
add: Added support for sending profiler metrics out of the game for finer profiler detail
wip: Frontend coming soon
/:cl:
