### PR TITLE
Revert detective lethals, increase backfire damage

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -33,7 +33,7 @@
 	desc = "A .38 bullet casing."
 	caliber = "38"
 	icon_state = "r-casing"
-	projectile_type = /obj/item/projectile/bullet/c38
+	projectile_type = /obj/item/projectile/bullet/weakbullet2
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -109,9 +109,9 @@
 		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
 			playsound(user, fire_sound, 50, 1)
 			to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
-			user.take_organ_damage(0,20)
+			user.take_organ_damage(60)
 			user.unEquip(src)
-			return 0
+			return FALSE
 	..()
 
 /obj/item/gun/projectile/revolver/detective/screwdriver_act(mob/user, obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR:

- Reverts changes to detective revolver that made it lethal-only. (25dmg -> 5dmg + 35stam)
- Increases the amount of damage (20 -> 60) dealt by a misfire on modified revolvers, and does brute damage instead of burn.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Since we've had the detective revolver as a roundstart lethal, and the only ranged weapon given to the detective, we have seen an uptick in detectives gunning down people or just shooting them where not needed.
Administration are not all in agreement on how this should be handled, since the detectives are freely allowed to shoot whoever they please on red alert, and we are on red alert a lot of the time.
Due to this point, I decided to try and handle this as a mechanical issue, not an administrative one.
It's clear that _something_ has to be done about this revolver in its current implementation. For now, a revert to less-lethal alongside some long-needed tweaks to misfires is what I think would suit best. 

Community discussion can be seen here, and in discord if you can be bothered to search for the threads.
https://www.paradisestation.org/forum/topic/22176-detectives-lethal-revolver/


<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Tweaked detective revolver to do 35 stamina and 5 brute damage.
tweak: Tweaked detective revolver misfire damage from 20 burn to 60 brute when modified.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
