### PR TITLE
Fix - Smartfridges do not dispense if the custom amount is 0

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -273,7 +273,7 @@
 
 			var/index = text2num(params["index"])
 			var/amount = text2num(params["amount"])
-			if(isnull(index) || !ISINDEXSAFE(item_quants, index) || isnull(amount))
+			if(isnull(index) || !ISINDEXSAFE(item_quants, index) || isnull(amount) || amount == 0)
 				return FALSE
 			var/K = item_quants[index]
 			var/count = item_quants[K]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check for the input amount to see if it's 0 in the smartfridge UI.

## Why It's Good For The Game
Fixes #17513

## Changelog
:cl:
fix: Smartfridges do not dispense anything if the custom amount is set to 0.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
