### PR TITLE
Adds more obvious logging to buildmode explosions

### DIFF
--- a/code/modules/buildmode/submodes/boom.dm
+++ b/code/modules/buildmode/submodes/boom.dm
@@ -1,6 +1,6 @@
 /datum/buildmode_mode/boom
 	key = "boom"
-	
+
 	var/devastation = -1
 	var/heavy = -1
 	var/light = -1
@@ -29,4 +29,5 @@
 	var/left_click = pa.Find("left")
 
 	if(left_click)
+		log_admin("Build Mode: [key_name(user)] created an explosion at ([object.x],[object.y],[object.z])")
 		explosion(object, devastation, heavy, light, flash, null, TRUE, flames)


### PR DESCRIPTION
## What Does This PR Do
Adds more obvious logging to buildmode explosions
![image](https://user-images.githubusercontent.com/25063394/159931009-c9dd3d84-62f9-4644-844e-77b20c89011f.png)

## Why It's Good For The Game
This should really be more obvious in the logs

## Changelog
:cl: AffectedArc07
add: Improved buildmode logging
/:cl:
