### PR TITLE
Allows ghosts signed up for ghost roles to leave the pool

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -522,6 +522,7 @@ so as to remain in compliance with the most up-to-date laws."
 	var/action = NOTIFY_JUMP
 	var/show_time_left = FALSE // If true you need to call START_PROCESSING manually
 	var/image/time_left_overlay // The last image showing the time left
+	var/image/signed_up_overlay // image showing that you're signed up
 	var/datum/candidate_poll/poll // If set, on Click() it'll register the player as a candidate
 
 /obj/screen/alert/notify_action/process()
@@ -551,6 +552,9 @@ so as to remain in compliance with the most up-to-date laws."
 
 /obj/screen/alert/notify_action/Destroy()
 	target = null
+	if(signed_up_overlay)
+		overlays -= signed_up_overlay
+		qdel(signed_up_overlay)
 	return ..()
 
 /obj/screen/alert/notify_action/Click()
@@ -561,9 +565,14 @@ so as to remain in compliance with the most up-to-date laws."
 		return
 
 	if(poll)
-		if(poll.sign_up(G))
+		var/success
+		if(G in poll.signed_up)
+			success = poll.remove_mob(G)
+		else
+			success = poll.sign_up(G)
+		if(success)
 			// Add a small overlay to indicate we've signed up
-			display_signed_up()
+			update_signed_up_alert()
 	else if(target)
 		switch(action)
 			if(NOTIFY_ATTACK)
@@ -576,14 +585,26 @@ so as to remain in compliance with the most up-to-date laws."
 				G.ManualFollow(target)
 
 /obj/screen/alert/notify_action/Topic(href, href_list)
-	if(href_list["signup"] && poll?.sign_up(usr))
-		display_signed_up()
+	if(!href_list["signup"])
+		return
+	if(!poll)
+		return
+	var/mob/dead/observer/G = usr
+	if(G in poll.signed_up)
+		poll.remove_mob(G)
+	else
+		poll.sign_up(G)
+	update_signed_up_alert()
 
-/obj/screen/alert/notify_action/proc/display_signed_up()
-	var/image/I = image('icons/mob/screen_gen.dmi', icon_state = "selector")
-	I.layer = FLOAT_LAYER
-	I.plane = FLOAT_PLANE + 2
-	overlays += I
+/obj/screen/alert/notify_action/proc/update_signed_up_alert()
+	if(!signed_up_overlay)
+		signed_up_overlay = image('icons/mob/screen_gen.dmi', icon_state = "selector")
+		signed_up_overlay.layer = FLOAT_LAYER
+		signed_up_overlay.plane = FLOAT_PLANE + 2
+	if(usr in poll.signed_up)
+		overlays += signed_up_overlay
+	else
+		overlays -= signed_up_overlay
 
 /obj/screen/alert/notify_action/proc/display_stacks(stacks = 1)
 	if(stacks <= 1)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -567,7 +567,7 @@ so as to remain in compliance with the most up-to-date laws."
 	if(poll)
 		var/success
 		if(G in poll.signed_up)
-			success = poll.remove_mob(G)
+			success = poll.remove_candidate(G)
 		else
 			success = poll.sign_up(G)
 		if(success)
@@ -591,7 +591,7 @@ so as to remain in compliance with the most up-to-date laws."
 		return
 	var/mob/dead/observer/G = usr
 	if(G in poll.signed_up)
-		poll.remove_mob(G)
+		poll.remove_candidate(G)
 	else
 		poll.sign_up(G)
 	update_signed_up_alert()

--- a/code/controllers/subsystem/ghost_spawns.dm
+++ b/code/controllers/subsystem/ghost_spawns.dm
@@ -284,7 +284,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 
 	signed_up -= M
 	if(!silent)
-		to_chat(M, "<span class='notice'>You have been unregistered as a candidate for this role. You can freely sign up again before the poll ends.</span>")
+		to_chat(M, "<span class='danger'>You have been unregistered as a candidate for this role. You can freely sign up again before the poll ends.</span>")
 
 		for(var/existing_poll in SSghost_spawns.currently_polling)
 			var/datum/candidate_poll/P = existing_poll

--- a/code/controllers/subsystem/ghost_spawns.dm
+++ b/code/controllers/subsystem/ghost_spawns.dm
@@ -284,7 +284,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 
 	signed_up -= M
 	if(!silent)
-		to_chat(M, "<span class='danger'>You have been unregistered as a candidate for this role. You can freely sign up again before the poll ends.</span>")
+		to_chat(M, "<span class='notice'>You have been unregistered as a candidate for this role. You can freely sign up again before the poll ends.</span>")
 
 		for(var/existing_poll in SSghost_spawns.currently_polling)
 			var/datum/candidate_poll/P = existing_poll

--- a/code/controllers/subsystem/ghost_spawns.dm
+++ b/code/controllers/subsystem/ghost_spawns.dm
@@ -234,7 +234,6 @@ SUBSYSTEM_DEF(ghost_spawns)
   * Arguments:
   * * M - The (controlled) mob to sign up
   * * silent - Whether no messages should appear or not. If not TRUE, signing up to this poll will also sign the mob up for identical polls
-  * * can_unregister - If TRUE, calling this proc again while already registered will remove M from the poll.
   */
 /datum/candidate_poll/proc/sign_up(mob/dead/observer/M, silent = FALSE)
 	. = FALSE
@@ -269,7 +268,7 @@ SUBSYSTEM_DEF(ghost_spawns)
  * * M - The mob to remove from the poll, if present.
  * * Silent - If true, no messages will be sent to M about their removal.
  */
-/datum/candidate_poll/proc/remove_mob(mob/dead/observer/M, silent = FALSE)
+/datum/candidate_poll/proc/remove_candidate(mob/dead/observer/M, silent = FALSE)
 	. = FALSE
 	if(!istype(M) || !M.key || !M.client)
 		return
@@ -290,7 +289,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 		for(var/existing_poll in SSghost_spawns.currently_polling)
 			var/datum/candidate_poll/P = existing_poll
 			if(src != P && hash == P.hash && (M in P.signed_up))
-				P.remove_mob(M, TRUE)
+				P.remove_candidate(M, TRUE)
 	return TRUE
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
After signing up for a ghost role, you can now click the signup alert popup (or the link in chat) to remove yourself from the pool of ghosts that will be pulled to fill the role.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's been a constant gripe of mine that if you sign up for a ghost role and change your mind, there's no way to cancel and remove yourself from the pool of ghosts that might be selected. It should be pretty intuitive (click on, click off) and help out indecisive players and admins who have to help out while trying to prep an ERT.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/158281128-a6729734-5842-4508-b145-f7e9e8ce3df7.mp4

Slightly modified the text after making the video so it's now clear if you've accidentally unregistered yourself (thanks qwerty)
![image](https://gay.aura.dog/tLMVjykH.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: You can click on a ghost role sign-up again to remove yourself from the pool of chosen ghosts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
