### PR TITLE
Adds DB logging to crew transfer and map votes

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -176,9 +176,10 @@ SUBSYSTEM_DEF(blackbox)
   * * increment - If using "amount", how much to increment why
   * * data - The actual data to logged
   * * overwrite - Do we want to overwrite the existing key
+  * * ignore_seal - Does the feedback go in regardless of blackbox sealed status? (EG: map vote results)
   */
-/datum/controller/subsystem/blackbox/proc/record_feedback(key_type, key, increment, data, overwrite)
-	if(sealed || !key_type || !istext(key) || !isnum(increment || !data))
+/datum/controller/subsystem/blackbox/proc/record_feedback(key_type, key, increment, data, overwrite, ignore_seal)
+	if((sealed && !ignore_seal) || !key_type || !istext(key) || !isnum(increment || !data))
 		return
 	var/datum/feedback_variable/FV = find_feedback_datum(key, key_type)
 	switch(key_type)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -160,6 +160,8 @@ SUBSYSTEM_DEF(vote)
 	. = announce_result()
 	var/restart = 0
 	if(.)
+		for(var/option in choices)
+			SSblackbox.record_feedback("nested tally", "votes", choices[option], list(mode, option), ignore_seal = TRUE)
 		switch(mode)
 			if("restart")
 				if(. == "Restart Round")
@@ -177,8 +179,6 @@ SUBSYSTEM_DEF(vote)
 			if("crew transfer")
 				if(. == "Initiate Crew Transfer")
 					init_shift_change(null, TRUE)
-				for(var/option in choices)
-					SSblackbox.record_feedback("nested tally", "votes", choices[option], list("Transfer Vote", option))
 			if("map")
 				// Find target map.
 				var/datum/map/top_voted_map
@@ -189,8 +189,6 @@ SUBSYSTEM_DEF(vote)
 						top_voted_map = M
 				to_chat(world, "<font color='purple'>Map for next round: [initial(top_voted_map.fluff_name)] ([initial(top_voted_map.technical_name)])</font>")
 				SSmapping.next_map = new top_voted_map
-				for(var/option in choices)
-					SSblackbox.record_feedback("nested tally", "votes", choices[option], list("Map Vote", option), FALSE, TRUE)
 
 	if(restart)
 		SSticker.reboot_helper("Restart vote successful.", "restart vote")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -177,6 +177,8 @@ SUBSYSTEM_DEF(vote)
 			if("crew transfer")
 				if(. == "Initiate Crew Transfer")
 					init_shift_change(null, TRUE)
+				for(var/option in choices)
+					SSblackbox.record_feedback("nested tally", "votes", choices[option], list("Transfer Vote", option))
 			if("map")
 				// Find target map.
 				var/datum/map/top_voted_map
@@ -187,7 +189,8 @@ SUBSYSTEM_DEF(vote)
 						top_voted_map = M
 				to_chat(world, "<font color='purple'>Map for next round: [initial(top_voted_map.fluff_name)] ([initial(top_voted_map.technical_name)])</font>")
 				SSmapping.next_map = new top_voted_map
-
+				for(var/option in choices)
+					SSblackbox.record_feedback("nested tally", "votes", choices[option], list("Map Vote", option), FALSE, TRUE)
 
 	if(restart)
 		SSticker.reboot_helper("Restart vote successful.", "restart vote")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ensures votes for crew transfer and map choice are logged to the DB.
Introduces a new way to bypass black-box seal at round-end for late stats.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Average #design-chat / #coding_chat discussion:
Coder 1: "Meta bad"
Coder 2: "no U"
Coder 3: "why can't we all get along and follow rational data trends to determine decisions"
Coders 1 & 2: "it's not logged your idea sucks"

This fixes the above, given enough time for an adequate sample size.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
No player-facing changes.