### PR TITLE
Add qdeleting component. Fix machine related GC issues

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -293,6 +293,11 @@
 #define COMSIG_MOB_ALTCLICKON "mob_altclickon"
 	#define COMSIG_MOB_CANCEL_CLICKON (1<<0)
 
+///from base of mob/proc/set_machine(obj/O)
+#define COMSIG_MOB_MACHINE_SET "mob_machine_set"
+///from base of mob/proc/unset_machine()
+#define COMSIG_MOB_MACHINE_UNSET "mob_machine_unset"
+
 ///from base of obj/allowed(mob/M): (/obj) returns bool, if TRUE the mob has id access to the obj
 #define COMSIG_MOB_ALLOWED "mob_allowed"
 ///from base of mob/anti_magic_check(): (mob/user, magic, holy, tinfoil, chargecost, self, protection_sources)

--- a/code/datums/components/qdeleting.dm
+++ b/code/datums/components/qdeleting.dm
@@ -1,0 +1,41 @@
+/**
+ * A technical component which allows datums to register to other datums their QDELETION.
+ * Created so that, for instance, a human can listen to the same object twice to handle different things.
+ * Since you can only subscribe to a target once given a specific signal.
+ */
+
+/datum/component/qdeleting
+	dupe_mode = COMPONENT_DUPE_ALLOWED
+	/// Who are we listening to?
+	var/datum/target
+	/// What do we call when the target gets destroyed?
+	var/datum/callback/callback
+	/// What signal causes us to qdel?
+	var/delete_signal
+
+/datum/component/qdeleting/Initialize(datum/target, datum/callback/callback, delete_signal)
+	if(!istype(target) || !istype(callback))
+		return COMPONENT_INCOMPATIBLE
+	src.callback = callback
+	src.target = target
+	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/do_callback)
+	if(delete_signal)
+		RegisterSignal(parent, delete_signal, .proc/delete_comp)
+		src.delete_signal = delete_signal
+
+/datum/component/qdeleting/Destroy(force, silent)
+	target = null
+	callback = null
+	return ..()
+
+/datum/component/qdeleting/proc/delete_comp()
+	qdel(src)
+
+/datum/component/qdeleting/proc/do_callback()
+	callback.InvokeAsync(target)
+	qdel(src)
+
+/datum/component/qdeleting/UnregisterFromParent()
+	UnregisterSignal(parent, delete_signal)
+	if(delete_signal)
+		UnregisterSignal(parent, delete_signal)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -173,6 +173,7 @@
 	if(machine)
 		machine.on_unset_machine(src)
 		machine = null
+		SEND_SIGNAL(src, COMSIG_MOB_MACHINE_UNSET)
 
 //called when the user unsets the machine.
 /atom/movable/proc/on_unset_machine(mob/user)
@@ -183,7 +184,9 @@
 		unset_machine()
 	src.machine = O
 	if(istype(O))
+		AddComponent(/datum/component/qdeleting, O, CALLBACK(src, .proc/unset_machine), COMSIG_MOB_MACHINE_UNSET)
 		O.in_use = TRUE
+		SEND_SIGNAL(src, COMSIG_MOB_MACHINE_SET, O)
 
 /obj/item/proc/updateSelfDialog()
 	var/mob/M = src.loc

--- a/paradise.dme
+++ b/paradise.dme
@@ -340,6 +340,7 @@
 #include "code\datums\components\orbiter.dm"
 #include "code\datums\components\paintable.dm"
 #include "code\datums\components\proximity_monitor.dm"
+#include "code\datums\components\qdeleting.dm"
 #include "code\datums\components\radioactive.dm"
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\spawner.dm"


### PR DESCRIPTION
## What Does This PR Do
Alternative to #17507
Creates a component whose sole purpose is to listen to a target being destroyed.
I'd gladly hear your thoughts on using stuff like this to fix more complex technical issues.

>Why a component and not just listen directly?

You can only listen once to a given target with a given signal from a source.
So if we listen here directly to an item/machine being deleted then other mob code (for the same mob) can't do that safely anymore.
In practice, this should not happen often. But in GC related cases this can happen more frequently.

> Why does this work then?

The component acts as a layer between the mob and the target. So the component will take the "slot" to listen to the destroy signal of the target. Keeping that slot free for the actual mob. The component also allows for duplicate components types on the mob. So the mob can create as many as it needs of this component without issues.

> Can't you just make signals accept multiple procs to call for a given target and a given signal?

Well.. yes. But as stated above. This (should) rarely happen. And usually, when it happens it's due to bad design.
Which in the end. This sort of is in my opinion. The code responsible for setting the references should also clear them. But with the existing legacy code, this is rather difficult to get done properly.
Implementing this change will most likely cause some all-around performance issues for edge cases. It would also make the signal system more complex for, again, little gain.

Fixes: And any other machine-related GC issues. Spellbooks being for instance also set the reference without ever removing it.
```
[2022-03-23T20:24:16] Beginning search for references to a /obj/item/paper_bundle.
[2022-03-23T20:24:16] Finished searching globals
[2022-03-23T20:24:16] Found /obj/item/paper_bundle [0x2008aa3] in /mob/living/carbon/human's [0x300009c] machine var. World -> /mob/living/carbon/human
[2022-03-23T20:26:41] Finished searching atoms
[2022-03-23T20:26:53] Finished searching datums
[2022-03-23T20:26:53] Finished searching clients
[2022-03-23T20:26:53] Completed search for references to a /obj/item/paper_bundle.
```

## Why It's Good For The Game
This component should help with annoying cases like the one fixed in this PR. It should however not be used when you can just listen to the delete signal.

## Changelog
Tech only