### PR TITLE
Fixes bedsheet bin update_icon() not working

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -263,7 +263,7 @@ LINEN BINS
 	switch(amount)
 		if(0)
 			icon_state = "linenbin-empty"
-		if(1 to amount / 2)
+		if(1 to 10)
 			icon_state = "linenbin-half"
 		else
 			icon_state = "linenbin-full"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The second switch case will *never* pass. It shouldn't compile in the first place but lummox hasn't fixed http://www.byond.com/forum/post/2750423

Another win for OpenDream.

## Changelog
:cl:
fix: Bedsheet bins will now actually look half-empty when they're at least half-empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
