### PR TITLE
Relocates The Entertainment Offices and Custodial Closet on DeltaStation

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -35178,6 +35178,12 @@
 	dir = 4
 	},
 /obj/machinery/disposal,
+/obj/machinery/requests_console{
+	department = "Janitorial";
+	departmentType = 1;
+	name = "Janitor Requests Console";
+	pixel_y = 29
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "bEZ" = (

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -7023,7 +7023,6 @@
 	name = "Custodial Maintenance";
 	req_access_txt = "26"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/janitor)
 "azj" = (
@@ -9353,6 +9352,7 @@
 /area/crew_quarters/toilet)
 "aEC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "aED" = (
@@ -9415,6 +9415,7 @@
 	dir = 10
 	},
 /obj/effect/landmark/start/janitor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "aEK" = (
@@ -9749,6 +9750,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "aFt" = (
@@ -10190,6 +10192,9 @@
 "aGq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aGr" = (
@@ -11454,17 +11459,11 @@
 /turf/space,
 /area/space/nearstation)
 "aIU" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aIV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12086,21 +12085,10 @@
 	},
 /area/maintenance/fore)
 "aKh" = (
-/obj/structure/closet/secure_closet/clown,
-/turf/simulated/floor/wood,
-/area/clownoffice)
-"aKi" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/mime,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -12108,6 +12096,10 @@
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
+"aKi" = (
+/obj/structure/closet/secure_closet/clown,
+/turf/simulated/floor/wood,
+/area/clownoffice)
 "aKk" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
@@ -12685,7 +12677,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aLE" = (
-/obj/structure/closet/secure_closet/mime,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/mime,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -12693,18 +12696,26 @@
 	},
 /area/mimeoffice)
 "aLF" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "46"
+/obj/structure/closet/secure_closet/mime,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/turf/simulated/floor/plating,
-/area/clownoffice)
+/area/mimeoffice)
 "aLG" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "46"
 	},
 /turf/simulated/floor/plating,
-/area/mimeoffice)
+/area/clownoffice)
 "aLH" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "46"
+	},
+/turf/simulated/floor/plating,
+/area/mimeoffice)
+"aLI" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plasteel{
@@ -18340,6 +18351,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
+"aXA" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/maintenance/fore)
 "aXB" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/staff/broom,
@@ -19063,6 +19083,9 @@
 /area/maintenance/fore)
 "aYY" = (
 /obj/effect/landmark/lightsout,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -30942,6 +30965,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -32196,6 +32222,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -49508,6 +49537,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -54104,6 +54136,9 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -54136,6 +54171,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -54672,7 +54710,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Custodial Junction";
+	sortType = 22
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -54692,6 +54734,9 @@
 "cus" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -54715,6 +54760,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -54727,6 +54775,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -54773,6 +54825,7 @@
 "cuB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -54802,12 +54855,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j2s";
-	name = "Janitor";
-	sortType = 22
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
@@ -54875,6 +54922,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "cuK" = (
@@ -55495,6 +55543,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -55510,6 +55562,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -55534,6 +55589,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/lightsout,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -55995,6 +56054,9 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -56816,6 +56878,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/start/assistant,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -56855,7 +56918,7 @@
 /area/maintenance/fore)
 "cyU" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
@@ -57532,6 +57595,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -58252,6 +58316,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -58756,6 +58821,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -58847,6 +58915,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -59304,6 +59373,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "cEu" = (
@@ -59628,6 +59698,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -59643,6 +59717,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -59688,6 +59765,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59774,6 +59854,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -60759,6 +60842,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -61231,6 +61317,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -61569,6 +61659,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -134331,11 +134424,11 @@ aor
 bcm
 aHS
 aor
-bfd
+aXA
 aor
 lqK
 bfd
-aor
+aIU
 aTa
 bfd
 ayC
@@ -150320,7 +150413,7 @@ cqD
 bTg
 khY
 cuF
-awZ
+cqI
 azi
 cyU
 aEC
@@ -150590,9 +150683,9 @@ cIh
 aFw
 cLo
 cMM
-aKh
+aKi
 cQf
-aLF
+aLG
 boG
 dDy
 dlz
@@ -151361,10 +151454,10 @@ aFu
 cJy
 aHC
 cMO
-aKi
+aLE
 cQi
 aGr
-aLH
+aLI
 dDE
 dlz
 cZi
@@ -151617,10 +151710,10 @@ cGW
 cWh
 aHA
 cLq
-aIU
-aLE
+aKh
+aLF
 cQh
-aLG
+aLH
 cSY
 dDD
 dlz

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -12692,18 +12692,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aLE" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "46"
+/obj/machinery/cryopod/right,
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
-/turf/simulated/floor/plating,
-/area/clownoffice)
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/sleep)
 "aLF" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "46"
 	},
 /turf/simulated/floor/plating,
-/area/mimeoffice)
+/area/clownoffice)
 "aLG" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "46"
+	},
+/turf/simulated/floor/plating,
+/area/mimeoffice)
+"aLH" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plasteel{
@@ -54915,6 +54926,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "cuK" = (
@@ -55514,6 +55526,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "cvW" = (
@@ -55568,6 +55581,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Public Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -59851,6 +59865,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "cFx" = (
@@ -61346,6 +61361,11 @@
 "cIj" = (
 /obj/structure/closet/jcloset,
 /obj/item/key/janitor,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "cIk" = (
@@ -61365,6 +61385,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "cIn" = (
@@ -61656,6 +61677,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -79992,6 +80014,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "dwK" = (
@@ -96467,6 +96490,11 @@
 /obj/machinery/cryopod,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -150674,7 +150702,7 @@ cLo
 cMM
 aHQ
 cQf
-aLE
+aLF
 boG
 dDy
 dlz
@@ -151446,7 +151474,7 @@ cMO
 aKh
 cQi
 aFv
-aLG
+aLH
 dDE
 dlz
 cZi
@@ -151702,7 +151730,7 @@ cLq
 aHC
 aKi
 cQh
-aLF
+aLG
 cSY
 dDD
 dlz
@@ -152215,7 +152243,7 @@ bmW
 oXY
 cBY
 oFL
-cyY
+aLE
 aFx
 cTc
 dDD

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1883,9 +1883,22 @@
 	},
 /area/hallway/secondary/entry)
 "any" = (
-/obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
-/area/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central)
 "anz" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small{
@@ -6076,11 +6089,9 @@
 /area/maintenance/fore2)
 "awZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/maintenance/fsmaint)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard2)
 "axa" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6094,13 +6105,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
+/area/maintenance/fore)
 "axb" = (
-/turf/simulated/wall,
-/area/janitor)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/starboard2)
 "axc" = (
-/turf/simulated/wall/rust,
-/area/janitor)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard2)
 "axd" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -6668,101 +6685,32 @@
 /turf/simulated/floor/wood,
 /area/maintenance/fore)
 "ayi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/maintenance/fsmaint)
+/turf/simulated/wall,
+/area/janitor)
 "ayj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/mousetraps,
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -30
-	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/table_frame,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "ayk" = (
-/obj/vehicle/janicart,
-/obj/item/storage/bag/trash,
-/obj/item/key/janitor,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/janitor)
-"ayl" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/closet/jcloset,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "aym" = (
-/obj/machinery/camera{
-	c_tag = "Janitor's Closet"
-	},
-/obj/structure/closet/l3closet/janitor,
-/obj/machinery/requests_console{
-	department = "Janitorial";
-	departmentType = 1;
-	name = "Janitor Requests Console";
-	pixel_y = 29
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/janitor)
-"ayn" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/crew/janitor,
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel,
-/area/janitor)
-"ayo" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/item/crowbar,
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 32
-	},
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 32
-	},
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
+"ayo" = (
+/obj/structure/table_frame,
+/turf/simulated/floor/plasteel,
+/area/maintenance/fore)
 "ayp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -7065,31 +7013,27 @@
 /area/maintenance/fore)
 "azh" = (
 /obj/structure/table/reinforced,
-/obj/structure/mirror{
-	pixel_x = -26;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/item/storage/bag/trash,
+/obj/item/soap/nanotrasen,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fsmaint)
 "azi" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/janitor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Custodial Maintenance";
+	req_access_txt = "26"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/janitor)
 "azj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Janitor"
+	},
 /turf/simulated/floor/plating,
 /area/janitor)
 "azk" = (
@@ -7098,26 +7042,19 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "azl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/janitor,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitegreen"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "azm" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "azn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/spawner/blob,
@@ -7616,71 +7553,43 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
 /obj/item/lightreplacer,
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fsmaint)
 "aAt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitegreen"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aAu" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aAv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aAw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aAx" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/door/window/westleft{
-	name = "Janitoral Delivery";
-	req_access_txt = "26"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
-/area/janitor)
+/area/maintenance/fore)
 "aAy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -8164,27 +8073,16 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/toilet)
 "aBv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aBw" = (
 /obj/machinery/light/small,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12
@@ -8194,56 +8092,33 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "aBx" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/janitorialcart,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aBy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aBz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitegreen"
 	},
-/area/janitor)
+/area/maintenance/fore)
 "aBA" = (
-/obj/machinery/disposal,
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 30
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "aBB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8552,44 +8427,31 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aCq" = (
-/obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access_txt = "26"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/barricade/wooden,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "aCr" = (
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
-	id_tag = "janitorshutters";
-	name = "Janitor Shutters"
+	id_tag = "maintenanceshutters"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "aCs" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/door_control{
+	id = "maintenanceshutters";
+	name = "shutter control";
+	pixel_x = 25;
+	req_access_txt = 0
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
-	id_tag = "janitorshutters";
-	name = "Janitor Shutters"
+	id_tag = "maintenanceshutters"
 	},
-/obj/machinery/door_control{
-	id = "janitorshutters";
-	name = "Janitor Shutters Control";
-	pixel_x = 25;
-	req_access_txt = "26"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/janitor)
+/area/maintenance/fore)
 "aCt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -8981,6 +8843,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aDt" = (
@@ -9036,21 +8901,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aDz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -9083,23 +8947,11 @@
 /turf/space,
 /area/space/nearstation)
 "aDD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -9452,16 +9304,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"aEv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
 "aEw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9510,17 +9352,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/toilet)
 "aEC" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Custodial Junction";
-	sortType = 22
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/maintenance/fore)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "aED" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -9571,10 +9405,18 @@
 	},
 /area/quartermaster/sorting)
 "aEJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/landmark/start/janitor,
 /turf/simulated/floor/plasteel,
-/area/maintenance/fore)
+/area/janitor)
 "aEK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9879,16 +9721,13 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
 	},
 /area/maintenance/fore)
 "aFr" = (
-/obj/machinery/door/airlock/multi_tile{
-	name = "maintenance access";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -9896,46 +9735,53 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
+"aFs" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/janitor)
+"aFt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
-"aFs" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
-"aFt" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/area/crew_quarters/fitness)
 "aFu" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/rainbow,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "neutral"
 	},
-/area/hallway/primary/central/nw)
+/area/crew_quarters/fitness)
 "aFv" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/turf/simulated/wall,
+/area/clownoffice)
 "aFw" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/clownoffice)
 "aFx" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep)
@@ -10328,61 +10174,31 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics/abandoned_garden)
 "aGo" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/newscaster{
-	name = "west bump";
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/gloves/color/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/obj/item/clothing/shoes/rainbow,
+/obj/item/clothing/under/rainbow,
+/obj/item/toy/crayon/rainbow,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aGp" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/item/toy/windup_toolbox,
+/obj/item/toy/snappop/phoenix,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aGq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/structure/bed,
+/obj/item/bedsheet/rainbow,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aGr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/turf/simulated/wall,
+/area/mimeoffice)
 "aGs" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "25"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/effect/spawner/random_barrier/obstruction,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aGv" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -10916,26 +10732,37 @@
 	},
 /area/quartermaster/storage)
 "aHA" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/mimeoffice)
 "aHB" = (
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/area/hallway/primary/central/nw)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/clownoffice)
 "aHC" = (
-/obj/structure/closet/wardrobe/mixed,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/area/hallway/primary/central/nw)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "aHD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10955,14 +10782,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/hydroponics/abandoned_garden)
-"aHH" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
 "aHI" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -10977,9 +10796,6 @@
 	},
 /area/crew_quarters/bar)
 "aHJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -10992,7 +10808,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -11049,11 +10865,15 @@
 	},
 /area/crew_quarters/bar)
 "aHQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/hallway/primary/central/nw)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/clownoffice)
 "aHR" = (
 /obj/machinery/newscaster{
 	name = "east bump";
@@ -11066,23 +10886,20 @@
 	},
 /area/crew_quarters/bar)
 "aHS" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	icon_state = "pipe-j2s";
-	name = "Bar Junction";
-	sortType = 19
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "aHT" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -11594,16 +11411,6 @@
 	},
 /area/maintenance/fore)
 "aIR" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/camera{
-	c_tag = "Service Hall North";
-	dir = 4;
-	pixel_y = -22
-	},
-/obj/machinery/newscaster{
-	name = "west bump";
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -11616,11 +11423,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "Bar Junction";
+	sortType = 19
 	},
-/area/hallway/primary/central/nw)
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aIS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -11630,9 +11440,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -11647,20 +11454,25 @@
 /turf/space,
 /area/space/nearstation)
 "aIU" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/hallway/primary/central/nw)
+/area/mimeoffice)
 "aIV" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -11855,16 +11667,10 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aJt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/effect/spawner/random_spawners/blood_maybe,
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aJu" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -12280,25 +12086,28 @@
 	},
 /area/maintenance/fore)
 "aKh" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/structure/closet/secure_closet/clown,
 /turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
+/area/clownoffice)
 "aKi" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
-"aKj" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
+/obj/effect/landmark/start/mime,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "aKk" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
@@ -12306,26 +12115,11 @@
 	},
 /area/civilian/barber)
 "aKl" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
-"aKm" = (
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aKn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -12885,75 +12679,39 @@
 	},
 /area/maintenance/fore)
 "aLD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aLE" = (
-/obj/structure/table/wood,
-/obj/machinery/newscaster{
-	name = "west bump";
-	pixel_x = -32
+/obj/structure/closet/secure_closet/mime,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
+/area/mimeoffice)
 "aLF" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
-"aLG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
-"aLH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
-"aLI" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "25"
+	req_access_txt = "46"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/clownoffice)
+"aLG" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "46"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
-"aLJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/turf/simulated/floor/plating,
+/area/mimeoffice)
+"aLH" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/starboard)
 "aLL" = (
 /obj/machinery/disposal,
 /obj/machinery/alarm{
@@ -13321,11 +13079,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
-"aMD" = (
-/obj/structure/dresser,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
 "aME" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13513,11 +13266,6 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/fore)
-"aNa" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
 "aNb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -13528,48 +13276,10 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"aNc" = (
-/obj/machinery/light,
-/obj/structure/closet/wardrobe/mixed,
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
-"aNd" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
 "aNe" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"aNf" = (
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
-"aNg" = (
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
 "aNh" = (
 /obj/machinery/light{
 	dir = 8
@@ -13957,15 +13667,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
-"aNX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
 "aNY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel{
@@ -14096,11 +13797,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"aOn" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "redbluefull"
-	},
-/area/clownoffice)
 "aOo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -14608,12 +14304,11 @@
 	},
 /area/security/permabrig)
 "aPw" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/landmark/start/clown,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aPx" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
@@ -14780,73 +14475,45 @@
 	},
 /area/maintenance/gambling_den)
 "aPP" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/structure/closet/secure_closet/clown,
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 32
-	},
+/obj/structure/statue/bananium/clown,
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aPQ" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/crayons{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/storage/fancy/crayons,
-/obj/machinery/camera{
-	c_tag = "Clown and Mime office"
-	},
+/obj/item/storage/backpack/duffel/clown,
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aPR" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/vending/autodrobe,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/vendor,
+/obj/item/vending_refill/autodrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aPS" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/toy/figure/crew/clown,
+/obj/item/toy/crayon/rainbow,
+/obj/item/reagent_containers/food/snacks/grown/banana,
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aPT" = (
-/obj/structure/table/wood,
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 30
-	},
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/item/flashlight/lamp/bananalamp,
+/obj/structure/table_frame/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aPU" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -15577,32 +15244,6 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/gambling_den)
-"aRp" = (
-/obj/structure/mirror{
-	pixel_x = -26;
-	pixel_y = 3
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redbluefull"
-	},
-/area/clownoffice)
-"aRq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/landmark/start/clown,
-/turf/simulated/floor/plasteel{
-	icon_state = "redbluefull"
-	},
-/area/clownoffice)
-"aRr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redbluefull"
-	},
-/area/clownoffice)
 "aRs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16202,10 +15843,37 @@
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den)
 "aSS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Entertainment Office";
-	req_access_txt = "46"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plasteel,
+/area/maintenance/fore)
+"aST" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/fore)
+"aSX" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16219,93 +15887,7 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fore)
-"aST" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/clownoffice)
-"aSU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/clownoffice)
-"aSV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/clownoffice)
-"aSW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/clownoffice)
-"aSX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/clownoffice)
 "aSY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Entertainment Office";
-	req_access_txt = "46"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16317,12 +15899,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/spawner/random_barrier/obstruction,
 /turf/simulated/floor/plasteel,
-/area/clownoffice)
+/area/maintenance/fore)
 "aSZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -16345,13 +15925,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aTa" = (
-/obj/structure/disposalpipe/junction,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16362,7 +15939,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "aTb" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -16386,7 +15963,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/sleep)
+/area/crew_quarters/bar/atrium)
 "aTd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17172,41 +16749,17 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"aUx" = (
-/obj/structure/mirror{
-	pixel_x = -26;
-	pixel_y = 3
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/clownoffice)
 "aUy" = (
-/obj/effect/landmark/start/mime,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/clownoffice)
-"aUz" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aUA" = (
-/obj/machinery/disposal,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aUB" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -17218,19 +16771,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"aUC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
 "aUE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -17948,73 +17488,40 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "aVY" = (
-/obj/structure/sign/nosmoking_2{
-	pixel_y = -32
-	},
-/obj/structure/closet/secure_closet/mime,
-/obj/machinery/requests_console{
-	department = "Clown & Mime Office";
-	departmentType = 2;
-	name = "Clown and Mime Requests Console";
-	pixel_x = -30
-	},
+/obj/structure/statue/tranquillite/mime,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aVZ" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
+/obj/item/toy/crayon/mime,
 /obj/item/reagent_containers/food/snacks/baguette,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aWa" = (
-/obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/vending/autodrobe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aWb" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/toy/figure/crew/mime,
+/obj/structure/table_frame/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/clownoffice)
+/area/maintenance/fore)
 "aWc" = (
 /obj/structure/table/wood,
-/obj/item/lipstick/random{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/lipstick/random{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/lipstick/random{
-	pixel_x = -1;
-	pixel_y = 1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/clownoffice)
-"aWd" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "aWe" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -18823,11 +18330,6 @@
 	},
 /area/hallway/secondary/entry)
 "aXz" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -18835,22 +18337,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
-"aXA" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aXB" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/staff/broom,
@@ -19557,7 +19046,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -19569,22 +19059,15 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aYY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "aYZ" = (
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
@@ -20521,7 +20004,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hos)
 "baK" = (
-/obj/machinery/door/firedoor,
 /obj/item/radio/intercom{
 	name = "west bump";
 	pixel_x = -28
@@ -20533,20 +20015,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
-"baL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "baM" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -21267,11 +20740,6 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "bcl" = (
-/obj/machinery/camera{
-	c_tag = "Service Hall South";
-	dir = 4;
-	pixel_y = -22
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -21283,14 +20751,14 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "bcm" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "bcn" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -21963,7 +21431,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "bdH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21980,7 +21448,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "bdI" = (
 /obj/machinery/door/airlock/freezer{
 	req_access_txt = "28"
@@ -22609,14 +22077,13 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "bfd" = (
-/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "bfe" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -23166,9 +22633,6 @@
 /area/hydroponics)
 "bgr" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Service Hall"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -23176,8 +22640,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/nw)
+/area/maintenance/fore)
 "bgs" = (
 /turf/simulated/wall,
 /area/maintenance/starboard2)
@@ -35674,11 +35141,17 @@
 	},
 /area/engine/break_room)
 "bEY" = (
-/obj/structure/dresser,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
-/area/crew_quarters/fitness)
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "bEZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41702,8 +41175,9 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "bRc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -42694,10 +42168,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "bTh" = (
@@ -53461,7 +52931,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "cqE" = (
@@ -55330,9 +54803,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	name = "Janitor";
+	sortType = 22
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
@@ -57373,40 +56848,27 @@
 	},
 /area/crew_quarters/locker)
 "cyT" = (
-/obj/structure/dresser,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/primary/central/nw)
+/obj/effect/spawner/random_spawners/blood_maybe,
+/obj/item/gun/throw/crossbow,
+/obj/item/clothing/suit/soldiercoat,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "cyU" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/suit/leathercoat,
-/obj/item/clothing/head/fedora,
-/obj/item/clothing/under/blacktango,
-/obj/item/clothing/head/bowlerhat,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cyV" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/machinery/door/window/westleft{
+	name = "Janitoral Delivery";
+	req_access_txt = "26"
 	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/geranium,
-/obj/item/reagent_containers/food/snacks/grown/poppy/geranium,
-/obj/item/reagent_containers/food/snacks/grown/poppy/geranium,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/fitness)
+/obj/structure/window/reinforced,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cyW" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -58082,12 +57544,9 @@
 	},
 /area/crew_quarters/locker)
 "cAn" = (
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/fitness)
+/obj/vehicle/janicart,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cAo" = (
 /obj/machinery/newscaster{
 	name = "west bump";
@@ -58108,8 +57567,10 @@
 	},
 /area/civilian/barber)
 "cAq" = (
-/turf/simulated/floor/wood,
-/area/hallway/primary/central/nw)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "cAr" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -58815,15 +58276,27 @@
 /turf/space,
 /area/space/nearstation)
 "cBV" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/newscaster{
+/obj/structure/rack{
+	dir = 1
+	},
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/power/apc{
+	dir = 8;
 	name = "west bump";
-	pixel_x = -32
+	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cBW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -59393,13 +58866,20 @@
 	},
 /area/crew_quarters/locker)
 "cDq" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/lighter/zippo,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/reagent_dispensers/spacecleanertank{
+	pixel_x = -32
 	},
-/area/crew_quarters/fitness)
+/obj/structure/rack{
+	dir = 1
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cDr" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -59812,13 +59292,20 @@
 	},
 /area/ai_monitored/storage/eva)
 "cEt" = (
-/obj/machinery/door/airlock/glass{
-	name = "Cabin"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access_txt = "26"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cEu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -59831,6 +59318,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -59841,6 +59329,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -60233,6 +59722,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -61707,10 +61201,12 @@
 	},
 /area/crew_quarters/fitness)
 "cIc" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/janitorialcart,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cId" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -61723,7 +61219,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -61731,10 +61238,8 @@
 /area/crew_quarters/fitness)
 "cIh" = (
 /obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -61746,24 +61251,25 @@
 	c_tag = "Dorm Hallway Port";
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
 "cIj" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/fitness)
+/obj/structure/closet/jcloset,
+/obj/item/key/janitor,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cIk" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/fitness)
+/obj/structure/closet/l3closet/janitor,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "cIl" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -62141,6 +61647,10 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "cJn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -62238,11 +61748,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cJy" = (
-/obj/machinery/door/airlock/glass{
-	name = "Cabin"
+/obj/machinery/door/airlock/tranquillite{
+	name = "Mime's Office";
+	req_access_txt = "46"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "cJz" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62967,24 +62489,40 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cLo" = (
-/obj/structure/dresser,
+/obj/item/flag/clown,
 /obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+	name = "east bump";
+	pixel_x = 28
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "cLp" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
-"cLq" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/structure/statue/tranquillite/mime,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
+/obj/machinery/camera{
+	c_tag = "Mime's Office";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
+"cLq" = (
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/item/flag/mime,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "cLr" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -63552,26 +63090,41 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cMM" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "cMN" = (
 /obj/structure/table/wood,
-/obj/item/storage/briefcase,
-/obj/item/cane,
 /obj/machinery/newscaster{
 	name = "west bump";
 	pixel_x = -32
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
-"cMO" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/item/paper_bin,
+/obj/item/toy/crayon/mime,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
+/area/mimeoffice)
+"cMO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "cMP" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64362,24 +63915,52 @@
 /area/maintenance/starboard)
 "cOp" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/newscaster{
+/obj/item/flashlight/lamp/bananalamp,
+/obj/item/reagent_containers/food/snacks/pie,
+/obj/machinery/power/apc{
+	dir = 8;
 	name = "west bump";
-	pixel_x = -32
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "cOq" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/clown,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "cOr" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/pen,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
+/obj/item/flashlight/lamp/green,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "cOs" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -65003,6 +64584,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -65066,37 +64648,57 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cQe" = (
-/obj/structure/table/wood,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/item/paicard,
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "cQf" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/maid,
-/obj/item/clothing/suit/browntrenchcoat,
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "cQg" = (
-/obj/structure/dresser,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/spray/waterflower,
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "cQh" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "cQi" = (
-/obj/structure/bed,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/item/bedsheet/yellow,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "cQj" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -66382,14 +65984,6 @@
 "cTa" = (
 /obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"cTb" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
 /area/maintenance/starboard)
 "cTc" = (
 /obj/structure/closet/crate,
@@ -93318,16 +92912,9 @@
 /turf/simulated/wall,
 /area/security/processing)
 "gpU" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 8;
-	location = "Janitor"
-	},
+/obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
-/area/janitor)
+/area/maintenance/fore)
 "gpX" = (
 /obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/plasteel{
@@ -93643,8 +93230,12 @@
 /turf/simulated/floor/plasteel,
 /area/security/permasolitary)
 "hcU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -94090,9 +93681,14 @@
 /area/atmos)
 "imS" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/item/clothing/under/soldieruniform,
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "ipD" = (
 /obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
@@ -94116,9 +93712,15 @@
 	},
 /area/security/permabrig)
 "iuU" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/stamp/clown,
+/obj/machinery/newscaster{
+	name = "west bump";
+	pixel_x = -32
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "iwQ" = (
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -94559,9 +94161,6 @@
 	icon_state = "cult"
 	},
 /area/magistrateoffice)
-"jET" = (
-/turf/simulated/wall,
-/area/clownoffice)
 "jFV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -94583,11 +94182,20 @@
 	},
 /area/crew_quarters/fitness)
 "jHd" = (
-/obj/machinery/door/airlock/glass{
-	name = "Cabin"
+/obj/machinery/door/airlock/bananium{
+	name = "Clown's Office";
+	req_access_txt = "46"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "jIs" = (
 /turf/simulated/wall/r_wall,
 /area/security/evidence)
@@ -94733,7 +94341,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard2)
 "kii" = (
@@ -95041,8 +94648,9 @@
 	},
 /area/security/seceqstorage)
 "lqK" = (
-/turf/simulated/wall,
-/area/hallway/primary/central/nw)
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "lso" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -97072,8 +96680,13 @@
 /turf/simulated/floor/plasteel,
 /area/security/warden)
 "rkJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -98309,8 +97922,16 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "uGp" = (
+/obj/structure/statue/bananium/clown,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Clown's Office";
+	dir = 4
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/fitness)
+/area/clownoffice)
 "uJk" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -132648,21 +132269,21 @@ aAq
 awX
 aCn
 aDt
+aor
+awX
+aCL
+awX
+awX
+aor
 lqK
-lqK
-lqK
-lqK
-lqK
-lqK
-lqK
-lqK
-jET
-jET
-jET
+aVK
+awX
+awX
+aCL
 aSS
-jET
-jET
-jET
+awX
+aVK
+aVK
 bqe
 baF
 bcf
@@ -132905,21 +132526,21 @@ ayg
 awX
 aCo
 aEz
-lqK
-aFs
+aor
+aVK
 aGo
-aHA
-lqK
-aKh
-aLE
-aNa
-jET
+aor
+aVK
+aor
+aor
+axZ
+aVK
 aPP
-aRp
-aSU
-aUx
+aEg
+avU
+aUy
 aVY
-jET
+awX
 aXJ
 baF
 bcg
@@ -133162,21 +132783,21 @@ aAr
 awX
 aor
 aEy
-lqK
-aFt
+aor
+aVK
 aGp
-aHB
-lqK
-aKi
-aLF
+aor
+awX
+aor
+aor
 cAq
-jET
+awX
 aPQ
-aRq
+aEg
 aST
 aUy
 aVZ
-jET
+aVK
 bpZ
 baF
 bch
@@ -133412,28 +133033,28 @@ aoo
 aoo
 aor
 aBB
-any
-any
+aVK
+aVK
 aBg
 aDH
 ayC
 auR
 aDw
-lqK
-aFu
+aor
+awX
 aGq
-aHC
+aor
+aCL
 lqK
-aKj
-aLG
-aNc
-jET
+aor
+awX
+aVK
 aPR
-aRr
-aSW
-aUz
+aEg
+avU
+aza
 aWa
-jET
+aVK
 byM
 baF
 bci
@@ -133669,28 +133290,28 @@ aoT
 aoo
 azb
 aDy
-awZ
-awZ
+aEt
+aEt
 aor
 aor
 aqF
 azb
 aEz
-lqK
-aHQ
-aGr
-aFv
-lqK
-aMD
-aLH
-aNd
-jET
+aor
+awX
+awX
+awX
+awX
+aor
+aor
+asq
+awX
 aPS
 aPw
 aSX
 aUy
 aWb
-jET
+awX
 bqe
 baF
 bcj
@@ -133927,27 +133548,27 @@ aoo
 auS
 avW
 axa
-ayi
+aES
 azg
 aBD
 aBD
 aES
 aDx
-lqK
-aFw
+aor
+ayC
 aJt
 cyT
-lqK
+aVK
 aKl
-aNX
-cAq
-jET
+aor
+bkR
+aCL
 aPT
-aOn
-aSV
+aPw
+aSX
 aUA
 aWc
-jET
+awX
 aYV
 baF
 bck
@@ -134183,28 +133804,28 @@ atr
 aoo
 aEz
 avX
-axb
-axb
-axb
-axb
-axb
-axb
+awX
+awX
+aCL
+awX
+awX
+awX
 aDy
-lqK
-lqK
+aor
+awX
 aGs
-lqK
-lqK
-lqK
-aLI
-lqK
-jET
-jET
-jET
+aVK
+awX
+aor
+aor
+awX
+awX
+aVK
+aVK
 aSY
-jET
-jET
-jET
+awX
+awX
+awX
 aYW
 baF
 baF
@@ -134223,7 +133844,7 @@ buU
 buU
 bxl
 baG
-buU
+any
 bEa
 bDR
 bEp
@@ -134440,27 +134061,27 @@ ats
 aoo
 auT
 avX
-axc
+aDH
 ayj
 azh
 aAs
 aBw
-axb
+aCL
 aDz
-aEv
+aXz
 aFr
-aLJ
-aUC
+aXz
+aXz
 aIR
-aKm
-aLJ
-aNf
-aUC
-aUC
-aUC
+aXz
+aXz
+aXz
+aXz
+aXz
+aXz
 aSZ
-aUC
-aUC
+aXz
+aXz
 aXz
 aYX
 baK
@@ -134480,7 +134101,7 @@ bva
 bva
 bva
 byP
-bva
+byP
 bCf
 bva
 bFs
@@ -134697,34 +134318,34 @@ att
 aoo
 auU
 avY
-axb
+awX
 ayk
-azi
+azb
 aAt
 aBv
 aCq
 aDD
-aEJ
-aXA
-aIU
-aHH
+aUv
+awX
+aor
+bcm
 aHS
-aIU
-aXA
-aNg
-aXA
-aXA
-aIU
+aor
+bfd
+aor
+lqK
+bfd
+aor
 aTa
-aXA
-aWd
-aXA
+bfd
+ayC
+bfd
 aYY
-baL
+aor
 bcm
 bdH
 bfd
-lqK
+awX
 bhG
 bjo
 bld
@@ -134954,12 +134575,12 @@ atu
 aoo
 aDt
 avZ
-axb
-ayl
-azj
+awX
+aBA
+azb
 aAu
 aBx
-axb
+awX
 aDB
 aEx
 aFA
@@ -135211,7 +134832,7 @@ atv
 aoo
 auT
 awa
-axb
+aCL
 aym
 azk
 aAv
@@ -135468,13 +135089,13 @@ atu
 aoo
 aEz
 avX
-axb
-ayn
+awX
+ayo
 azl
 aAw
 aBz
 aCs
-aEC
+aDB
 aor
 aFA
 aGw
@@ -135725,12 +135346,12 @@ atw
 aoo
 aEz
 avX
-axb
+awX
 ayo
 azm
 aAx
 aBA
-axb
+awX
 aDE
 aLA
 aFA
@@ -135982,12 +135603,12 @@ atx
 aoo
 aDt
 aBb
-axb
-axc
-axb
+awX
+aDH
+awX
 gpU
-axb
-axb
+aVK
+aVK
 aDF
 aLA
 aFA
@@ -150186,21 +149807,21 @@ csc
 cnP
 cnP
 cnP
-csi
-csi
-csi
-csi
-csi
-csi
+ayi
+ayi
+ayi
+ayi
+ayi
+ayi
 cFw
 csj
 cIm
-csi
-csi
-csi
-csi
-csi
-csi
+aFv
+aFv
+aFv
+aFv
+aFv
+aFv
 cSX
 dDE
 cXI
@@ -150440,24 +150061,24 @@ bgs
 coU
 cJn
 bRc
-cqI
-brS
-cqI
-csi
+awZ
+axb
+axc
+ayi
 bEY
 cIc
 cBV
 cDq
-csi
+ayi
 cFq
 cGT
 cJz
-csi
+aFw
 uGp
 iuU
 cOp
 imS
-csi
+aFv
 cSY
 dDE
 cXI
@@ -150699,22 +150320,22 @@ cqD
 bTg
 khY
 cuF
-cqI
-csi
+awZ
+azi
 cyU
-cIc
-cIc
-cIc
+aEC
+aEJ
+aFs
 cEt
 cIg
-dTF
+rkJ
 hcU
 jHd
-uGp
-uGp
+aHB
+aHQ
 cOq
 cQe
-csi
+aFv
 cSZ
 cUw
 dlz
@@ -150957,21 +150578,21 @@ bgt
 bwR
 ckV
 brS
-csi
+azj
 cyV
 cAn
 cIj
 cIk
-csi
-cFx
-cGW
+ayi
+aFt
+dTF
 cIh
-csi
+aFw
 cLo
 cMM
-uGp
+aKh
 cQf
-csi
+aLF
 boG
 dDy
 dlz
@@ -151223,12 +150844,12 @@ oNd
 cFr
 cGW
 cIi
-csi
-csi
-csi
-csi
-csi
-csi
+aGr
+aGr
+aGr
+aGr
+aGr
+aGr
 cSY
 dDC
 dlz
@@ -151480,12 +151101,12 @@ nFX
 cFx
 cGW
 cJz
-csi
+aHA
 cLp
 cMN
 cOr
 cQg
-csi
+aGr
 cTa
 dDE
 dlz
@@ -151736,14 +151357,14 @@ wtE
 cEu
 cFs
 rkJ
-cAu
+aFu
 cJy
-cLp
+aHC
 cMO
-cLp
+aKi
 cQi
-csi
-cSY
+aGr
+aLH
 dDE
 dlz
 cZi
@@ -151994,13 +151615,13 @@ nFX
 cFv
 cGW
 cWh
-csi
+aHA
 cLq
-cLp
-cLp
+aIU
+aLE
 cQh
-csi
-cTb
+aLG
+cSY
 dDD
 dlz
 cZj
@@ -152251,12 +151872,12 @@ oNd
 cFu
 cGW
 cWh
-csi
-csi
-csi
-csi
-csi
-csi
+aGr
+aGr
+aGr
+aGr
+aGr
+aGr
 cjn
 dDE
 dlz

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -61370,6 +61370,11 @@
 /area/janitor)
 "cIk" = (
 /obj/structure/closet/l3closet/janitor,
+/obj/machinery/light_switch{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "cIl" = (

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -6089,7 +6089,7 @@
 /area/maintenance/fore2)
 "awZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "axa" = (
@@ -6107,17 +6107,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard2)
+/turf/simulated/wall,
+/area/janitor)
 "axc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/airlock/maintenance{
+	name = "Custodial Maintenance";
+	req_access_txt = "26"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard2)
+/area/janitor)
 "axd" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -6685,7 +6683,14 @@
 /turf/simulated/floor/wood,
 /area/maintenance/fore)
 "ayi" = (
-/turf/simulated/wall,
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Janitor"
+	},
+/turf/simulated/floor/plating,
 /area/janitor)
 "ayj" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -7019,21 +7024,23 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/fsmaint)
 "azi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Custodial Maintenance";
-	req_access_txt = "26"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
 /area/janitor)
 "azj" = (
-/obj/structure/plasticflaps{
-	opacity = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Janitor"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
+/obj/effect/landmark/start/janitor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
 /area/janitor)
 "azk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9351,7 +9358,13 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/toilet)
 "aEC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -9406,18 +9419,16 @@
 /area/quartermaster/sorting)
 "aEJ" = (
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/obj/effect/landmark/start/janitor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/janitor)
+/area/crew_quarters/fitness)
 "aEK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9743,29 +9754,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aFs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/janitor)
-"aFt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
-"aFu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -9777,13 +9765,20 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/fitness)
-"aFv" = (
+"aFt" = (
 /turf/simulated/wall,
 /area/clownoffice)
-"aFw" = (
+"aFu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/clownoffice)
+"aFv" = (
+/turf/simulated/wall,
+/area/mimeoffice)
+"aFw" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/mimeoffice)
 "aFx" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep)
@@ -10198,8 +10193,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aGr" = (
-/turf/simulated/wall,
-/area/mimeoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/clownoffice)
 "aGs" = (
 /obj/effect/spawner/random_barrier/obstruction,
 /turf/simulated/floor/plating,
@@ -10737,10 +10741,6 @@
 	},
 /area/quartermaster/storage)
 "aHA" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mimeoffice)
-"aHB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -10750,17 +10750,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
+"aHB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aHC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10870,13 +10880,7 @@
 	},
 /area/crew_quarters/bar)
 "aHQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
+/obj/structure/closet/secure_closet/clown,
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aHR" = (
@@ -12085,10 +12089,17 @@
 	},
 /area/maintenance/fore)
 "aKh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/mime,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -12097,9 +12108,13 @@
 	},
 /area/mimeoffice)
 "aKi" = (
-/obj/structure/closet/secure_closet/clown,
-/turf/simulated/floor/wood,
-/area/clownoffice)
+/obj/structure/closet/secure_closet/mime,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "aKk" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
@@ -12677,45 +12692,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aLE" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/mime,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
-"aLF" = (
-/obj/structure/closet/secure_closet/mime,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
-"aLG" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "46"
 	},
 /turf/simulated/floor/plating,
 /area/clownoffice)
-"aLH" = (
+"aLF" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "46"
 	},
 /turf/simulated/floor/plating,
 /area/mimeoffice)
-"aLI" = (
+"aLG" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plasteel{
@@ -41204,11 +41192,10 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "bRc" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard2)
 "bRd" = (
@@ -42197,6 +42184,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "bTh" = (
@@ -52963,10 +52954,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "cqE" = (
@@ -54855,6 +54843,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
@@ -61740,10 +61732,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "cJn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -94434,6 +94422,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard2)
 "kii" = (
@@ -149900,21 +149889,21 @@ csc
 cnP
 cnP
 cnP
-ayi
-ayi
-ayi
-ayi
-ayi
-ayi
+axb
+axb
+axb
+axb
+axb
+axb
 cFw
 csj
 cIm
-aFv
-aFv
-aFv
-aFv
-aFv
-aFv
+aFt
+aFt
+aFt
+aFt
+aFt
+aFt
 cSX
 dDE
 cXI
@@ -150154,24 +150143,24 @@ bgs
 coU
 cJn
 bRc
+cqI
+brS
 awZ
 axb
-axc
-ayi
 bEY
 cIc
 cBV
 cDq
-ayi
+axb
 cFq
 cGT
 cJz
-aFw
+aFu
 uGp
 iuU
 cOp
 imS
-aFv
+aFt
 cSY
 dDE
 cXI
@@ -150414,21 +150403,21 @@ bTg
 khY
 cuF
 cqI
-azi
+axc
 cyU
+azi
+azj
 aEC
-aEJ
-aFs
 cEt
 cIg
 rkJ
 hcU
 jHd
+aGr
 aHB
-aHQ
 cOq
 cQe
-aFv
+aFt
 cSZ
 cUw
 dlz
@@ -150671,21 +150660,21 @@ bgt
 bwR
 ckV
 brS
-azj
+ayi
 cyV
 cAn
 cIj
 cIk
-ayi
-aFt
+axb
+aEJ
 dTF
 cIh
-aFw
+aFu
 cLo
 cMM
-aKi
+aHQ
 cQf
-aLG
+aLE
 boG
 dDy
 dlz
@@ -150937,12 +150926,12 @@ oNd
 cFr
 cGW
 cIi
-aGr
-aGr
-aGr
-aGr
-aGr
-aGr
+aFv
+aFv
+aFv
+aFv
+aFv
+aFv
 cSY
 dDC
 dlz
@@ -151194,12 +151183,12 @@ nFX
 cFx
 cGW
 cJz
-aHA
+aFw
 cLp
 cMN
 cOr
 cQg
-aGr
+aFv
 cTa
 dDE
 dlz
@@ -151450,14 +151439,14 @@ wtE
 cEu
 cFs
 rkJ
-aFu
+aFs
 cJy
-aHC
+aHA
 cMO
-aLE
+aKh
 cQi
-aGr
-aLI
+aFv
+aLG
 dDE
 dlz
 cZi
@@ -151708,12 +151697,12 @@ nFX
 cFv
 cGW
 cWh
-aHA
+aFw
 cLq
-aKh
-aLF
+aHC
+aKi
 cQh
-aLH
+aLF
 cSY
 dDD
 dlz
@@ -151965,12 +151954,12 @@ oNd
 cFu
 cGW
 cWh
-aGr
-aGr
-aGr
-aGr
-aGr
-aGr
+aFv
+aFv
+aFv
+aFv
+aFv
+aFv
 cjn
 dDE
 dlz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Moves the Clown office, Mime office, and custodial closet on DeltaStation to the fitness room/locker room area, taking the places of the bedrooms there. The old locations have been kept, but maintenance-ified. Adds firelocks to the fitness room/locker room area as well since they were critically lacking and weren't meeting mapping standards and I was in the area.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> The custodian being in a maintenance tunnel proper was weird since it didn't match what occurs on MetaStation or BoxStation, and this now gives the clown and mime their own spaces. Plus it addresses/ fixes #17477 sort of? The complaint of that PR is that the "central hallway" the clown/mime office was down pulled double duty as maintenance while not being maintenance.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

Current:

![image](https://user-images.githubusercontent.com/16112919/158041908-c3139aa5-b9d4-4661-a780-c94eb31b2c68.png)

![image](https://user-images.githubusercontent.com/16112919/158041926-689ce8b5-91a2-4ace-8780-74568329054a.png)

New:

![image](https://user-images.githubusercontent.com/16112919/158041962-af888335-e2c3-4747-b7d7-2de8c35f7f0f.png)

![image](https://user-images.githubusercontent.com/16112919/158041942-ccaf8c81-b6f2-41fd-be6b-40d50858e9f7.png)


## Changelog
:cl:
tweak: Mime and Clown now have separate offices on DeltaStation
tweak: Mime, Clown, and Custodial areas have been relocated to a more "public" part of DeltaStation, taking the places of the bedrooms by Cryodorms
tweak: Maint-ifies the old clown/mime office, custodial closet, and removes the bedrooms in that area for maintenance
tweak: Adds firelocks to the locker room/fitness room areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
