### PR TITLE
Players can no longer exploit Meteorshot to throw anything that's not a turf

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -6,6 +6,7 @@
 		density = 1
 		opacity = FALSE
 		anchored = 1
+		move_resist = INFINITY
 		resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 		flags_2 = RAD_NO_CONTAMINATE_2
 		max_integrity = 200
@@ -532,6 +533,7 @@
 		icon_state = "shieldwall"
 		anchored = 1
 		density = 1
+		move_resist = INFINITY
 		resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 		light_range = 3
 		var/needs_power = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -58,6 +58,7 @@
 	req_access = list(ACCESS_ENGINE_EQUIP)
 	siemens_strength = 1
 	damage_deflection = 10
+	move_resist = INFINITY
 	var/area/area
 	var/areastring = null
 	var/obj/item/stock_parts/cell/cell

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -194,7 +194,7 @@
 	..()
 	if(ismovable(target))
 		var/atom/movable/M = target
-		if(!M.move_resist != INFINITY)
+		if(M.move_resist < INFINITY)
 			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 			M.throw_at(throw_target, 3, 2)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -194,7 +194,7 @@
 	..()
 	if(ismovable(target))
 		var/atom/movable/M = target
-		if(!M.anchored)
+		if(!M.move_resist != INFINITY)
 			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 			M.throw_at(throw_target, 3, 2)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -194,8 +194,9 @@
 	..()
 	if(ismovable(target))
 		var/atom/movable/M = target
-		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-		M.throw_at(throw_target, 3, 2)
+		if(!M.anchored)
+			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
+			M.throw_at(throw_target, 3, 2)
 
 /obj/item/projectile/bullet/meteorshot/New()
 	..()


### PR DESCRIPTION
## What Does This PR Do
Adds an additional `move_resist < INFINITY` check to meteorshot to prevent anything thats not supposed to be immobile from being thrown around. This allows meteorshot to blow stuff off its anchor points but not critical things like cryodorm computers or shields

## Why It's Good For The Game
Players should not have the ability to throw any seemingly immovable object off their hinges/anchors. Not to mention this will likely causes serious issues when knocking APCs, or even cryodorm equipment off their anchorpoints. Also has serious balance implications because all a nukie needs to get passed a reinforced vault door or shieldwall is a meteorshot or two

## Changelog
:cl:
fix: fixes an exploit with meteorshot
/:cl:
