### PR TITLE
Fixes Jestosteron and Clipboard runtime

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -31,12 +31,6 @@
 	if(istype(W, /obj/item/photo))
 		return PHOTO
 
-/obj/item/clipboard/proc/checkTopPaper()
-	if(toppaper.loc != src) //Oh no! We're missing a top sheet! Better get another one to be at the top.
-		toppaper = locate(/obj/item/paper) in src
-		if(!toppaper) //In case there's no paper, try find a paper bundle instead (why is paper_bundle not a subtype of paper?)
-			toppaper = locate(/obj/item/paper_bundle) in src
-
 /obj/item/clipboard/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) && toppaper)
@@ -136,7 +130,9 @@
 		if(isPaperwork(P))
 			usr.put_in_hands(P)
 			to_chat(usr, "<span class='notice'>You remove [P] from [src].</span>")
-			checkTopPaper() //So we don't accidentally make the top sheet not be on the clipboard
+			toppaper = locate(/obj/item/paper) in src
+			if(!toppaper) //In case there's no paper, try find a paper bundle instead
+				toppaper = locate(/obj/item/paper_bundle) in src
 	else if(href_list["viewOrWrite"])
 		var/obj/item/P = locate(href_list["viewOrWrite"]) in src
 		if(!isPaperwork(P))

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -464,12 +464,12 @@
 	C.AddElement(/datum/element/waddling)
 
 /datum/reagent/jestosterone/on_mob_life(mob/living/carbon/M)
-	if(!istype(M))
-		return ..()
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(10))
 		M.emote("giggle")
-	if(M?.mind.assigned_role == "Clown")
+	if(!M.mind)
+		return ..() | update_flags
+	if(M.mind.assigned_role == "Clown")
 		update_flags |= M.adjustBruteLoss(-1.5 * REAGENTS_EFFECT_MULTIPLIER) //Screw those pesky clown beatings!
 	else
 		M.AdjustDizzy(10, 0, 500)
@@ -489,7 +489,7 @@
 			"Your legs feel like jelly.",
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
-		if(M?.mind.assigned_role == "Mime")
+		if(M.mind.assigned_role == "Mime")
 			update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags
 


### PR DESCRIPTION
## What Does This PR Do

- Cleans up a bit of clipboard code so we don't accidently use null references
- Cleaned up sanity checking in jestosterone to be less unnecessary and more concise

## Why It's Good For The Game
runtimes bad
