### PR TITLE
Fixes a runtime in mob_hunt_game_app.dm

### DIFF
--- a/code/modules/pda/mob_hunt_game_app.dm
+++ b/code/modules/pda/mob_hunt_game_app.dm
@@ -29,7 +29,8 @@
 	STOP_PROCESSING(SSobj, pda)
 
 /datum/data/pda/app/mob_hunter_game/Destroy()
-	STOP_PROCESSING(SSobj, pda)
+	if(pda)
+		STOP_PROCESSING(SSobj, pda)
 	SSmob_hunt.connected_clients -= src
 	return ..()
 


### PR DESCRIPTION
## What Does This PR Do
Adds a null check for the variable `pda` used in `/datum/data/pda/app/mob_hunter_game/Destroy()`

Prevents a runtime that occurs when the PDA is being qdel'd (such as in cryo) before the game app is being qdel'd resulting in the destroy proc attempting to call `STOP_PROCESSING()` on a null reference.

## Why It's Good For The Game
runtime bad
