### PR TITLE
Replaces Most Privacy Shutters with Polarized Windows on BoxStation

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -58372,10 +58372,11 @@
 /obj/item/clipboard{
 	pixel_x = -5
 	},
-/obj/machinery/door_control{
-	id = "psychoffice";
-	name = "Privacy Shutters Control";
-	pixel_x = -25
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Psych";
+	pixel_x = -24;
+	req_access_txt = "64"
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
@@ -61129,20 +61130,14 @@
 	},
 /area/hallway/primary/aft)
 "cBw" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "psychoffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Psych"
+	},
 /turf/simulated/floor/plating,
 /area/medical/psych)
 "cBx" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -13993,15 +13993,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aHA" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "courtroomshutters";
-	layer = 3.21;
-	name = "Courtroom Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Courtroom"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
 "aHB" = (
@@ -15725,6 +15719,11 @@
 /obj/structure/table/wood,
 /obj/item/gavelblock,
 /obj/item/gavelhammer,
+/obj/machinery/button/windowtint{
+	id = "Courtroom";
+	pixel_x = -8;
+	req_one_access_txt = "74;3"
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aLP" = (
@@ -15733,12 +15732,6 @@
 "aLQ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "courtroomshutters";
-	name = "Brig Courtroom Shutter Control";
-	pixel_x = 25;
-	req_one_access_txt = "74;3"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -16620,20 +16613,12 @@
 /area/maintenance/fsmaint)
 "aNS" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom";
-	req_access_txt = "63"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "courtroomshutters";
-	layer = 3.21;
-	name = "Courtroom Privacy Shutters";
-	opacity = 0
+/obj/machinery/door/airlock{
+	name = "Courtroom";
+	req_access_txt = "63"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -17030,10 +17015,6 @@
 /area/maintenance/fpmaint2)
 "aOO" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom";
-	req_access_txt = "63"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17042,13 +17023,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "courtroomshutters";
-	layer = 3.21;
-	name = "Courtroom Privacy Shutters";
-	opacity = 0
+/obj/machinery/door/airlock{
+	name = "Courtroom";
+	req_access_txt = "63"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -4105,7 +4105,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	id_tag = "hosofficedoor";
 	name = "Head of Security";
 	req_access_txt = "58"
@@ -13266,8 +13266,9 @@
 /area/hallway/primary/fore)
 "aFG" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Detective";
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_access = null;
 	req_access_txt = "4"
 	},
 /obj/structure/cable{
@@ -23202,11 +23203,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/button/windowtint{
-	id = "Chapel";
-	pixel_y = 24;
-	req_access_txt = "22"
-	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bcv" = (
@@ -25136,9 +25132,7 @@
 	},
 /area/chapel/main)
 "bgg" = (
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Chapel"
-	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/chapel/office)
 "bgh" = (
@@ -51114,16 +51108,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "rdofficedoor";
-	name = "Research Director";
-	req_access_txt = "30"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	id_tag = "rdofficedoor";
+	name = "Research Director's Office";
+	req_access_txt = "30"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -69146,9 +69140,9 @@
 /area/engine/chiefs_office)
 "cTg" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	id_tag = "ceofficedoor";
-	name = "Chief Engineer";
+	name = "Chief Engineer's Office";
 	req_access_txt = "56"
 	},
 /obj/structure/disposalpipe/segment{
@@ -70383,9 +70377,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = null;
-	name = "Chief Engineer";
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office";
 	req_access_txt = "56"
 	},
 /turf/simulated/floor/plasteel,
@@ -80175,17 +80168,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"hch" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "CMO"
-	},
-/turf/simulated/floor/plating,
-/area/medical/cmo)
 "heB" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
@@ -122410,7 +122392,7 @@ chi
 bTZ
 bWd
 chr
-hch
+bZz
 ccG
 ccG
 cIx

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -504,7 +504,9 @@
 	},
 /area/security/main)
 "adq" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "HoS"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "adr" = (
@@ -1006,6 +1008,13 @@
 	},
 /obj/machinery/computer/secure_data{
 	dir = 8
+	},
+/obj/machinery/button/windowtint{
+	dir = 8;
+	id = "HoS";
+	pixel_x = 24;
+	pixel_y = -8;
+	req_access_txt = "58"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2973,7 +2982,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "HoS"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "akI" = (
@@ -3179,14 +3190,6 @@
 	},
 /area/security/brig)
 "alc" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "lawyer";
-	name = "Internal Affairs Privacy Shutters";
-	opacity = 0
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -3195,7 +3198,9 @@
 	opacity = 0
 	},
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "IAA"
+	},
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "ald" = (
@@ -3454,7 +3459,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "HoS"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "alD" = (
@@ -4697,17 +4704,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
-/area/lawoffice)
-"aod" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "lawyer";
-	name = "Internal Affairs Privacy Shutters";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
 /area/lawoffice)
 "aoe" = (
 /obj/structure/table/reinforced,
@@ -6034,14 +6030,6 @@
 /turf/simulated/floor/carpet/cyan,
 /area/security/prison/cell_block/A)
 "aqV" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "lawyer";
-	name = "Internal Affairs Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -6053,7 +6041,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "IAA"
+	},
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "aqW" = (
@@ -6961,14 +6951,6 @@
 	},
 /area/security/permabrig)
 "asD" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "lawyer";
-	name = "Internal Affairs Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -6990,7 +6972,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "IAA"
+	},
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "asE" = (
@@ -7849,14 +7833,6 @@
 	},
 /area/security/prison/cell_block/A)
 "auo" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "lawyer";
-	name = "Internal Affairs Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -7865,7 +7841,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "IAA"
+	},
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "aup" = (
@@ -8212,18 +8190,20 @@
 	dir = 4;
 	pixel_y = -22
 	},
-/obj/machinery/door_control{
-	id = "Processing Shutter";
-	name = "Processing Shutter Privacy";
-	pixel_x = -28;
-	pixel_y = -8;
-	req_access_txt = "63"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/item/radio/intercom/department/security{
 	pixel_x = -28
+	},
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Processing";
+	name = "processing tint control";
+	pixel_x = -24;
+	pixel_y = -8;
+	req_access_txt = "63";
+	tag = null
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -8260,7 +8240,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "HoS"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "auY" = (
@@ -8556,14 +8538,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Processing Shutter";
-	name = "Processing Shutter";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Processing"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/processing)
 "avA" = (
@@ -8960,14 +8937,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Processing Shutter";
-	name = "Processing Shutter";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Processing"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/processing)
 "awh" = (
@@ -9461,18 +9433,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
-"axv" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Processing Shutter";
-	name = "Processing Shutter";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/processing)
 "axw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10111,12 +10071,14 @@
 	},
 /area/security/permabrig)
 "ayH" = (
-/obj/machinery/door_control{
-	id = "lawyer";
-	name = "Internal Affairs Privacy Shutters Control";
-	pixel_x = -25
-	},
 /obj/machinery/vending/coffee,
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "IAA";
+	pixel_x = -24;
+	pixel_y = 6;
+	req_access_txt = "38"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -10372,15 +10334,9 @@
 /area/security/prison/cell_block/A)
 "ayY" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "Processing Shutter";
-	name = "Processing Shutter";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Processing"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/processing)
 "ayZ" = (
@@ -10412,15 +10368,9 @@
 /area/space/nearstation)
 "azc" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "Interrogation";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Interrogation"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/interrogation)
 "azd" = (
@@ -10668,18 +10618,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
-"azF" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "magistrate";
-	name = "Magistrate Privacy Shutters";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/magistrateoffice)
 "azG" = (
 /obj/machinery/light{
 	dir = 8
@@ -10884,13 +10822,6 @@
 	},
 /area/security/interrogation)
 "azY" = (
-/obj/machinery/door_control{
-	id = "Interrogation";
-	name = "Interrogation Privacy Shutter";
-	pixel_x = -28;
-	pixel_y = -3;
-	req_access_txt = "2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -10900,6 +10831,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Interrogation";
+	name = "interrogation tint control";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -11191,15 +11129,16 @@
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar)
 "aAM" = (
-/obj/machinery/door_control{
-	id = "magistrate";
-	name = "Privacy Shutters Control";
-	pixel_x = -25;
-	pixel_y = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Magistrate's Office";
 	dir = 4
+	},
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Magistrate";
+	pixel_x = -24;
+	pixel_y = 6;
+	req_access_txt = "74"
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -11738,15 +11677,9 @@
 	},
 /area/hallway/primary/fore)
 "aCb" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "lawyer";
-	name = "Internal Affairs Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "IAA"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "aCc" = (
@@ -11822,17 +11755,6 @@
 /obj/item/stamp/magistrate,
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/carpet,
-/area/magistrateoffice)
-"aCk" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "magistrate";
-	name = "Magistrate Privacy Shutters";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
 /area/magistrateoffice)
 "aCl" = (
 /obj/structure/closet/secure_closet/magistrate,
@@ -12241,15 +12163,9 @@
 	},
 /area/crew_quarters/courtroom)
 "aDe" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "magistrate";
-	name = "Magistrate Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Magistrate"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/magistrateoffice)
 "aDf" = (
@@ -12721,12 +12637,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door_control{
-	id = "brig_detprivacy";
-	name = "Detective Privacy Shutters Control";
-	pixel_x = 25;
-	pixel_y = 25
-	},
 /obj/effect/landmark/start/detective,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -12754,6 +12664,12 @@
 	},
 /obj/machinery/computer/security/wooden_tv{
 	network = list("SS13","Research Outpost","Mining Outpost")
+	},
+/obj/machinery/button/windowtint{
+	id = "Detective";
+	pixel_x = -8;
+	pixel_y = 24;
+	req_access_txt = "4"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -13284,15 +13200,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "brig_detprivacy";
-	name = "Detective Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Detective"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "aFA" = (
@@ -13346,7 +13256,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Detective"
+	},
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "aFF" = (
@@ -14012,7 +13924,9 @@
 /area/maintenance/fore)
 "aHq" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "HoS"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "aHr" = (
@@ -23288,6 +23202,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/button/windowtint{
+	id = "Chapel";
+	pixel_y = 24;
+	req_access_txt = "22"
+	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bcv" = (
@@ -25217,7 +25136,9 @@
 	},
 /area/chapel/main)
 "bgg" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Chapel"
+	},
 /turf/simulated/floor/plating,
 /area/chapel/office)
 "bgh" = (
@@ -45927,14 +45848,6 @@
 /turf/simulated/wall/r_wall,
 /area/medical/genetics_cloning)
 "bXT" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -45944,23 +45857,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/cmo)
-"bXU" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "bXV" = (
@@ -46107,7 +46006,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "RD"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "bYi" = (
@@ -46120,7 +46021,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "RD"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "bYj" = (
@@ -46797,19 +46700,13 @@
 	},
 /area/medical/cmo)
 "bZz" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "bZA" = (
@@ -46820,6 +46717,12 @@
 	name = "custom placement";
 	pixel_x = -10;
 	pixel_y = 24
+	},
+/obj/machinery/button/windowtint{
+	id = "CMO";
+	pixel_x = 10;
+	pixel_y = 24;
+	req_access_txt = "40"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -47211,7 +47114,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "RD"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "bZV" = (
@@ -47471,7 +47376,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "RD"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "caD" = (
@@ -47706,14 +47613,6 @@
 	},
 /area/medical/cmo)
 "caU" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -47723,7 +47622,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "caV" = (
@@ -48695,14 +48596,6 @@
 	},
 /area/medical/cmo)
 "ccG" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -48712,7 +48605,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "ccH" = (
@@ -49000,7 +48895,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "RD"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "cdg" = (
@@ -50008,10 +49905,10 @@
 /area/hallway/primary/central/se)
 "cfA" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/machinery/door_control{
-	id = "surgeryobs1";
-	name = "Privacy Shutters Control";
-	pixel_y = 25
+/obj/machinery/button/windowtint{
+	id = "Surgery 1";
+	pixel_y = 24;
+	req_access_txt = "45"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50060,15 +49957,9 @@
 	},
 /area/medical/ward)
 "cfE" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "surgeryobs1";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Surgery 1"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
 "cfF" = (
@@ -50090,14 +49981,9 @@
 	},
 /area/medical/ward)
 "cfH" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "open";
-	id_tag = "surgeryobs2";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Surgery 2"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/surgery2)
 "cfI" = (
@@ -50118,10 +50004,10 @@
 /area/medical/surgery2)
 "cfK" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/machinery/door_control{
-	id = "surgeryobs2";
-	name = "Privacy Shutters Control";
-	pixel_y = 25
+/obj/machinery/button/windowtint{
+	id = "Surgery 2";
+	pixel_y = 24;
+	req_access_txt = "45"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
@@ -50725,29 +50611,17 @@
 /area/toxins/server_coldroom)
 "cgU" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "blueshield";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "BS"
+	},
 /turf/simulated/floor/plating,
 /area/blueshield)
 "cgV" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "blueshield";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "BS"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/blueshield)
 "cgW" = (
@@ -50765,28 +50639,16 @@
 "cgY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "representative";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "NT"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ntrep)
 "cgZ" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "representative";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "NT"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ntrep)
 "cha" = (
@@ -51039,16 +50901,10 @@
 	},
 /area/medical/cmo)
 "chz" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "chA" = (
@@ -51733,70 +51589,26 @@
 	},
 /area/medical/medbay2)
 "ciV" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "ciW" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "ciX" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "cmooffice";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -51808,7 +51620,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "ciY" = (
@@ -52029,11 +51843,13 @@
 /area/medical/medbreak)
 "cjw" = (
 /obj/machinery/light_switch{
+	dir = 4;
 	name = "custom placement";
 	pixel_x = -23;
 	pixel_y = -5
 	},
 /obj/machinery/holosign_switch{
+	dir = 4;
 	id = "surgery1";
 	pixel_x = -23;
 	pixel_y = 4
@@ -52164,11 +51980,6 @@
 "cjF" = (
 /obj/structure/table/glass,
 /obj/machinery/door_control{
-	id = "cmooffice";
-	name = "Privacy Shutters Control";
-	pixel_y = -3
-	},
-/obj/machinery/door_control{
 	id = "Biohazard_medi";
 	name = "Emergency Medbay Quarantine";
 	pixel_y = 7
@@ -52187,7 +51998,7 @@
 	id = "cmoofficedoor";
 	name = "Office Door";
 	normaldoorcontrol = 1;
-	pixel_y = -13;
+	pixel_y = -3;
 	req_access_txt = "40"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -52285,6 +52096,13 @@
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
+	},
+/obj/machinery/button/windowtint{
+	dir = 1;
+	id = "RD";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access_txt = "30"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -56727,10 +56545,10 @@
 /turf/simulated/floor/wood,
 /area/ntrep)
 "csx" = (
-/obj/machinery/door_control{
-	id = "blueshield";
-	name = "Privacy Shutters Control";
-	pixel_x = -4;
+/obj/machinery/button/windowtint{
+	dir = 1;
+	id = "BS";
+	pixel_x = -8;
 	pixel_y = -24;
 	req_access_txt = "67"
 	},
@@ -56796,13 +56614,6 @@
 /area/toxins/storage)
 "csC" = (
 /obj/machinery/door_control{
-	id = "representative";
-	name = "Privacy Shutters Control";
-	pixel_x = -4;
-	pixel_y = -24;
-	req_access_txt = "73"
-	},
-/obj/machinery/door_control{
 	id = "ntrepofficedoor";
 	name = "Office Door";
 	normaldoorcontrol = 1;
@@ -56812,6 +56623,12 @@
 	},
 /obj/machinery/computer/secure_data{
 	dir = 1
+	},
+/obj/machinery/button/windowtint{
+	dir = 1;
+	id = "NT";
+	pixel_x = -8;
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -63448,7 +63265,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cGn" = (
@@ -63797,7 +63616,9 @@
 	},
 /area/gateway)
 "cHa" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -63885,7 +63706,9 @@
 /area/hallway/primary/aft)
 "cHk" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cHm" = (
@@ -64423,7 +64246,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cIx" = (
@@ -64466,7 +64291,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cIz" = (
@@ -68118,7 +67945,6 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = -5;
-	pixel_y = 0;
 	req_access_txt = "56"
 	},
 /obj/item/clipboard{
@@ -68679,7 +68505,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cRK" = (
@@ -70537,7 +70365,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cVV" = (
@@ -70770,7 +70600,6 @@
 /area/engine/engineering)
 "cWD" = (
 /obj/machinery/computer/card/minor/ce{
-	icon_state = "computer";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -80346,6 +80175,17 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"hch" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CMO"
+	},
+/turf/simulated/floor/plating,
+/area/medical/cmo)
 "heB" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
@@ -80967,6 +80807,12 @@
 	pixel_y = 24
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/button/windowtint{
+	id = "CE";
+	pixel_x = -8;
+	pixel_y = 24;
+	req_access_txt = "56"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
@@ -82317,7 +82163,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "tOE" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "CE"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -109135,11 +108983,11 @@ egR
 alc
 aoe
 aMO
-aod
-aod
+aCb
+aCb
 avW
-aod
-aod
+aCb
+aCb
 aoe
 aAI
 aCb
@@ -109390,8 +109238,8 @@ wyJ
 aie
 ajP
 aIo
-aod
-aod
+aCb
+aCb
 aIo
 aAz
 avT
@@ -110174,7 +110022,7 @@ aCg
 aDi
 aDU
 aFq
-azF
+aDe
 aHF
 aJd
 aKu
@@ -110425,13 +110273,13 @@ auD
 axZ
 avP
 ayL
-azF
+aDe
 aAM
 aCf
 aLE
 aCm
 aFp
-azF
+aDe
 aHD
 aDL
 aKu
@@ -110682,13 +110530,13 @@ auG
 axZ
 aAW
 ayN
-azF
+aDe
 aAO
 aCj
 aDj
 aEd
 aFs
-azF
+aDe
 aHD
 aDL
 aKu
@@ -110939,7 +110787,7 @@ auG
 axZ
 axz
 ayN
-azF
+aDe
 aAN
 aCi
 aCf
@@ -111455,9 +111303,9 @@ avZ
 ayO
 aDf
 aIl
-aCk
-aCk
-aCk
+aDe
+aDe
+aDe
 aIl
 aIl
 aHH
@@ -114789,7 +114637,7 @@ atC
 awV
 avz
 awg
-axv
+ayY
 awV
 awf
 axP
@@ -122562,7 +122410,7 @@ chi
 bTZ
 bWd
 chr
-bZz
+hch
 ccG
 ccG
 cIx
@@ -123074,7 +122922,7 @@ bUa
 bZX
 ccb
 bWD
-bXU
+ciV
 bZy
 caT
 clb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Changes most uses of shutters from shutters to polarized/tinting windows. Adds polarized windows to Head of Staff Offices.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> We have lots of shutters where they feel semi-out of place as they are used just to tone out the greytide outside/create a bit of privacy however they don't need _really_ the added benefit of being extra secure. This PR changes most uses of those to now use polarized windows. 

Currently, the HoP office, Robotics Desk, Virology, Chemistry, Research and Development, the Bridge Conference Room, and the Kitchen keep their shutters due to either a) not having polarized windoors or b) needing the extra security.

Places that have moved to polarized windows: CE Office, HoS Office, CMO Office, RD Office, Surgery 1 and 2, Psych Office, Internal Affairs Office, Magistrate's Office, Blueshield's Office, NT Rep's Office, Detective's Office, Interrogation, Prisoner Processing, and the Courtroom. This also changes some of the Head of Staff airlocks from the glass variant to the solid variant to complete the privacy.

I'm also game to revert some back to shutters if the powers that be want areas to maintain their current level of security.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Replaces shutters with polarized windows at various offices
add: Adds polarized windows to Head of Staff offices
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
