### PR TITLE
BRPED provides user feedback for out-of-range exchanges and prevents false-positive logs

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -24,11 +24,12 @@
 /obj/item/storage/part_replacer/afterattack(obj/machinery/M, mob/user, flag, params)
 	if(!flag && works_from_distance && istype(M))
 		// Make sure its in range
-		if(M in view(user))
+		if(get_dist(src, M) <= (world.view + 2))
 			if(M.component_parts)
 				M.exchange_parts(user, src)
 				user.Beam(M,icon_state="rped_upgrade", icon='icons/effects/effects.dmi', time=5)
 		else
+			message_admins("\[EXPLOIT] [key_name_admin(user)] attempted to upgrade machinery with a BRPED via a camera console. (Attempted range exploit)")
 			playsound(src, 'sound/machines/synth_no.ogg', 15, TRUE)
 			to_chat(user, "ERROR: [M] is out of [src]'s range!")
 

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -29,7 +29,8 @@
 				M.exchange_parts(user, src)
 				user.Beam(M,icon_state="rped_upgrade", icon='icons/effects/effects.dmi', time=5)
 		else
-			message_admins("\[EXPLOIT] [key_name_admin(user)] attempted to upgrade machinery with a BRPED via a camera console. (Attempted range exploit)")
+			playsound(src, 'sound/machines/synth_no.ogg', 15, TRUE)
+			to_chat(user, "ERROR: [M] is out of [src]'s range!")
 
 /obj/item/storage/part_replacer/bluespace
 	name = "bluespace rapid part exchange device"

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -24,7 +24,7 @@
 /obj/item/storage/part_replacer/afterattack(obj/machinery/M, mob/user, flag, params)
 	if(!flag && works_from_distance && istype(M))
 		// Make sure its in range
-		if(get_dist(src, M) <= (world.view + 2))
+		if(get_dist(src, M) <= (user.client.view + 2))
 			if(M.component_parts)
 				M.exchange_parts(user, src)
 				user.Beam(M,icon_state="rped_upgrade", icon='icons/effects/effects.dmi', time=5)

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -31,7 +31,7 @@
 		else
 			message_admins("\[EXPLOIT] [key_name_admin(user)] attempted to upgrade machinery with a BRPED via a camera console. (Attempted range exploit)")
 			playsound(src, 'sound/machines/synth_no.ogg', 15, TRUE)
-			to_chat(user, "ERROR: [M] is out of [src]'s range!")
+			to_chat(user, "<span class='notice'>ERROR: [M] is out of [src]'s range!</span>")
 
 /obj/item/storage/part_replacer/bluespace
 	name = "bluespace rapid part exchange device"


### PR DESCRIPTION
## What Does This PR Do
BRPED now provides an error message to the player and makes a angry buzz noise when an out-of-range exchange is attempted. Admin logs are no longer triggered accidently by players walking just out of range while using the BRPED

Tweaks logging implemented by #17222
## Why It's Good For The Game
False positive (accidental triggering) of admin logs for exploits is bad. Now it should only log when players are actually using it through the camera console.

EDIT: made my summary less sassy and with the requested changes in mind
## Changelog
:cl:
tweak: BRPED now provides user feedback and no longer 
/:cl:
