### PR TITLE
Makes admin spawned organs properly serialize. And fixes 1 by 1 map saves to work

### DIFF
--- a/code/modules/awaymissions/maploader/writer.dm
+++ b/code/modules/awaymissions/maploader/writer.dm
@@ -60,7 +60,7 @@
 	if(length(templates) == 0)
 		CRASH("No templates found!")
 
-	var/key_length = round(log(length(letter_digits), length(templates) - 1) + 1) // or floor
+	var/key_length = round(log(length(letter_digits), max(length(templates) - 1, 1)) + 1) // or floor
 	var/list/keys[length(templates)]
 
 	// Write the list of key/model pairs to the file

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -282,7 +282,7 @@ I use this so that this can be made better once the organ overhaul rolls out -- 
 
 	// Save the DNA datum if: The owner doesn't exist, or the dna doesn't match the owner
 	// Don't save when the organ has no initialized DNA. Happens when you spawn it in as admin
-	if(dna.unique_enzymes != initial(dna.unique_enzymes) && !(owner && dna.unique_enzymes == owner.dna.unique_enzymes))
+	if(dna.unique_enzymes && !(owner && dna.unique_enzymes == owner.dna.unique_enzymes))
 		data["dna"] = dna.serialize()
 	return data
 

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -280,9 +280,9 @@ I use this so that this can be made better once the organ overhaul rolls out -- 
 	if(status != 0)
 		data["status"] = status
 
-	// Save the DNA datum if: The owner doesn't exist, or the dna doesn't match
-	// the owner
-	if(!(owner && dna.unique_enzymes == owner.dna.unique_enzymes))
+	// Save the DNA datum if: The owner doesn't exist, or the dna doesn't match the owner
+	// Don't save when the organ has no initialized DNA. Happens when you spawn it in as admin
+	if(dna.unique_enzymes != initial(dna.unique_enzymes) && !(owner && dna.unique_enzymes == owner.dna.unique_enzymes))
 		data["dna"] = dna.serialize()
 	return data
 


### PR DESCRIPTION
## What Does This PR Do
Makes it so that admin spawned organs (without a properly set DNA variable) serialize properly. The `dna` variable they had was not initialized yet was serialized. Causing the outcome to have weird data that the deserializer then didn't expect. The data it saved was useless as well.

I did not want to touch too much organ/DNA code. So I left it at this local fix.

Makes it so that saving a 1 by 1 map actually works. The code did a `log(0)` which is impossible.

## Why It's Good For The Game
Bug fixes

## Changelog
:cl:
fix: Admin spawned organs can now be saved and loaded in a map without them breaking the loading
fix: Saving a 1 by 1 map using building mode now works
/:cl: