### PR TITLE
Fixes qdeling the supermatter with the supermatter (sliver) 

### DIFF
--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -356,6 +356,8 @@
 		return
 	else if(istype(AM, /obj/item/nuke_core_container))
 		return
+	else if(istype(AM, /obj/machinery/power/supermatter_crystal))
+		return
 	else
 		investigate_log("has consumed [AM].", "supermatter")
 		qdel(AM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

GBP no update pls

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Fixes qdeling the supermatter (and dusting yourself) when you click on the supermatter with supermatter tongs that has a sliver in it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

You should not be able to delete the supermatter with a sliver, bug was introduced when I tried to keep people from dusting themself by accident by clicking on the supermatter with tongs by accident.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fixed being able to delete the supermatter with a suppermatter sliver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
