### PR TITLE
Transforming species as a cling now properly handles dropping items. Fixing cling blades laying on the floor

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1360,8 +1360,10 @@
 		dna.species.create_organs(src)
 
 	for(var/obj/item/thing in kept_items)
-		equip_to_slot_if_possible(thing, kept_items[thing])
+		var/equiped = equip_to_slot_if_possible(thing, kept_items[thing])
 		thing.flags = item_flags[thing] // Reset the flags to the origional ones
+		if(!equiped)
+			thing.dropped() // Ensures items know they are dropped. Using their original flags
 
 	//Handle default hair/head accessories for created mobs.
 	var/obj/item/organ/external/head/H = get_organ("head")


### PR DESCRIPTION
## What Does This PR Do
Bug happens when a cling is resting or stunned etc and they transform into another species while holding a cling blade.
The blade is not equipped, since they are incapacitated, and thus just lays there on the floor.
This makes it so that dropped items actually call `dropped`

## Why It's Good For The Game
No more fake clings due to bugs. Or clings duping their blades for others to use...
Also fixes other cases where you change species.

## Changelog
:cl:
fix: Cling blades etc are now properly deleted when you transform into another species as cling
/:cl: