### PR TITLE
Properly unsets the machine when undoing a paper bundle. Fixing a GC issue

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -21,7 +21,7 @@
 		new /obj/item/paper(src)
 		new /obj/item/paper(src)
 		amount += 1
-		
+
 /obj/item/paper_bundle/attackby(obj/item/W as obj, mob/user as mob, params)
 	..()
 	var/obj/item/paper/P
@@ -173,7 +173,9 @@
 				var/obj/item/paper/P = src[1]
 				usr.unEquip(src)
 				usr.put_in_hands(P)
+				usr.unset_machine() // Ensure the bundle GCs
 				qdel(src)
+				return
 			else if(page == amount)
 				screen = 2
 			else if(page == amount+1)


### PR DESCRIPTION
## What Does This PR Do
Makes it so that paper bundles properly GC when you undo the bundle by removing all the papers using the UI.

```
[2022-03-23T20:24:16] Beginning search for references to a /obj/item/paper_bundle.
[2022-03-23T20:24:16] Finished searching globals
[2022-03-23T20:24:16] Found /obj/item/paper_bundle [0x2008aa3] in /mob/living/carbon/human's [0x300009c] machine var. World -> /mob/living/carbon/human
[2022-03-23T20:26:41] Finished searching atoms
[2022-03-23T20:26:53] Finished searching datums
[2022-03-23T20:26:53] Finished searching clients
[2022-03-23T20:26:53] Completed search for references to a /obj/item/paper_bundle.
```

An alternative PR is made using a component to circumvent the issue stated below. #17520

OLD:
I was debating making the mob listen to `COMSIG_PARENT_QDELETING` when a machine gets set.
However, you can only register once to a given signal from a given target and I can see that the `COMSIG_PARENT_QDELETING` signal becoming quite popular for mobs to register to.
![image](https://user-images.githubusercontent.com/15887760/159794674-ba81bf31-5933-4f23-8270-73067dffe3ac.png)
This would solve the issue for all `mob.machine` related GC issues. But it would also block `mob`'s from registering *safely* to objects which use the `set_machine` proc.

A component might work. But this requires some designing and testing. Something I can't do till early April I'm afraid. (Seems I did have time)


## Why It's Good For The Game
Small GC improvements are always nice.

## Changelog
Technical only.
