### PR TITLE
Grammar and spelling edits

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -562,8 +562,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	flags = DROPDEL
 
 /obj/item/restraints/handcuffs/energy/used/dropped(mob/user)
-	user.visible_message("<span class='danger'>[user]'s [src] break in a discharge of energy!</span>", \
-							"<span class='userdanger'>[user]'s [src] break in a discharge of energy!</span>")
+	user.visible_message("<span class='danger'>[src] restraining [user] breaks in a discharge of energy!</span>", \
+							"<span class='userdanger'>[src] restraining [user] breaks in a discharge of energy!</span>")
 	do_sparks(4, 0, user.loc)
 	. = ..()
 

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -755,7 +755,7 @@
 		return
 
 	if(B.chemicals >= 100)
-		to_chat(src, "<span class='danger'>Your host twitches and quivers as you rapdly excrete several larvae from your sluglike body.</span>")
+		to_chat(src, "<span class='danger'>Your host twitches and quivers as you rapidly excrete several larvae from your sluglike body.</span>")
 		visible_message("<span class='danger'>[src] heaves violently, expelling a rush of vomit and a wriggling, sluglike creature!</span>")
 		B.chemicals -= 100
 		var/turf/T = get_turf(src)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -48,7 +48,7 @@
 /obj/item/areaeditor/permit
 	name = "construction permit"
 	icon_state = "permit"
-	desc = "This is a one-use permit that allows the user to officially declare a built room as a new addition to the station."
+	desc = "This is a one-use permit that allows the user to officially declare a built room as an addition to the station."
 	fluffnotice = "Nanotrasen Engineering requires all on-station construction projects to be approved by a head of staff, as detailed in Nanotrasen Company Regulation 512-C (Mid-Shift Modifications to Company Property). \
 						By submitting this form, you accept any fines, fees, or personal injury/death that may occur during construction."
 	w_class = WEIGHT_CLASS_TINY

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -48,7 +48,7 @@
 /obj/item/areaeditor/permit
 	name = "construction permit"
 	icon_state = "permit"
-	desc = "This is a one-use permit that allows the user to officially declare a built room as new addition to the station."
+	desc = "This is a one-use permit that allows the user to officially declare a built room as a new addition to the station."
 	fluffnotice = "Nanotrasen Engineering requires all on-station construction projects to be approved by a head of staff, as detailed in Nanotrasen Company Regulation 512-C (Mid-Shift Modifications to Company Property). \
 						By submitting this form, you accept any fines, fees, or personal injury/death that may occur during construction."
 	w_class = WEIGHT_CLASS_TINY
@@ -205,7 +205,7 @@
 	if(!str || !length(str)) //cancel
 		return area_created
 	if(length(str) > 50)
-		to_chat(usr, "<span class='warning'>The given name is too long.  The area remains undefined.</span>")
+		to_chat(usr, "<span class='warning'>The given name is too long. The area remains undefined.</span>")
 		return area_created
 	var/area/A = new
 	A.name = str

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1351,7 +1351,7 @@
 
 /obj/item/toy/russian_revolver
 	name = "russian revolver"
-	desc = "for fun and games!"
+	desc = "For fun and games!"
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "detective_gold"
 	item_state = "gun"

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -107,7 +107,7 @@
 			else if(role == ROLE_WIZARD)
 				message_say = "FOR THE FEDERATION!"
 			else if(role == ROLE_REV || role == "head revolutionary")
-				message_say = "FOR THE REVOLOUTION!"
+				message_say = "FOR THE REVOLUTION!"
 			else if(role == "death commando" || role == ROLE_ERT)
 				message_say = "FOR NANOTRASEN!"
 	user.say(message_say)

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -255,7 +255,7 @@
 /obj/item/pizzabox/vegetable/New()
 	..()
 	pizza = new /obj/item/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza(src)
-	boxtag = "gourmet vegatable"
+	boxtag = "gourmet vegetable"
 
 /obj/item/pizzabox/mushroom/New()
 	..()

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -526,7 +526,7 @@
 		if(prob(2) && prob(t))
 			var/phrases = list()
 			if(Target)
-				phrases += "[Target]... looks yummy..."
+				phrases += "[Target]... look yummy..."
 			if(nutrition < get_starve_nutrition())
 				phrases += "So... hungry..."
 				phrases += "Very... hungry..."

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -486,18 +486,18 @@
 					for(var/mob/living/L in view(7,src)-list(src,who))
 						if(findtext(phrase, lowertext(L.name)))
 							if(isslime(L))
-								to_say = "NO... [L] slime friend"
+								to_say = "NO... [L] slime friend..."
 								--Friends[who] //Don't ask a slime to attack its friend
 							else if(!Friends[L] || Friends[L] < 1)
 								Target = L
 								AIprocess()//Wake up the slime's Target AI, needed otherwise this doesn't work
-								to_say = "Ok... I attack [Target]"
+								to_say = "Ok... I attack [Target]..."
 							else
-								to_say = "No... like [L] ..."
+								to_say = "No... like [L]..."
 								--Friends[who] //Don't ask a slime to attack its friend
 							break
 				else
-					to_say = "No... no listen"
+					to_say = "No... no listen..."
 
 		speech_buffer = list()
 
@@ -526,7 +526,7 @@
 		if(prob(2) && prob(t))
 			var/phrases = list()
 			if(Target)
-				phrases += "[Target]... look yummy..."
+				phrases += "[Target]... looks yummy..."
 			if(nutrition < get_starve_nutrition())
 				phrases += "So... hungry..."
 				phrases += "Very... hungry..."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Three grammar changes, three spelling fixes, and one removal of an unnecessary space.

-'John Doe's the hard-light energy field break in a discharge of energy!' - 'The hard-light energy field restraining John Doe breaks in a discharge of energy!'
-'Your host twitches and quivers as you rapdly excrete several larvae from your sluglike body.' - 'Your host twitches and quivers as you rapidly excrete several larvae from your sluglike body.'
-'This is a one-use permit that allows the user to officially declare a built room as new addition to the station.' - 'This is a one-use permit that allows the user to officially declare a built room as an addition to the station.'
-'The given name is too long.(doublespace)The area remains undefined.' - 'The given name is too long. The area remains undefined.'
-'for fun and games!' - 'For fun and games!'
-"FOR THE REVOLOUTION!" - "FOR THE REVOLUTION!"
-'The box has a tag, it reads: 'gourmet vegatable'.' - 'The box has a tag, it reads: 'gourmet vegetable'.'
-adds ellipses to simplemob slime phrases which ended without punctuation

## Why It's Good For The Game
Improved readability.

## Changelog
:cl:
spellcheck: Fixed a few typos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
