### PR TITLE
Fixes new players having half their prefs disabled

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -272,7 +272,7 @@ CREATE TABLE `player` (
   `be_role` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `default_slot` smallint(4) DEFAULT '1',
   `toggles` int(11) DEFAULT NULL,
-  `toggles_2` int(11) DEFAULT '0',
+  `toggles_2` int(11) DEFAULT NULL,
   `sound` mediumint(8) DEFAULT '31',
   `volume_mixer` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `lastchangelog` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '0',

--- a/SQL/updates/33-34.sql
+++ b/SQL/updates/33-34.sql
@@ -1,0 +1,12 @@
+# Updates DB from 33 to 34 -AffectedArc07
+# Fixes new players not getting the default toggles_2 value
+ALTER TABLE `player` CHANGE COLUMN `toggles_2` `toggles_2` INT(11) NULL DEFAULT NULL AFTER `toggles`;
+
+# Only run the below script if you wish to manually set everyones toggles_2 to the defaults
+UPDATE `player` SET `toggles_2` = `toggles_2` + 2 WHERE (`toggles_2` & 2) != 2;
+UPDATE `player` SET `toggles_2` = `toggles_2` + 4 WHERE (`toggles_2` & 4) != 4;
+UPDATE `player` SET `toggles_2` = `toggles_2` + 8 WHERE (`toggles_2` & 8) != 8;
+UPDATE `player` SET `toggles_2` = `toggles_2` + 64 WHERE (`toggles_2` & 64) != 64;
+UPDATE `player` SET `toggles_2` = `toggles_2` + 128 WHERE (`toggles_2` & 128) != 128;
+UPDATE `player` SET `toggles_2` = `toggles_2` + 256 WHERE (`toggles_2` & 256) != 256;
+UPDATE `player` SET `toggles_2` = `toggles_2` + 4096 WHERE (`toggles_2` & 4096) != 4096;

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -367,7 +367,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 33
+#define SQL_VERSION 34
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -145,7 +145,7 @@ ipc_screens = [
 # Enable/disable the database on a whole
 sql_enabled = false
 # SQL version. If this is a mismatch, round start will be delayed
-sql_version = 33
+sql_version = 34
 # SQL server address. Can be an IP or DNS name
 sql_address = "127.0.0.1"
 # SQL server port


### PR DESCRIPTION
## What Does This PR Do
Fixes new players having half their preference toggles disabled

Fixes #17445

Why it broke:
<details>
<summary>TLDR: DB issues</summary>
So, with the DB, if you have a null entry, your prefs get sanitized as the default value, however, toggles2 had `0` as its default, which is a valid number in having all your bitflags off. This PR makes that column `NULL` by default, removing the bad loading issue. 
</details>

New players will now have the following things enabled by default:
- Fancy UI
- Item attack animations
- Window flashing
- Runechat
- Deathchat death notifications
- Emote bubbles
- Item outlines

This will also be editing for existing players who do not have these options enabled. You can manually disable them after.


## Why It's Good For The Game
New players should have things enabled by default.

## Changelog
:cl: AffectedArc07
fix: Fixed new players not having proper default preferences
/:cl:
