### PR TITLE
[GBP no update] Fixes a disposals runtime

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -789,8 +789,9 @@
 		return
 	if(T.intact && istype(T,/turf/simulated/floor)) //intact floor, pop the tile
 		var/turf/simulated/floor/F = T
+		var/turf_typecash = F.floor_tile
 		if(F.remove_tile(null, TRUE, FALSE))
-			new F.floor_tile(H)
+			new turf_typecash(T)
 
 	if(direction)		// direction is specified
 		if(istype(T, /turf/space)) // if ended in space, then range is unlimited

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -789,9 +789,9 @@
 		return
 	if(T.intact && istype(T,/turf/simulated/floor)) //intact floor, pop the tile
 		var/turf/simulated/floor/F = T
-		var/turf_typecash = F.floor_tile
+		var/turf_typecache = F.floor_tile
 		if(F.remove_tile(null, TRUE, FALSE))
-			new turf_typecash(T)
+			new turf_typecache(T)
 
 	if(direction)		// direction is specified
 		if(istype(T, /turf/space)) // if ended in space, then range is unlimited


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes a runtime caused by turfs changing mid proc. the turf was being removed then it was trying to create the tile type of the plating, which is null.

## Why It's Good For The Game
runtimes bad, also prevents losing items down disposals this way.

## Changelog
:cl:
fix: you no longer lose items that go through severed disposals pipes when the output of the pipe is under a tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
