### PR TITLE
Ensures stacks GC when merged in a storage. Also properly updates the users screen

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -162,6 +162,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	if(ismob(loc))
 		var/mob/m = loc
 		m.unEquip(src, 1)
+	else if(istype(loc, /obj/item/storage))
+		var/obj/item/storage/S = loc
+		S.remove_from_storage(src)
 	QDEL_LIST(actions)
 	master = null
 	return ..()


### PR DESCRIPTION
## What Does This PR Do
Tells the storage item the stack is in that the stack got removed from the backpack. This makes it so that the user's screen gets updated and thus removes the reference in `client.screen`
This also makes it so that you don't get an empty spot in your inventory.
![image](https://user-images.githubusercontent.com/15887760/159793840-c1382c14-bbfc-4d3a-9ca0-12d163dc0ff3.png)


```
[2022-03-23T19:02:22] Beginning search for references to a /obj/item/stack/sheet/bone.
[2022-03-23T19:02:22] Finished searching globals
[2022-03-23T19:05:07] Finished searching atoms
[2022-03-23T19:05:21] Finished searching datums
[2022-03-23T19:05:21] Found /obj/item/stack/sheet/bone [0x202166d] in list World -> /client [0x5000000] -> screen (list).
[2022-03-23T19:05:21] Finished searching clients
[2022-03-23T19:05:21] Completed search for references to a /obj/item/stack/sheet/bone.
[2022-03-23T19:05:21] GC: -- [0x2100000c] | /obj/item/stack/sheet/bone was unable to be GC'd --
```

## Why It's Good For The Game
Happens fairly often and each failure costs some ms.

## Changelog
:cl:
fix: Merging stacks in your backpack or such now properly updates the inventory
/:cl: