### PR TITLE
Makes git blame annotations ignore #13131

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Ignores the line-ending explosion in #13131
+04ba5c1cc902bf2eada751de7b1b72ebc64ecd86


### PR DESCRIPTION
## What Does This PR Do
Makes git blame annotations ignore #13131 when code diving on the web editor. You can also make local git blame viewing things use this file to ignore that commit by means different for each blame viewer.

## Why It's Good For The Game
I am tired of people whining that I made code diving for old things impossible.

## Changelog
N/A, repo only