### PR TITLE
Closes UI for all players looking into a storage inside a recently closed locker

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -85,6 +85,12 @@
 	LAZYCLEARLIST(mobs_viewing)
 	return ..()
 
+/obj/item/storage/forceMove(atom/destination)
+	. = ..()
+	if(!ismob(destination.loc))
+		for(var/mob/player in mobs_viewing)
+			hide_from(player)
+
 /obj/item/storage/MouseDrop(obj/over_object)
 	if(!ismob(usr)) //so monkeys can take off their backpacks -- Urist
 		return

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -89,6 +89,8 @@
 	. = ..()
 	if(!ismob(destination.loc))
 		for(var/mob/player in mobs_viewing)
+			if(player == destination)
+				continue
 			hide_from(player)
 
 /obj/item/storage/MouseDrop(obj/over_object)
@@ -538,9 +540,6 @@
 		show_to(user)
 	else
 		..()
-		for(var/mob/M in range(1))
-			if(M.s_active == src)
-				close(M)
 	add_fingerprint(user)
 
 /obj/item/storage/equipped(mob/user, slot, initial)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -126,6 +126,10 @@
 		if(!I.anchored)
 			I.forceMove(src)
 			itemcount++
+		if(istype(I, /obj/item/storage))
+			var/obj/item/storage/S = I
+			for(var/mob/player in S.mobs_viewing)
+				S.hide_from(player)
 
 	for(var/mob/M in loc)
 		if(itemcount >= storage_capacity)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -126,10 +126,6 @@
 		if(!I.anchored)
 			I.forceMove(src)
 			itemcount++
-		if(istype(I, /obj/item/storage))
-			var/obj/item/storage/S = I
-			for(var/mob/player in S.mobs_viewing)
-				S.hide_from(player)
 
 	for(var/mob/M in loc)
 		if(itemcount >= storage_capacity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #16528, not allowing people to put items inside of storage items **inside** a recently closed locker.

When the locker is closed, it loops through all the players that have the stored item inventory open and closes it for each of them.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One bug less, one problem less.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl: Nazsgull
fix: Fixed a few things

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
