### PR TITLE
Expands MetaStation Maintenance

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4748,12 +4748,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/armoury)
-"alV" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "alW" = (
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -8205,6 +8199,13 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"aur" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "aus" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -10470,6 +10471,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "azo" = (
@@ -10488,21 +10492,20 @@
 "azq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/warning_stripes/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "azr" = (
@@ -16648,6 +16651,9 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
+"aMN" = (
+/turf/space,
+/area/chapel/main)
 "aMP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -65533,16 +65539,6 @@
 /area/toxins/mixing{
 	name = "\improper Toxins Lab"
 	})
-"cMw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=9.3-Escape-3";
-	location = "9.2-Escape-2"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "cMx" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/mask/gas,
@@ -70703,6 +70699,14 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
+"cWX" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cWZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71030,6 +71034,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"cXG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium";
+	req_access_txt = "27"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "cXH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -74481,14 +74494,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"dmh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard,
-/obj/item/radio/off,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "dmU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -74551,10 +74556,10 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"dvN" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"dwf" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/mask/surgical,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dwC" = (
@@ -74571,27 +74576,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
-"dxv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"dyW" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "dAs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -74604,34 +74588,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"dAE" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/maintenance/aft)
 "dAH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"dAJ" = (
-/obj/machinery/door/window/eastleft{
-	name = "Coffin Storage";
-	req_access_txt = "22"
-	},
-/turf/simulated/floor/plating,
-/area/chapel/main)
-"dBX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "dCV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -74686,11 +74648,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"dGb" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+"dFQ" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "dGT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -74725,13 +74691,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"dIk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/girder,
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+"dKH" = (
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "dKL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74755,15 +74729,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
-"dMn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "dMV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -74781,11 +74746,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
-"dQs" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "dRN" = (
 /obj/machinery/light{
 	dir = 4
@@ -74814,6 +74774,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"dUt" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"dVw" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "dVK" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -74871,13 +74849,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
-"dZd" = (
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/space/nearstation)
 "dZe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/warning_stripes/west,
@@ -74937,18 +74908,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"ecc" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/closet/crate,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "edg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -74968,13 +74927,6 @@
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"efY" = (
-/obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -74997,29 +74949,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"eic" = (
-/obj/machinery/atm{
-	pixel_y = 32
+"eif" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "eiF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -75035,25 +74975,10 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
-"ekm" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "elK" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
 /area/security/permabrig)
-"emU" = (
-/obj/structure/closet/coffin,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/chapel/main)
 "eoq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75073,14 +74998,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"ery" = (
-/obj/structure/closet/coffin,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/chapel/main)
 "esf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75103,11 +75020,17 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"eCr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/welded,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+"eDd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "eEV" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -75152,6 +75075,23 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
+"eKz" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "eKV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -75161,6 +75101,11 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
+"eMr" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "eMs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -75249,21 +75194,13 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"fba" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
-"fed" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+"fcP" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/aft)
 "ffD" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -75271,18 +75208,27 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/hor)
-"ffT" = (
-/obj/item/flashlight/lantern{
-	pixel_y = 7
+"ffU" = (
+/obj/item/reagent_containers/food/drinks/bottle/holywater{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/item/organ/internal/heart,
+/obj/structure/closet/secure_closet/chaplain,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "cult"
 	},
-/area/chapel/main)
+/area/chapel/office)
+"ffY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.3-Escape-3";
+	location = "9.2-Escape-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "fga" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/door/window/northleft{
@@ -75353,17 +75299,6 @@
 /obj/effect/spawner/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
-"fmL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "fmP" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
@@ -75371,11 +75306,25 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"fnT" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/space/nearstation)
 "foM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"fpS" = (
+/obj/structure/bookcase{
+	name = "Holy Bookcase"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "fsY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -75432,22 +75381,26 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"fxw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "fxB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/engine/break_room)
-"fyH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "fyS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -75497,6 +75450,11 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"fFt" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "fGt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75513,6 +75471,12 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"fGM" = (
+/obj/structure/chair,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "fOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -75520,6 +75484,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"fOU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "fPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75537,17 +75512,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
-"fWe" = (
-/obj/machinery/light/small,
-/obj/machinery/door_control{
-	id = "chapelparlourshutters";
-	name = "Window Shutter Control";
-	pixel_y = -25
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "fWW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75610,6 +75574,18 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"gaG" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "gbT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -75668,12 +75644,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"geM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "gfB" = (
 /obj/structure/window/plasmareinforced,
 /obj/machinery/power/rad_collector{
@@ -75685,21 +75655,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"ggY" = (
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "gid" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -75780,6 +75735,18 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"gpG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "gqj" = (
 /obj/structure/window/plasmareinforced,
 /obj/machinery/power/rad_collector{
@@ -75805,6 +75772,17 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
+"gwr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "gwJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -75832,6 +75810,41 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"gyZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/starboardsolar)
+"gzs" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
+"gzu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"gAK" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "gDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75849,15 +75862,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
-"gIr" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+"gGC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard,
+/obj/item/radio/off,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "gIN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -75870,22 +75882,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
-"gIO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "gKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -75938,20 +75934,11 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
-"gQJ" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "gRw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
-"gRx" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "gSK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -75972,6 +75959,17 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"gZH" = (
+/obj/machinery/light/small,
+/obj/machinery/door_control{
+	id = "chapelparlourshutters";
+	name = "Window Shutter Control";
+	pixel_y = -25
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "gZY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -76013,13 +76011,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"hgn" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/bed/roller,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hgN" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -76072,12 +76063,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
-"hiN" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/mask/surgical,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hiO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -76155,6 +76140,12 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"hpf" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "hqN" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -76211,6 +76202,18 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"hBr" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hBM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76225,6 +76228,22 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
+"hCZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hDK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -76253,9 +76272,6 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"hEy" = (
-/turf/space,
-/area/chapel/main)
 "hEA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -76267,21 +76283,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"hGk" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hHE" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -76347,6 +76348,13 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"hKO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "hLt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76421,24 +76429,10 @@
 /area/quartermaster/miningdock{
 	name = "\improper Mining Office"
 	})
-"hVz" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "hWr" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"hXY" = (
-/obj/structure/girder,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76517,6 +76511,18 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
+"iic" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/closet/crate,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "iip" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76545,22 +76551,6 @@
 	},
 /turf/space,
 /area/space)
-"iiU" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "ijt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -76637,6 +76627,11 @@
 	icon_state = "neutral"
 	},
 /area/hallway/primary/port)
+"iob" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "iof" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76651,6 +76646,24 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"iqh" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "isf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
@@ -76671,6 +76684,16 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"ivc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ivn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76690,6 +76713,13 @@
 	icon_state = "white"
 	},
 /area/toxins/explab)
+"izl" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "iAT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76738,43 +76768,42 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
-"iHH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"iHM" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "iIk" = (
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"iJi" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/double/map/right{
-	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
-	icon_state = "map-right-MS";
-	pixel_y = 32
+"iJQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"iKt" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"iKX" = (
+/obj/item/bedsheet/clown,
+/obj/structure/bed,
+/obj/structure/sign/clown{
+	pixel_x = 32
+	},
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"iNf" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "iNu" = (
 /obj/structure/reagent_dispensers/beerkeg/nuke{
 	name = "Nanotrasen-brand nuclear fizz-sion explosive"
@@ -76792,6 +76821,15 @@
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
+"iPy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "iRu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76840,44 +76878,16 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"iTW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "iUs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
-"iUx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"iVQ" = (
-/obj/machinery/mecha_part_fabricator{
-	dir = 1;
-	id = "0";
-	name = "counterfeit fabricator";
-	req_access = "0"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"iWh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "iWv" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -76886,24 +76896,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"iXI" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "iXL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76942,13 +76934,26 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"jdO" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+"jcb" = (
+/obj/machinery/door/window/eastleft{
+	name = "Coffin Storage";
+	req_access_txt = "22"
 	},
+/turf/simulated/floor/plating,
 /area/chapel/main)
+"jcf" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "jeY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -76997,12 +77002,29 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"jos" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "jrE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"jtr" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "juN" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm - Far";
@@ -77015,6 +77037,18 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"jvl" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jwh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77024,17 +77058,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
-"jyw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "jCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77048,6 +77071,20 @@
 	icon_state = "floorgrime"
 	},
 /area/crew_quarters/locker)
+"jCo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jCT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77140,30 +77177,26 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"jQZ" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "chapel"
-	},
-/area/chapel/main)
-"jSQ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Crematorium";
-	req_access_txt = "27"
+"jPy" = (
+/obj/structure/closet,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"jQb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"jTM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"jQZ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "chapel"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/chapel/main)
 "jUV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -77172,24 +77205,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"jWU" = (
-/obj/item/bedsheet/clown,
-/obj/structure/bed,
-/obj/structure/sign/clown{
-	pixel_x = 32
-	},
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"jYx" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "jZd" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_y = -32
@@ -77225,28 +77240,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"kkA" = (
+"kmv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "kmF" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"kmU" = (
-/obj/structure/bookcase{
-	name = "Holy Bookcase"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "knc" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
@@ -77360,13 +77372,6 @@
 /obj/machinery/message_server,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/server)
-"kwY" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/storage/labcoat/mortician,
-/obj/item/clothing/mask/surgical,
-/obj/item/storage/box/bodybags,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "kxf" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -77389,6 +77394,29 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
+"kzW" = (
+/obj/machinery/atm{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kBa" = (
 /obj/machinery/door_control{
 	id = "maint1";
@@ -77439,6 +77467,12 @@
 	icon_state = "white"
 	},
 /area/medical/reception)
+"kIq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "kKa" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -77482,24 +77516,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
-"kRL" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "kSC" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -77518,12 +77534,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"kUy" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "kWg" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -77549,11 +77559,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"kXh" = (
-/obj/effect/landmark/spawner/xeno,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "kXs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -77606,21 +77611,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"leq" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/driver_button{
-	id_tag = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -4;
-	pixel_y = -26
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "leu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77643,13 +77633,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"lgl" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "lgr" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -77688,10 +77671,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"lif" = (
+/obj/effect/landmark/spawner/xeno,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "lio" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"ljT" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ljZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -77705,14 +77705,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"lnx" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+"lmY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "lpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77749,20 +77746,8 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"lyK" = (
-/obj/machinery/light/small,
-/obj/machinery/door_control{
-	id = "chapelspaceshutters";
-	name = "Space Window Shutter Control";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "custom placement";
-	pixel_x = 6;
-	pixel_y = -24
-	},
+"lAk" = (
+/obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
@@ -77800,6 +77785,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"lES" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "lFH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -77810,6 +77800,10 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"lFQ" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "lFT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -77861,15 +77855,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
-"lIy" = (
-/obj/machinery/door/poddoor{
-	id_tag = "chapelgun";
-	name = "Chapel Launcher Door";
-	protected = 0
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/chapel/main)
 "lIR" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -77880,11 +77865,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"lMO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "lOU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77912,12 +77892,25 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"lUo" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "lUv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"lVu" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "lWo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77936,10 +77929,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"mdk" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "mea" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -77957,16 +77946,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"meo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "mfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77974,13 +77953,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
-"mgd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "mhq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -78069,6 +78041,21 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"mqU" = (
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "custom placement";
+	pixel_x = 28
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "msg" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
@@ -78080,6 +78067,22 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"mzY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Office";
+	req_access_txt = "27"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "mAa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78102,17 +78105,27 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"mBw" = (
-/obj/item/reagent_containers/food/drinks/bottle/holywater{
-	pixel_x = -2;
-	pixel_y = 2
+"mBa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/item/organ/internal/heart,
-/obj/structure/closet/secure_closet/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"mCS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "mDj" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -78153,17 +78166,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"mGR" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "mKy" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -78171,30 +78173,22 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"mKQ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"mMS" = (
+/obj/machinery/light/small,
+/obj/machinery/door_control{
+	id = "chapelspaceshutters";
+	name = "Space Window Shutter Control";
+	pixel_x = -6;
+	pixel_y = -25
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"mLG" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"mMU" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "custom placement";
+	pixel_x = 6;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -78208,6 +78202,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"mOB" = (
+/obj/structure/lattice,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/turf/space,
+/area/space/nearstation)
 "mQu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78220,19 +78220,6 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
-"mRb" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "mRP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -78243,18 +78230,18 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay3)
-"mTf" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;5;39;6"
+"mSv" = (
+/obj/item/flashlight/lantern{
+	pixel_y = 7
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/chapel/main)
 "mVG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -78288,6 +78275,15 @@
 "mXy" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
+"mXN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "mZH" = (
 /obj/structure/chair{
 	dir = 1
@@ -78355,6 +78351,13 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"ngH" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "nhK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78395,23 +78398,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
-"nkL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel - Funeral Parlour";
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "nnI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -78424,6 +78410,15 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
+"npY" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "nqA" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -78444,13 +78439,16 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"ntb" = (
-/obj/structure/lattice,
-/obj/effect/spawner/window/reinforced,
+"ntm" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/flashlight,
+/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/maintenance/aft)
 "nuB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78484,6 +78482,26 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"nzC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "nzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78498,18 +78516,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"nDX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+"nAA" = (
+/obj/structure/table,
+/obj/item/candle,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"nAG" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel - Funeral Parlour";
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "nEQ" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	name = "Gas to Cooling Loop"
@@ -78531,24 +78562,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"nFB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "nFC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/binary/valve/digital{
@@ -78560,6 +78573,11 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"nHr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "nHB" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -78570,11 +78588,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
-"nIv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"nIK" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-24"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/chapel/main)
 "nIZ" = (
 /obj/docking_port/stationary{
@@ -78615,15 +78635,6 @@
 /area/turret_protected/aisat_interior{
 	name = "\improper MiniSat Central Foyer"
 	})
-"nPF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "nRh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -78695,6 +78706,50 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"nZf" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"oaH" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"ocl" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
+"ocp" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "chapelspaceshutters";
+	name = "chapel shutters";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "odF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78704,13 +78759,6 @@
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/server)
-"oeo" = (
-/obj/item/candle,
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "oeP" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -78722,6 +78770,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
+"oeY" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ofz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78757,6 +78811,21 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"oma" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"onk" = (
+/obj/machinery/door/morgue{
+	name = "Chapel Garden"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/main)
 "onG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
@@ -78774,27 +78843,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"ovJ" = (
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkblue"
-	},
-/area/space/nearstation)
-"owG" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "oxC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -78806,14 +78854,27 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
-"oyQ" = (
+"oyr" = (
+/obj/structure/sign/vacuum{
+	pixel_x = 32
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"oBI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "oCE" = (
@@ -78822,12 +78883,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
-	})
-"oFs" = (
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
 	})
 "oJQ" = (
 /obj/structure/cable/yellow{
@@ -78843,24 +78898,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"oMV" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"oOo" = (
-/obj/structure/table,
-/obj/item/candle,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "oOs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -79008,11 +79045,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"pdq" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "pef" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -79047,6 +79079,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"phf" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "phx" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79099,14 +79138,6 @@
 	icon_state = "brown"
 	},
 /area/hallway/primary/port)
-"plf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "plu" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -79119,20 +79150,26 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"pov" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"pmk" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/driver_button{
+	id_tag = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -4;
+	pixel_y = -26
 	},
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
+"pne" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/welded,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/starboard)
 "ppw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -79145,6 +79182,25 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
+"pri" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"pru" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -79185,20 +79241,21 @@
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"pxY" = (
-/obj/machinery/door/morgue{
-	name = "Chapel Garden"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/main)
 "pyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"pzo" = (
+/obj/machinery/mecha_part_fabricator{
+	dir = 1;
+	id = "0";
+	name = "counterfeit fabricator";
+	req_access = "0"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "pzX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -79270,13 +79327,6 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"pMd" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "pMx" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall,
@@ -79312,6 +79362,26 @@
 	},
 /area/quartermaster/sorting{
 	name = "\improper Warehouse"
+	})
+"pPw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "pQx" = (
 /obj/structure/cable/yellow{
@@ -79397,12 +79467,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/lawoffice)
-"pYF" = (
-/obj/structure/lattice,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/turf/space,
-/area/space/nearstation)
 "qaB" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79439,18 +79503,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/construction)
-"qdr" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "qee" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79520,6 +79572,12 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"qor" = (
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "qpO" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Storage"
@@ -79528,25 +79586,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"qpY" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/flashlight,
-/obj/item/storage/box/lights/mixed,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"qte" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/trash/candy,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "qts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -79598,6 +79637,14 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"qyO" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating,
+/area/space/nearstation)
+"qAm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/maintenance/starboard)
 "qAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79684,6 +79731,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"qRj" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/space/nearstation)
 "qSf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -79696,13 +79750,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"qSr" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "qTK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -79732,40 +79779,10 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"rax" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "raV" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"rbF" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"rcT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "rdz" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -79845,6 +79862,21 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"rnt" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/main)
+"rnT" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "rnY" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
@@ -79852,11 +79884,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"roo" = (
-/obj/structure/rack,
-/obj/item/storage/box/bodybags,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "rpg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -79866,6 +79893,15 @@
 	},
 /turf/space,
 /area/solar/starboard)
+"rpk" = (
+/obj/machinery/door/poddoor{
+	id_tag = "chapelgun";
+	name = "Chapel Launcher Door";
+	protected = 0
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "rqY" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -79880,6 +79916,20 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"rss" = (
+/obj/structure/chair,
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
+"rvh" = (
+/obj/item/candle,
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "rvu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79934,19 +79984,25 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rAh" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"rAq" = (
+/obj/structure/closet/coffin,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/chapel/main)
+"rBE" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "rDe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -80151,19 +80207,11 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"rPn" = (
-/obj/machinery/power/apc{
-	name = "Chapel Office APC";
-	pixel_y = -25
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
+"rTo" = (
+/obj/structure/closet/coffin,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "rTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -80191,17 +80239,16 @@
 	icon_state = "vault"
 	},
 /area/chapel/main)
-"rVr" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "chapelspaceshutters";
-	name = "chapel shutters";
-	opacity = 0
+"rUY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/chapel/main)
+/area/maintenance/aft)
 "rVv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -80216,6 +80263,13 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"rYo" = (
+/obj/structure/lattice,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "rYO" = (
 /obj/effect/landmark/spawner/xeno,
 /obj/machinery/light/small{
@@ -80267,36 +80321,6 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"seq" = (
-/obj/structure/closet/secure_closet/chaplain,
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
-"sgt" = (
-/obj/item/candle,
-/obj/machinery/light_switch{
-	name = "custom placement";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/structure/table/wood,
-/obj/machinery/door_control{
-	id = "chapelescapeshutters";
-	name = "Side Windows Shutter Control";
-	pixel_x = -6;
-	pixel_y = 25
-	},
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -80324,10 +80348,30 @@
 	icon_state = "dark"
 	},
 /area/space/nearstation)
-"skx" = (
-/obj/effect/landmark/damageturf,
+"slt" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"slZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/space/nearstation)
+/area/maintenance/aft)
 "soT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -80360,14 +80404,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"spq" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-24"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "spv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
@@ -80393,15 +80429,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"stc" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "svF" = (
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
@@ -80450,21 +80477,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"sDm" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
+"sEQ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"sDK" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "sFz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80492,21 +80508,19 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"sJU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+"sJG" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/door_control{
+	id = "maint3";
+	name = "Blast Door Control C";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "sLs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80552,12 +80566,42 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"sOW" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "sRB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"sSC" = (
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "sVC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80631,14 +80675,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"thp" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "thC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80650,14 +80686,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
-"thL" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "tjR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80667,33 +80695,16 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"tkc" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "custom placement";
-	pixel_x = 28
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "tlh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
-"tok" = (
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+"tlF" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/maintenance/aft)
 "tpg" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -80709,13 +80720,6 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"tqh" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "tvk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -80769,19 +80773,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"tyi" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/door_control{
-	id = "maint3";
-	name = "Blast Door Control C";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "tAk" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80822,6 +80813,15 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/main)
+"tEB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "tEL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80832,6 +80832,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"tEZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tFb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80843,25 +80854,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"tKb" = (
-/obj/machinery/door/morgue{
-	name = "Relic Closet";
-	req_access_txt = "22"
+"tKC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/office)
-"tLv" = (
-/obj/item/storage/fancy/crayons,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80913,6 +80915,25 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"tUA" = (
+/obj/item/candle,
+/obj/machinery/light_switch{
+	name = "custom placement";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/structure/table/wood,
+/obj/machinery/door_control{
+	id = "chapelescapeshutters";
+	name = "Side Windows Shutter Control";
+	pixel_x = -6;
+	pixel_y = 25
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "tVw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -80926,6 +80947,15 @@
 "tWl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/e_to_w,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"tXl" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "tYX" = (
@@ -80958,24 +80988,32 @@
 /area/security/checkpoint2{
 	name = "Customs"
 	})
+"uaP" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/trash/candy,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "uaQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"uca" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"ube" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "udB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -81084,15 +81122,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
-"uvW" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"uwQ" = (
+/obj/machinery/power/apc{
+	name = "Chapel Office APC";
+	pixel_y = -25
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "uzt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -81118,22 +81160,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
-"uCn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Office";
-	req_access_txt = "27"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "uEN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -81142,35 +81168,23 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
-"uHP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+"uHR" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/storage/labcoat/mortician,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/box/bodybags,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "uJn" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboard)
-"uKb" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "uKm" = (
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/wall,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"uKz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/maintenance/starboard)
 "uLE" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plating,
@@ -81204,10 +81218,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
-"uNa" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "uOL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -81245,6 +81255,15 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"uSk" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "uTZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -81266,11 +81285,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"uWa" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "uWq" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -81300,32 +81314,6 @@
 "vaO" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry)
-"vdH" = (
-/obj/structure/chair,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
-"veH" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "vfe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81355,6 +81343,16 @@
 	icon_state = "redfull"
 	},
 /area/security/main)
+"vhF" = (
+/obj/structure/noticeboard{
+	desc = "A memorial wall for pinning up momentos";
+	name = "memorial board";
+	pixel_y = 32
+	},
+/obj/item/storage/bible,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "vjp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -81366,6 +81364,12 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"vmn" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "vmT" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81384,24 +81388,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"voO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/starboardsolar)
-"vrD" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/pennywise,
-/obj/item/toy/syndicateballoon,
-/obj/item/clothing/shoes/clown_shoes,
-/obj/item/clothing/mask/gas/clown_hat/pennywise,
-/obj/item/coin/clown,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -81499,9 +81485,13 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"vCo" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+"vCD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "vCR" = (
@@ -81542,18 +81532,16 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
-"vFB" = (
-/obj/structure/sign/directions/evac,
-/turf/simulated/wall,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"vHf" = (
-/obj/machinery/light/small{
-	dir = 4
+"vEr" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/double/map/right{
+	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
+	icon_state = "map-right-MS";
+	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -81618,30 +81606,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
-"vPN" = (
-/obj/structure/sign/atmosplaque{
-	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
-	icon_state = "kiddieplaque";
-	name = "Remembrance Plaque";
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
-"vRN" = (
+"vRX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "vRY" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -81666,16 +81646,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"vTG" = (
-/obj/structure/noticeboard{
-	desc = "A memorial wall for pinning up momentos";
-	name = "memorial board";
-	pixel_y = 32
-	},
-/obj/item/storage/bible,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "vUD" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -81707,6 +81677,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
+"wew" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "wfs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81720,20 +81700,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
-"wgB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "whC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -81746,6 +81712,12 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
+"wqP" = (
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wri" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -81835,6 +81807,22 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
+"wvP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"wwr" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wxE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -81904,12 +81892,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"wDa" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "wEq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81948,15 +81930,23 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"wIw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"wIe" = (
+/obj/structure/closet/secure_closet/chaplain,
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
+/area/chapel/office)
+"wID" = (
+/obj/structure/sign/directions/evac,
+/turf/simulated/wall,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wJQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -81979,6 +81969,15 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
+	})
+"wRS" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "wSh" = (
 /obj/structure/chair/wood,
@@ -82012,6 +82011,16 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/locker)
+"wUW" = (
+/obj/item/storage/fancy/crayons,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "wVS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -82020,26 +82029,41 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
-"xdY" = (
-/obj/structure/disposalpipe/segment{
+"wWn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/chapel/main)
+"wWO" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/under/pennywise,
+/obj/item/toy/syndicateballoon,
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/clothing/mask/gas/clown_hat/pennywise,
+/obj/item/coin/clown,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"wXH" = (
+/obj/machinery/door/morgue{
+	name = "Relic Closet";
+	req_access_txt = "22"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/office)
+"wXT" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82090,15 +82114,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
-"xqE" = (
-/obj/structure/sign/vacuum{
-	pixel_x = 32
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "xrG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -82141,6 +82156,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"xxe" = (
+/obj/effect/landmark/spawner/xeno,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "xxA" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -82150,6 +82170,13 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
+"xCr" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "xDw" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
@@ -82171,16 +82198,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"xEy" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "xFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82201,33 +82218,9 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"xHm" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"xIS" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+"xJn" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "xJB" = (
@@ -82245,18 +82238,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"xKX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "xLf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82271,6 +82252,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"xPl" = (
+/obj/structure/sign/atmosplaque{
+	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
+	icon_state = "kiddieplaque";
+	name = "Remembrance Plaque";
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "xSh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82285,22 +82279,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
-	},
-/area/chapel/main)
-"xUZ" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
-"xXJ" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
 	},
 /area/chapel/main)
 "xYR" = (
@@ -82320,11 +82298,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/solar/starboard)
-"yaf" = (
-/obj/effect/landmark/spawner/xeno,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "yag" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82335,15 +82308,6 @@
 "yaq" = (
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"yaE" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "yaQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -82352,6 +82316,30 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"ybv" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
+"ybG" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth (Chaplain)";
+	req_access_txt = "22"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "ycU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -82360,15 +82348,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"yeQ" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/main)
 "yeW" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -82414,6 +82393,29 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
+"yiz" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"ykV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 
 (1,1,1) = {"
 aaa
@@ -97469,7 +97471,7 @@ apf
 aaa
 aaa
 cmi
-mdk
+lFQ
 cmi
 bZU
 cpu
@@ -98235,7 +98237,7 @@ bYW
 caJ
 ceN
 ceN
-mRb
+ykV
 chP
 ceN
 xJB
@@ -98752,7 +98754,7 @@ bWo
 cdJ
 ceO
 cTa
-uvW
+lVu
 ckD
 chy
 ebA
@@ -99028,7 +99030,7 @@ bZU
 bZU
 cOx
 cqS
-uWa
+fFt
 bZU
 cNa
 cNP
@@ -99546,7 +99548,7 @@ cJR
 cuV
 cuV
 chy
-uKb
+mCS
 chy
 chy
 bZU
@@ -99783,7 +99785,7 @@ chw
 ckH
 bZU
 cuV
-qte
+uaP
 chy
 cFQ
 cLU
@@ -99794,7 +99796,7 @@ chy
 chy
 chy
 czf
-geM
+kIq
 cBX
 cFT
 ckD
@@ -99802,8 +99804,8 @@ cIb
 cDT
 ckJ
 ckJ
-stc
-stc
+tXl
+tXl
 ckJ
 cJR
 bZU
@@ -100551,7 +100553,7 @@ apd
 bZU
 cfW
 cjr
-iVQ
+pzo
 cTa
 chy
 bgZ
@@ -100808,7 +100810,7 @@ cgo
 cTa
 idx
 dgG
-dmh
+gGC
 cTa
 chy
 bgZ
@@ -101060,7 +101062,7 @@ apd
 cgm
 isf
 apf
-tyi
+sJG
 cgo
 cTa
 bZU
@@ -101090,7 +101092,7 @@ cKA
 dxa
 cKL
 cEY
-mKQ
+ube
 bZU
 abq
 aaa
@@ -101576,13 +101578,13 @@ bZW
 bFw
 bzK
 cho
-stc
+tXl
 ckJ
-vRN
+rBE
 ckJ
 ckJ
 ckJ
-ecc
+iic
 coC
 cpX
 crV
@@ -101832,7 +101834,7 @@ jrE
 bZc
 bZZ
 bzK
-rAh
+jcf
 chy
 chy
 cmi
@@ -102135,12 +102137,12 @@ cRh
 cRh
 cRh
 cSO
-ery
+rAq
 cWn
 cWn
-emU
+rTo
 cSO
-yeQ
+rnt
 dfv
 abq
 aaa
@@ -102383,21 +102385,21 @@ dfR
 dfU
 cRg
 cHZ
-roo
+xJn
 chy
 bZU
 cSI
 cTy
 cUg
-owG
+ybv
 cUg
 cSO
 cVM
 cVM
-dAJ
+jcb
 cVM
 cSO
-pxY
+onk
 cSO
 abq
 aaa
@@ -102647,14 +102649,14 @@ cSJ
 cTz
 cUh
 cUN
-plf
+jQb
 cSO
 cSO
-ggY
+dKH
 cVR
 cVR
 dbX
-fWe
+gZH
 cSO
 abq
 aaa
@@ -102898,12 +102900,12 @@ dfV
 dgH
 cHZ
 cuV
-uHP
+vCD
 bZU
 cRh
 cRh
 cRh
-jSQ
+cXG
 cRh
 cSO
 cWp
@@ -102911,7 +102913,7 @@ cWO
 cWN
 cWN
 cYk
-vdH
+fGM
 dfv
 abq
 aaa
@@ -103146,7 +103148,7 @@ cFd
 cLw
 cNL
 cPy
-mKQ
+ube
 chy
 chy
 cHZ
@@ -103155,20 +103157,20 @@ cMR
 cHZ
 cHZ
 cuV
-uHP
+vCD
 bZU
 cSK
 cTA
-tLv
+wUW
 cZs
-seq
+wIe
 cSO
-vPN
+xPl
 cWO
-xUZ
+ocl
 cWN
 cYk
-xXJ
+rss
 dfv
 abq
 aaa
@@ -103412,20 +103414,20 @@ day
 lrA
 bZU
 cFe
-fyH
+ivc
 bZU
 cSL
 cTB
 cUk
 cUP
-sDK
+uSk
 cSO
-vTG
+vhF
 cWO
 cYk
-nkL
+nAG
 cYk
-kUy
+jos
 dfv
 abq
 aaa
@@ -103630,7 +103632,7 @@ bXy
 cgt
 bzK
 caK
-pov
+fxw
 ccB
 cdT
 cfa
@@ -103675,14 +103677,14 @@ deI
 cWR
 cUl
 cZt
-rPn
+uwQ
 cSO
 cSO
-kRL
+sSC
 cYk
 cSO
 cYl
-leq
+pmk
 cSO
 abq
 aaa
@@ -103919,14 +103921,14 @@ cNM
 cPy
 cRo
 cyE
-mdk
+lFQ
 bZU
 cZw
 daM
 dby
 bZU
 chy
-jTM
+rUY
 bZU
 cZs
 cTD
@@ -103940,7 +103942,7 @@ cYk
 cSO
 dbc
 dag
-lIy
+rpk
 abq
 aaa
 aaa
@@ -104185,15 +104187,15 @@ cPy
 svF
 csh
 bZU
-tKb
+wXH
 cRh
 cRh
 cRh
-fba
+ybG
 cSO
-iXI
+iqh
 dgg
-spq
+nIK
 cSO
 cSO
 cSO
@@ -104440,20 +104442,20 @@ daO
 cRV
 cPy
 chy
-uHP
+vCD
 bZU
-mBw
+ffU
 cRh
 cUn
 cUT
-tkc
+mqU
 cSO
 cSO
-uCn
+mzY
 cSO
 cSO
 cSO
-hEy
+aMN
 abq
 abq
 aaa
@@ -104697,18 +104699,18 @@ daN
 cRu
 cPy
 ckw
-uHP
+vCD
 bZU
 cRh
 cRh
-thp
+gAK
 cRh
 cRh
 cSO
 cYk
 dgg
 dhj
-kmU
+fpS
 cSO
 aaa
 aaa
@@ -104953,18 +104955,18 @@ daP
 daP
 dbG
 cPy
-vCo
-uHP
+lES
+vCD
 bZU
 deL
-thL
+dUt
 deN
 cSO
 cSO
 dfw
 xUe
 dhi
-mMU
+npY
 cVA
 cSO
 aaa
@@ -105210,19 +105212,19 @@ cZO
 cYC
 cRU
 cRU
-dGb
-uHP
+iNf
+vCD
 bZU
-oeo
+rvh
 deN
 deN
 cZX
 cVU
 cWz
 jQZ
-uca
+wWn
 jQZ
-pMd
+xCr
 cSO
 aaa
 aaa
@@ -105468,19 +105470,19 @@ daU
 cRX
 cRU
 coD
-uHP
+vCD
 bZU
 ktX
 lUv
 deY
 cVw
 cUY
-jdO
+lAk
 xUe
 cXm
 cXJ
 dhl
-rVr
+ocp
 aaa
 aaa
 aaa
@@ -105725,19 +105727,19 @@ daQ
 dbH
 der
 dek
-oMV
+iJQ
 bZU
 cTK
-nIv
+iTW
 deN
 cVz
-alV
-qSr
+vmn
+izl
 jQZ
-qdr
+sOW
 cYk
 dhl
-rVr
+ocp
 aaa
 aaa
 aaa
@@ -105987,14 +105989,14 @@ cSS
 cTJ
 deP
 dfo
-dyW
+gaG
 fPa
 fPa
 fPa
 cXn
 cXK
-kUy
-rVr
+jos
+ocp
 aaa
 aaa
 aaa
@@ -106239,19 +106241,19 @@ daV
 dbN
 cRU
 chy
-hGk
+slZ
 bZU
 cTK
-wIw
+tEB
 deN
-jdO
+lAk
 cUY
-jdO
+lAk
 xUe
-gIr
+gzs
 cYk
 dhl
-rVr
+ocp
 aaa
 aaa
 aaa
@@ -106501,14 +106503,14 @@ bZU
 rUJ
 cUs
 cUZ
-qSr
-alV
-qSr
+izl
+vmn
+izl
 jQZ
 wzo
-ffT
+mSv
 dhl
-rVr
+ocp
 aaa
 aaa
 aaa
@@ -106755,8 +106757,8 @@ cRU
 cuV
 dVK
 bZU
-sgt
-wIw
+tUA
+tEB
 deN
 cVA
 cVa
@@ -106764,7 +106766,7 @@ cVA
 xUe
 cVA
 xUe
-lyK
+mMS
 cSO
 aaa
 aaa
@@ -107010,18 +107012,18 @@ ckJ
 ckJ
 ckJ
 ckJ
-wgB
+jCo
 bZU
 cSO
 cUt
-mgd
+hKO
 cSO
 cSO
-iHM
+wew
 jQZ
 cZC
 cZR
-yaE
+dFQ
 cSO
 aaa
 aaa
@@ -107267,12 +107269,12 @@ chy
 bZU
 bZU
 bZU
-mTf
+hBr
 bZU
 cVs
 cWi
 cXc
-oOo
+nAA
 cSO
 cSO
 cSO
@@ -107527,15 +107529,15 @@ cSr
 cTq
 cTO
 cWb
-dBX
-hVz
+gwr
+wRS
 cUv
 dau
-wDa
+wwr
 cXc
 cYf
 cZp
-dMn
+iPy
 cZp
 aaa
 aaa
@@ -107781,16 +107783,16 @@ cdN
 cVk
 cQM
 pue
-iUx
+tEZ
 cVc
 cRt
-dBX
+gwr
 cRt
 nej
 cRt
 cRt
 cTr
-tok
+wqP
 cTX
 cTX
 cTX
@@ -108036,20 +108038,20 @@ cYW
 cQh
 cjn
 cVk
-lnx
+cWX
 cTg
 cSk
 gnZ
 cTQ
-iHH
+eDd
 cSo
 gTp
 cRt
 cRt
 cXb
-tok
+wqP
 cZp
-tok
+wqP
 cZp
 aaa
 aaa
@@ -108290,13 +108292,13 @@ cmw
 diT
 com
 cIm
-xIS
+jvl
 chy
 cVk
 cVk
 cRv
 cRt
-oFs
+qor
 cRt
 cRt
 cRt
@@ -108304,7 +108306,7 @@ cRt
 cRt
 cRt
 cTr
-tok
+wqP
 cTX
 cTX
 cTX
@@ -108561,7 +108563,7 @@ cTW
 cUu
 cRt
 cTr
-tok
+wqP
 cTX
 aaa
 aaa
@@ -108808,7 +108810,7 @@ bgZ
 chy
 cVk
 bYy
-xdY
+pPw
 cTr
 cUz
 cTR
@@ -108818,7 +108820,7 @@ cUz
 dap
 cRt
 cTr
-tqh
+ngH
 cTX
 aaa
 aaa
@@ -109062,10 +109064,10 @@ cVv
 cot
 cIm
 clu
-kwY
+uHR
 cVk
-iJi
-xdY
+vEr
+pPw
 cTt
 cUv
 cUv
@@ -109075,7 +109077,7 @@ cUv
 cWb
 cRt
 cTr
-tok
+wqP
 cTX
 aaa
 aaa
@@ -109320,9 +109322,9 @@ cIm
 cIm
 cNV
 bZU
-vFB
+wID
 cVk
-eic
+kzW
 cRt
 cRt
 cRt
@@ -109332,7 +109334,7 @@ cRt
 cRt
 cRt
 cTr
-tok
+wqP
 cTX
 cTX
 cTX
@@ -109578,8 +109580,8 @@ cNS
 cNW
 cON
 cPN
-mLG
-veH
+iKt
+nzC
 cRt
 nej
 cRt
@@ -109588,10 +109590,10 @@ cRt
 cVc
 cRt
 cRt
-cMw
-tok
+ffY
+wqP
 cZp
-vHf
+slt
 cZp
 aaa
 aaa
@@ -109846,7 +109848,7 @@ cVC
 cRt
 cRt
 cTr
-tok
+wqP
 cTX
 cTX
 cTX
@@ -110103,9 +110105,9 @@ dac
 dat
 cUB
 cXM
-xqE
+oyr
 cZp
-tok
+wqP
 cZp
 aaa
 aaa
@@ -110363,7 +110365,7 @@ cTX
 cVk
 cTX
 cTX
-ntb
+rYo
 aaa
 aaa
 aaa
@@ -111635,7 +111637,7 @@ ryN
 cOX
 cPW
 cSs
-iiU
+hCZ
 cTa
 bZU
 bZU
@@ -111892,10 +111894,10 @@ cQv
 cOW
 cPV
 cIx
-nFB
+oaH
 iTR
 chy
-uKb
+mCS
 chy
 aef
 aef
@@ -113920,7 +113922,7 @@ bUR
 bWl
 bWl
 bZU
-qpY
+ntm
 cqp
 crU
 cmz
@@ -114205,7 +114207,7 @@ cPi
 cPe
 cQa
 cOp
-xKX
+ljT
 cwt
 cmi
 aaa
@@ -114945,7 +114947,7 @@ cfA
 cgN
 cip
 bZu
-ekm
+yiz
 cmz
 cnh
 cpT
@@ -115751,7 +115753,7 @@ bgZ
 cPT
 cPT
 cmy
-yaf
+lif
 bZU
 bZU
 aaa
@@ -115973,7 +115975,7 @@ cbO
 cgR
 ciC
 cjV
-kkA
+tKC
 cmz
 cnF
 coV
@@ -116001,7 +116003,7 @@ cKE
 cOc
 cQg
 cQE
-oyQ
+dVw
 cxT
 cRP
 clT
@@ -116770,9 +116772,9 @@ cEK
 crU
 cdN
 cjn
-iWh
+oBI
 jaV
-xHm
+eKz
 bZO
 cQU
 cTo
@@ -117027,9 +117029,9 @@ bZU
 cKG
 cLB
 chy
-rax
+kmv
 bZU
-jyw
+fOU
 cQI
 cuV
 cuV
@@ -117284,9 +117286,9 @@ hLW
 ceD
 ceN
 ceN
-sJU
+mBa
 cTa
-jyw
+fOU
 bZU
 cQW
 cQW
@@ -117532,18 +117534,18 @@ cDX
 bZU
 cTa
 dVK
-lMO
+nHr
 bZU
 cHQ
 cJd
 cKu
 bZU
-jYx
+fcP
 cuV
 chy
 chy
 cmY
-fmL
+eif
 chy
 cQW
 cRQ
@@ -117789,7 +117791,7 @@ cfU
 bZU
 chy
 dVK
-gQJ
+iob
 cFH
 cFH
 cHY
@@ -118577,7 +118579,7 @@ aaa
 abq
 aaa
 cOy
-voO
+gyZ
 xZq
 aaa
 abq
@@ -118807,14 +118809,14 @@ bcj
 cwt
 csh
 chy
-geM
+kIq
 chy
 chy
 chy
 chy
 chy
 cuV
-pdq
+wXT
 bZU
 cFe
 bZU
@@ -119323,7 +119325,7 @@ csj
 cwF
 bZU
 cyT
-hgn
+phf
 cyT
 cPT
 abq
@@ -119567,7 +119569,7 @@ cdi
 aGW
 aGW
 aGW
-gIO
+vRX
 clq
 clq
 aQS
@@ -119575,19 +119577,19 @@ bal
 asJ
 coM
 aoG
-efY
-nPF
-dvN
-dIk
+jPy
+gzu
+oeY
+aur
 pes
 chy
-rbF
+rnT
 bZU
-skx
-ovJ
+qyO
+fnT
 bZU
 bZU
-mdk
+lFQ
 bZU
 abq
 abq
@@ -119824,7 +119826,7 @@ asJ
 aoG
 aoG
 aoG
-dxv
+mXN
 aEx
 aEx
 asJ
@@ -119837,11 +119839,11 @@ bZU
 bZU
 bZU
 rHl
-hXY
+eMr
 bZU
 bZU
-dZd
-pYF
+qRj
+mOB
 bZU
 hLL
 vZo
@@ -120079,7 +120081,7 @@ bEG
 caI
 asJ
 bdl
-vrD
+wWO
 bYG
 azy
 asI
@@ -120090,16 +120092,16 @@ aoG
 aoG
 buC
 cLV
-hiN
-xEy
+dwf
+pri
 cuG
 cji
-kXh
+xxe
 cye
 bZU
-dAE
-dAE
-dAE
+tlF
+tlF
+tlF
 abq
 aef
 aaa
@@ -120337,7 +120339,7 @@ azy
 asJ
 bdl
 asJ
-eCr
+pne
 azy
 cis
 buC
@@ -120349,7 +120351,7 @@ buC
 cqF
 chy
 cdK
-mGR
+jtr
 csh
 cuH
 cyf
@@ -120593,8 +120595,8 @@ bEG
 azy
 asJ
 bdl
-jWU
-uKz
+iKX
+qAm
 azy
 cir
 buC
@@ -120606,8 +120608,8 @@ buC
 cqE
 chy
 chy
-gRx
-rcT
+sEQ
+pru
 chy
 cyg
 cmi
@@ -120861,7 +120863,7 @@ cfK
 cfK
 cfK
 cqH
-sDm
+nZf
 chy
 cuH
 uBl
@@ -121105,8 +121107,8 @@ brg
 tbK
 tbK
 tbK
-uNa
-dQs
+lUo
+lmY
 bwE
 asJ
 azy
@@ -121365,7 +121367,7 @@ bYG
 aoG
 aoG
 cdm
-meo
+wvP
 ofz
 cfK
 chs
@@ -121621,7 +121623,7 @@ uLE
 bVL
 aoG
 azp
-nDX
+gpG
 asJ
 bcj
 cfK
@@ -122132,7 +122134,7 @@ bqN
 rDF
 axh
 asJ
-fed
+hpf
 aoG
 cSa
 cdp
@@ -122903,7 +122905,7 @@ asJ
 bVL
 uqy
 aXP
-lgl
+oma
 bCM
 bCM
 cds

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2518,16 +2518,16 @@
 	},
 /area/security/permabrig)
 "ahC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/auxsolarstarboard)
 "ahD" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3754,10 +3754,12 @@
 	},
 /area/security/permabrig)
 "ajS" = (
-/obj/machinery/suit_storage_unit/engine/secure,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/structure/closet/crate,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "ajT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4195,9 +4197,6 @@
 	},
 /area/security/armoury)
 "akP" = (
-/obj/machinery/camera{
-	c_tag = "Engineering - Storage"
-	},
 /obj/machinery/suit_storage_unit/engine/secure,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -4696,12 +4695,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/main)
-"alQ" = (
-/obj/structure/sign/securearea{
-	pixel_y = 32
-	},
-/turf/simulated/wall/r_wall,
-/area/engine/engineering)
 "alR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -4905,15 +4898,14 @@
 	},
 /area/security/main)
 "amr" = (
-/obj/machinery/door/airlock/engineering{
-	icon_state = "door_closed";
-	name = "Fore Port Solar Access";
-	req_access_txt = "10"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Fore Port Solar Access";
+	req_access_txt = "10"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -6012,15 +6004,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"apa" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Secure Storage Room";
-	req_access_txt = "65"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "apb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -6956,6 +6939,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
+"art" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "arw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -7711,6 +7700,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/spawner/xeno,
+/obj/item/cigbutt,
+/obj/item/cigbutt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -7718,6 +7709,7 @@
 "ath" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
+/obj/item/bikehorn/rubberducky,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "ati" = (
@@ -8054,6 +8046,7 @@
 	dir = 5
 	},
 /obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "atW" = (
@@ -8160,6 +8153,7 @@
 	tag = "90Curve"
 	},
 /obj/effect/landmark/spawner/xeno,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "aul" = (
@@ -8295,15 +8289,12 @@
 	name = "Port Maintenance"
 	})
 "auD" = (
-/obj/machinery/light_construct/small,
-/obj/item/toolbox_tiles/sensor,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fore)
 "auE" = (
-/obj/item/vending_refill/cigarette,
-/turf/simulated/floor/plating,
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -8320,12 +8311,10 @@
 	},
 /area/hallway/primary/fore)
 "auG" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/gloves/color/fyellow,
+/obj/item/cigbutt,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/starboard)
 "auH" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
@@ -8651,14 +8640,6 @@
 	},
 /area/security/main)
 "avm" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/main)
-"avn" = (
 /obj/item/phone{
 	desc = "Supposedly a direct line to NanoTrasen Central Command. It's not even plugged in.";
 	pixel_x = -3;
@@ -8678,6 +8659,11 @@
 	icon_state = "grimy"
 	},
 /area/security/main)
+"avn" = (
+/obj/item/trash/syndi_cakes,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "avo" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -8888,6 +8874,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "avM" = (
@@ -8967,14 +8954,13 @@
 	name = "Port Maintenance"
 	})
 "avX" = (
-/obj/structure/closet/crate,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/starboard)
 "avY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9030,10 +9016,8 @@
 	name = "Port Maintenance"
 	})
 "awg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room";
-	req_access_txt = "12"
-	},
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "awh" = (
@@ -9265,7 +9249,16 @@
 	},
 /area/security/brig)
 "awG" = (
-/obj/structure/chair,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/obj/item/radio/intercom{
+	frequency = 1424;
+	name = "custom placement";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -9327,6 +9320,7 @@
 	})
 "awL" = (
 /obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "awM" = (
@@ -9334,6 +9328,7 @@
 	dir = 1;
 	in_use = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "awN" = (
@@ -9434,40 +9429,13 @@
 	name = "Port Maintenance"
 	})
 "awX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/landmark/spawner/xeno,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/starboard)
 "awZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
 /area/maintenance/fore)
 "axb" = (
 /obj/structure/closet,
@@ -9694,23 +9662,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;63"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axw" = (
@@ -9743,6 +9695,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axy" = (
@@ -9763,24 +9716,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axz" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axA" = (
@@ -9820,20 +9759,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axC" = (
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/structure/table/wood,
-/obj/item/radio/intercom{
-	frequency = 1424;
-	name = "custom placement";
-	pixel_y = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/main)
+/obj/structure/closet,
+/obj/item/stock_parts/matter_bin,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "axG" = (
 /obj/machinery/computer/prisoner{
 	dir = 4
@@ -10021,7 +9950,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aya" = (
@@ -10113,10 +10042,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "ayn" = (
-/obj/structure/closet,
-/obj/item/stock_parts/matter_bin,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/spawner/window/reinforced/polarized,
+/turf/simulated/wall,
+/area/security/main)
 "ayp" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster{
@@ -10187,11 +10115,9 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/locker)
 "ayv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "ayw" = (
@@ -10266,17 +10192,11 @@
 	name = "Arrivals"
 	})
 "ayE" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/drone_fabricator,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "yellow"
-	},
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "ayF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted{
@@ -10511,6 +10431,15 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"azg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "azh" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -10542,19 +10471,24 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "azo" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "ceprivacy";
-	name = "privacy shutters";
-	opacity = 0
+/obj/machinery/ai_status_display{
+	pixel_y = 32
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/computer/station_alert,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/engine/chiefs_office)
 "azp" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -10571,12 +10505,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -10618,15 +10548,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "azv" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/engine/engineering)
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "azx" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10736,17 +10660,14 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "azJ" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 5
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
-	},
+/obj/machinery/drone_fabricator,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 9;
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
@@ -11155,18 +11076,15 @@
 	},
 /area/security/brig)
 "aAz" = (
-/obj/machinery/camera{
-	c_tag = "Interrogation";
-	dir = 8;
-	network = list("interrogation")
+/obj/machinery/door_control{
+	id = "maint2";
+	name = "Blast Control Door B";
+	pixel_x = -28;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aAA" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -11217,9 +11135,6 @@
 	name = "RADIOACTIVE AREA";
 	pixel_y = 32
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11253,6 +11168,9 @@
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
 	pixel_y = 32
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -11294,23 +11212,27 @@
 	},
 /area/security/brig)
 "aAO" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/closet/radiation,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_y = 32
 	},
-/obj/machinery/computer/security/telescreen{
-	dir = 4;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
-	pixel_x = -29
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
-	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aAP" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -11337,14 +11259,15 @@
 	},
 /area/security/main)
 "aAW" = (
-/obj/structure/chair/office/dark{
-	dir = 4
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "maint2";
+	name = "Blast Door";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aAX" = (
 /obj/structure/closet/crate,
 /obj/item/coin/silver,
@@ -11543,11 +11466,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
 "aBG" = (
-/obj/structure/chair{
+/obj/machinery/camera{
+	c_tag = "Interrogation";
+	dir = 8;
+	network = list("interrogation")
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -11564,6 +11492,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
+"aBK" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aBL" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -11708,7 +11640,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aBY" = (
@@ -11731,27 +11663,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/bridge)
-"aBZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "aCa" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11768,6 +11679,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aCb" = (
@@ -11779,19 +11691,27 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aCc" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/mob/living/simple_animal/mouse,
+/obj/item/trash/pistachios,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aCd" = (
-/obj/structure/sign/securearea{
-	pixel_y = 32
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 4;
+	location = "Engineering"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aCe" = (
@@ -11808,7 +11728,7 @@
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aCg" = (
@@ -11988,17 +11908,17 @@
 	},
 /area/security/nuke_storage)
 "aCD" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	layer = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "maint2";
+	name = "Blast Door";
+	opacity = 0
 	},
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aCE" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -12161,14 +12081,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"aCM" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/engine/equipmentstorage)
 "aCN" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -12309,25 +12221,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aDa" = (
+/obj/structure/rack,
 /obj/item/wrench,
+/obj/item/screwdriver,
+/obj/item/stack/cable_coil/random,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aDb" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Foyer";
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"aDc" = (
+/obj/machinery/door/window/southright{
+	dir = 4;
+	name = "Engineering Deliveries";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
-"aDc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aDd" = (
@@ -12356,7 +12266,7 @@
 "aDe" = (
 /obj/structure/closet,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aDg" = (
@@ -12369,18 +12279,13 @@
 	},
 /area/security/warden)
 "aDi" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 8;
-	network = list("SS13","engine")
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "aDp" = (
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating/airless,
@@ -12430,13 +12335,10 @@
 	name = "\improper Mining Office"
 	})
 "aDw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aDx" = (
@@ -12597,14 +12499,12 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
@@ -12819,15 +12719,14 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aEd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aEe" = (
 /obj/structure/table/wood,
@@ -12843,6 +12742,8 @@
 /area/security/detectives_office)
 "aEf" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aEg" = (
@@ -12884,6 +12785,16 @@
 /area/crew_quarters/locker/locker_toilet{
 	name = "\improper Restrooms"
 	})
+"aEl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aEm" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
@@ -12891,19 +12802,17 @@
 	},
 /area/crew_quarters/sleep)
 "aEn" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	name = "Engineering Junction";
+	sortType = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aEo" = (
 /obj/structure/disposalpipe/junction{
@@ -13018,10 +12927,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aEw" = (
@@ -13029,11 +12935,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -13048,45 +12949,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aEx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 4;
-	location = "Engineering"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aEy" = (
-/obj/machinery/door/window/southright{
-	dir = 4;
-	name = "Engineering Deliveries";
-	req_access_txt = "10"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aEz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"aEA" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"aEA" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aEB" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/small{
@@ -13102,16 +12983,10 @@
 	name = "\improper Mining Office"
 	})
 "aEC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/starboard)
 "aED" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -13128,15 +13003,17 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aEE" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aEH" = (
 /obj/structure/closet/crate,
 /obj/item/stack/ore/glass,
@@ -13514,11 +13391,16 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aFy" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Foyer";
+	req_access_txt = "10"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "aFz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -13649,11 +13531,6 @@
 	icon_state = "barber"
 	},
 /area/crew_quarters/sleep)
-"aFM" = (
-/obj/machinery/vending/engidrobe,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aFO" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -13666,22 +13543,10 @@
 	name = "\improper Mining Office"
 	})
 "aFP" = (
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "ceprivacy";
-	name = "privacy shutters";
-	opacity = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/maintenance/fore)
 "aFQ" = (
 /obj/machinery/door_control{
 	id = "qm_mine_warehouse";
@@ -13736,48 +13601,29 @@
 	},
 /area/security/brig)
 "aFY" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/engineering)
-"aFZ" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aGb" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Fore"
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aGc" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/structure/table,
+/obj/item/stack/sheet/rglass{
+	amount = 30;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/equipmentstorage)
 "aGf" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -13848,14 +13694,28 @@
 	name = "\improper Warehouse"
 	})
 "aGl" = (
-/obj/structure/chair{
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/starboard)
 "aGm" = (
 /obj/structure/rack{
 	dir = 8;
@@ -13932,19 +13792,22 @@
 /area/security/brig)
 "aGt" = (
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "ceprivacy";
-	name = "privacy shutters";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/maintenance/starboard)
 "aGu" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -14022,12 +13885,6 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"aGC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aGD" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -14119,17 +13976,12 @@
 	},
 /area/crew_quarters/sleep)
 "aGN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "aGO" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -14199,15 +14051,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aGX" = (
-/obj/machinery/suit_storage_unit/ce/secure,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -29
+/obj/structure/sign/securearea{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/engine/chiefs_office)
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "aGY" = (
 /obj/item/stack/ore/silver,
 /obj/item/stack/ore/silver,
@@ -14228,7 +14077,8 @@
 	name = "\improper Mining Office"
 	})
 "aHa" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/vending/engidrobe,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aHb" = (
@@ -14246,12 +14096,6 @@
 /area/construction/Storage{
 	name = "Storage Wing"
 	})
-"aHc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aHf" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -14259,9 +14103,8 @@
 	},
 /area/security/processing)
 "aHg" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/wall,
+/area/engine/equipmentstorage)
 "aHh" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -14281,8 +14124,18 @@
 	},
 /area/security/processing)
 "aHi" = (
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aHj" = (
 /obj/structure/cable/yellow{
@@ -14303,17 +14156,17 @@
 /turf/simulated/wall,
 /area/construction)
 "aHl" = (
-/obj/structure/table,
-/obj/machinery/light{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = 30
+/obj/machinery/computer/security/telescreen{
+	dir = 4;
+	name = "MiniSat Monitor";
+	network = list("MiniSat","tcomm");
+	pixel_x = -29
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 8;
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
@@ -14397,19 +14250,14 @@
 	name = "Port Maintenance"
 	})
 "aHw" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Drone Fabricator APC";
-	pixel_x = -24
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
-	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aHx" = (
 /obj/structure/closet/crate,
@@ -14462,14 +14310,14 @@
 /turf/simulated/wall,
 /area/hallway/primary/fore)
 "aHH" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-20";
-	pixel_y = 3
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/effect/spawner/random_barrier/possibly_welded_airlock,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aHI" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14676,16 +14524,17 @@
 	},
 /area/security/detectives_office)
 "aHX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/unary/portables_connector{
+	layer = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "aHY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -14740,10 +14589,21 @@
 /turf/simulated/floor/mineral/tranquillite,
 /area/crew_quarters/sleep)
 "aId" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet3";
-	name = "Unit 3"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/machinery/newscaster{
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/machinery/door_control{
+	id = "Toilet3";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -14751,13 +14611,11 @@
 	name = "\improper Restrooms"
 	})
 "aIe" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -14771,17 +14629,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aIi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aIk" = (
@@ -14867,36 +14725,21 @@
 /turf/simulated/floor/mineral/tranquillite,
 /area/crew_quarters/sleep)
 "aIu" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "aIv" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "aIw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "aIy" = (
@@ -14911,18 +14754,30 @@
 	name = "\improper Mining Office"
 	})
 "aIz" = (
-/obj/structure/dispenser,
-/obj/machinery/light{
-	dir = 1
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-20";
+	pixel_y = 3
 	},
+/obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "aIA" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/equipmentstorage)
 "aIB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Storage";
+	req_access_txt = "32"
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -14934,8 +14789,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/equipmentstorage)
 "aIC" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -14953,7 +14809,7 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"aID" = (
+"aIE" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -14973,36 +14829,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"aIE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"aIF" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aIG" = (
 /obj/structure/table/wood,
 /obj/machinery/power/apc{
@@ -15044,12 +14870,6 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "aIJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
@@ -15095,16 +14915,9 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aIS" = (
-/obj/item/stack/sheet/plasteel{
-	amount = 10;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/rglass{
-	amount = 30;
-	pixel_x = 2;
-	pixel_y = -2
+/obj/structure/dispenser,
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -15128,14 +14941,14 @@
 	name = "Port Maintenance"
 	})
 "aIV" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aIX" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -15390,14 +15203,19 @@
 	},
 /area/security/detectives_office)
 "aJt" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1;
-	on = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/meter,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -15409,24 +15227,17 @@
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "aJv" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Restrooms";
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet{
-	name = "\improper Restrooms"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aJw" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -15458,30 +15269,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/security/warden)
-"aJz" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet{
-	name = "\improper Restrooms"
-	})
 "aJA" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15498,11 +15286,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15521,11 +15304,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15563,18 +15341,16 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
 "aJI" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "aJJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/effect/spawner/window/reinforced/plasma,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aJK" = (
@@ -15591,9 +15367,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
 "aJL" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "aJN" = (
 /obj/structure/cable/yellow,
 /obj/machinery/door/poddoor/preopen{
@@ -15604,41 +15379,22 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "aJO" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aJQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "aJR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Storage";
-	req_access_txt = "32"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "aJS" = (
@@ -15662,21 +15418,34 @@
 	name = "\improper Warehouse"
 	})
 "aJT" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "aJW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10;
-	initialize_directions = 10
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Mix Bypass"
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aJX" = (
@@ -15698,11 +15467,15 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "aJZ" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aKc" = (
 /obj/structure/cable/yellow{
@@ -16154,6 +15927,17 @@
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "aKW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
+"aKX" = (
 /obj/structure/toilet{
 	pixel_y = 8
 	},
@@ -16165,24 +15949,13 @@
 	pixel_y = -32
 	},
 /obj/machinery/door_control{
-	id = "Toilet3";
+	id = "Toilet2";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet{
-	name = "\improper Restrooms"
-	})
-"aKX" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet2";
-	name = "Unit 2"
-	},
+/obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -16190,18 +15963,21 @@
 	name = "\improper Restrooms"
 	})
 "aKZ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 8;
+	network = list("SS13","engine")
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "dark"
 	},
-/area/crew_quarters/locker/locker_toilet{
-	name = "\improper Restrooms"
-	})
+/area/engine/engineering)
 "aLa" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -16336,6 +16112,16 @@
 	name = "\improper Warehouse"
 	})
 "aLp" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"aLq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"aLr" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
 	amount = 50
@@ -16361,7 +16147,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"aLq" = (
+"aLu" = (
 /obj/structure/table,
 /obj/item/stack/rods{
 	amount = 50
@@ -16374,49 +16160,6 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"aLr" = (
-/obj/structure/closet/crate{
-	name = "solar pack crate"
-	},
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/circuitboard/solar_control,
-/obj/item/tracker_electronics,
-/obj/item/paper/solar,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"aLu" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/obj/item/airlock_electronics,
-/obj/item/airlock_electronics,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "aLv" = (
@@ -16442,24 +16185,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
-"aLx" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	state = 2
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
 /area/engine/engineering)
 "aLy" = (
 /obj/machinery/computer/guestpass{
@@ -16482,27 +16209,28 @@
 /turf/simulated/floor/plating,
 /area/construction)
 "aLC" = (
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "aLD" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plasteel,
 /area/construction)
 "aLE" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/trinary/filter/flipped,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/supermatter)
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "aLF" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light_construct{
@@ -16541,22 +16269,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"aLN" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Mix Bypass"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "aLP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16575,8 +16287,22 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aLR" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/yellow,
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil,
+/obj/item/airlock_electronics,
+/obj/item/airlock_electronics,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -5;
+	pixel_y = 6
+	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -16591,13 +16317,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"aLU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aLV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16751,17 +16470,8 @@
 	},
 /area/security/processing)
 "aMp" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet{
-	name = "\improper Restrooms"
-	})
+/turf/simulated/wall/r_wall,
+/area/space/nearstation)
 "aMq" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -16781,9 +16491,12 @@
 	name = "\improper Warehouse"
 	})
 "aMr" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet4";
-	name = "Unit 4"
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -16793,7 +16506,8 @@
 	})
 "aMs" = (
 /obj/machinery/door/airlock{
-	name = "Unit B"
+	id_tag = "Toilet4";
+	name = "Unit 4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -16941,15 +16655,6 @@
 	},
 /area/security/detectives_office)
 "aMK" = (
-/obj/machinery/light/small,
-/obj/machinery/power/apc{
-	name = "Restrooms APC";
-	pixel_y = -26
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -16963,13 +16668,9 @@
 /turf/simulated/floor/plasteel,
 /area/construction)
 "aMM" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/turf/simulated/floor/plasteel,
-/area/construction)
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aMP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16980,26 +16681,9 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_upload)
-"aMQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "aMR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "aMS" = (
 /obj/structure/cable/yellow{
@@ -17040,18 +16724,6 @@
 /obj/machinery/vending/cargodrobe,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"aMU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "aMW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17072,18 +16744,17 @@
 /area/quartermaster/storage)
 "aMX" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aMY" = (
@@ -17166,16 +16837,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"aNd" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/supermatter)
 "aNe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17536,10 +17197,24 @@
 	},
 /area/hallway/primary/fore)
 "aNK" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet1";
-	name = "Unit 1"
+/obj/structure/toilet{
+	pixel_y = 8
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/machinery/door_control{
+	id = "Toilet1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	specialfunctions = 4
+	},
+/obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -17557,8 +17232,19 @@
 	},
 /area/hallway/primary/fore)
 "aNM" = (
-/obj/machinery/light/small,
-/obj/machinery/recharge_station,
+/obj/machinery/door_control{
+	id = "Toilet4";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -17570,43 +17256,17 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"aNR" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "aNS" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
+"aNU" = (
 /obj/machinery/field/generator{
 	state = 2
 	},
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/storage/secure)
-"aNT" = (
-/obj/machinery/field/generator{
-	state = 2
-	},
-/turf/simulated/floor/plating,
-/area/storage/secure)
-"aNU" = (
-/obj/machinery/shieldgen,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Secure Storage"
-	},
-/turf/simulated/floor/plating,
-/area/storage/secure)
-"aNV" = (
-/obj/machinery/suit_storage_unit/engine/secure,
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "aNX" = (
@@ -17640,13 +17300,16 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aOa" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1441;
+	icon_state = "on";
+	id = "engine-waste_out";
+	name = "engine outlet injector";
+	on = 1;
+	volume_rate = 200
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "aOb" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -17659,12 +17322,13 @@
 	},
 /area/security/brig)
 "aOd" = (
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	dir = 1;
+	filter_type = -1
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
-"aOe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
 "aOf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17678,23 +17342,6 @@
 /area/construction/Storage{
 	name = "Storage Wing"
 	})
-"aOg" = (
-/obj/structure/table,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/light_switch{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aOh" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -17750,12 +17397,11 @@
 /turf/simulated/floor/plasteel,
 /area/construction)
 "aOl" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Arrivals Expansion Area";
-	req_access_txt = "32"
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/construction)
+/area/maintenance/fore)
 "aOp" = (
 /obj/machinery/door/poddoor{
 	id_tag = "QMLoaddoor2";
@@ -17771,30 +17417,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aOw" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/machinery/door_control{
-	id = "Toilet2";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/spawner/blob,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet{
-	name = "\improper Restrooms"
-	})
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "aOx" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17953,18 +17578,17 @@
 	name = "Disposals Junction";
 	sortType = 1
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
 "aOX" = (
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
-	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/yellow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/equipmentstorage)
 "aOY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17988,17 +17612,14 @@
 	name = "\improper Restrooms"
 	})
 "aPa" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aPb" = (
 /obj/structure/cable/yellow{
@@ -18014,13 +17635,12 @@
 	},
 /area/security/brig)
 "aPe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "aPf" = (
 /obj/machinery/conveyor/east{
 	id = "QMLoad2"
@@ -18058,17 +17678,10 @@
 	name = "\improper Garden"
 	})
 "aPk" = (
-/obj/structure/closet/crate,
-/obj/item/wirecutters,
-/obj/item/weldingtool,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"aPl" = (
-/obj/machinery/shieldgen,
-/turf/simulated/floor/plating,
-/area/storage/secure)
 "aPm" = (
 /obj/machinery/light{
 	dir = 1
@@ -18082,22 +17695,29 @@
 	},
 /area/security/brig)
 "aPn" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Fore"
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aPo" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"aPp" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aPq" = (
@@ -18121,6 +17741,11 @@
 /turf/simulated/floor/plasteel,
 /area/construction)
 "aPs" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
+"aPu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
 	initialize_directions = 11
@@ -18140,34 +17765,9 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"aPt" = (
+"aPv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
-"aPu" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Gas to Chamber"
-	},
-/obj/machinery/power/apc{
-	cell_type = 25000;
-	dir = 1;
-	name = "Engineering Engine Super APC";
-	pixel_y = 24;
-	shock_proof = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
-"aPv" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -18196,13 +17796,14 @@
 	name = "Storage Wing"
 	})
 "aPy" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1;
+	name = "Gas to Mix"
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/binary/valve/digital/open{
-	name = "Output Release"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18210,7 +17811,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aPz" = (
@@ -18252,16 +17853,16 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads)
 "aPD" = (
-/obj/machinery/light_construct{
-	dir = 4
+/obj/machinery/door/airlock{
+	id_tag = "Toilet3";
+	name = "Unit 3"
 	},
-/obj/machinery/light_switch{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
 	},
-/turf/simulated/floor/plasteel,
-/area/construction)
+/area/crew_quarters/locker/locker_toilet{
+	name = "\improper Restrooms"
+	})
 "aPE" = (
 /obj/machinery/conveyor/northeast/ccw{
 	id = "QMLoad2"
@@ -18319,23 +17920,21 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"aPK" = (
-/obj/structure/table,
-/obj/machinery/computer/guestpass,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aPL" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aPM" = (
 /obj/structure/window/reinforced{
@@ -18390,12 +17989,10 @@
 	name = "Port Maintenance"
 	})
 "aPS" = (
-/obj/structure/sink{
+/obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
+	name = "west bump";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -18508,11 +18105,12 @@
 	},
 /area/turret_protected/ai_upload)
 "aQi" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "aQj" = (
 /obj/structure/sign/kiddieplaque{
 	pixel_y = 32
@@ -18646,12 +18244,18 @@
 /area/crew_quarters/locker)
 "aQF" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "aQG" = (
 /obj/effect/decal/warning_stripes/arrow{
@@ -18777,36 +18381,23 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"aQR" = (
-/obj/structure/table,
-/obj/item/rpd,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/head/radiation,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aQS" = (
-/obj/machinery/power/emitter,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/storage/secure)
-"aQT" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/landmark/spawner/blob,
-/turf/simulated/floor/plating,
-/area/storage/secure)
+/area/maintenance/starboard)
 "aQU" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	id_tag = "Secure Storage";
+	name = "Secure Storage Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "aQV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -18841,15 +18432,42 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"aRa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "aRb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
+"aRc" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "Gas to Filter"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
+"aRd" = (
 /obj/machinery/door/airlock/engineering/glass{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
@@ -18862,27 +18480,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"aRc" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
-"aRd" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
 "aRe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aRf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -18890,17 +18491,21 @@
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "aRg" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+/obj/machinery/atmospherics/binary/pump{
+	name = "Mix to Gas"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aRh" = (
@@ -18938,27 +18543,29 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "aRn" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
 "aRo" = (
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aRs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 10
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engine/engineering)
 "aRt" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -19308,37 +18915,40 @@
 	name = "\improper Garden"
 	})
 "aSf" = (
-/obj/item/storage/box/donkpockets,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "aSg" = (
-/obj/machinery/power/emitter,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/storage/secure)
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/valve/digital/open{
+	name = "Output Release"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "aSh" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/airlock_electronics,
-/obj/item/airlock_electronics,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/gps,
+/obj/machinery/power/emitter,
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "aSl" = (
@@ -19364,7 +18974,16 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aSn" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aSo" = (
@@ -19425,12 +19044,9 @@
 	name = "\improper Garden"
 	})
 "aSC" = (
-/obj/machinery/computer/sm_monitor{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/suit_storage_unit/engine/secure,
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "aSD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -19448,19 +19064,7 @@
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "aSE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aSF" = (
@@ -19509,30 +19113,14 @@
 	},
 /area/quartermaster/qm)
 "aSJ" = (
-/obj/structure/toilet{
-	pixel_y = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/newscaster{
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/machinery/door_control{
-	id = "Toilet1";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/spawner/blob,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet{
-	name = "\improper Restrooms"
-	})
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "aSK" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -19553,14 +19141,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fore)
 "aSN" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/warning_stripes/yellow,
@@ -19582,13 +19169,15 @@
 	},
 /area/storage/primary)
 "aST" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sign/double/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = 32
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/computer/station_alert,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/engine/engineering)
 "aSU" = (
 /obj/machinery/porta_turret{
@@ -19698,24 +19287,21 @@
 	},
 /area/crew_quarters/courtroom)
 "aTg" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/structure/mirror{
+	pixel_x = 28
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/obj/machinery/newscaster{
-	name = "east bump";
-	pixel_x = 32
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/machinery/door_control{
-	id = "Toilet4";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -19798,6 +19384,11 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -19965,32 +19556,11 @@
 	name = "\improper Garden"
 	})
 "aTJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/sign/securearea{
+	pixel_y = 32
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disaster_counter/supermatter{
-	pixel_x = 32
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
+/turf/simulated/wall/r_wall,
 /area/engine/engineering)
-"aTK" = (
-/obj/structure/window/plasmareinforced,
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/visible/supply{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
 "aTL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -20006,12 +19576,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
-"aTR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
 "aTS" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -20185,11 +19749,7 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "aUh" = (
-/obj/machinery/camera{
-	c_tag = "Engineering - Central";
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/east,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aUi" = (
@@ -20463,9 +20023,8 @@
 	name = "\improper Garden"
 	})
 "aUI" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aUK" = (
@@ -20474,20 +20033,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aUL" = (
-/obj/structure/sign/double/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/computer/station_alert,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/engine/engineering)
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "aUN" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -20518,19 +20078,18 @@
 	},
 /area/storage/primary)
 "aUR" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 8;
+	name = "Engine Room APC";
+	pixel_x = -26;
+	shock_proof = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aUT" = (
@@ -20642,30 +20201,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
-"aVf" = (
-/obj/machinery/vending/tool,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "aVg" = (
-/obj/machinery/vending/engivend,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"aVh" = (
-/obj/structure/table,
-/obj/item/rpd,
-/obj/item/geiger_counter,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/head/radiation,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Power Monitoring"
+	},
+/obj/machinery/computer/monitor{
+	name = "Engineering Power Monitoring Console"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/engine/engineering)
 "aVk" = (
 /obj/structure/cable/yellow{
@@ -20674,6 +20227,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -20722,6 +20276,7 @@
 	icon_state = "1-2"
 	},
 /mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -20743,20 +20298,15 @@
 	},
 /area/crew_quarters/locker)
 "aVs" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Gas to Filter"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aVt" = (
@@ -20888,13 +20438,19 @@
 	},
 /area/crew_quarters/courtroom)
 "aVF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "aVG" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -21007,24 +20563,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"aVT" = (
-/obj/structure/table,
-/obj/item/clothing/head/soft/grey{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"aVU" = (
-/obj/structure/table,
-/obj/item/razor{
-	pixel_y = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "aVV" = (
-/obj/structure/table,
-/obj/item/paicard,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "aVX" = (
@@ -21094,35 +20636,21 @@
 	name = "\improper Garden"
 	})
 "aWf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/cigbutt,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"aWg" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
-	dir = 8;
-	network = list("SS13","engine")
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/light,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
+/area/engine/engineering)
+"aWg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "aWh" = (
 /obj/machinery/camera/autoname,
@@ -21191,26 +20719,25 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aWn" = (
-/obj/machinery/power/apc{
-	cell_type = 25000;
-	dir = 8;
-	name = "Engine Room APC";
-	pixel_x = -26;
-	shock_proof = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "aWo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -21219,11 +20746,11 @@
 	},
 /area/security/brig)
 "aWp" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aWq" = (
@@ -21295,18 +20822,18 @@
 /turf/simulated/wall,
 /area/maintenance/fore)
 "aWw" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21343,9 +20870,10 @@
 	},
 /area/crew_quarters/locker)
 "aWA" = (
-/obj/structure/lattice,
-/turf/simulated/wall/r_wall,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "aWB" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -21413,21 +20941,16 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aWN" = (
-/obj/structure/sign/double/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
+/obj/machinery/door/airlock{
+	id_tag = "Toilet2";
+	name = "Unit 2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "freezerfloor"
 	},
-/area/engine/engineering)
+/area/crew_quarters/locker/locker_toilet{
+	name = "\improper Restrooms"
+	})
 "aWO" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -21522,20 +21045,17 @@
 	},
 /area/storage/primary)
 "aWX" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/status_display{
-	layer = 4;
+/obj/structure/sign/double/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
 	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Power Monitoring"
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/computer/monitor{
-	name = "Engineering Power Monitoring Console"
-	},
+/obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -21628,16 +21148,6 @@
 /obj/item/paper,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"aXo" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/supermatter)
 "aXp" = (
 /obj/machinery/vending/crittercare,
 /obj/effect/decal/warning_stripes/north,
@@ -21658,15 +21168,13 @@
 	name = "\improper Garden"
 	})
 "aXs" = (
-/obj/machinery/atmospherics/trinary/filter/flipped,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/crew_quarters/locker/locker_toilet{
+	name = "\improper Restrooms"
+	})
 "aXt" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -21697,32 +21205,25 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aXx" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow/fake,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/geiger_counter,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"aXy" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring";
+	req_access_txt = "32"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"aXy" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aXz" = (
@@ -21758,13 +21259,14 @@
 "aXF" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aXG" = (
@@ -21854,23 +21356,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aXQ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aXR" = (
@@ -22173,20 +21667,37 @@
 	},
 /area/crew_quarters/courtroom)
 "aYD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/crate{
+	name = "solar pack crate"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/circuitboard/solar_control,
+/obj/item/tracker_electronics,
+/obj/item/paper/solar,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
+"aYE" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"aYE" = (
+"aYG" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -22204,21 +21715,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/landmark/start/engineer,
 /obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"aYG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aYJ" = (
@@ -22254,12 +21750,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "aYO" = (
 /obj/structure/table,
@@ -22277,27 +21769,25 @@
 	},
 /area/storage/primary)
 "aYP" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/locker)
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "aYQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aYS" = (
@@ -22306,12 +21796,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aYT" = (
@@ -22335,20 +21824,6 @@
 	})
 "aYU" = (
 /obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/engine/engineering)
-"aYV" = (
-/obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -22362,16 +21837,26 @@
 	icon_state = "vault"
 	},
 /area/engine/engineering)
+"aYV" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8;
+	initialize_directions = 11
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "aYW" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aYX" = (
@@ -22396,24 +21881,26 @@
 	})
 "aYY" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "aYZ" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/engine/engineering)
 "aZa" = (
 /obj/structure/cable/yellow{
@@ -22457,6 +21944,30 @@
 /turf/simulated/floor/plasteel,
 /area/security/brig)
 "aZc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"aZd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"aZe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -22479,7 +21990,7 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"aZd" = (
+"aZg" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -22488,7 +21999,7 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"aZe" = (
+"aZh" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -22498,31 +22009,6 @@
 	pixel_y = 32
 	},
 /obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
-"aZg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 5
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/supermatter)
-"aZh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aZj" = (
@@ -22640,17 +22126,21 @@
 	name = "\improper Garden"
 	})
 "aZB" = (
-/obj/item/book/manual/engineering_hacking{
-	pixel_x = 4;
-	pixel_y = 5
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
 	},
-/obj/item/book/manual/engineering_construction{
-	pixel_y = 3
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/engine/engineering)
 "aZC" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -22711,17 +22201,11 @@
 	},
 /area/storage/primary)
 "aZI" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "aZJ" = (
 /turf/simulated/wall/r_wall,
@@ -22734,18 +22218,12 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload_foyer)
 "aZM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Monitoring";
-	req_access_txt = "32"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aZN" = (
@@ -22765,19 +22243,6 @@
 	icon_state = "vault"
 	},
 /area/turret_protected/ai_upload_foyer)
-"aZO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "aZP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -22903,46 +22368,75 @@
 /turf/simulated/wall,
 /area/crew_quarters/locker)
 "baa" = (
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
 	},
-/area/crew_quarters/locker)
+/turf/simulated/floor/plating,
+/area/construction)
 "bab" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/crew_quarters/locker)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "bac" = (
-/obj/structure/closet/wardrobe/white,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/crew_quarters/locker)
+/obj/structure/rack,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/head/hardhat,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "bad" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
 /area/crew_quarters/locker)
 "bae" = (
-/obj/structure/closet/wardrobe/green,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/area/crew_quarters/locker)
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "baf" = (
-/obj/machinery/vending/clothing,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/structure/table,
+/obj/item/rpd,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/head/radiation,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
 	},
-/area/crew_quarters/locker)
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bag" = (
-/obj/structure/closet/wardrobe/mixed,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8;
+	initialize_directions = 11
 	},
-/area/crew_quarters/locker)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bah" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -22965,10 +22459,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bal" = (
@@ -22977,6 +22469,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bam" = (
@@ -23010,24 +22503,22 @@
 	},
 /area/storage/primary)
 "bao" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 5;
-	initialize_directions = 12
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "bap" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/obj/machinery/meter,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "baq" = (
@@ -23079,27 +22570,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
-"baw" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "bay" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
@@ -23117,7 +22587,7 @@
 	name = "\improper Command Hallway"
 	})
 "baB" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "baC" = (
@@ -23143,11 +22613,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "baE" = (
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "yellow"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/engine/break_room)
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 10
+	},
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
 "baF" = (
 /obj/machinery/light{
 	dir = 4
@@ -23167,12 +22642,10 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "baG" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
-	},
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "baH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -23272,19 +22745,13 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "baU" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering{
+/obj/machinery/light{
 	dir = 8
-	})
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "baV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23421,7 +22888,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/item/toolbox_tiles/sensor,
+/obj/machinery/light_construct/small,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -23525,24 +22993,22 @@
 	},
 /area/hallway/primary/central)
 "bbu" = (
-/obj/machinery/light,
-/obj/machinery/newscaster{
-	name = "south bump";
-	pixel_y = -32
-	},
+/obj/structure/closet/wardrobe/mixed,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "vault"
 	},
 /area/crew_quarters/locker)
 "bbv" = (
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 27
+/obj/machinery/door/airlock{
+	id_tag = "Toilet1";
+	name = "Unit 1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "freezerfloor"
 	},
-/area/crew_quarters/locker)
+/area/crew_quarters/locker/locker_toilet{
+	name = "\improper Restrooms"
+	})
 "bbx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Tech Storage";
@@ -23594,28 +23060,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "bbD" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
 /area/hallway/primary/central)
 "bbE" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bbG" = (
@@ -23636,10 +23096,19 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
 "bbK" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/keycard_auth{
+	pixel_x = -25;
+	pixel_y = 25
+	},
+/obj/machinery/status_display{
+	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/computer/station_alert,
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
+	},
+/obj/machinery/computer/card/minor/ce,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -23655,13 +23124,27 @@
 	name = "Customs"
 	})
 "bbM" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet{
+	name = "\improper Restrooms"
+	})
 "bbO" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bbP" = (
@@ -23865,38 +23348,19 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bcj" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bck" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/shieldgen,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/camera{
+	c_tag = "Engineering - Secure Storage"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellow"
-	},
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "bcl" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -23973,17 +23437,14 @@
 	},
 /area/turret_protected/ai_upload_foyer)
 "bcq" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bcr" = (
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 4;
-	name = "Engineering RC"
-	},
-/turf/simulated/wall,
+/obj/structure/closet/firecloset,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bcs" = (
 /obj/machinery/hologram/holopad,
@@ -24254,16 +23715,16 @@
 	},
 /area/hallway/primary/central)
 "bdk" = (
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bdl" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/window/reinforced/tinted,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bdm" = (
@@ -24271,9 +23732,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bdp" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
+	dir = 5
 	},
 /turf/space,
 /area/space/nearstation)
@@ -24388,18 +23849,11 @@
 	},
 /area/storage/tech)
 "bdy" = (
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/engine/chiefs_office)
+/obj/structure/table,
+/obj/machinery/computer/guestpass,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bdz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24410,21 +23864,22 @@
 	},
 /area/engine/chiefs_office)
 "bdA" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 6;
-	pixel_y = 30
+/obj/structure/table,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/light_switch{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/camera{
-	c_tag = "Chief Engineer's Office"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/engine/chiefs_office)
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bdB" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
@@ -24448,40 +23903,32 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bdD" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office";
-	req_access_txt = "56"
+/obj/structure/disaster_counter/supermatter{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bdE" = (
-/obj/machinery/keycard_auth{
-	pixel_x = -25;
-	pixel_y = 25
+/obj/structure/window/plasmareinforced,
+/obj/machinery/power/rad_collector{
+	anchored = 1
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/visible/supply{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
-	},
-/obj/machinery/computer/card/minor/ce,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/engine/chiefs_office)
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
 "bdF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -24709,6 +24156,7 @@
 "bef" = (
 /obj/structure/closet/crate,
 /obj/item/stack/cable_coil/random,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "beg" = (
@@ -25014,6 +24462,21 @@
 	},
 /area/hallway/primary/central)
 "beI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8;
+	initialize_directions = 11
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
+"beJ" = (
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
+/area/space/nearstation)
+"beK" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the engineering security doors.";
 	id = "Engineering";
@@ -25037,22 +24500,6 @@
 	icon_state = "vault"
 	},
 /area/engine/chiefs_office)
-"beJ" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/engine/chiefs_office)
-"beK" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
-/obj/item/reagent_containers/food/pill/patch/silver_sulf,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
-/area/engine/chiefs_office)
 "beL" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -25064,33 +24511,20 @@
 /area/lawoffice)
 "beM" = (
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/paper/tcommskey,
+/obj/item/folder/yellow,
+/obj/item/stamp/ce,
+/obj/item/reagent_containers/food/pill/patch/silver_sulf,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/engine/chiefs_office)
 "beN" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer's Office"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "neutral"
 	},
 /area/engine/chiefs_office)
 "beP" = (
@@ -25218,18 +24652,12 @@
 	name = "\improper MiniSat Exterior"
 	})
 "bfd" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_y = 32
+/obj/machinery/door/airlock/engineering{
+	name = "Arrivals Expansion Area";
+	req_access_txt = "32"
 	},
-/obj/machinery/computer/atmos_alert,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/engine/chiefs_office)
+/turf/simulated/floor/plating,
+/area/construction)
 "bff" = (
 /obj/effect/decal/warning_stripes/yellow/partial,
 /obj/effect/decal/warning_stripes/arrow{
@@ -25293,18 +24721,20 @@
 	name = "Port Maintenance"
 	})
 "bfl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
+/area/crew_quarters/locker/locker_toilet{
+	name = "\improper Restrooms"
 	})
 "bfm" = (
 /obj/structure/cable/yellow{
@@ -25350,29 +24780,32 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bfr" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring the singularity engine safely.";
+/obj/machinery/power/apc{
 	dir = 8;
-	name = "Singularity Monitor";
-	network = list("Singulo");
-	pixel_x = 32
+	name = "Drone Fabricator APC";
+	pixel_x = -24
 	},
-/obj/machinery/computer/drone_control{
-	dir = 8
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 8;
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
 "bfs" = (
 /obj/machinery/shower{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bfu" = (
@@ -25407,14 +24840,26 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bfy" = (
-/obj/structure/sign/securearea{
-	pixel_y = 32
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "CE Office APC";
+	pixel_x = 28
 	},
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/engine/chiefs_office)
 "bfz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -25511,11 +24956,13 @@
 	},
 /area/hallway/primary/central)
 "bfM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Engineering - Central";
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "bfN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25830,6 +25277,31 @@
 	},
 /area/storage/tech)
 "bgu" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Gas to Chamber"
+	},
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 1;
+	name = "Engineering Engine Super APC";
+	pixel_y = 24;
+	shock_proof = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
+"bgv" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
+"bgw" = (
 /obj/machinery/door_control{
 	id = "transittube";
 	name = "Transit Tube Lockdown";
@@ -25850,7 +25322,7 @@
 	icon_state = "vault"
 	},
 /area/engine/chiefs_office)
-"bgv" = (
+"bgx" = (
 /obj/item/cartridge/engineering{
 	pixel_x = 4;
 	pixel_y = 5
@@ -25867,24 +25339,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
-	},
-/area/engine/chiefs_office)
-"bgw" = (
-/obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/effect/landmark/start/chief_engineer,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/engine/chiefs_office)
-"bgx" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
 	},
 /area/engine/chiefs_office)
 "bgy" = (
@@ -26154,8 +25608,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bhb" = (
 /obj/structure/closet/emcloset,
@@ -26216,21 +25669,16 @@
 	},
 /area/quartermaster/office)
 "bhf" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "CE Office APC";
-	pixel_x = 28
+/obj/item/storage/secure/safe{
+	pixel_x = 6;
+	pixel_y = 30
 	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "vault"
@@ -26294,17 +25742,10 @@
 	},
 /area/hallway/primary/port)
 "bho" = (
-/obj/structure/closet/radiation,
 /obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
 	pixel_y = 32
 	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
+/obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -26358,10 +25799,10 @@
 	name = "\improper Captain's Quarters"
 	})
 "bhA" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bhB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -26495,30 +25936,23 @@
 	name = "Arrivals"
 	})
 "bhS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/engine/chiefs_office)
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bhT" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/engine/chiefs_office)
-"bhU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/engine/chiefs_office)
 "bhV" = (
@@ -26557,8 +25991,10 @@
 	},
 /area/atmos)
 "bhZ" = (
-/obj/structure/cable/yellow,
-/obj/effect/spawner/window/reinforced,
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "bia" = (
@@ -26631,19 +26067,23 @@
 	},
 /area/turret_protected/ai)
 "big" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/chiefs_office)
 "bih" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -26665,21 +26105,18 @@
 	})
 "bik" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/lightsout,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "bil" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -26917,9 +26354,10 @@
 	},
 /area/crew_quarters/bar)
 "biM" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/theatre)
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/landmark/spawner/blob,
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "biN" = (
 /obj/machinery/computer/supplycomp{
 	dir = 1
@@ -27371,48 +26809,41 @@
 	},
 /area/storage/tools)
 "bjG" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/computer/security/telescreen{
-	desc = "A telescreen that connects to the engine's camera network.";
-	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 30
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/engine/chiefs_office)
 "bjH" = (
-/obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/Poly,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/storage/secure/briefcase,
+/obj/item/clothing/mask/cigarette/cigar,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "MiniSat Monitor";
+	network = list("MiniSat","tcomm");
+	pixel_y = -30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "vault"
 	},
 /area/engine/chiefs_office)
 "bjI" = (
-/obj/machinery/alarm{
+/obj/structure/rack{
 	dir = 8;
-	name = "east bump";
-	pixel_x = 24
+	layer = 2.9
 	},
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/lighter/zippo,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/door_control{
+	id = "ceprivacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -27758,12 +27189,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bkt" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/security/telescreen{
+	desc = "A telescreen that connects to the engine's camera network.";
+	dir = 8;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("engine");
+	pixel_x = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/engine/chiefs_office)
 "bku" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mailroom Maintenance";
@@ -27773,25 +27221,13 @@
 /area/quartermaster/office)
 "bkv" = (
 /obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Entrance";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bkw" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bkx" = (
@@ -28147,16 +27583,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
 "blt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 4;
+	name = "Engineering RC"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/wall,
 /area/engine/engineering)
 "blx" = (
 /obj/structure/disposalpipe/segment,
@@ -28577,22 +28009,13 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bmh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
 "bmi" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -28632,20 +28055,10 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bmm" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/engine/chiefs_office)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bmn" = (
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -28828,11 +28241,10 @@
 	},
 /area/hallway/primary/port)
 "bmB" = (
-/obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bmC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -28862,25 +28274,12 @@
 	},
 /area/janitor)
 "bmE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/newscaster{
-	name = "east bump";
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/engine/chiefs_office)
 "bmF" = (
@@ -28888,6 +28287,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "bmG" = (
+/obj/item/gun/throw/crossbow/french,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -28965,11 +28366,9 @@
 /area/maintenance/starboard)
 "bmN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer's Office"
-	},
+/obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral"
+	icon_state = "neutralcorner"
 	},
 /area/engine/chiefs_office)
 "bmO" = (
@@ -29311,27 +28710,8 @@
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"bny" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/engine/break_room)
 "bnz" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -29424,27 +28804,15 @@
 	name = "\improper MiniSat Exterior"
 	})
 "bnL" = (
-/obj/structure/table,
-/obj/item/toy/figure/crew/clown,
-/obj/item/reagent_containers/food/snacks/baguette,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/maintenance/starboard)
 "bnM" = (
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/engine/chiefs_office)
+/obj/machinery/power/emitter,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "bnN" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29493,13 +28861,30 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "bnR" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/area/maintenance/starboard)
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/airlock_electronics,
+/obj/item/airlock_electronics,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/gps,
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "bnS" = (
-/obj/item/storage/backpack/duffel/clown,
+/obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -29516,9 +28901,7 @@
 	name = "\improper MiniSat Exterior"
 	})
 "bnU" = (
-/obj/structure/bed,
-/obj/item/bedsheet/clown,
-/obj/effect/decal/cleanable/blood/old,
+/obj/item/storage/backpack/duffel/clown,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -29572,16 +28955,9 @@
 	name = "Customs"
 	})
 "bob" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/lighter/zippo,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/door_control{
-	id = "ceprivacy";
-	name = "Privacy Shutters Control";
-	pixel_y = -26
+/obj/machinery/suit_storage_unit/ce/secure,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -29630,24 +29006,12 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "bof" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Engineering";
-	name = "Engineering Security Doors";
-	opacity = 0
+/obj/machinery/computer/sm_monitor{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "bog" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -29693,17 +29057,13 @@
 	},
 /area/quartermaster/office)
 "bom" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
-/obj/item/storage/secure/briefcase,
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
-	pixel_y = -30
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -30178,26 +29538,23 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "bpj" = (
-/obj/structure/closet/emcloset,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Gas to Filter"
+	},
+/obj/machinery/alarm/engine{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
 "bpk" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
 "bpm" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -30914,18 +30271,29 @@
 	},
 /area/hallway/primary/starboard)
 "bqN" = (
-/obj/structure/sign/clown,
-/turf/simulated/wall/r_wall,
+/obj/structure/bed,
+/obj/item/bedsheet/clown,
+/obj/effect/decal/cleanable/blood/old,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/maintenance/starboard)
 "bqO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/engine/break_room)
 "bqQ" = (
 /obj/structure/cable/yellow{
@@ -30979,10 +30347,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "bqW" = (
 /obj/machinery/door/firedoor,
@@ -31082,8 +30459,18 @@
 /turf/space,
 /area/space/nearstation)
 "bre" = (
-/turf/simulated/wall/r_wall,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8;
+	initialize_directions = 11
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Starboard";
+	dir = 4;
+	network = list("SS13","engine")
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "brf" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31098,10 +30485,12 @@
 	name = "\improper MiniSat Exterior"
 	})
 "brg" = (
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "brh" = (
 /obj/structure/window/reinforced{
@@ -31504,7 +30893,7 @@
 	},
 /area/turret_protected/ai)
 "brR" = (
-/obj/effect/decal/remains/human,
+/obj/structure/barricade/wooden,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -31822,6 +31211,9 @@
 /area/engine/break_room)
 "bsC" = (
 /obj/structure/table/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "bsD" = (
@@ -31846,16 +31238,17 @@
 /turf/simulated/floor/plating,
 /area/janitor)
 "bsF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/disposalpipe/sortjunction{
-	name = "Engineering Junction";
-	sortType = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bsG" = (
@@ -32815,7 +32208,7 @@
 	},
 /area/bridge)
 "buy" = (
-/obj/structure/closet/firecloset,
+/obj/effect/spawner/random_barrier/wall_probably,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "buz" = (
@@ -32901,12 +32294,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "buI" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "buJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -34080,17 +33479,18 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bwD" = (
-/obj/structure/grille,
+/obj/structure/reflector/double{
+	anchored = 1;
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
+"bwE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"bwE" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -34149,22 +33549,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"bwN" = (
-/obj/item/assembly/prox_sensor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "bwO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/storage/box/lights/mixed,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bwP" = (
@@ -34179,7 +33570,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bwS" = (
@@ -34254,14 +33645,12 @@
 /turf/space,
 /area/space/nearstation)
 "bwZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/engine/engineering)
 "bxa" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34464,12 +33853,16 @@
 	name = "Arrivals"
 	})
 "bxs" = (
-/obj/item/gun/throw/crossbow/french,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/maintenance/starboard)
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bxu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -34649,9 +34042,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bxH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -34665,12 +34058,21 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/bar)
 "bxI" = (
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bxJ" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -36219,10 +35621,7 @@
 	name = "\improper MiniSat Central Foyer"
 	})
 "bAB" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/spawner/random_barrier/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bAC" = (
@@ -36243,10 +35642,9 @@
 	name = "Arrivals"
 	})
 "bAL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bAP" = (
@@ -36878,11 +36276,13 @@
 	name = "\improper Captain's Quarters"
 	})
 "bCe" = (
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bCg" = (
 /obj/structure/table/wood,
 /obj/item/hand_tele,
@@ -36928,13 +36328,7 @@
 	name = "\improper Command Hallway"
 	})
 "bCj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bCk" = (
@@ -38066,18 +37460,22 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bEA" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bEB" = (
 /obj/structure/piano,
 /obj/machinery/light_switch{
@@ -38087,30 +37485,25 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "bEC" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "bED" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/theatre)
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
 "bEE" = (
 /obj/structure/sign/securearea{
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
@@ -38132,11 +37525,19 @@
 	},
 /area/crew_quarters/bar)
 "bEF" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/staff/broom,
-/obj/item/wrench,
-/turf/simulated/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
 "bEG" = (
 /turf/simulated/wall,
 /area/crew_quarters/theatre)
@@ -38176,8 +37577,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "bEM" = (
 /obj/structure/sign/double/map/left{
@@ -38465,8 +37866,7 @@
 /turf/space,
 /area/space/nearstation)
 "bFl" = (
-/obj/structure/bed,
-/obj/item/bedsheet/mime,
+/obj/item/toy/figure/crew/mime,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -38883,17 +38283,22 @@
 	},
 /area/crew_quarters/bar)
 "bGh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Theatre APC";
-	pixel_y = 25
+/obj/structure/table/wood,
+/obj/item/twohanded/staff/broom,
+/obj/item/clothing/glasses/monocle,
+/obj/item/clothing/glasses/regular/hipster{
+	name = "Hipster Glasses"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/monocle,
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 1;
+	name = "Bar APC";
+	pixel_y = 25
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bGi" = (
@@ -38953,27 +38358,28 @@
 	},
 /area/medical/research)
 "bGp" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/theatre)
-"bGq" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	name = "east bump";
 	pixel_x = 24
 	},
 /obj/item/clothing/head/sombrero,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"bGq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "bGr" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -39682,15 +39088,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "bHX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/theatre)
-"bHY" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	name = "east bump";
@@ -39698,8 +39095,25 @@
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/pie,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"bHY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bHZ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -40601,10 +40015,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bJN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/item/soap/nanotrasen,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/obj/structure/table/wood,
+/obj/item/wrench,
+/turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bJO" = (
 /obj/machinery/hologram/holopad,
@@ -40617,24 +40034,19 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "bJP" = (
-/obj/structure/table/wood,
-/obj/item/lipstick{
-	pixel_y = 5
-	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/camera{
-	c_tag = "Theatre - Stage";
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/instrument/guitar,
-/turf/simulated/floor/wood,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/clothing/head/soft/grey{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bJQ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -41547,7 +40959,6 @@
 "bLJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "bLK" = (
@@ -41558,14 +40969,6 @@
 	name = "Port Maintenance"
 	})
 "bLL" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/theatre)
-"bLM" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi';
 	name = "Theatre Stage";
@@ -41578,6 +40981,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
+"bLM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/razor{
+	pixel_y = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bLO" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -42401,20 +41817,26 @@
 	},
 /area/crew_quarters/kitchen)
 "bNE" = (
-/obj/item/soap/nanotrasen,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
+/area/crew_quarters/locker)
 "bNF" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bNG" = (
@@ -42831,7 +42253,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bOz" = (
@@ -43160,6 +42582,9 @@
 	icon_state = "right";
 	name = "Theatre Stage"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "bPe" = (
@@ -43169,21 +42594,26 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "bPg" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small,
-/obj/item/clothing/glasses/regular/hipster{
-	name = "Hipster Glasses"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/theatre)
-"bPh" = (
 /obj/item/instrument/violin,
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"bPh" = (
+/obj/machinery/vending/engivend,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bPi" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/extinguisher_cabinet{
@@ -44764,9 +44194,10 @@
 	name = "E.V.A. Storage"
 	})
 "bSG" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/vending/tool,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bSI" = (
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
@@ -44955,23 +44386,15 @@
 	},
 /area/medical/morgue)
 "bTc" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/table,
+/obj/item/rpd,
+/obj/item/geiger_counter,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/head/radiation,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "bTd" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -45342,10 +44765,8 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bTR" = (
@@ -45470,6 +44891,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bUl" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bUn" = (
@@ -45491,7 +44915,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bUp" = (
-/obj/item/toy/figure/crew/mime,
+/obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46004,6 +45428,7 @@
 /obj/item/cigbutt,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/spawner/blob,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bVs" = (
@@ -46686,11 +46111,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/warning_stripes/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bWU" = (
@@ -46929,11 +46353,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bXu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	id_tag = "Secure Storage";
-	name = "Secure Storage Blast Doors"
-	},
+/obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "bXv" = (
@@ -47063,10 +46483,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bXK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room";
-	req_access_txt = "12"
-	},
+/obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -47455,11 +46872,15 @@
 	name = "Port Maintenance"
 	})
 "bYy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/coffee,
+/obj/structure/sign/double/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -47509,8 +46930,8 @@
 	},
 /area/crew_quarters/kitchen)
 "bYG" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/plating,
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
 /area/maintenance/starboard)
 "bYI" = (
 /obj/structure/cable/yellow{
@@ -47656,6 +47077,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -47980,14 +47403,14 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bZH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 5
+	},
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
+"bZI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"bZI" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bZJ" = (
@@ -48215,6 +47638,11 @@
 "cap" = (
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/warning_stripes/west,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "car" = (
@@ -48369,11 +47797,16 @@
 	pixel_x = -1;
 	pixel_y = 26
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "caJ" = (
@@ -48503,18 +47936,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "caX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 9
 	},
-/obj/structure/cable/yellow{
+/obj/machinery/camera{
+	c_tag = "Supermatter Chamber";
+	dir = 4;
+	network = list("engine")
+	},
+/obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
 "caY" = (
 /obj/structure/cable/yellow,
 /obj/machinery/door/poddoor{
@@ -48533,10 +47969,12 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "caZ" = (
-/obj/structure/disposalpipe/segment,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "cba" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -49198,22 +48636,16 @@
 /area/maintenance/aft)
 "ccz" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "ccB" = (
@@ -49299,8 +48731,13 @@
 	},
 /area/hallway/primary/central)
 "ccH" = (
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engine/equipmentstorage)
 "ccI" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -49426,12 +48863,12 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "cdi" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/decal/warning_stripes/west,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cdj" = (
@@ -49508,6 +48945,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cdq" = (
@@ -50023,18 +49461,13 @@
 	},
 /area/hydroponics)
 "cex" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	dir = 1;
+	filter_type = 2
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "ceD" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -50169,24 +49602,32 @@
 	},
 /area/medical/paramedic)
 "ceT" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "ceU" = (
-/turf/simulated/floor/mech_bay_recharge_floor,
-/area/maintenance/aft)
-"ceV" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
-/obj/machinery/computer/mech_bay_power_console,
-/turf/simulated/floor/bluegrid,
-/area/maintenance/aft)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "ceW" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -50264,16 +49705,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cfd" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin/nanotrasen,
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
 	},
-/obj/item/clipboard,
+/obj/effect/landmark/start/chief_engineer,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutral"
+	icon_state = "neutralfull"
 	},
 /area/engine/chiefs_office)
 "cfe" = (
@@ -50501,7 +49940,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cfz" = (
@@ -50706,25 +50145,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cfV" = (
+/obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cfW" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/mech_bay_recharge_floor,
 /area/maintenance/aft)
 "cfY" = (
 /obj/structure/closet/firecloset,
@@ -51009,8 +50438,13 @@
 	},
 /area/medical/research)
 "cgH" = (
-/obj/structure/girder,
-/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "maint3";
+	name = "Blast Door";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -51309,19 +50743,21 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "chn" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "cho" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -51728,13 +51164,11 @@
 	name = "Medbay Storage"
 	})
 "cin" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "cio" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -51770,6 +51204,7 @@
 /obj/structure/closet,
 /obj/item/stack/cable_coil/random,
 /obj/effect/decal/warning_stripes/north,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cis" = (
@@ -52216,6 +51651,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cjj" = (
@@ -52283,13 +51722,12 @@
 	},
 /area/maintenance/incinerator)
 "cjr" = (
-/obj/machinery/mecha_part_fabricator{
-	dir = 1;
-	id = "0";
-	name = "counterfeit fabricator";
-	req_access = "0"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/bluegrid,
 /area/maintenance/aft)
 "cjs" = (
 /obj/item/cigbutt,
@@ -52550,9 +51988,22 @@
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "cjX" = (
-/obj/item/flashlight,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	state = 2
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/engine/engineering)
 "cjZ" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -52637,7 +52088,9 @@
 	},
 /area/medical/reception)
 "ckg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "ckh" = (
@@ -53285,14 +52738,14 @@
 /area/maintenance/incinerator)
 "clG" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -53367,8 +52820,6 @@
 /area/medical/morgue)
 "clR" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -53608,6 +53059,7 @@
 /obj/item/coin/silver,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/warning_stripes/south,
+/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cmy" = (
@@ -53797,14 +53249,8 @@
 /turf/simulated/wall,
 /area/medical/exam_room)
 "cmY" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_barrier/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cmZ" = (
@@ -54237,7 +53683,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cnQ" = (
@@ -54387,6 +53832,7 @@
 	dir = 5
 	},
 /obj/effect/decal/warning_stripes/west,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "coi" = (
@@ -54688,10 +54134,17 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "coI" = (
-/obj/machinery/space_heater,
-/obj/effect/decal/warning_stripes/north,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	state = 2
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/engine/engineering)
 "coK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -54716,14 +54169,13 @@
 /obj/item/storage/belt/utility,
 /obj/item/stack/cable_coil/random,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "coN" = (
 /obj/structure/closet/crate,
 /obj/item/cane,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/north,
+/obj/item/flashlight,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "coO" = (
@@ -55453,14 +54905,13 @@
 "cqo" = (
 /obj/item/storage/toolbox/emergency,
 /obj/item/clothing/mask/gas,
+/obj/structure/rack,
+/obj/item/stack/packageWrap,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cqp" = (
 /obj/machinery/light/small,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cqq" = (
@@ -55469,8 +54920,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/flashlight,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cqr" = (
@@ -55549,14 +55000,23 @@
 	},
 /area/medical/research)
 "cqC" = (
-/obj/structure/table,
-/obj/item/shard,
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "cqE" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
+/obj/item/hatchet,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cqF" = (
@@ -56074,12 +55534,13 @@
 	},
 /area/medical/reception)
 "crQ" = (
-/obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "crR" = (
 /obj/structure/closet/crate,
 /obj/item/assembly/infra,
@@ -56299,10 +55760,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "csh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -56326,22 +55783,37 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "csj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/spawner/xeno,
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "csk" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/mask/surgical,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "csl" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
@@ -56367,11 +55839,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"csn" = (
-/obj/item/stack/packageWrap,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cso" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /turf/simulated/floor/plasteel{
@@ -56437,18 +55904,24 @@
 /area/medical/reception)
 "csy" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "csz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Experimentation Lab Maintenance";
@@ -56936,11 +56409,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/storage/box/lights/mixed,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "ctl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56948,23 +56430,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage Room";
+	req_access_txt = "12"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "ctm" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/engine/engineering)
 "ctn" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -56994,15 +56473,12 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
 "ctp" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/engine/engineering)
 "ctr" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plating,
@@ -57476,12 +56952,14 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
 "cuE" = (
-/obj/structure/girder,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/closet/wardrobe/black,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/crew_quarters/locker)
 "cuF" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
@@ -58172,10 +57650,11 @@
 	},
 /area/medical/chemistry)
 "cvV" = (
-/obj/structure/barricade/wooden,
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/crew_quarters/locker)
 "cvW" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
@@ -58193,7 +57672,7 @@
 /area/medical/research)
 "cvY" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cvZ" = (
@@ -58228,11 +57707,11 @@
 	},
 /area/toxins/explab)
 "cwd" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/closet/wardrobe/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/crew_quarters/locker)
 "cwe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58338,16 +57817,11 @@
 	},
 /area/medical/reception)
 "cww" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/structure/closet/wardrobe/green,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/crew_quarters/locker)
 "cwx" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -58431,18 +57905,9 @@
 	},
 /area/hallway/primary/aft)
 "cwF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cwG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cwH" = (
@@ -58619,11 +58084,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cxf" = (
-/obj/structure/bed/roller,
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cxj" = (
@@ -58973,6 +58433,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cxU" = (
@@ -59049,20 +58510,20 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
 "cyc" = (
-/obj/structure/bed/roller,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cyd" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin{
-	pixel_x = 2
+/obj/machinery/vending/clothing,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/obj/item/clothing/mask/muzzle,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/crew_quarters/locker)
+"cyd" = (
+/obj/structure/closet/wardrobe/mixed,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/crew_quarters/locker)
 "cye" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable/white,
@@ -59070,8 +58531,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cyf" = (
-/obj/structure/rack,
-/obj/item/hatchet,
+/obj/structure/table,
+/obj/structure/bedsheetbin{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cyg" = (
@@ -59368,9 +58832,8 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
 "cyT" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/bed/roller,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cyU" = (
@@ -60007,11 +59470,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cAe" = (
-/obj/structure/closet,
-/obj/item/storage/toolbox/emergency,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cAf" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -60198,16 +59659,17 @@
 /turf/simulated/floor/plating,
 /area/medical/surgeryobs)
 "cAy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cAz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62301,6 +61763,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/west,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cEM" = (
@@ -65028,7 +64491,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
-/area/assembly/robotics)
+/area/hallway/primary/aft)
 "cKq" = (
 /obj/item/radio/intercom{
 	name = "west bump";
@@ -65657,6 +65120,7 @@
 /area/assembly/robotics)
 "cLB" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/remains/robot,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cLC" = (
@@ -65845,6 +65309,8 @@
 "cLV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/large,
+/obj/item/shard,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cLX" = (
@@ -66093,6 +65559,7 @@
 "cMx" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/mask/gas,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cMy" = (
@@ -66516,10 +65983,6 @@
 /area/assembly/robotics)
 "cMY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cMZ" = (
@@ -67203,11 +66666,6 @@
 	name = "\improper Toxins Lab"
 	})
 "cOs" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/sign/biohazard{
 	pixel_y = 32
 	},
@@ -67217,48 +66675,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cOt" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cOu" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cOw" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cOx" = (
@@ -67819,29 +67245,56 @@
 	},
 /area/maintenance/aft)
 "cPH" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "cPI" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Atmos to Loop"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "cPJ" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "cPK" = (
 /obj/item/folder/white,
 /obj/item/folder/white,
@@ -67870,31 +67323,18 @@
 	},
 /area/medical/virology)
 "cPL" = (
-/obj/machinery/vending/coffee,
-/obj/structure/sign/double/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/simulated/wall/r_wall,
+/area/engine/engineering)
 "cPM" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/double/map/right{
-	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
-	icon_state = "map-right-MS";
-	pixel_y = 32
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/space,
+/area/space/nearstation)
 "cPN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -68299,14 +67739,11 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cQx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/crew_quarters/locker)
 "cQz" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -68338,11 +67775,6 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cQE" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -68376,25 +67808,32 @@
 	},
 /area/medical/virology)
 "cQH" = (
-/obj/structure/rack,
-/obj/effect/landmark/costume,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cQI" = (
-/obj/structure/closet,
-/obj/item/clothing/glasses/science,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cQJ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cQK" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
@@ -68414,8 +67853,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cQM" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -68487,21 +67928,10 @@
 	},
 /area/medical/research)
 "cQR" = (
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 1;
-	name = "Departure Lounge APC";
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/engine/engineering)
 "cQS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -68521,7 +67951,12 @@
 	name = "Port Maintenance"
 	})
 "cQU" = (
-/obj/item/storage/box/lights/mixed,
+/obj/structure/rack,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/under/rank/hydroponics,
+/obj/item/clothing/suit/apron,
+/obj/item/storage/belt/botany,
+/obj/item/storage/backpack/satchel_hyd,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cQW" = (
@@ -68605,27 +68040,30 @@
 /turf/simulated/wall,
 /area/chapel/office)
 "cRi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Crematorium Maintenance";
-	req_access_txt = "27"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Office Maintenance";
-	req_access_txt = "27"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRl" = (
@@ -68638,12 +68076,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -68669,29 +68110,17 @@
 	},
 /area/medical/medbay3)
 "cRq" = (
-/obj/machinery/atm{
-	pixel_y = 32
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/space,
+/area/space/nearstation)
 "cRr" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;5;39;6"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cRt" = (
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
@@ -68712,15 +68141,21 @@
 	},
 /area/medical/medbay3)
 "cRv" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 1;
+	name = "Departure Lounge APC";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -68728,15 +68163,20 @@
 	name = "\improper Departure Lounge"
 	})
 "cRx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -68761,6 +68201,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -68773,11 +68217,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/warning_stripes/north,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -68936,7 +68377,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRQ" = (
@@ -68953,10 +68394,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cRR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cRS" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -69021,71 +68461,68 @@
 	},
 /area/medical/virology)
 "cSa" = (
-/obj/structure/crematorium,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
-"cSb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"cSb" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium Maintenance";
+	req_access_txt = "27"
 	},
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "cSc" = (
-/obj/machinery/newscaster{
-	name = "north bump";
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/cheesie,
+/obj/item/trash/chips,
+/obj/item/trash/pistachios,
+/obj/item/trash/raisins,
+/obj/item/trash/spacetwinkie,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"cSd" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
 	pixel_y = 32
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cSd" = (
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
+/area/engine/chiefs_office)
 "cSe" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Office Maintenance";
+	req_access_txt = "27"
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "cSf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/light_switch{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel Office";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -69093,71 +68530,34 @@
 	},
 /area/chapel/office)
 "cSg" = (
-/obj/machinery/door/morgue{
-	name = "Relic Closet";
-	req_access_txt = "22"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "ceprivacy";
+	name = "privacy shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/office)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engine/chiefs_office)
 "cSh" = (
-/obj/item/reagent_containers/food/drinks/bottle/holywater{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/organ/internal/heart,
-/obj/structure/closet/secure_closet/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/office)
-"cSi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance Access ";
-	req_one_access_txt = "12;27"
-	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cSj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office";
+	req_access_txt = "56"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cSk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cSl" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"cSn" = (
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/engine/chiefs_office)
+"cSi" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -69174,9 +68574,51 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"cSj" = (
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"cSk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"cSl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"cSn" = (
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/engine/engineering)
 "cSo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -69184,28 +68626,22 @@
 	name = "\improper Departure Lounge"
 	})
 "cSq" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "yellow"
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/engine/engineering)
 "cSr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -69354,50 +68790,58 @@
 	},
 /area/medical/virology)
 "cSI" = (
-/obj/machinery/crema_switch{
-	pixel_x = -25
-	},
+/obj/structure/crematorium,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
 "cSJ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
 "cSK" = (
-/obj/item/flashlight/lamp,
-/obj/machinery/newscaster{
-	name = "west bump";
-	pixel_x = -32
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
-/obj/structure/table/wood,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/chapel/office)
 "cSL" = (
-/obj/structure/chair,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/chaplain,
+/obj/machinery/requests_console{
+	department = "Chapel";
+	departmentType = 2;
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/chapel/office)
 "cSN" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -69423,56 +68867,47 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboardsolar)
 "cSR" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
 	},
-/area/chapel/main)
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "cSS" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance Access ";
+	req_one_access_txt = "12;27"
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "cST" = (
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/structure/noticeboard{
-	pixel_y = 29
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/chapel/main)
+/area/hallway/primary/central)
 "cSU" = (
-/obj/item/candle,
-/obj/machinery/light_switch{
-	name = "custom placement";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/structure/table/wood,
-/obj/machinery/door_control{
-	id = "chapelescapeshutters";
-	name = "Side Windows Shutter Control";
-	pixel_x = -6;
-	pixel_y = 25
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "cSV" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -69552,9 +68987,8 @@
 	},
 /area/medical/virology)
 "cTa" = (
-/obj/machinery/space_heater,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
 /area/maintenance/aft)
 "cTc" = (
 /obj/structure/cable/yellow{
@@ -69571,10 +69005,10 @@
 	name = "\improper Departure Lounge"
 	})
 "cTd" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/warning_stripes/north,
+/obj/item/cigbutt,
+/obj/structure/door_assembly/door_assembly_mai,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cTe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -69611,15 +69045,12 @@
 	},
 /area/medical/virology)
 "cTg" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=10-Aft-To-Central";
-	location = "9.4-Escape-4"
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
@@ -69693,10 +69124,9 @@
 	name = "\improper Secure Lab"
 	})
 "cTo" = (
-/obj/structure/closet/crate,
-/obj/item/poster/random_official,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/rack,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/paper/hydroponics,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cTp" = (
@@ -69714,17 +69144,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cTq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Departure Lounge - Port Fore";
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-24"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -69797,29 +69223,28 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cTy" = (
-/obj/structure/morgue,
+/obj/machinery/crema_switch{
+	pixel_x = -25
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
 "cTz" = (
-/obj/machinery/camera{
-	c_tag = "Chapel Office - Backroom";
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/light/small{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
 "cTA" = (
-/obj/item/storage/fancy/crayons,
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/flashlight/lamp,
+/obj/machinery/newscaster{
+	name = "west bump";
+	pixel_x = -32
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
@@ -69827,8 +69252,9 @@
 	},
 /area/chapel/office)
 "cTB" = (
-/obj/structure/table/wood,
+/obj/structure/chair,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -69850,72 +69276,54 @@
 	name = "\improper Departure Lounge"
 	})
 "cTD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 30
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/chapel/office)
 "cTE" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "custom placement";
-	pixel_x = -28
-	},
-/obj/structure/chair,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "cTF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/obj/item/trash/cheesie,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"cTH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "cTJ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
 /area/chapel/main)
 "cTK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
 /area/chapel/main)
 "cTM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
 	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
+/area/engine/chiefs_office)
 "cTN" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -69927,19 +69335,24 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
 /obj/effect/decal/warning_stripes/west,
+/obj/machinery/camera{
+	c_tag = "Departure Lounge - Port Fore";
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-24"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cTQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70101,37 +69514,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cUg" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
+/obj/structure/morgue,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
 "cUh" = (
+/obj/machinery/camera{
+	c_tag = "Chapel Office - Backroom";
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
 "cUi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Crematorium";
-	req_access_txt = "27"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/chapel/office)
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cUk" = (
+/obj/structure/table/wood,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -70143,31 +69555,38 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/storage/fancy/candle_box{
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/chapel/office)
 "cUm" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_x = 30
 	},
-/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 4;
+	icon_state = "yellow"
 	},
-/area/chapel/office)
+/area/engine/engineering)
 "cUn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted{
-	dir = 5
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "custom placement";
+	pixel_x = -28
 	},
+/obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70229,7 +69648,10 @@
 	},
 /area/medical/medbay3)
 "cUs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
@@ -70238,6 +69660,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
@@ -70257,22 +69685,13 @@
 	name = "\improper Departure Lounge"
 	})
 "cUx" = (
-/obj/item/storage/bible,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel - Fore"
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "cUz" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -70401,9 +69820,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cUN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70426,10 +69844,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cUP" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -70440,25 +69855,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cUS" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "cUT" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "custom placement";
-	pixel_x = 28
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 5
 	},
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70479,6 +69887,10 @@
 	},
 /area/medical/medbay3)
 "cUX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Office";
+	req_access_txt = "27"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70486,20 +69898,22 @@
 "cUY" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "cUZ" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "cVa" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -70648,13 +70062,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "cVs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table,
+/obj/item/candle,
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70695,23 +70109,31 @@
 /area/medical/morgue)
 "cVw" = (
 /obj/structure/chair/stool,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "cVz" = (
 /obj/structure/chair/stool,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "cVA" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -70724,17 +70146,10 @@
 	name = "\improper Departure Lounge"
 	})
 "cVD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "cVF" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
@@ -70770,13 +70185,18 @@
 	},
 /area/medical/research)
 "cVL" = (
-/obj/structure/closet/coffin,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
 	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/chapel/main)
+/obj/item/paper/tcommskey,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/engine/chiefs_office)
 "cVM" = (
 /obj/structure/closet/coffin,
 /obj/structure/window/reinforced{
@@ -70785,17 +70205,22 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "cVN" = (
-/obj/structure/noticeboard{
-	desc = "A memorial wall for pinning up momentos";
-	name = "memorial board";
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/table/wood,
-/obj/item/storage/fancy/candle_box/eternal,
-/obj/item/storage/fancy/candle_box/eternal,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/lightsout,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cVO" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -70815,15 +70240,14 @@
 	},
 /area/medical/virology)
 "cVP" = (
-/obj/structure/noticeboard{
-	desc = "A memorial wall for pinning up momentos";
-	name = "memorial board";
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/item/storage/bible,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cVR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -70831,49 +70255,56 @@
 	},
 /area/chapel/main)
 "cVS" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring the singularity engine safely.";
+	dir = 8;
+	name = "Singularity Monitor";
+	network = list("Singulo");
+	pixel_x = 32
 	},
-/obj/machinery/light_switch{
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/computer/drone_control{
+	dir = 8
 	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
-"cVT" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
-"cVU" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
+	icon_state = "yellow"
+	},
+/area/engine/engineering)
+"cVT" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
+"cVU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "cVX" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/nanotrasen,
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/cobweb2,
+/obj/item/clipboard,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+	dir = 8;
+	icon_state = "neutral"
 	},
-/area/chapel/main)
+/area/engine/chiefs_office)
 "cWb" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
@@ -70952,7 +70383,13 @@
 	name = "\improper Secure Lab"
 	})
 "cWi" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -70984,17 +70421,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"cWm" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 30
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "cWn" = (
 /obj/structure/closet/coffin,
 /turf/simulated/floor/plating,
@@ -71026,46 +70452,36 @@
 	name = "\improper Departure Lounge"
 	})
 "cWp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/noticeboard{
+	desc = "A memorial wall for pinning up momentos";
+	name = "memorial board";
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/structure/table/wood,
+/obj/item/storage/fancy/candle_box/eternal,
+/obj/item/storage/fancy/candle_box/eternal,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "cWq" = (
 /obj/structure/chair,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"cWs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "cWt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Office";
-	req_access_txt = "27"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cWz" = (
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -71198,12 +70614,29 @@
 	},
 /area/medical/virology)
 "cWM" = (
-/obj/machinery/door/window/eastleft{
-	name = "Coffin Storage";
-	req_access_txt = "22"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/chapel/main)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/engine/engineering)
 "cWN" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -71213,22 +70646,26 @@
 	},
 /area/chapel/main)
 "cWO" = (
-/obj/structure/chair{
-	pixel_y = -2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/chapel/main)
 "cWR" = (
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/item/storage/fancy/candle_box{
-	pixel_y = 5
 	},
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71261,84 +70698,58 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cWV" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "cWW" = (
-/obj/item/storage/bible,
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 6;
+	icon_state = "yellow"
 	},
-/area/chapel/main)
-"cWY" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel - Starboard";
-	dir = 8
+/area/engine/engineering)
+"cWZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "chapel"
+	icon_state = "neutralcorner"
 	},
-/area/chapel/main)
-"cWZ" = (
-/obj/structure/table,
-/obj/item/candle,
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"cXa" = (
-/obj/structure/table,
-/obj/item/candle,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/engine/chiefs_office)
 "cXb" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.4-Escape-4";
+	location = "9.3-Escape-3"
+	},
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cXc" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
-	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "cXe" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/engine/chiefs_office)
 "cXg" = (
 /obj/structure/sink{
 	dir = 8;
@@ -71381,33 +70792,33 @@
 	name = "\improper Secure Lab"
 	})
 "cXj" = (
-/obj/structure/closet/coffin,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/chapel/main)
-"cXk" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/alarm{
-	dir = 8;
+/obj/machinery/newscaster{
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel - Funeral Parlour";
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/chapel/main)
+/area/engine/chiefs_office)
 "cXm" = (
-/obj/item/flashlight/lantern{
-	pixel_y = 7
-	},
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -71415,7 +70826,12 @@
 	},
 /area/chapel/main)
 "cXn" = (
-/obj/effect/landmark/start/chaplain,
+/obj/item/storage/bible,
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -71606,27 +71022,27 @@
 	name = "\improper Recreation Area"
 	})
 "cXE" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/structure/cable/yellow,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "cXF" = (
-/obj/machinery/door/window{
-	name = "Mass Driver";
-	req_access_txt = "22"
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/airlock/engineering,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cXH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -71645,48 +71061,26 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"cXI" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "cXJ" = (
+/obj/item/flashlight/lantern{
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/chapel/main)
 "cXK" = (
-/obj/machinery/hologram/holopad,
+/obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
-"cXL" = (
-/obj/machinery/light/small,
-/obj/machinery/door_control{
-	id = "chapelspaceshutters";
-	name = "Space Window Shutter Control";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "custom placement";
-	pixel_x = 6;
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+	icon_state = "dark"
 	},
 /area/chapel/main)
 "cXM" = (
-/obj/structure/sign/vacuum{
-	pixel_x = 32
-	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -71893,10 +71287,8 @@
 	name = "\improper Recreation Area"
 	})
 "cYf" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "emergency_home";
-	locked = 1;
-	name = "Departure Lounge Airlock"
+/obj/structure/sign/vacuum{
+	pixel_x = -32
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -71904,22 +71296,16 @@
 	name = "\improper Departure Lounge"
 	})
 "cYg" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/main)
+/turf/space,
+/area/space/nearstation)
 "cYh" = (
-/obj/machinery/door/morgue{
-	name = "Chapel Garden"
-	},
+/obj/structure/filingcabinet/chestdrawer,
+/mob/living/simple_animal/parrot/Poly,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/chapel/main)
+/area/engine/chiefs_office)
 "cYi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -71929,32 +71315,18 @@
 	},
 /turf/space,
 /area/solar/starboard)
-"cYj" = (
-/obj/structure/chair,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "cYk" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/chapel/main)
 "cYl" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/window{
+	name = "Mass Driver";
+	req_access_txt = "22"
 	},
-/obj/machinery/driver_button{
-	id_tag = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -4;
-	pixel_y = -26
-	},
-/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/chapel/main)
 "cYm" = (
@@ -72054,15 +71426,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/starboard)
-"cYB" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "cYC" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -72228,15 +71591,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/morgue)
-"cYX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "cYY" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -72246,23 +71600,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/starboard)
-"cZa" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "cZb" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -72336,14 +71673,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/starboard)
-"cZl" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-24"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "cZn" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72361,16 +71690,16 @@
 	name = "\improper Arcade"
 	})
 "cZp" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 18;
-	id = "emergency_home";
-	name = "emergency evac bay";
-	width = 29
+/obj/machinery/door/airlock/external{
+	id_tag = "emergency_home";
+	locked = 1;
+	name = "Departure Lounge Airlock"
 	},
-/turf/space,
-/area/space)
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cZq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72389,25 +71718,17 @@
 	name = "\improper Secure Lab"
 	})
 "cZs" = (
-/obj/structure/closet/secure_closet/chaplain,
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/chapel/office)
 "cZt" = (
-/obj/machinery/power/apc{
-	name = "Chapel Office APC";
-	pixel_y = -25
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -72483,11 +71804,15 @@
 /turf/space,
 /area/solar/starboard)
 "cZC" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel - Starboard";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -72581,11 +71906,11 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "cZR" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -72606,12 +71931,22 @@
 	},
 /area/engine/break_room)
 "cZT" = (
-/obj/structure/lattice,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/engine/chiefs_office)
 "cZU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -72638,15 +71973,17 @@
 /turf/space,
 /area/solar/starboard)
 "cZX" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Chapel APC";
+	pixel_x = -25
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -72722,12 +72059,7 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "dag" = (
-/obj/machinery/door/poddoor{
-	id_tag = "chapelgun";
-	name = "Chapel Launcher Door";
-	protected = 0
-	},
-/obj/structure/fans/tiny,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dak" = (
@@ -72994,24 +72326,24 @@
 	name = "\improper Secure Lab"
 	})
 "daS" = (
-/obj/structure/sign/atmosplaque{
-	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
-	icon_state = "kiddieplaque";
-	name = "Remembrance Plaque";
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellow"
 	},
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
+/area/engine/break_room)
 "daT" = (
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/engine/break_room)
 "daU" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop,
@@ -73035,7 +72367,20 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "dbc" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/machinery/mass_driver{
+	id_tag = "chapelgun"
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dbd" = (
@@ -73078,15 +72423,12 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "dbj" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=9.4-Escape-4";
-	location = "9.3-Escape-3"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/turf/space,
+/area/space/nearstation)
 "dbl" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -73113,15 +72455,20 @@
 	},
 /area/medical/cryo)
 "dbm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=9.3-Escape-3";
-	location = "9.2-Escape-2"
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "ceprivacy";
+	name = "privacy shutters";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engine/chiefs_office)
 "dbo" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
@@ -73131,20 +72478,22 @@
 	name = "\improper Secure Lab"
 	})
 "dbp" = (
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 32
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "ceprivacy";
+	name = "privacy shutters";
+	opacity = 0
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engine/chiefs_office)
 "dbr" = (
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
@@ -73181,38 +72530,24 @@
 	name = "Medbay Storage"
 	})
 "dbw" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Engineering";
+	name = "Engineering Security Doors";
+	opacity = 0
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
-"dbx" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "dby" = (
 /obj/machinery/camera{
 	c_tag = "Virology - Entrance";
@@ -73415,22 +72750,11 @@
 	name = "\improper Secure Lab"
 	})
 "dbL" = (
-/obj/machinery/mass_driver{
-	id_tag = "chapelgun"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
 	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/chapel/main)
+/area/engine/break_room)
 "dbM" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine,
@@ -73561,14 +72885,16 @@
 	name = "\improper Secure Lab"
 	})
 "dbX" = (
-/obj/machinery/light/small,
-/obj/machinery/door_control{
-	id = "chapelparlourshutters";
-	name = "Window Shutter Control";
-	pixel_y = -25
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/chapel/main)
 "dbZ" = (
@@ -74131,22 +73457,20 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ddZ" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "dea" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -74191,29 +73515,26 @@
 	name = "\improper Secure Lab"
 	})
 "dek" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "del" = (
-/obj/item/candle,
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "dem" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/machinery/light{
+	dir = 4
 	},
-/area/chapel/main)
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "deo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -74355,41 +73676,46 @@
 /turf/simulated/wall,
 /area/maintenance/maintcentral)
 "deI" = (
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/chapel/office)
 "deL" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/turf/simulated/floor/carpet,
 /area/chapel/main)
 "deM" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/chapel/office)
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "deN" = (
 /turf/simulated/floor/carpet,
 /area/chapel/main)
@@ -74399,8 +73725,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "deQ" = (
@@ -74451,43 +73781,39 @@
 	name = "\improper Secure Lab"
 	})
 "deU" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Chapel APC";
-	pixel_x = -25
-	},
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "deX" = (
-/obj/structure/chair/stool,
 /obj/structure/cable/yellow{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "deY" = (
-/obj/structure/chair/stool,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
-	},
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "dfi" = (
 /obj/effect/decal/warning_stripes/northeastcorner,
@@ -74512,24 +73838,21 @@
 "dfo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/carpet,
 /area/chapel/main)
 "dfs" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Office";
-	req_access_txt = "27"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "grimy"
 	},
-/area/chapel/main)
+/area/chapel/office)
 "dfv" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -74542,38 +73865,40 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "dfw" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "dfz" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dfB" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dfD" = (
@@ -74596,18 +73921,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dfG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "dfH" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
@@ -74622,6 +73935,9 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"dfN" = (
+/turf/space,
+/area/chapel/main)
 "dfO" = (
 /obj/structure/sign/lifestar,
 /turf/simulated/wall,
@@ -74787,8 +74103,10 @@
 	name = "Arrivals"
 	})
 "dgg" = (
-/obj/machinery/camera{
-	c_tag = "Chapel - Port";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -74859,9 +74177,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74874,12 +74189,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "dgG" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard,
-/obj/item/radio/off,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/bluegrid,
 /area/maintenance/aft)
 "dgH" = (
 /obj/structure/closet/l3closet,
@@ -74892,9 +74208,14 @@
 	},
 /area/medical/virology)
 "dgI" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "dgO" = (
 /obj/structure/sign/pods,
 /turf/simulated/wall,
@@ -74918,14 +74239,21 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "dhj" = (
-/obj/structure/bookcase{
-	name = "Holy Bookcase"
+/obj/machinery/camera{
+	c_tag = "Chapel - Port";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -74949,15 +74277,9 @@
 	},
 /area/medical/virology)
 "dhl" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "chapelspaceshutters";
-	name = "chapel shutters";
-	opacity = 0
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
 /area/chapel/main)
 "dhm" = (
 /obj/structure/cable/yellow{
@@ -74977,8 +74299,15 @@
 	},
 /area/medical/virology)
 "dhn" = (
-/turf/space,
-/area/chapel/main)
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/engineer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "dhq" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -75010,14 +74339,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dhu" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "dhw" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dhx" = (
@@ -75102,14 +74433,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dhF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "storage room";
-	req_access = "12"
+/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "dhG" = (
 /obj/item/seeds/watermelon,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -75141,6 +74476,18 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
+"djf" = (
+/obj/item/flashlight/lantern{
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "djx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -75171,6 +74518,17 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
+"dnm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "dnu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -75178,7 +74536,12 @@
 	},
 /area/security/main)
 "dom" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "doV" = (
@@ -75202,21 +74565,15 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dqm" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 4;
-	network = list("engine")
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engine/engineering)
 "dtM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75239,6 +74596,11 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
+"dyz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "dAs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -75251,12 +74613,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"dAy" = (
+/obj/structure/bookcase{
+	name = "Holy Bookcase"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "dAH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"dBm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.3-Escape-3";
+	location = "9.2-Escape-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "dCV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -75311,6 +74691,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
+"dFP" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "dGT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75342,8 +74729,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"dJp" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-24"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "dKL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75367,6 +74763,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
+"dMv" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/under/pennywise,
+/obj/item/toy/syndicateballoon,
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/clothing/mask/gas/clown_hat/pennywise,
+/obj/item/coin/clown,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "dMV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -75384,6 +74789,17 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"dPM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "dRN" = (
 /obj/machinery/light{
 	dir = 4
@@ -75405,6 +74821,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"dSk" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "dTK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -75439,9 +74868,19 @@
 	},
 /area/hallway/primary/aft)
 "dXb" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -75484,6 +74923,15 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
+"eaK" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/trash/candy,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ebA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -75500,24 +74948,23 @@
 /area/maintenance/aft)
 "ebM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+	dir = 5;
+	initialize_directions = 12
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "ebV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 6
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/wall/r_wall,
 /area/engine/supermatter)
 "edg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -75538,25 +74985,6 @@
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"edK" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Gas to Mix"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -75628,12 +75056,46 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"eub" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/maintenance/starboard)
 "evR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/engine/engineering)
+"eze" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"ezX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "eEV" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -75664,6 +75126,19 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"eHD" = (
+/obj/machinery/power/apc{
+	name = "Chapel Office APC";
+	pixel_y = -25
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "eIg" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -75687,20 +75162,33 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
+"eLN" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "eMs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"eOH" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "ePy" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75716,9 +75204,6 @@
 /turf/simulated/floor/carpet/blue,
 /area/blueshield)
 "eQt" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -75761,6 +75246,23 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"eXe" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"eXi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "eYE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -75841,24 +75343,32 @@
 /obj/machinery/power/rad_collector{
 	anchored = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 9
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"flN" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "fmg" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "fmP" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -75938,12 +75448,33 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
+"fAn" = (
+/obj/effect/landmark/spawner/xeno,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"fAA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "fBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/security/warden)
+"fCI" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "fCO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -75979,6 +75510,16 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"fFl" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "fGt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75995,13 +75536,16 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"fHC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5
+"fKC" = (
+/obj/item/storage/fancy/crayons,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "fOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -76054,6 +75598,16 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"fZA" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "fZC" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -76152,24 +75706,21 @@
 	anchored = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/visible/supply{
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "gid" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+	dir = 6
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "gip" = (
@@ -76231,20 +75782,26 @@
 	name = "\improper Departure Lounge"
 	})
 "gpj" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
-"gqj" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+/obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	initialize_directions = 11
+	name = "External Gas to Loop"
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine,
 /area/engine/engineering)
+"gqj" = (
+/obj/structure/window/plasmareinforced,
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 10
+	},
+/turf/simulated/floor/engine,
+/area/engine/supermatter)
 "gqF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -76303,17 +75860,28 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
+"gHb" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "gIN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
 "gKb" = (
@@ -76327,6 +75895,19 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
+"gMN" = (
+/obj/structure/sign/atmosplaque{
+	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
+	icon_state = "kiddieplaque";
+	name = "Remembrance Plaque";
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "gMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76358,6 +75939,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
+"gPh" = (
+/obj/machinery/door/morgue{
+	name = "Chapel Garden"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/main)
 "gQu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76373,6 +75962,13 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
+"gSF" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "gSK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -76388,21 +75984,28 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"gYM" = (
-/obj/machinery/light{
-	dir = 8
-	},
+"gUS" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "vault"
 	},
+/area/chapel/main)
+"gXv" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"gYM" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "gZY" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "har" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76412,8 +76015,9 @@
 /area/civilian/barber)
 "hdL" = (
 /obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -76430,23 +76034,34 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/engineering)
-"hgN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
+/area/engine/engineering)
+"hgN" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1;
+	name = "Cooling Loop to Gas"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "hgW" = (
 /obj/structure/cable/yellow{
@@ -76555,22 +76170,32 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"hqN" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
+"hob" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"hqN" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Cooling Loop Bypass"
+	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"hsU" = (
+/obj/structure/lattice,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/turf/space,
+/area/space/nearstation)
 "huo" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -76601,6 +76226,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"hyl" = (
+/obj/structure/chair,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "hAg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76613,8 +76244,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "hBM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -76659,6 +76290,34 @@
 	},
 /area/atmos)
 "hEA" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Entrance";
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"hGL" = (
+/obj/structure/closet,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"hHE" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/assembly/prox_sensor,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"hIG" = (
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -76687,31 +76346,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "yellow"
-	},
-/area/engine/engineering)
-"hHE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"hIG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
@@ -76744,10 +76378,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "hLH" = (
@@ -76799,6 +76430,17 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"hTM" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hVe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76815,14 +76457,17 @@
 /area/quartermaster/miningdock{
 	name = "\improper Mining Office"
 	})
-"hWr" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+"hVX" = (
+/obj/structure/chair,
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/chapel/main)
+"hWr" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "hYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76839,6 +76484,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
+"hZq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hZZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76848,23 +76499,17 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "ibi" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/cigbutt,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "maint1";
+	name = "Blast Door";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "ibR" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -76878,14 +76523,14 @@
 	})
 "idx" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
+/obj/machinery/computer/mech_bay_power_console,
+/turf/simulated/floor/plating,
 /area/maintenance/aft)
 "ied" = (
 /obj/structure/cable/yellow{
@@ -76900,6 +76545,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"ieo" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"ifq" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"ifA" = (
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "ihM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76907,6 +76570,12 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
+"ihY" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/space/nearstation)
 "iip" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76917,6 +76586,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -76932,15 +76604,6 @@
 	},
 /turf/space,
 /area/space)
-"ijf" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "ijt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -77027,11 +76690,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "isf" = (
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb2,
@@ -77071,21 +76734,33 @@
 	},
 /area/toxins/explab)
 "iAT" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 4;
-	network = list("SS13","engine")
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "maint1";
+	name = "Blast Door";
+	opacity = 0
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "iDw" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"iDW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "iEd" = (
@@ -77117,20 +76792,33 @@
 	},
 /area/hallway/primary/starboard)
 "iIk" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"iNu" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
+"iNt" = (
+/obj/item/candle,
+/obj/machinery/light_switch{
+	name = "custom placement";
+	pixel_x = 6;
+	pixel_y = 24
 	},
-/area/engine/break_room)
+/obj/structure/table/wood,
+/obj/machinery/door_control{
+	id = "chapelescapeshutters";
+	name = "Side Windows Shutter Control";
+	pixel_x = -6;
+	pixel_y = 25
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
+"iNu" = (
+/obj/structure/reagent_dispensers/beerkeg/nuke{
+	name = "Nanotrasen-brand nuclear fizz-sion explosive"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "iNI" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel,
@@ -77157,14 +76845,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Atmos to Loop"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -77215,6 +76901,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"iZY" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth (Chaplain)";
+	req_access_txt = "22"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "jap" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -77222,24 +76917,25 @@
 	name = "Port Maintenance"
 	})
 "jaV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "jbk" = (
-/obj/structure/reflector/double{
-	anchored = 1;
-	dir = 8
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	dir = 1;
+	filter_type = -1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "jeY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77274,6 +76970,13 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"jjD" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "jlB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77289,6 +76992,12 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"jmX" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "jrE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77323,6 +77032,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/paicard,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -77339,6 +77050,16 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"jEC" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/flashlight,
+/obj/item/storage/box/lights/mixed,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jGr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -77359,6 +77080,19 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"jJy" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"jJP" = (
+/obj/structure/closet/coffin,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "jJV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77411,42 +77145,26 @@
 	},
 /area/turret_protected/ai)
 "jPv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/alarm{
 	dir = 4;
-	icon_state = "pipe-c"
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "jQZ" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "chapel"
 	},
 /area/chapel/main)
 "jUV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "Output to Waste"
-	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "jZd" = (
 /obj/machinery/door_timer/cell_3{
@@ -77456,9 +77174,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"kez" = (
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
 "keY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -77491,18 +77206,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "knc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "kry" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -77537,10 +77243,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/item/vending_refill/cigarette,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"ksM" = (
+/obj/item/bedsheet/clown,
+/obj/structure/bed,
+/obj/structure/sign/clown{
+	pixel_x = 32
+	},
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "kto" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -77550,10 +77268,21 @@
 /turf/space,
 /area/space/nearstation)
 "ktX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/item/storage/bible,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel - Fore"
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/chapel/main)
 "kuf" = (
 /obj/structure/cable/yellow{
@@ -77565,6 +77294,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"kug" = (
+/obj/item/candle,
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
+"kuM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"kuY" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "kvG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -77601,16 +77355,6 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/server)
 "kxf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -77632,27 +77376,30 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
-"kBa" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Gas to Cooling Loop"
-	},
+"kAJ" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"kBa" = (
+/obj/machinery/door_control{
+	id = "maint1";
+	name = "Blast Control Door A";
+	pixel_x = -28;
+	pixel_y = -6
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "kBq" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -77736,20 +77483,29 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
-"kRX" = (
-/obj/structure/window/plasmareinforced{
-	dir = 1
+"kNS" = (
+/obj/machinery/atm{
+	pixel_y = 32
 	},
-/obj/machinery/power/rad_collector{
-	anchored = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "kSC" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -77769,15 +77525,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "kWg" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8;
+	initialize_directions = 11
 	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/engine/supermatter)
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "kWi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -77801,20 +77560,45 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"kYx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "kZl" = (
+/obj/structure/table/wood,
+/obj/item/lipstick{
+	pixel_y = 5
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/machinery/camera{
+	c_tag = "Theatre - Stage";
+	dir = 8
+	},
+/obj/item/instrument/guitar,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"lag" = (
+/obj/structure/sign/vacuum{
+	pixel_x = 32
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "law" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -77835,10 +77619,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"len" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "leu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77908,12 +77688,19 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "lmi" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
+	dir = 4
 	},
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/engine/engineering)
+"lnu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/welded,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "lpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77927,10 +77714,9 @@
 	},
 /area/hydroponics)
 "lpU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/structure/sign/fire,
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
 "lrA" = (
 /obj/structure/sign/biohazard{
 	pixel_x = -32
@@ -77941,16 +77727,16 @@
 	},
 /area/maintenance/aft)
 "lwN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/starboard)
 "lBy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77983,6 +77769,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"lFa" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "lFH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -77999,31 +77790,57 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab)
-"lGk" = (
+"lGf" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"lGk" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "lGr" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Gas to Filter"
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
 	},
-/obj/machinery/alarm/engine{
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -22
+	name = "east bump";
+	pixel_x = 24
 	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Port";
+	dir = 8;
+	network = list("SS13","engine")
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engine/engineering)
 "lHZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -78039,21 +77856,17 @@
 	},
 /area/hydroponics)
 "lJX" = (
-/obj/structure/window/plasmareinforced,
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/visible/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
+"lOU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"lOU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78074,11 +77887,24 @@
 	},
 /area/crew_quarters/bar)
 "lUv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"lVE" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/door_control{
+	id = "maint3";
+	name = "Blast Door Control C";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "lWo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78088,6 +77914,37 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
+"lXl" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"lXA" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/closet/crate,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"lYm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "mcP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -78147,18 +78004,23 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"mli" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "mmk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78174,13 +78036,13 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
 "moi" = (
-/obj/machinery/atmospherics/trinary/filter/flipped{
-	dir = 1;
-	filter_type = -1
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
 	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
 "moJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -78213,10 +78075,25 @@
 	},
 /area/atmos)
 "msg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"mtS" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
+"mtV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/aft)
 "myY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
@@ -78224,22 +78101,21 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"mzf" = (
-/obj/structure/window/plasmareinforced{
+"mzl" = (
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "custom placement";
+	pixel_x = 28
+	},
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/power/rad_collector{
-	anchored = 1
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/chapel/office)
 "mAa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78266,13 +78142,10 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/landmark/start/engineer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "mFx" = (
@@ -78312,6 +78185,21 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"mNv" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "mOc" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78345,19 +78233,15 @@
 	},
 /area/medical/medbay3)
 "mVG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -78378,6 +78262,11 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"mXi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "mXy" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
@@ -78393,12 +78282,15 @@
 	},
 /area/crew_quarters/courtroom)
 "mZJ" = (
-/obj/structure/reflector/single{
-	anchored = 1;
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "naY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78438,6 +78330,17 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"neO" = (
+/obj/machinery/light/small,
+/obj/machinery/door_control{
+	id = "chapelparlourshutters";
+	name = "Window Shutter Control";
+	pixel_y = -25
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "neT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/warning_stripes/north,
@@ -78445,6 +78348,13 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"ngK" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "nhK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78505,11 +78415,16 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "nss" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Cooling Loop Bypass"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "nuB" = (
@@ -78559,10 +78474,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"nAn" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "nEQ" = (
 /obj/machinery/atmospherics/binary/pump/on{
-	dir = 1;
-	name = "Cooling Loop to Gas"
+	name = "Gas to Cooling Loop"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78578,7 +78497,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "nFC" = (
@@ -78623,6 +78542,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"nMl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "nMx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -78658,6 +78586,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"nTO" = (
+/obj/structure/closet/coffin,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "nUW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78681,7 +78614,16 @@
 	},
 /area/medical/reception)
 "nVz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Restrooms";
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -78712,6 +78654,13 @@
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/server)
+"oeg" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "oeP" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -78729,22 +78678,14 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "ogE" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10;
+	initialize_directions = 10
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "oiv" = (
@@ -78766,19 +78707,47 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"ojl" = (
-/obj/machinery/atmospherics/trinary/filter/flipped{
-	dir = 1;
-	filter_type = 2
+"okx" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
+"olR" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/space/nearstation)
 "onG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
+"oot" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "orm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -78803,21 +78772,40 @@
 	},
 /area/security/permabrig)
 "oCE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"oET" = (
+/obj/machinery/door/poddoor{
+	id_tag = "chapelgun";
+	name = "Chapel Launcher Door";
+	protected = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/chapel/main)
+"oHm" = (
+/obj/machinery/light/small,
+/obj/machinery/door_control{
+	id = "chapelspaceshutters";
+	name = "Space Window Shutter Control";
+	pixel_x = -6;
+	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "custom placement";
+	pixel_x = 6;
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "oJQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78833,10 +78821,12 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
 "oOs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "oQz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78848,6 +78838,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
+"oQE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard,
+/obj/item/radio/off,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "oRr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -78858,10 +78856,32 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
+"oSh" = (
+/obj/machinery/door/morgue{
+	name = "Relic Closet";
+	req_access_txt = "22"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/office)
+"oSX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "oTM" = (
-/obj/structure/sign/fire,
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "oUk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78891,13 +78911,14 @@
 	name = "\improper Recreation Area"
 	})
 "oWm" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/theatre)
 "oWL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -78971,8 +78992,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/engine,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "pef" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -78982,6 +79003,16 @@
 	icon_state = "red"
 	},
 /area/security/processing)
+"pej" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "peo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -78992,13 +79023,11 @@
 /turf/simulated/wall,
 /area/maintenance/starboard)
 "pes" = (
-/obj/structure/barricade/wooden,
-/obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -79025,6 +79054,24 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
+"piG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "pjn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -79063,16 +79110,33 @@
 	},
 /area/hallway/primary/port)
 "plu" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"plZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"pmh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/engineering)
-"pmh" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/meter,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79089,6 +79153,29 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
+"pqF" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
+"prF" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -79109,12 +79196,7 @@
 	},
 /area/medical/research)
 "pue" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -79126,10 +79208,14 @@
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "pvv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "pyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79188,8 +79274,14 @@
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
 "pKs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "Output to Waste"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -79200,6 +79292,15 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
+	})
+"pLj" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "pMx" = (
 /obj/effect/spawner/airlock/w_to_e,
@@ -79236,6 +79337,14 @@
 	},
 /area/quartermaster/sorting{
 	name = "\improper Warehouse"
+	})
+"pNQ" = (
+/obj/structure/table,
+/obj/item/candle,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "pQx" = (
 /obj/structure/cable/yellow{
@@ -79301,13 +79410,34 @@
 	},
 /area/medical/morgue)
 "pUq" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+/obj/structure/table,
+/obj/item/toy/figure/crew/clown,
+/obj/item/reagent_containers/food/snacks/baguette,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/maintenance/starboard)
+"pVQ" = (
+/obj/structure/noticeboard{
+	desc = "A memorial wall for pinning up momentos";
+	name = "memorial board";
+	pixel_y = 32
+	},
+/obj/item/storage/bible,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"pWB" = (
+/obj/item/reagent_containers/food/drinks/bottle/holywater{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/organ/internal/heart,
+/obj/structure/closet/secure_closet/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/office)
 "pXV" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79420,19 +79550,33 @@
 /area/medical/research)
 "qob" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
 "qpO" = (
-/turf/simulated/wall,
+/obj/machinery/camera{
+	c_tag = "Engineering - Storage"
+	},
+/obj/machinery/suit_storage_unit/engine/secure,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
+"qsa" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"qsE" = (
+/obj/machinery/door/window/eastleft{
+	name = "Coffin Storage";
+	req_access_txt = "22"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "qts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -79467,23 +79611,22 @@
 /turf/simulated/floor/plating,
 /area/medical/surgery2)
 "qxn" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "qAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -79517,6 +79660,21 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"qFs" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
+"qGq" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "qHi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79527,16 +79685,12 @@
 	name = "\improper Mining Office"
 	})
 "qHS" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/engine/break_room)
 "qIg" = (
@@ -79548,6 +79702,30 @@
 	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/starboard)
+"qKp" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"qKK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "qME" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79572,6 +79750,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qSf" = (
@@ -79599,10 +79778,8 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
 "qWn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
 "qWM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79618,13 +79795,9 @@
 	name = "\improper Recreation Area"
 	})
 "raV" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/maintenance/starboard)
 "rdz" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -79646,9 +79819,9 @@
 	},
 /area/crew_quarters/bar)
 "riM" = (
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/structure/sign/clown,
+/turf/simulated/wall/r_wall,
+/area/maintenance/starboard)
 "rjj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -79676,9 +79849,25 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"rkK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "rlJ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -79733,24 +79922,27 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rsT" = (
-/obj/machinery/atmospherics/binary/pump{
-	name = "Mix to Gas"
+"rsW" = (
+/obj/structure/chair{
+	pixel_y = -2
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
+/area/chapel/main)
+"rto" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "rvu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79768,7 +79960,11 @@
 	name = "Port Maintenance"
 	})
 "rwh" = (
-/obj/machinery/power/supermatter_crystal/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "rxV" = (
@@ -79800,6 +79996,17 @@
 	},
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
+	})
+"rBA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
 	})
 "rDe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -79843,18 +80050,12 @@
 /turf/space,
 /area/space)
 "rDF" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed,
+/obj/item/bedsheet/mime,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellow"
+	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/maintenance/starboard)
 "rDS" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79881,18 +80082,24 @@
 /area/hallway/primary/aft)
 "rFa" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "rGT" = (
 /obj/structure/cable/yellow{
@@ -79919,10 +80126,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "rIq" = (
@@ -79969,7 +80180,13 @@
 	name = "\improper MiniSat Exterior"
 	})
 "rNt" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "rOZ" = (
@@ -79998,21 +80215,18 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"rRM" = (
+"rSn" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "rTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -80025,13 +80239,20 @@
 	name = "Arrivals"
 	})
 "rUJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/obj/structure/table/wood,
+/obj/structure/noticeboard{
+	pixel_y = 29
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
 /area/chapel/main)
 "rVv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -80048,13 +80269,12 @@
 /turf/space,
 /area/space/nearstation)
 "rYO" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/effect/landmark/spawner/xeno,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "rZk" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80099,6 +80319,12 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
+"sdl" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/mask/surgical,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -80126,6 +80352,40 @@
 	icon_state = "dark"
 	},
 /area/space/nearstation)
+"slA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
+"slH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "soT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -80172,21 +80432,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "ssZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/engine,
 /area/engine/engineering)
 "svF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "svR" = (
@@ -80199,13 +80457,23 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "swl" = (
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/engine/engineering)
 "sxA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80218,13 +80486,16 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "sBY" = (
+/obj/machinery/field/generator{
+	state = 2
+	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "sFz" = (
-/obj/machinery/light{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellowcorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "sHl" = (
 /obj/structure/chair/comfy/black{
@@ -80232,6 +80503,28 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
+"sHs" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"sIN" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "sJe" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -80281,6 +80574,10 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"sOG" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/maintenance/aft)
 "sOJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -80292,6 +80589,24 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"sQS" = (
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "sRB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -80304,6 +80619,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"sXf" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "sYp" = (
 /obj/structure/chair{
 	dir = 1
@@ -80315,13 +80636,19 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"tbK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+"taB" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"tbK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "tca" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80336,6 +80663,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"tef" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "teE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80362,6 +80699,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -80399,33 +80737,48 @@
 /turf/simulated/floor/plasteel,
 /area/construction)
 "tpg" = (
-/obj/machinery/firealarm{
-	name = "north bump";
-	pixel_y = 24
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
+"trh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Office";
+	req_access_txt = "27"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/chapel/main)
 "tvk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
@@ -80439,13 +80792,19 @@
 	},
 /area/security/detectives_office)
 "tvr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/engine/engineering)
 "tvw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -80471,18 +80830,15 @@
 	},
 /area/security/main)
 "tAn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/machinery/meter,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -80525,6 +80881,24 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"tFv" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"tKO" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/double/map/right{
+	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
+	icon_state = "map-right-MS";
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80577,16 +80951,31 @@
 	},
 /area/hydroponics)
 "tVw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
 	},
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/obj/machinery/meter,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "tWl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"tYz" = (
+/obj/structure/closet/secure_closet/chaplain,
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "tYX" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -80603,15 +80992,10 @@
 	},
 /area/security/permabrig)
 "tZI" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1441;
-	icon_state = "on";
-	id = "engine-waste_out";
-	name = "engine outlet injector";
-	on = 1;
-	volume_rate = 200
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
 /area/engine/engineering)
 "tZW" = (
 /obj/structure/cable/yellow,
@@ -80624,10 +81008,17 @@
 	})
 "uaQ" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 9;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
+"udo" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "udB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -80666,6 +81057,22 @@
 	icon_state = "dark"
 	},
 /area/security/hos)
+"uhi" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium";
+	req_access_txt = "27"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
+"uhV" = (
+/obj/structure/lattice,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "uhY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80704,12 +81111,21 @@
 	},
 /area/medical/surgery1)
 "uqy" = (
+/obj/item/wrench,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"usg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "uuE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -80759,6 +81175,9 @@
 "uBN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "uEN" = (
@@ -80769,6 +81188,17 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
+"uGA" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "uJn" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
@@ -80780,12 +81210,9 @@
 	name = "Port Maintenance"
 	})
 "uLE" = (
-/obj/structure/reflector/single{
-	anchored = 1;
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/maintenance/starboard)
 "uMj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80815,6 +81242,10 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
+"uNl" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "uOL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -80873,6 +81304,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"uWh" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "uWq" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -80889,6 +81328,13 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/atmos)
+"uZU" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "vaE" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -80902,6 +81348,32 @@
 "vaO" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry)
+"vdn" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"veA" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/main)
 "vfe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80916,14 +81388,9 @@
 	},
 /area/crew_quarters/kitchen)
 "vfv" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/obj/item/clothing/glasses/science,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "vge" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -80936,6 +81403,18 @@
 	icon_state = "redfull"
 	},
 /area/security/main)
+"vgT" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"vhD" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "vjp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -80944,17 +81423,36 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "vjL" = (
-/obj/effect/spawner/window/reinforced/plasma,
+/obj/machinery/power/supermatter_crystal/engine,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "vmT" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"vnD" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -81005,13 +81503,21 @@
 	},
 /area/medical/reception)
 "vwA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/window/plasmareinforced{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "vyo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -81044,14 +81550,25 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"vCR" = (
-/obj/machinery/light{
+"vCu" = (
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/area/chapel/main)
+"vCR" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -81099,21 +81616,27 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"vIz" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"vIk" = (
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
+"vJy" = (
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "vLL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81158,18 +81681,19 @@
 /area/crew_quarters/courtroom)
 "vRY" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "vSx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -81180,14 +81704,10 @@
 	},
 /area/security/brig)
 "vUD" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 1;
-	state = 2
-	},
 /obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -81202,6 +81722,21 @@
 "vZo" = (
 /turf/simulated/floor/plating,
 /area/space/nearstation)
+"vZw" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/driver_button{
+	id_tag = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -4;
+	pixel_y = -26
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "vZU" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 1
@@ -81227,6 +81762,15 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
+"wfL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/starboardsolar)
 "whC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -81234,6 +81778,13 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"wkP" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/storage/labcoat/mortician,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "wma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/spawner/window/reinforced,
@@ -81256,6 +81807,11 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"wrX" = (
+/obj/effect/landmark/spawner/xeno,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "wsx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81299,10 +81855,12 @@
 	name = "\improper Departure Lounge"
 	})
 "wuZ" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "wvK" = (
@@ -81349,12 +81907,9 @@
 	},
 /area/medical/research)
 "wzo" = (
-/obj/item/flashlight/lantern{
-	pixel_y = 7
-	},
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81428,6 +81983,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"wGj" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "wHZ" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -81436,6 +82004,21 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"wJL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "wJQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -81444,13 +82027,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "wLN" = (
-/obj/machinery/atmospherics/trinary/filter/flipped{
-	dir = 1;
-	filter_type = -1
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall,
+/area/engine/supermatter)
+"wRi" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/engine/engineering)
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel - Funeral Parlour";
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "wRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81485,6 +82081,15 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
+"wTV" = (
+/obj/machinery/mecha_part_fabricator{
+	dir = 1;
+	id = "0";
+	name = "counterfeit fabricator";
+	req_access = "0"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "wUE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81503,6 +82108,12 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
+"xcZ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81523,6 +82134,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
+"xho" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "chapelspaceshutters";
+	name = "chapel shutters";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "xhx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81606,10 +82228,9 @@
 /area/engine/gravitygenerator)
 "xDw" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/light,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "xDS" = (
@@ -81626,6 +82247,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"xFH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "xFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81643,18 +82275,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "xHf" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "xJB" = (
@@ -81673,13 +82294,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "xLf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/obj/structure/closet/crate/can,
+/obj/item/trash/fried_vox,
+/obj/item/trash/can,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"xOW" = (
+/obj/structure/sign/directions/evac,
+/turf/simulated/wall,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "xSh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81691,12 +82324,9 @@
 	},
 /area/medical/reception)
 "xUe" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "chapel"
 	},
 /area/chapel/main)
 "xYR" = (
@@ -81724,20 +82354,6 @@
 	},
 /area/medical/surgeryobs)
 "yaq" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 1;
-	state = 2
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "yaQ" = (
@@ -81757,13 +82373,9 @@
 	},
 /area/crew_quarters/bar)
 "yeW" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA"
-	},
-/turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/engineering)
 "ygd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81790,8 +82402,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
@@ -93727,7 +94339,7 @@ abq
 aaa
 abq
 aGw
-aLB
+baa
 aLB
 aLB
 aLB
@@ -94489,7 +95101,7 @@ aaa
 abq
 abq
 apf
-apd
+aDi
 apf
 abq
 abq
@@ -94747,10 +95359,10 @@ abq
 apf
 apf
 apd
-apf
+auE
 aAA
 alL
-apf
+auE
 aoX
 aHn
 cgo
@@ -94758,7 +95370,7 @@ aHk
 aLG
 aML
 aML
-aML
+bav
 aRi
 aSw
 aTQ
@@ -95013,9 +95625,9 @@ anE
 cgo
 aHk
 aHk
-aMM
-aML
-aPD
+aHk
+bfd
+aHk
 aHk
 aHk
 aHk
@@ -95265,18 +95877,18 @@ atk
 atk
 atk
 ijy
-aEC
 fZo
-aHX
-apd
-aHk
-aHk
-aOl
-aHk
-aHk
+fZo
+fZo
+fZo
+bab
+fZo
+fZo
+fZo
+fZo
 qob
 fZo
-vHW
+ceT
 vHW
 aYm
 aWq
@@ -95521,17 +96133,17 @@ apf
 apd
 arI
 apd
-apf
-alL
-apf
+apd
+apd
+apd
 aIJ
-uqy
-aVF
-aVF
-aPe
-lwN
-uqy
-ahC
+apd
+cgo
+cgo
+apd
+apd
+apd
+apd
 apd
 apd
 apd
@@ -95779,7 +96391,7 @@ apf
 alL
 apf
 apf
-aaa
+alL
 apf
 apf
 apf
@@ -95816,7 +96428,7 @@ cdn
 aEj
 bKy
 apf
-atj
+oCE
 apd
 ayB
 auy
@@ -96593,7 +97205,7 @@ bRA
 bHh
 bTo
 bFp
-apd
+cgo
 cQS
 bXK
 cdD
@@ -96852,7 +97464,7 @@ bUD
 bFp
 apd
 rvu
-apf
+auE
 bWk
 bFX
 bYT
@@ -96860,7 +97472,7 @@ apf
 aaa
 aaa
 cmi
-chy
+qKp
 cmi
 bZU
 cpu
@@ -97082,7 +97694,7 @@ aaa
 aaa
 aaa
 alL
-bfl
+avU
 bgX
 bmS
 bkp
@@ -97108,10 +97720,10 @@ bHf
 bUE
 bFp
 apd
-rvu
+eYE
 apf
 apf
-apf
+auE
 apf
 apf
 cmi
@@ -97365,12 +97977,12 @@ bHf
 bHf
 bWj
 bYx
-eYE
+vmT
 apd
 apd
 apd
 ckw
-chy
+cwt
 chy
 chy
 chy
@@ -97626,7 +98238,7 @@ bYW
 caJ
 ceN
 ceN
-ceN
+wGj
 chP
 ceN
 xJB
@@ -97879,10 +98491,10 @@ bTo
 bUF
 bFp
 apd
-avU
+cEg
 bZU
 bZU
-bZU
+cTa
 bZU
 bZU
 bZU
@@ -97890,7 +98502,7 @@ bgZ
 ckw
 chy
 coe
-bZU
+cTa
 cpy
 cpy
 cpy
@@ -98142,12 +98754,12 @@ cbs
 bWo
 cdJ
 ceO
-bZU
-bgZ
-ckw
+cTa
+kYx
+ckD
 chy
 ebA
-bZU
+cTa
 cpS
 crc
 cry
@@ -98393,7 +99005,7 @@ bTp
 bUG
 apf
 bRD
-avU
+cEg
 bZU
 cem
 dfi
@@ -98401,7 +99013,7 @@ dgC
 cfm
 bZU
 bgZ
-ckw
+coD
 cuV
 ebA
 bZU
@@ -98419,7 +99031,7 @@ bZU
 bZU
 cOx
 cqS
-cdN
+tFv
 bZU
 cNa
 cNP
@@ -98649,27 +99261,27 @@ bRE
 arJ
 apd
 apf
-apd
+cgo
 avU
-bZU
+cTa
 cbu
 ceE
 chy
 ceZ
 cfb
 nTF
-ckw
+bZU
 cuV
 ebA
 bZU
 bZU
-bZU
+cTa
 bZU
 cdO
 cdO
 bZU
-bZU
-bZU
+cTa
+cTa
 bZU
 cAg
 cDk
@@ -98678,12 +99290,12 @@ cuV
 bgZ
 clP
 bZU
-bZU
+cTa
 bZU
 cPT
 cKC
+cTa
 bZU
-aaa
 aaa
 cHZ
 cOG
@@ -98905,10 +99517,10 @@ bBK
 bRF
 arU
 apd
-apf
-apd
+auE
+cgo
 avU
-bZU
+cTa
 ceu
 cHV
 cak
@@ -98921,7 +99533,7 @@ dhr
 cod
 cod
 cod
-csy
+cod
 cod
 cod
 cod
@@ -98934,10 +99546,10 @@ ckJ
 ckJ
 cGg
 cJR
+cuV
+cuV
 chy
-chy
-chy
-chy
+hZq
 chy
 chy
 bZU
@@ -99115,8 +99727,8 @@ aux
 xuA
 axn
 ayB
-apf
-apf
+auE
+auE
 aCs
 aFF
 aEK
@@ -99164,8 +99776,8 @@ apd
 bib
 apf
 apd
-avU
-bZU
+cEg
+cTa
 cbw
 ccx
 cbq
@@ -99174,7 +99786,7 @@ chw
 ckH
 bZU
 cuV
-bgZ
+eaK
 chy
 cFQ
 cLU
@@ -99185,7 +99797,7 @@ chy
 chy
 chy
 czf
-chy
+xcZ
 cBX
 cFT
 ckD
@@ -99193,8 +99805,8 @@ cIb
 cDT
 ckJ
 ckJ
-ckJ
-ckJ
+hob
+hob
 ckJ
 cJR
 bZU
@@ -99426,8 +100038,8 @@ bZU
 bZU
 bZU
 cbr
-bgZ
-chy
+clG
+cJR
 chy
 bZU
 chy
@@ -99677,16 +100289,16 @@ bRI
 bRH
 bVR
 apf
-apd
-avU
+aDi
+cEg
 apf
 auC
 apf
-ceT
-cfV
-chy
-chy
 bZU
+cfV
+cjr
+chy
+cTa
 chy
 bgZ
 coC
@@ -99883,7 +100495,7 @@ aqk
 atd
 akt
 auz
-aGN
+axn
 aNn
 aHY
 aHY
@@ -99931,19 +100543,19 @@ bBK
 bBK
 bBK
 apf
-apf
-apf
+auE
+auE
 apf
 apd
-avU
+cEg
 cgH
-cgU
-apf
-ceU
+apd
+apd
+bZU
 cfW
 cjr
-chy
-bZU
+wTV
+cTa
 chy
 bgZ
 coC
@@ -99967,7 +100579,7 @@ cGo
 cGo
 cMV
 cEY
-bgZ
+hLt
 bZU
 abq
 cHZ
@@ -100193,14 +100805,14 @@ bgY
 bgY
 bgY
 bZR
-apf
-chn
-apf
-ceV
+cgH
+apd
+cgo
+cTa
 idx
 dgG
-cuV
-bZU
+oQE
+cTa
 chy
 bgZ
 coC
@@ -100224,7 +100836,7 @@ cKD
 cLi
 cNc
 cEY
-bgZ
+hLt
 bZU
 aaa
 aaa
@@ -100451,13 +101063,13 @@ apd
 cgm
 isf
 apf
-apf
-apf
+lVE
+cgo
+cTa
 bZU
 bZU
 bZU
-bZU
-bZU
+cTa
 chy
 bgZ
 coC
@@ -100481,7 +101093,7 @@ cKA
 dxa
 cKL
 cEY
-bgZ
+uGA
 bZU
 abq
 aaa
@@ -100709,10 +101321,10 @@ bzK
 bzK
 bzK
 bzK
-avX
+cgo
 chy
 chy
-chy
+cmi
 chy
 chy
 chy
@@ -100738,7 +101350,7 @@ cGo
 cGo
 cNs
 cEY
-bgZ
+hLt
 bZU
 abq
 abq
@@ -100907,12 +101519,12 @@ alw
 apH
 anE
 awe
-apd
+bFX
 apd
 aoZ
 gqF
-ajg
-ajg
+awZ
+awZ
 ayF
 azP
 ajg
@@ -100967,13 +101579,13 @@ bZW
 bFw
 bzK
 cho
+hob
+ckJ
+prF
 ckJ
 ckJ
 ckJ
-ckJ
-ckJ
-ckJ
-clT
+lXA
 coC
 cpX
 crV
@@ -101163,9 +101775,9 @@ ajB
 ajB
 ajB
 aky
-apa
+bXK
 aky
-apf
+auE
 atf
 apf
 ajg
@@ -101223,10 +101835,10 @@ jrE
 bZc
 bZZ
 bzK
-avU
+dSk
 chy
-cjn
-cdN
+chy
+cmi
 cem
 ciK
 cmX
@@ -101275,7 +101887,7 @@ dfv
 cSO
 dfv
 cSO
-aaa
+cSO
 aaa
 aaa
 aaa
@@ -101424,8 +102036,8 @@ auq
 atH
 arI
 apb
-aGl
-ajg
+apf
+axv
 axs
 alW
 aMc
@@ -101517,7 +102129,8 @@ cHZ
 cMO
 cHZ
 cHZ
-aaa
+cmi
+cmi
 bZU
 cRh
 cRh
@@ -101525,15 +102138,14 @@ cRh
 cRh
 cRh
 cSO
-cVL
+jJP
 cWn
 cWn
-cXj
+nTO
 cSO
-cYg
+veA
 dfv
 abq
-aaa
 aaa
 aaa
 aaa
@@ -101681,8 +102293,8 @@ auB
 aqy
 apd
 atg
-cgm
-ajg
+apf
+alW
 axt
 aAY
 iip
@@ -101692,7 +102304,7 @@ aAY
 bMC
 bMC
 aAY
-aAY
+aSM
 aKi
 aMH
 aOf
@@ -101774,23 +102386,23 @@ dfR
 dfU
 cRg
 cHZ
+lFa
+chy
 bZU
-bZU
-cSa
 cSI
 cTy
 cUg
-cTy
+okx
+cUg
 cSO
 cVM
 cVM
-cWM
+qsE
 cVM
 cSO
-cYh
+gPh
 cSO
 abq
-aaa
 aaa
 aaa
 aaa
@@ -101938,9 +102550,9 @@ apd
 aqz
 cgo
 bbj
-auD
-ajg
-awX
+apf
+alW
+axy
 ajg
 ajg
 ajg
@@ -101996,7 +102608,7 @@ bHr
 bzK
 avU
 auy
-bZU
+cTa
 cga
 caW
 cjn
@@ -102038,16 +102650,16 @@ cSJ
 cTz
 cUh
 cUN
+mli
 cSO
 cSO
-dbp
+vIk
 cVR
 cVR
-cXE
 dbX
+neO
 cSO
 abq
-aaa
 aaa
 aaa
 aaa
@@ -102196,8 +102808,8 @@ aqA
 apd
 ksz
 auE
-ajg
-axv
+caj
+axy
 ajg
 aaa
 aaa
@@ -102211,7 +102823,7 @@ aKj
 aNa
 hDK
 apf
-avU
+bik
 apf
 aSK
 aTZ
@@ -102252,8 +102864,8 @@ bZf
 tNG
 bzK
 cEg
-auJ
-bZU
+ayB
+cTa
 cgb
 cmJ
 cjo
@@ -102288,23 +102900,23 @@ cOI
 dfV
 dgH
 cHZ
-cQx
+cuV
+eXi
 bZU
 cRh
 cRh
 cRh
-cUi
+uhi
 cRh
 cSO
-cVN
 cWp
+cWO
 cWN
 cWN
-cUX
-cYj
+cYk
+hyl
 dfv
 abq
-aaa
 aaa
 aaa
 aaa
@@ -102452,8 +103064,8 @@ aky
 aky
 arJ
 ati
-arJ
-ajg
+auE
+caj
 axZ
 ajg
 abq
@@ -102468,7 +103080,7 @@ aGy
 aLV
 aRB
 apf
-avU
+cEg
 apf
 bZa
 aWt
@@ -102537,7 +103149,7 @@ cFd
 cLw
 cNL
 cPy
-bgZ
+uGA
 chy
 chy
 cHZ
@@ -102545,23 +103157,23 @@ cHZ
 cMR
 cHZ
 cHZ
-cQx
+cuV
+eXi
 bZU
-cUm
 cSK
 cTA
-cTD
+fKC
 cZs
+tYz
 cSO
-daS
-cWp
+gMN
 cWO
+rsW
 cWN
-cUX
 cYk
+hVX
 dfv
 abq
-aaa
 aaa
 aaa
 aaa
@@ -102708,9 +103320,9 @@ abq
 abq
 apf
 aAA
+auE
 apf
-apf
-ajg
+alW
 axx
 axT
 aaa
@@ -102725,7 +103337,7 @@ aHj
 aLW
 aNe
 apf
-avU
+cEg
 apf
 apf
 apf
@@ -102802,23 +103414,23 @@ cZv
 day
 lrA
 bZU
-cQx
+cFe
+iDW
 bZU
-cSd
 cSL
 cTB
 cUk
 cUP
+eOH
 cSO
-cVP
-cWp
-cUX
-cXk
-cUX
-cXK
+pVQ
+cWO
+cYk
+wRi
+cYk
+gUS
 dfv
 abq
-aaa
 aaa
 aaa
 aaa
@@ -102965,9 +103577,9 @@ aaa
 apf
 apf
 arK
-aoX
-auG
-ajg
+ajS
+apf
+caj
 axy
 axQ
 aaa
@@ -102983,11 +103595,11 @@ aLW
 aNf
 aOy
 aPV
-bgY
-aSM
+cJU
+cJU
 aVk
 aVq
-bgY
+cqC
 aYX
 axq
 axq
@@ -103021,7 +103633,7 @@ bXy
 cgt
 bzK
 caK
-axq
+lGf
 ccB
 cdT
 cfa
@@ -103059,23 +103671,23 @@ cZq
 dax
 cZq
 deg
-cSl
+cjl
 cRj
 cSe
 deI
 cWR
 cUl
 cZt
+eHD
 cSO
 cSO
-dbw
-cUX
+sQS
+cYk
 cSO
-cXF
 cYl
+vZw
 cSO
 abq
-aaa
 aaa
 aaa
 aaa
@@ -103223,9 +103835,9 @@ apf
 aqB
 arU
 atj
-apd
-ajg
+apf
 axz
+axy
 axQ
 aaa
 aBb
@@ -103278,7 +103890,7 @@ bWx
 bXR
 bzK
 ayB
-aoX
+apd
 bqQ
 cdT
 chT
@@ -103310,29 +103922,29 @@ cNM
 cPy
 cRo
 cyE
-chy
+qKp
 bZU
 cZw
 daM
 dby
 bZU
-svF
+chy
+fAA
 bZU
+cZs
 cTD
-cWm
-cTD
-cZa
+cZs
 cSf
 dfs
 cUX
-cWs
-cUX
+cYk
+dgg
+cYk
 cSO
-dbL
 dbc
 dag
+oET
 abq
-aaa
 aaa
 aaa
 aaa
@@ -103479,10 +104091,10 @@ abq
 alL
 aqC
 apd
-apd
 auI
+bXK
 awg
-awZ
+axy
 axQ
 aaa
 aBb
@@ -103574,22 +104186,22 @@ daL
 cPy
 cPy
 svF
+csh
 bZU
-cSg
+oSh
 cRh
 cRh
 cRh
-cUS
+iZY
 cSO
-cVS
-cWs
-cZl
+slA
+dgg
+dJp
 cSO
 cSO
 cSO
 cSO
 abq
-aaa
 aaa
 aaa
 aaa
@@ -103830,23 +104442,23 @@ cZI
 daO
 cRV
 cPy
-svF
+chy
+eXi
 bZU
-cSh
+pWB
 cRh
-cTE
 cUn
 cUT
+mzl
 cSO
 cSO
-cWt
+trh
 cSO
 cSO
 cSO
-dhn
+dfN
 abq
 abq
-aaa
 aaa
 aaa
 aaa
@@ -104087,20 +104699,20 @@ cZy
 daN
 cRu
 cPy
-svF
+ckw
+eXi
 bZU
 cRh
 cRh
-deM
+uWh
 cRh
 cRh
 cSO
-cUX
-cWs
+cYk
 dgg
 dhj
+dAy
 cSO
-aaa
 aaa
 aaa
 aaa
@@ -104344,20 +104956,20 @@ daP
 daP
 dbG
 cPy
-svF
+nAn
+eXi
 bZU
-dem
 deL
+taB
 deN
 cSO
 cSO
-cVT
 dfw
-dbx
+xUe
 dhi
-cVa
+vCu
+cVA
 cSO
-aaa
 aaa
 aaa
 aaa
@@ -104601,20 +105213,20 @@ cZO
 cYC
 cRU
 cRU
-svF
+jJy
+eXi
 bZU
-del
+kug
 deN
 deN
-deU
 cZX
 cVU
 cWz
-dfG
-cWz
-cXI
+jQZ
+rto
+jQZ
+ngK
 cSO
-aaa
 aaa
 aaa
 aaa
@@ -104858,20 +105470,20 @@ cOU
 daU
 cRX
 cRU
-svF
+coD
+eXi
 bZU
-cUx
 ktX
 lUv
 deY
 cVw
 cUY
-dfw
-cWV
+mtS
+xUe
 cXm
 cXJ
 dhl
-aaa
+xho
 aaa
 aaa
 aaa
@@ -105116,19 +105728,19 @@ daQ
 dbH
 der
 dek
+fZA
 bZU
-cSR
-cTH
+cTK
+art
 deN
-deX
 cVz
-cUZ
-cWz
+fCI
+dFP
 jQZ
-cUX
-cXJ
+pqF
+cYk
 dhl
-aaa
+xho
 aaa
 aaa
 aaa
@@ -105372,20 +105984,20 @@ daf
 dbb
 dep
 cRU
-cSn
+cFe
 cSi
 cSS
 cTJ
 deP
 dfo
+usg
 fPa
 fPa
 fPa
-cWW
 cXn
 cXK
-dhl
-aaa
+gUS
+xho
 aaa
 aaa
 aaa
@@ -105629,20 +106241,20 @@ dad
 daV
 dbN
 cRU
-bTc
+chy
+mNv
 bZU
-cSR
 cTK
+azg
 deN
+mtS
 cUY
-cVw
-cUY
-dfw
+mtS
 xUe
-cUX
-cXJ
+kuY
+cYk
 dhl
-aaa
+xho
 aaa
 aaa
 aaa
@@ -105886,20 +106498,20 @@ dak
 dbf
 deq
 cRU
+cuV
 dVK
 bZU
-cST
 rUJ
 cUs
 cUZ
-cVz
-cUZ
-cWz
-ijf
+dFP
+fCI
+dFP
+jQZ
 wzo
-cXJ
+djf
 dhl
-aaa
+xho
 aaa
 aaa
 aaa
@@ -106143,20 +106755,20 @@ cRU
 cRU
 cRU
 cRU
+cuV
 dVK
 bZU
-cSU
-cTK
+iNt
+azg
 deN
-cVa
 cVA
 cVa
-dfw
-cVa
-dfw
-cXL
+cVA
+xUe
+cVA
+xUe
+oHm
 cSO
-aaa
 aaa
 aaa
 aaa
@@ -106400,20 +107012,20 @@ cNR
 ckJ
 ckJ
 ckJ
-cSq
+ckJ
+kAJ
 bZU
 cSO
-cTM
 cUt
+udo
 cSO
 cSO
-cVX
-cWz
-cWY
+qFs
+jQZ
 cZC
 cZR
+vnD
 cSO
-aaa
 aaa
 aaa
 aaa
@@ -106654,15 +107266,16 @@ cnc
 cpJ
 cIm
 bgZ
+chy
 bZU
 bZU
 bZU
-cRr
+gHb
 bZU
-cWZ
 cVs
 cWi
-cXa
+cXc
+pNQ
 cSO
 cSO
 cSO
@@ -106670,7 +107283,6 @@ cSO
 cSO
 cVk
 cVk
-aaa
 aaa
 aaa
 aaa
@@ -106910,24 +107522,24 @@ cmu
 cVm
 col
 cIm
-bgZ
-bZU
-cPH
+hLt
+coD
+cVk
 cSN
 cSr
 cTq
 cTO
-cVD
-cTt
-cUv
+cWb
+dnm
+flN
 cUv
 dau
-cWi
+ieo
 cXc
 cYf
-cYB
-cYf
-aaa
+cZp
+pLj
+cZp
 aaa
 aaa
 aaa
@@ -107168,23 +107780,23 @@ cVl
 cIn
 cIm
 hLt
-bZU
-cPI
+cdN
+cVk
 cQM
 pue
-cRt
+dPM
 cVc
-pue
 cRt
+dnm
 cRt
 nej
 cRt
+cRt
 cTr
-cXb
+ifA
 cTX
 cTX
 cTX
-aaa
 aaa
 aaa
 aaa
@@ -107425,23 +108037,23 @@ cVu
 cYI
 cYW
 cQh
-bZU
-cPJ
-cQM
+cjn
+cVk
+eXe
 cTg
 cSk
 gnZ
 cTQ
-cSo
+rBA
 cSo
 gTp
 cRt
-dbj
+cRt
 cXb
-cYf
-cXb
-cYf
-aaa
+ifA
+cZp
+ifA
+cZp
 aaa
 aaa
 aaa
@@ -107681,12 +108293,13 @@ cmw
 diT
 com
 cIm
-bgZ
-bZU
-bZU
-cQR
+rSn
+chy
+cVk
+cVk
 cRv
 cRt
+vJy
 cRt
 cRt
 cRt
@@ -107694,11 +108307,10 @@ cRt
 cRt
 cRt
 cTr
-cXb
+ifA
 cTX
 cTX
 cTX
-aaa
 aaa
 aaa
 aaa
@@ -107939,8 +108551,8 @@ cnC
 coq
 cIm
 bgZ
-bZU
-cSc
+chy
+cVk
 cRn
 cRx
 cTs
@@ -107950,10 +108562,10 @@ cTW
 cTW
 cTW
 cUu
+cRt
 cTr
-cXb
+ifA
 cTX
-aaa
 aaa
 aaa
 aaa
@@ -108196,10 +108808,10 @@ pUh
 cQA
 cIm
 bgZ
-bZU
-cPL
+chy
+cVk
 bYy
-cRx
+qKK
 cTr
 cUz
 cTR
@@ -108207,10 +108819,10 @@ cXs
 cVf
 cUz
 dap
+cRt
 cTr
-cXe
+jjD
 cTX
-aaa
 aaa
 aaa
 aaa
@@ -108453,10 +109065,10 @@ cVv
 cot
 cIm
 clu
-bZU
-cPM
-bYy
-cRx
+wkP
+cVk
+tKO
+qKK
 cTt
 cUv
 cUv
@@ -108464,10 +109076,10 @@ cUv
 cUv
 cUv
 cWb
+cRt
 cTr
-cXb
+ifA
 cTX
-aaa
 aaa
 aaa
 aaa
@@ -108710,10 +109322,11 @@ bSZ
 cIm
 cIm
 cNV
-czI
 bZU
-cRq
-cRx
+xOW
+cVk
+kNS
+cRt
 cRt
 cRt
 cRt
@@ -108722,11 +109335,10 @@ cRt
 cRt
 cRt
 cTr
-cXb
+ifA
 cTX
 cTX
 cTX
-aaa
 aaa
 aaa
 aaa
@@ -108969,8 +109581,8 @@ cNS
 cNW
 cON
 cPN
-bYy
-cRx
+uZU
+plZ
 cRt
 nej
 cRt
@@ -108978,11 +109590,11 @@ cRt
 cRt
 cVc
 cRt
-dbm
-cXb
-cYf
-cYX
-cYf
+cRt
+dBm
+ifA
+cZp
+kuM
 cZp
 aaa
 aaa
@@ -109235,12 +109847,12 @@ cUA
 cVi
 cVC
 cRt
+cRt
 cTr
-cXb
+ifA
 cTX
 cTX
 cTX
-aaa
 aaa
 aaa
 aaa
@@ -109492,12 +110104,12 @@ cWB
 cWT
 dac
 dat
-daT
+cUB
 cXM
-cYf
-cXb
-cYf
-aaa
+lag
+cZp
+ifA
+cZp
 aaa
 aaa
 aaa
@@ -109749,12 +110361,12 @@ cUC
 cVk
 cTX
 cVk
+cVk
 cTX
 cVk
 cTX
 cTX
-cZT
-aaa
+uhV
 aaa
 aaa
 aaa
@@ -110255,7 +110867,7 @@ cQk
 cOS
 cpR
 cIx
-ebA
+coe
 bZU
 cUG
 nxh
@@ -110512,7 +111124,7 @@ pzX
 cOT
 cPS
 cIx
-ebA
+coe
 bZU
 cTh
 cTU
@@ -110769,7 +111381,7 @@ cQv
 cPR
 cSx
 cIx
-ebA
+coe
 bZU
 cTi
 cWo
@@ -111026,8 +111638,8 @@ ryN
 cOX
 cPW
 cSs
-cXx
-bZU
+eze
+cTa
 bZU
 bZU
 qbl
@@ -111283,10 +111895,10 @@ cQv
 cOW
 cPV
 cIx
-ebA
+piG
 iTR
 chy
-chy
+hZq
 chy
 aef
 aef
@@ -111777,7 +112389,7 @@ cul
 cvv
 cwK
 cmz
-cAy
+ciw
 czM
 cDs
 cAG
@@ -113055,7 +113667,7 @@ chy
 bYQ
 bZU
 chy
-chy
+cuV
 crS
 cta
 cic
@@ -113311,7 +113923,7 @@ bUR
 bWl
 bWl
 bZU
-chy
+jEC
 cqp
 crU
 cmz
@@ -113563,14 +114175,14 @@ bqR
 cek
 bwI
 bwP
-cin
+bHE
 bHE
 dhq
 cjl
 cjl
 bVr
 cqq
-ctj
+cNZ
 ctb
 cur
 cvC
@@ -113596,7 +114208,7 @@ cPi
 cPe
 cQa
 cOp
-tfV
+lXl
 cwt
 cmi
 aaa
@@ -113772,7 +114384,7 @@ aCS
 aCS
 aCS
 aCS
-caj
+aWA
 aMn
 aMn
 aMn
@@ -113826,7 +114438,7 @@ bgZ
 bZO
 cqo
 cfY
-csn
+cMY
 ctE
 cmz
 cus
@@ -114283,13 +114895,13 @@ aCA
 akD
 amX
 alW
+alW
+alW
+alW
+alW
+alW
+alW
 ajg
-aBI
-aBI
-aBI
-aBI
-aBI
-aBI
 aQz
 aQC
 aTo
@@ -114299,7 +114911,7 @@ uQj
 aYM
 aZZ
 bbD
-bde
+cST
 bey
 bgd
 bMR
@@ -114336,7 +114948,7 @@ cfA
 cgN
 cip
 bZu
-bgZ
+fFl
 cmz
 cnh
 cpT
@@ -114367,7 +114979,7 @@ cOn
 cPh
 cQd
 cOp
-hLt
+bgZ
 bZU
 cVe
 chy
@@ -114533,7 +115145,7 @@ amI
 amO
 avm
 awG
-axW
+ayn
 aze
 aBG
 aAy
@@ -114541,11 +115153,11 @@ akD
 atF
 caj
 ajg
-aKW
 aBI
-aOw
 aBI
-aSJ
+aBI
+aBI
+aBI
 aBI
 aQA
 aQC
@@ -114555,8 +115167,8 @@ aVO
 aTp
 bbe
 aoG
-bbE
 aoG
+cSU
 bez
 bez
 bez
@@ -114593,7 +115205,7 @@ cfB
 cgO
 ciq
 bZu
-bgZ
+hLt
 cmz
 cnG
 coS
@@ -114625,7 +115237,7 @@ cQq
 cQe
 cOp
 bgZ
-bZU
+cTa
 cVj
 cuV
 cuV
@@ -114788,14 +115400,14 @@ alq
 awp
 azL
 amO
-avn
-axC
 amO
-aze
-aAz
-aze
+amO
+amO
 akD
-msg
+akD
+akD
+akD
+alW
 alW
 ajg
 aId
@@ -115044,33 +115656,33 @@ alq
 alq
 awp
 dFD
-amO
-amO
-amO
-amO
-akD
-akD
-akD
-akD
+auD
+avn
+caj
+caj
 alW
-aFT
-aFy
-aJw
-aJv
-aJw
-aMp
-aJw
-aOZ
-aQC
+caj
+caj
+alW
+alW
+aMM
+ajg
+aPD
+aBI
+aWN
+aBI
+bbv
+aBI
+bad
 aQC
 aTq
 aUy
 aVP
-aTo
-aYP
+crQ
+aZZ
 aoG
-aoG
-azy
+cRr
+bwO
 bez
 bgf
 bhB
@@ -115142,7 +115754,7 @@ bgZ
 cPT
 cPT
 cmy
-cvW
+wrX
 bZU
 bZU
 aaa
@@ -115304,29 +115916,29 @@ asA
 alW
 alW
 alW
+ayE
+caj
+caj
+aFP
 alW
 alW
-alW
-alW
-alW
-alW
-alW
-aWv
-aGJ
+aFT
+aOl
+aJw
 nVz
-aKZ
+aJw
 aPS
-aPS
+aJw
 aOZ
-aQD
-aQD
+aQC
+aQC
 aTo
 ygK
 aVQ
 aTo
-aYK
-baa
-aoG
+cuE
+aZZ
+asJ
 bdW
 beA
 bgg
@@ -115364,7 +115976,7 @@ cbO
 cgR
 ciC
 cjV
-cLz
+pej
 cmz
 cnF
 coV
@@ -115392,13 +116004,13 @@ cKE
 cOc
 cQg
 cQE
-cPj
+tef
 cxT
 cRP
 clT
 cPT
 cVo
-chy
+cuV
 cUK
 cZN
 bZU
@@ -115568,22 +116180,22 @@ aBI
 ccc
 ccc
 aBI
-aBI
+ccc
 aGJ
 aMK
-aBI
-aBI
-aBI
-aBI
+aJw
+aJw
+bbM
+bfl
 aRn
-aQD
+aRn
 aTs
 spj
 aVR
 aXk
-aYK
-bab
-aoG
+cvV
+aZZ
+asJ
 bak
 bez
 bjF
@@ -115649,14 +116261,14 @@ cNy
 cPm
 cEK
 cOs
-bZU
-bZU
-dhF
-bZU
+hLt
+chy
+chy
+ckw
 bZU
 cVq
 dhG
-chy
+cuV
 cZY
 bZU
 aaa
@@ -115835,12 +116447,12 @@ aBI
 aQI
 aQD
 aTt
-wsx
-aTq
+bHY
+aTo
 aTp
-aYK
-bac
-aoG
+cwd
+aZZ
+asJ
 azy
 bez
 bgi
@@ -115878,7 +116490,7 @@ cdh
 cgT
 cjf
 bZv
-bgZ
+hLt
 cmB
 cnK
 cnK
@@ -115906,9 +116518,9 @@ cEK
 cEK
 cEK
 cOt
+hLt
 bZU
-cQH
-cRR
+bZO
 cTa
 bZU
 cVp
@@ -116084,21 +116696,21 @@ aEk
 aJw
 aGL
 aJw
-aJz
-aJw
+aJA
+aXs
 aBI
 aBI
 aBI
 aVp
 aQC
-aTu
-ygK
-aVT
-aTq
-aYK
+bxs
+bJP
+aVV
+aTo
 bad
-bbG
-baD
+cQx
+cRR
+azy
 bez
 bez
 bez
@@ -116135,7 +116747,7 @@ cdh
 bYA
 chm
 bZv
-bgZ
+hLt
 cmB
 cnK
 coW
@@ -116161,10 +116773,10 @@ cEK
 crU
 cdN
 cjn
-chy
+oot
 jaV
-bZU
-cQJ
+vdn
+bZO
 cQU
 cTo
 bZU
@@ -116348,14 +116960,14 @@ aNM
 aBI
 aVm
 aQC
-aTu
-ygK
-aVU
+bxs
+bLM
+aVV
 aTo
-aYK
-bae
-aoG
-azy
+cww
+aZZ
+cSa
+bwO
 aoG
 bgj
 bhF
@@ -116392,7 +117004,7 @@ cde
 edg
 cjf
 bZv
-hLt
+bgZ
 cmB
 cnK
 cnK
@@ -116418,12 +117030,12 @@ bZU
 cKG
 cLB
 chy
-cuV
-jaV
+wJL
 bZU
+oSX
 cQI
-chy
-cTd
+cuV
+cuV
 cdO
 ceE
 cWq
@@ -116605,17 +117217,17 @@ aBI
 aBI
 aVr
 aQC
-aTu
+bxG
 jCi
 aVV
-aTq
-aYK
-baf
-aoG
+aTo
+cyc
+aZZ
+cSc
 bec
 bmM
 bks
-asJ
+aEE
 aoG
 blm
 bne
@@ -116675,9 +117287,9 @@ hLW
 ceD
 ceN
 ceN
-chP
-cOu
-bZU
+rkK
+cTa
+oSX
 bZU
 cQW
 cQW
@@ -116863,13 +117475,13 @@ bVm
 aQJ
 aVH
 aTx
-eRU
+bNE
 eQt
 aTp
 bbu
 aZZ
-aoG
-azy
+aEC
+bwO
 aoG
 buC
 buC
@@ -116920,21 +117532,21 @@ cyO
 cmB
 clP
 cDX
-dhu
 bZU
+cTa
 dVK
-cuV
+dyz
 bZU
 cHQ
 cJd
 cKu
 bZU
-cfY
+vhD
 cuV
 chy
 chy
 cmY
-chy
+xFH
 chy
 cQW
 cRQ
@@ -117123,13 +117735,13 @@ aTy
 vge
 aTo
 aTp
-aYK
-bag
-aoG
+cyd
+aZZ
+aEx
 bdr
 aGW
 aGW
-aGW
+bNF
 bmR
 bln
 bnj
@@ -117175,12 +117787,12 @@ clS
 cha
 cyS
 cmB
-bZU
+cTa
 cfU
 bZU
-bZU
-dVK
 chy
+dVK
+vgT
 cFH
 cFH
 cHY
@@ -117380,9 +117992,9 @@ aTz
 aUC
 aVX
 aXm
-bbv
-bag
-aoG
+aZZ
+aZZ
+aEx
 azy
 aoG
 aoG
@@ -117420,7 +118032,7 @@ imQ
 gaa
 cku
 bZv
-bgZ
+hLt
 cmB
 cnK
 cnK
@@ -117435,7 +118047,7 @@ cmB
 cAc
 chP
 ceN
-ctm
+ceN
 cFc
 bZU
 cFH
@@ -117638,9 +118250,9 @@ lSh
 aNQ
 aNQ
 aNQ
-aoG
-aoG
-bak
+asJ
+asJ
+bwO
 aoG
 aaa
 aaa
@@ -117650,7 +118262,7 @@ bnk
 bpb
 bqC
 aoG
-bxI
+asJ
 asJ
 aoG
 bsp
@@ -117691,7 +118303,7 @@ cmB
 cmB
 dVK
 ckD
-chy
+cqp
 bZU
 bZU
 bZU
@@ -117913,12 +118525,12 @@ byO
 bAy
 bCF
 bEy
-bCH
-bEv
-bIL
-bEv
-bEv
-bEv
+bEy
+msg
+mZJ
+msg
+msg
+oOs
 bSj
 bQI
 bUi
@@ -117940,14 +118552,14 @@ ckJ
 ckJ
 ckJ
 csg
-ctm
-ceN
+chP
+chP
 cxe
 ceN
-ceN
-ceN
+chP
+chP
 cAd
-cem
+chy
 cEB
 cDa
 chy
@@ -117962,13 +118574,13 @@ abq
 aaa
 abq
 bZU
-bgZ
+srJ
 bZU
 aaa
 abq
 aaa
 cOy
-cWK
+wfL
 xZq
 aaa
 abq
@@ -118154,7 +118766,7 @@ aXr
 aNQ
 azy
 asI
-aub
+cTd
 beC
 bgm
 bhI
@@ -118164,18 +118776,18 @@ bne
 boY
 bqx
 aoG
-aoG
+asJ
 bbE
 aoG
 bAz
 bEv
-bEA
+bEv
 bEv
 bCH
 bJM
 bCH
 bEv
-bEv
+oTM
 bQS
 bQI
 bUh
@@ -118191,21 +118803,21 @@ cfS
 bZC
 chr
 bZv
-bqV
-aoG
-aoG
-aoG
-bZU
+azy
+asJ
+asJ
+bcj
+cwt
 csh
-bZU
-bZU
-bZU
-bZU
-bZU
-bZU
-bZU
-cfU
-bZU
+chy
+xcZ
+chy
+chy
+chy
+chy
+chy
+cuV
+gXv
 bZU
 cFe
 bZU
@@ -118409,9 +119021,9 @@ wSP
 aWa
 aXp
 aNQ
-azy
+cQH
 asJ
-asJ
+cTE
 beC
 bgn
 bhJ
@@ -118421,18 +119033,18 @@ bnn
 boY
 bqE
 aoG
-buy
-bwZ
+azp
+azy
 aoG
 bCJ
 bCH
-bEA
+bEv
 bCH
 bvz
 bHI
 bvz
 bCH
-bEv
+oTM
 bQT
 bQI
 bUj
@@ -118448,20 +119060,20 @@ cfR
 bZB
 cgV
 bZv
-bwZ
+azy
 asJ
-coI
+arr
 aoG
-crQ
+bZU
 ctl
-cwd
 bZU
-cxf
-cyc
-cxf
 bZU
-cAe
-ceu
+bZU
+bZU
+cTa
+bZU
+bZU
+cmi
 bZU
 iDw
 cDM
@@ -118682,7 +119294,7 @@ buz
 azy
 aoG
 aoG
-aoG
+bEG
 bEB
 bHU
 bHU
@@ -118705,20 +119317,20 @@ bZv
 cjV
 ciA
 bZv
-azy
-asJ
+bwO
+aEx
 asI
-aoG
+bYG
 crR
 csj
 cwF
-cuE
-cwG
-chy
+bZU
+cyT
+gSF
 cyT
 cPT
-cfY
-cvW
+abq
+abq
 bZU
 bZU
 cFe
@@ -118935,11 +119547,11 @@ bne
 boY
 bqx
 aoG
-arr
-bwN
-aLC
-bZJ
+hHE
+bwO
 aoG
+iNu
+bEG
 bEC
 bHW
 bLI
@@ -118957,28 +119569,28 @@ cap
 cdi
 aGW
 aGW
-cex
 aGW
+slH
 clq
 clq
-aGW
+aQS
 bal
 asJ
 coM
 aoG
-bZU
-bZU
-bZU
-bZU
+hGL
+nMl
+qsa
+lYm
 pes
-cvV
-bZU
-bZU
-bZU
-cmi
-bZU
-bZU
 chy
+sXf
+bZU
+uNl
+ihY
+bZU
+bZU
+qKp
 bZU
 abq
 abq
@@ -119180,7 +119792,7 @@ aUG
 aWd
 aPi
 aNQ
-azy
+bwO
 bbH
 bdt
 beE
@@ -119191,49 +119803,49 @@ bbH
 bnf
 iTo
 qIg
-bmB
+aoG
 buI
 bwO
-bCe
-bAB
 aoG
-bED
-biM
-biM
+bAB
+bEG
+bHW
+bHW
+bHW
 gIN
 bLJ
 bLJ
-bLJ
+oWm
 bQU
 bTQ
 uBN
 bVB
 bXp
 bEG
+xLf
 asJ
-azy
+aoG
+aoG
+aoG
+ezX
+aEx
+aEx
 asJ
-asJ
-azy
-asJ
-asJ
-asJ
-cjX
 cnQ
-asJ
+aEE
 coN
 aoG
-cqC
-csk
-ctp
-cww
-rHl
-ceu
-cyd
 bZU
-aaa
-abq
-aaa
+bZU
+bZU
+bZU
+rHl
+qGq
+bZU
+bZU
+olR
+hsU
+bZU
 hLL
 vZo
 hLL
@@ -119437,7 +120049,7 @@ aUH
 aWe
 aQQ
 aNQ
-azy
+bwO
 bbH
 bgO
 beE
@@ -119450,10 +120062,10 @@ bpb
 bqC
 aoG
 cbX
-bxG
+azy
 aoG
-aoG
-aoG
+knc
+bEG
 bGh
 bGp
 bHX
@@ -119468,11 +120080,11 @@ bnc
 bXq
 bEG
 caI
-caX
-asI
-asI
-bak
-bxI
+asJ
+bdl
+dMv
+bYG
+azy
 asI
 aoG
 aoG
@@ -119481,16 +120093,16 @@ aoG
 aoG
 buC
 cLV
-chy
-cdK
+sdl
+sIN
 cuG
 cji
-cvW
+fAn
 cye
 bZU
-abq
-abq
-abq
+sOG
+sOG
+sOG
 abq
 aef
 aaa
@@ -119694,7 +120306,7 @@ aNQ
 aNQ
 aNQ
 aNQ
-bak
+azy
 bbH
 bdv
 beE
@@ -119706,30 +120318,30 @@ bne
 boY
 bqx
 aoG
-aoG
-bbE
+hWr
+azy
 aoG
 buy
-aoG
-bEF
-bGq
-bHY
-bJP
+bEG
+bEG
+bEG
+bEG
+bEG
 bLL
-bNE
-bPh
+bEG
+bEG
 bEG
 bSB
 bUn
 bVD
 bXr
 bEG
-asJ
-azy
-arr
-asI
 azy
 asJ
+bdl
+asJ
+lnu
+azy
 cis
 buC
 cmx
@@ -119739,9 +120351,9 @@ coQ
 buC
 cqF
 chy
-chy
-chy
-cji
+cdK
+hTM
+csh
 cuH
 cyf
 bZU
@@ -119944,13 +120556,13 @@ aoG
 aoG
 buC
 aPk
-awv
-aQi
-asI
-aUI
-aSf
-aZB
+asJ
 aoG
+asJ
+aUI
+aoG
+azp
+cAe
 azy
 bbH
 bhd
@@ -119963,30 +120575,30 @@ iHk
 xfn
 bqx
 aoG
-arr
-bwZ
-aub
+cSa
+azy
+ibi
 asJ
-aoG
-bEG
-bEG
-bEG
-bEG
-bLM
-bEG
-bEG
+kBa
+asJ
+aEx
+asJ
+asJ
+azy
+ayx
+cAe
 bEG
 bEG
 bEG
 bVE
 bEG
 bEG
-bah
-bal
-bdl
-asI
 azy
 asJ
+bdl
+ksM
+eub
+azy
 cir
 buC
 clR
@@ -119997,8 +120609,8 @@ buC
 cqE
 chy
 chy
-chy
-cji
+eLN
+mtV
 chy
 cyg
 cmi
@@ -120191,24 +120803,24 @@ buC
 buC
 aoG
 aBU
-aCZ
+aJv
 aEw
-aGW
-aGW
-aGW
-aGW
-aGW
-aGW
-aNR
-aGW
-aGW
-aGW
-aGW
-aGW
-aWf
-aGW
-aGW
-bal
+asJ
+ayx
+asJ
+asJ
+aXx
+bac
+aoG
+aoG
+bbG
+aoG
+bbG
+aoG
+aoG
+buz
+asJ
+bwO
 bbH
 bdx
 bie
@@ -120222,28 +120834,28 @@ bqy
 bln
 bvj
 bwS
-aGW
+iAT
 bBq
-aGW
-aNR
-aGW
+lwN
 aGW
 aGW
+aGW
+aQS
 bOy
 aGW
 aGW
-aGW
-aNR
-aGW
+pvv
+aQS
+aQS
 bWT
 bNF
-bNF
+aGW
 ofz
-caZ
-bpj
-bwD
-azy
 asJ
+aoG
+aoG
+aoG
+azy
 cfK
 cfK
 cfK
@@ -120252,7 +120864,7 @@ cfK
 cfK
 cfK
 cqH
-cdK
+ifq
 chy
 cuH
 uBl
@@ -120443,36 +121055,36 @@ air
 air
 afb
 axb
-asJ
+axC
 ayk
-asI
 aoG
+aEy
 gip
-asI
-cwA
-cwA
-cwA
-cwA
-cwA
-cwA
-nMC
-nMC
-nMC
-nMC
-nMC
-nMC
-aCg
-aCg
-aCg
-aCg
-aCg
-bam
-bam
-bam
-bam
-bam
-bam
-bam
+aEx
+aLp
+aoG
+aoG
+aLp
+asJ
+asJ
+aEx
+aEx
+aEx
+asJ
+ayx
+aEx
+asJ
+aLp
+asJ
+asJ
+bwO
+bbH
+bbH
+bbH
+bbH
+bbH
+bbH
+bbH
 bqB
 boV
 bqJ
@@ -120490,17 +121102,17 @@ aoG
 aoG
 axh
 axh
-axh
-axh
-brg
-axh
-aoG
-aoG
-aoG
-asI
-bwE
-azy
 asJ
+asJ
+brg
+tbK
+tbK
+tbK
+aBK
+mXi
+bwE
+asJ
+azy
 cfK
 ciD
 cka
@@ -120702,34 +121314,34 @@ afb
 avy
 aub
 avC
-asJ
 aoG
-gip
-arr
-cwA
+asJ
+aGl
+aQS
+aGW
 aHH
 aIV
-aJI
-aJT
-aLq
-nMC
-aNS
-aNT
+aGW
+aGW
+aGW
+aGW
+aGW
 aQS
 aQS
-nMC
-aWN
-aYE
-aZI
-aYV
-aCg
-bdE
-bdy
-beI
-bgu
-bmm
-bnM
-bam
+aQS
+aQS
+aGW
+aGW
+aGW
+aGW
+ofz
+asJ
+asJ
+asJ
+asJ
+ayx
+asJ
+bbG
 bne
 boY
 bqK
@@ -120747,17 +121359,17 @@ bLO
 bkj
 bFh
 axh
-bxs
-bnR
+axh
+axh
 brR
 axh
 bYG
-bVL
+bYG
 aoG
-cbX
+aoG
 cdm
-bal
-asJ
+aEl
+ofz
 cfK
 chs
 ckb
@@ -120958,34 +121570,34 @@ air
 afb
 avz
 asJ
-asJ
-awL
+azv
 aAL
+aEz
 aBX
 asJ
 cwA
-ajS
-riM
-tbK
-hHE
-aLp
+cwA
+cwA
+cwA
+cwA
+cwA
 nMC
-aNT
-aNT
-aQS
-aSg
 nMC
-aUL
-aYD
-aXx
-aYU
+nMC
+nMC
+nMC
+nMC
 aCg
-bfd
-bdz
-beJ
-bgv
-bhS
-aGX
+aCg
+aCg
+aCg
+aCg
+bam
+bam
+bam
+bam
+bam
+bam
 bam
 bnr
 bpf
@@ -121008,13 +121620,13 @@ bmG
 bnS
 bUp
 axh
-bUr
-bZH
+uLE
+bVL
 aoG
 azp
-kUj
+sHs
 asJ
-asJ
+bcj
 cfK
 ciF
 ckc
@@ -121214,12 +121826,12 @@ afb
 afb
 afb
 aoG
-asI
-ayn
-asJ
 aoG
-gip
-asI
+aoG
+aoG
+aEA
+aGt
+aJI
 cwA
 aIz
 dom
@@ -121228,8 +121840,8 @@ rNt
 aLu
 nMC
 aNU
-aPl
-aQT
+sBY
+aSh
 aSh
 nMC
 aWX
@@ -121238,7 +121850,7 @@ aXF
 aYU
 aCg
 bbK
-bdz
+cTM
 beK
 bgw
 bhT
@@ -121265,7 +121877,7 @@ bnL
 bnU
 bFl
 axh
-asJ
+bUr
 bZI
 aoG
 bef
@@ -121469,36 +122081,36 @@ aqS
 afb
 arr
 asI
-aub
-aoG
-aoG
-aoG
-aoG
-aoG
-gip
+auG
+asJ
+asJ
+aAz
+aAW
+asJ
+aGt
 aDa
 cwA
 akP
-dom
-aIw
-rNt
+aOw
+aQi
+aUL
 aLr
 nMC
-aNV
 sBY
 sBY
-aNV
+aSh
+bnM
 nMC
 aST
 aUK
 aZM
-aST
+aYZ
 aCg
-bam
-bdA
+cSd
+bdz
 bmN
 bgx
-bhT
+cWZ
 bob
 bam
 bnt
@@ -121518,14 +122130,14 @@ bNK
 bCM
 bCM
 bCM
-axh
+pUq
 bqN
-axh
+rDF
 axh
 asJ
-asJ
+jmX
 aoG
-aoG
+cSa
 cdp
 chb
 cfL
@@ -121725,39 +122337,39 @@ anj
 aoF
 aqc
 aqt
-xGP
+ayv
+ayv
+avX
 ayv
 xGP
-ayv
-xGP
-ayv
+aCD
 xGP
 qQy
-dgI
+arr
 cwA
 aIS
 aIv
-aID
+aJR
 aJQ
 aLR
 nMC
-nMC
+bck
 bXu
-bXu
-nMC
+biM
+bnR
 nMC
 aVg
 aYQ
 aXQ
 aYZ
-bbM
+aCg
 azo
 bdz
 beM
 cfd
-bhU
+bmE
 bjH
-aGt
+bam
 brP
 bsY
 bxd
@@ -121775,14 +122387,14 @@ bNL
 bOE
 bQk
 bCM
-bSG
+axh
+riM
+axh
+axh
+cSa
 asJ
-asJ
-aDa
-asJ
-asJ
-awL
 aAL
+cRR
 cfy
 asJ
 cfK
@@ -121988,33 +122600,33 @@ aoG
 aoG
 aoG
 aoG
-aoG
-aBZ
+aEx
+dHr
 axh
 cwA
 qpO
-aCM
+aIv
 aJR
-aCM
-qpO
-aFR
-aPK
-aHa
+aJQ
+aYD
+nMC
+aSC
+aJL
 aJL
 aSC
-aFR
-aVf
+nMC
+aYY
 aYN
 aXy
 aYY
-baU
-bdD
+aCg
+bam
 bhf
 beN
 bjG
 bmE
 bjI
-aFP
+bam
 brb
 bpi
 bpn
@@ -122034,14 +122646,14 @@ bOD
 bCM
 cBF
 cBG
-avC
+rYO
 asJ
 aub
 ckg
-bXt
 aoG
-ceR
 asJ
+ceR
+bcj
 cfK
 chf
 ciJ
@@ -122245,33 +122857,33 @@ avA
 avz
 buC
 bZJ
-asJ
+aEC
 dHr
 aCg
-aEA
+cwA
 aGc
 aIA
 aIE
-aIA
+aVF
 aOX
-aMR
-aIA
-aPn
+nMC
+nMC
 aQU
-aIA
-aWn
-aIA
+aQU
+nMC
+nMC
+bPh
 aWm
-aIB
+csk
 aJO
 bcr
-bam
-bam
-bam
-bam
-bam
-bam
-bam
+cSg
+bdz
+cVL
+cVX
+cXe
+cYh
+dbm
 bnw
 bpi
 bpn
@@ -122279,7 +122891,7 @@ bsz
 dqh
 bAs
 bjN
-bxI
+asJ
 bCN
 bEM
 bGw
@@ -122289,12 +122901,12 @@ bLU
 bOQ
 bOQ
 bCM
-asJ
+raV
 asJ
 bVL
-asJ
+uqy
 aXP
-asJ
+oeg
 bCM
 bCM
 cds
@@ -122497,38 +123109,38 @@ aoG
 ape
 aoG
 atU
-asJ
+aEx
 awv
 asJ
 aoG
 aoG
-aoG
+asJ
 dgE
 aCg
-aEA
+cwA
 aHg
-aHc
+ccH
 aIB
 ccH
-ccH
-ccH
-ccH
-aPo
-ccH
-ccH
-aQY
-ccH
-aYS
-aIB
-aJO
-bbO
+aHg
 aFR
+bdy
+aPo
+bkw
+bof
+aFR
+bSG
+aYS
+csy
+cAy
+bbO
+cSh
 bfy
 big
 bkt
-bkT
-aFR
-bmu
+cXj
+cZT
+dbp
 bnx
 bpi
 bpn
@@ -122550,7 +123162,7 @@ bSI
 bUr
 bVM
 bXt
-asJ
+vfv
 arr
 bCM
 biJ
@@ -122754,41 +123366,41 @@ aaa
 aaa
 aoG
 aou
-asJ
-avC
+aEx
+awX
 awL
 aAL
 ayr
 aCZ
 aCa
 aCg
-aFM
+aGb
 jPv
 bCj
 aMX
-aPp
-aPp
-aPp
-aPp
-aPp
+bCj
+aYE
+bae
+bCj
+baB
 aSE
-aPp
+bCj
 aUR
-aPp
+bCj
 aZc
 ccz
-baw
+xHf
 blt
-bmh
-blt
-bik
-bkw
-blt
-bmh
-bof
-bny
-bpk
-bfM
+bam
+bam
+bam
+bam
+bam
+bam
+bam
+bnz
+bpi
+bpn
 mDj
 buJ
 bzv
@@ -123016,24 +123628,24 @@ asJ
 asJ
 aoG
 aAI
-aCg
+aEE
 aEx
 aCg
 aGb
 kxf
 bAL
-aIF
-baB
-aLU
-aQR
-aOg
+ccz
+iIk
+iIk
+iIk
+iIk
 aUh
 iIk
-baB
+iIk
 aWp
-aVh
+iIk
 aYW
-baB
+ccz
 xHf
 bcq
 aFR
@@ -123273,37 +123885,37 @@ avD
 aoG
 aoG
 azs
+axh
+asJ
 aCg
-aEy
-aEz
 aHa
 eMs
-aCg
+aPa
 vRY
 aJZ
-aJb
-aCg
-alQ
-aJb
-aPL
-aJb
-aCg
-aCg
-aZe
 aJZ
+aJZ
+aJZ
+aJZ
+aPL
+aJZ
+bxI
+aJZ
+aZe
+ctj
 rFa
-aCg
-aFR
-aFR
-aFR
-aFR
-aFR
-aFR
-aFR
+cQJ
+cSl
+cQJ
+cVN
+cWt
+cQJ
+cSl
+dbw
 aWw
-bpi
-bqS
-bsC
+deM
+dhn
+dhF
 gkU
 bxn
 bjN
@@ -123532,31 +124144,31 @@ ayN
 ayI
 amk
 aCd
-aEE
+aCg
 aPn
 iof
-aCg
+aPe
 hAg
-len
-len
-len
-len
-len
+plu
+aYP
+baf
+bdA
+bfM
 bEL
-len
-len
-len
+plu
+bCe
+bTc
 aZd
-len
+plu
 pcW
-aCg
-ayE
+cQR
+aFR
 aAO
 aHw
 hEA
-bhZ
-baE
-iNu
+bkT
+aFR
+bmu
 qHS
 dfz
 bxd
@@ -123787,33 +124399,33 @@ avG
 axc
 axO
 azq
-aDb
+amk
 aDc
 bsF
-aGC
+aPo
 aIi
-aJb
+aCg
 aLw
-aMU
-aPa
-aRg
+bao
+aJb
+aCg
 aTJ
-aPs
+aJb
 aVs
-aWg
-knc
-aXs
+aJb
+aCg
+aCg
 aZh
 bao
 bbC
 aCg
-azv
-aAW
-aQF
-bck
-aIu
-rDF
-bqO
+aFR
+aFR
+aFR
+aFR
+aFR
+aFR
+bjN
 bqO
 dfB
 foM
@@ -124049,31 +124661,31 @@ aCf
 aDw
 baB
 aSn
-aJb
-aLw
-aMQ
-aNd
-aNd
-kez
-aPt
-aRb
-aTR
+aCg
+aQF
 yeW
-aXo
+yeW
+yeW
+yeW
+yeW
+aRb
+yeW
+yeW
+yeW
 aZg
-aZO
+yeW
 miB
 aCg
 azJ
 aHl
 bfr
 hIG
-aFR
+cXE
 uaQ
-bpn
+dbL
 sFz
-bpn
-bpn
+deU
+dhu
 bvt
 iRu
 bqU
@@ -124301,35 +124913,35 @@ avI
 amk
 amk
 bqV
-cbc
-aCg
+aFy
+aGN
 aEn
-aCg
+aLq
 aHi
-aCg
+aJb
 ygY
 gid
 kWg
-kWg
-kez
+bag
+bdD
 aPu
 aRc
 lGr
-kez
+bEA
 aLE
-aLE
+ceU
 ebM
 iSH
 aCg
-aFR
-aFR
-aFR
-aFR
-aFR
-bjN
-bjN
-bjN
-bjN
+cSn
+cUi
+cVP
+cWM
+cXF
+daS
+del
+del
+deX
 dgO
 bjN
 rPb
@@ -124558,35 +125170,35 @@ avH
 axM
 amk
 aAK
-cbc
-nRh
+aCg
+aGX
 aEd
 plu
 aFY
-aOa
-rsT
+aJb
+ygY
 rlJ
 gpj
-aRa
-aOe
+gpj
+qWn
 aPv
 aRd
 huo
-aOe
+bED
 tVw
-gpj
+chn
 tAn
-ccu
+cPH
 aCg
-bfz
-pUc
-pUc
-kKa
-aaa
-aaa
-aaa
-aaa
-aaa
+cSq
+cUm
+cVS
+cWW
+aFR
+daT
+bpn
+dem
+dgI
 bnt
 bnt
 cZS
@@ -124815,35 +125427,35 @@ awU
 ayz
 amk
 aCb
+cbc
 aCg
-kLs
-pNG
-lcc
-vZU
-aJb
-aLw
+aJT
+aCg
+aMR
+aCg
+aQY
 aDL
-kGw
 aRs
-aTK
-aRf
-aSo
-aTV
-mzf
+aRs
+qWn
+bgu
+bmh
+bpj
+qWn
 dqm
-kGw
+dqm
 mVG
-ccu
+cPI
 aCg
-aKT
-bfz
-pUc
-rYj
-aaa
-aaa
-aaa
-aaa
-aaa
+aFR
+aFR
+aFR
+aFR
+aFR
+bjN
+bjN
+bjN
+bjN
 bnt
 bvu
 bly
@@ -125071,29 +125683,29 @@ amk
 amk
 amk
 amk
-azy
+bwO
 cbc
-aCD
-pNG
+nRh
+aKW
 pmh
-aFZ
-aJb
-aLw
-aDL
-kGw
+tZI
+aJJ
+aRg
+aWf
+wLN
 ebV
 lJX
-aRf
+bgv
 rwh
-aTV
-kRX
-ebV
-kGw
+bpk
+lJX
+bZH
+wLN
 tvk
 ccu
 aCg
-aKT
-tgE
+bfz
+pUc
 pUc
 kKa
 aaa
@@ -125327,7 +125939,7 @@ abq
 abq
 ape
 arr
-ayx
+asJ
 azy
 aCg
 kLs
@@ -125335,19 +125947,19 @@ pNG
 lcc
 vZU
 aJb
-vIz
-aLN
+ygY
+dXb
 kGw
-ebV
+baE
 gfB
 aRf
 aSo
 aTV
 flr
-ebV
+caX
 kGw
 dea
-oCE
+ccu
 aCg
 aKT
 bfz
@@ -125586,31 +126198,31 @@ ans
 ans
 asI
 azy
-aCg
-nRh
-aDi
+cbc
+aHX
+pNG
 fmP
-aFY
-aOa
-edK
+aNS
+aJb
+ygY
 dXb
-gpj
-kez
-kez
-oTM
+kGw
+lOU
+bdE
+aRf
 vjL
-hWr
-kez
-kez
-gpj
+aTV
+bEF
+lOU
+kGw
 aJt
-kBa
-gdM
-gyy
-xLf
-qtt
-vmT
-qtt
+ccu
+aCg
+aKT
+tgE
+pUc
+kKa
+cYg
 aaa
 aaa
 aaa
@@ -125842,32 +126454,32 @@ auj
 arT
 ans
 azr
-azy
+bwO
 aCg
-aCg
-aCg
-aCg
-aHi
-aCg
-aLw
+kLs
+pNG
+lcc
+vZU
+aJb
+aSf
 aJW
-pUq
+kGw
 lOU
 gqj
-pvv
-oOs
-iAT
+aRf
+aSo
+aTV
 vwA
-fHC
-len
+lOU
+kGw
 nss
-ccu
-aJb
-abq
+cPJ
+aCg
+aKT
 bfz
-wxE
-wxE
-gyy
+pUc
+rYj
+cYg
 aaa
 aaa
 aaa
@@ -126092,7 +126704,7 @@ aee
 aee
 auv
 arC
-arC
+ahC
 arC
 atV
 auk
@@ -126101,29 +126713,29 @@ axd
 aGW
 bal
 axh
-axh
-abq
-aef
+bnL
+aKZ
+aLC
 tZI
 aJJ
 aPy
 xDw
 wLN
 qWn
-wLN
+qWn
 lpU
 aRe
 moi
 qWn
-ojl
-ddZ
+qWn
+wLN
 bap
 nEQ
 gdM
-kKa
-tgE
-wxE
-wxE
+gyy
+cUx
+qtt
+cUS
 qtt
 aaa
 aaa
@@ -126356,28 +126968,28 @@ aul
 avM
 ayA
 azu
-asJ
+aEx
 axh
 axh
-abq
-aef
-aef
 aCg
-rRM
+aCg
+aMR
+aCg
+ygY
 ogE
-aJb
-aCg
-aCg
-aJb
-aJb
-aJb
-aCg
-aCg
-aJb
+aYV
+baG
+beI
+bhA
+bmm
+bre
+bGq
+caZ
+yeW
 hqN
-ibi
-aCg
-aKT
+ccu
+aJb
+abq
 bfz
 wxE
 wxE
@@ -126615,29 +127227,29 @@ aoG
 buC
 aCc
 axh
-axh
+aaa
 abq
-abq
-abq
-aCg
-mWL
+aef
+aOa
+aPs
+aSg
 jUV
 aOd
 gYM
-nRh
-nRh
-aSp
-jbk
-nRh
-gYM
 aOd
+bhS
+bmB
+jbk
+gYM
+cex
+cin
 gZY
 hgN
-aCg
-rYO
-xLf
-vfv
-vfv
+gdM
+kKa
+tgE
+wxE
+wxE
 qtt
 aaa
 aaa
@@ -126871,30 +127483,30 @@ asJ
 aoG
 cbX
 asJ
-arr
 axh
 aaa
-aaa
-aaa
+abq
+aef
+aef
 aCg
 tpg
 lGk
-raV
-nRh
-nRh
-nRh
-nRh
-nRh
-nRh
-nRh
-oWm
+aJb
+aCg
+aCg
+aJb
+aJb
+aJb
+aCg
+aCg
+aJb
 ssZ
 qxn
 aCg
-rYO
-vmT
-vfv
-vfv
+aKT
+bfz
+wxE
+wxE
 gyy
 aaa
 aaa
@@ -127127,31 +127739,31 @@ asJ
 asJ
 bnI
 asJ
-asJ
+aEx
 axh
-axh
+aaa
 aaa
 aaa
 aaa
 aCg
 mWL
 pKs
-aLx
-nRh
+yaq
+baU
 nRh
 nRh
 aSp
+bwD
 nRh
-nRh
-nRh
+baU
 yaq
-aOd
+ctm
 hfb
 aCg
-aKT
-tgE
-wxE
-wxE
+cSR
+cUx
+cVT
+cVT
 qtt
 aaa
 aaa
@@ -127394,21 +128006,21 @@ aCg
 tvr
 vCR
 hdL
-aOd
-aOd
-uLE
-aCg
-mZJ
-aOd
-aOd
+nRh
+nRh
+nRh
+nRh
+nRh
+nRh
+nRh
 vUD
 wuZ
 swl
 aCg
-aKT
-bfz
-wxE
-wxE
+cSR
+cUS
+cVT
+cVT
 gyy
 aaa
 aaa
@@ -127648,18 +128260,18 @@ aaa
 abq
 abq
 aCg
-aCg
-aCg
-aCg
-aCg
-aCg
-aCg
-aCg
-aCg
-aCg
-aCg
-aCg
-aCg
+mWL
+aWg
+aZB
+nRh
+nRh
+nRh
+aSp
+nRh
+nRh
+nRh
+cjX
+yaq
 evR
 aCg
 aKT
@@ -127898,32 +128510,32 @@ awD
 avN
 aaa
 aoG
-asJ
+aDb
 axh
-abq
-abd
-abd
 aaa
 aaa
 aaa
 aaa
-abq
-aaa
-aaa
-aaa
-aaa
-abq
-aaa
-aaa
-abq
-aef
+aCg
+aSJ
+aWn
+aZI
+yaq
+yaq
+bhZ
+aCg
+bwZ
+yaq
+yaq
+coI
+ctp
 lmi
-baG
-rYO
-bhA
-xLf
+aCg
+aKT
+bfz
+wxE
+wxE
 gyy
-rYO
 aaa
 aaa
 aaa
@@ -128158,29 +128770,29 @@ aoG
 asJ
 axh
 aaa
-abd
-bre
-bre
 aaa
 aaa
 aaa
-abq
-aaa
-aaa
-aaa
-aaa
-abq
-aaa
-aaa
-abq
-aaa
-aaa
-bIu
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+cPL
+aCg
+aKT
 tgE
-pUc
-pUc
-pUc
-rYj
+wxE
+wxE
+qtt
 aaa
 aaa
 aaa
@@ -128414,31 +129026,31 @@ aaa
 abq
 aef
 aCj
+aIu
+abd
+abd
 aaa
-abd
-abd
-bre
-abd
+aaa
+aaa
+aaa
 abq
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-arB
+aaa
+aaa
+aaa
+aaa
+abq
+aaa
+aaa
+abq
+aef
+cPM
 bdp
-cmL
-cmL
-cmL
-cmL
-cmL
-cmL
+cSR
+cVD
+cUx
+gyy
+cSR
+dbj
 cmL
 cmL
 cmL
@@ -128672,30 +129284,30 @@ abq
 aef
 axh
 aaa
+abd
+aMp
+aMp
 aaa
-abd
-abd
-abd
 aaa
-abd
-bre
-bre
-aWA
-bre
-bre
-bre
-bre
-aWA
-bre
-bre
-arB
 aaa
-arB
-abd
-arB
-abd
-abd
-abd
+abq
+aaa
+aaa
+aaa
+aaa
+abq
+aaa
+aaa
+abq
+aaa
+aaa
+bIu
+tgE
+pUc
+pUc
+pUc
+rYj
+bIu
 aaa
 aaa
 aaa
@@ -128929,33 +129541,33 @@ aaa
 aaa
 abq
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-arB
-bFb
-arB
-arB
-arB
+abd
+abd
+aMp
+abd
 abq
 arB
-bre
-aWA
-bre
-bre
-abd
-aaa
-aaa
-aaa
+arB
+arB
+arB
+arB
+arB
+arB
+arB
+arB
+arB
+arB
+arB
+cRq
+cmL
+cmL
+cmL
+cmL
+cmL
+cmN
+abq
+abq
+abq
 abq
 aaa
 bwL
@@ -129187,22 +129799,22 @@ aaa
 aaa
 aaa
 aaa
+abd
+abd
+abd
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abd
+aMp
+aMp
+beJ
+aMp
+aMp
+aMp
+aMp
+beJ
+aMp
+aMp
+arB
 aaa
 arB
 abd
@@ -129446,27 +130058,27 @@ aaa
 aaa
 aaa
 aaa
-aaD
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+arB
+arB
+arB
+arB
+arB
+arB
+arB
+arB
+bFb
+arB
+arB
+arB
 abq
-abq
-aaa
-abq
-aaa
-aaa
-aaa
+arB
+aMp
+beJ
+aMp
+aMp
+abd
 aaa
 aaa
 aaa
@@ -129717,13 +130329,13 @@ aaa
 aaa
 aaa
 aaa
-abq
-abq
 aaa
-abq
-aaa
-aaa
-aaa
+arB
+abd
+arB
+abd
+abd
+abd
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2153,6 +2153,10 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/auxstarboard)
+"agK" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/maintenance/asmaint)
 "agL" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -3757,9 +3761,7 @@
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/color/fyellow,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "ajT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4040,9 +4042,7 @@
 /area/maintenance/auxsolarport)
 "aky" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "akz" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -4561,9 +4561,7 @@
 	},
 /obj/item/restraints/handcuffs/cable/pink,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aly" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 6;
@@ -4577,9 +4575,7 @@
 /obj/item/clothing/mask/gas/monkeymask,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "alz" = (
 /obj/item/stack/sheet/cardboard,
 /obj/machinery/light_construct/small{
@@ -4595,9 +4591,7 @@
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "alA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -4659,9 +4653,7 @@
 "alL" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "alM" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -4942,22 +4934,16 @@
 /obj/item/bikehorn/rubberducky,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "amu" = (
 /obj/effect/landmark/spawner/xeno,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "amv" = (
 /obj/item/vending_refill/snack,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "amw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -5202,8 +5188,9 @@
 	})
 "amX" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/hand_labeler,
+/obj/item/pen,
+/obj/item/storage/box/evidence,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "amZ" = (
@@ -5308,8 +5295,9 @@
 	},
 /area/engine/gravitygenerator)
 "ano" = (
-/turf/space,
-/area/maintenance/auxsolarstarboard)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
 "anr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5358,10 +5346,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "anB" = (
@@ -5381,9 +5369,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "anC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -5398,9 +5384,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "anD" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -5420,15 +5404,11 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "anE" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "anH" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -5469,9 +5449,7 @@
 /obj/item/healthanalyzer,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "anJ" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine{
@@ -5985,9 +5963,7 @@
 "aoX" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aoY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -6001,21 +5977,17 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "apb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "apc" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -6029,20 +6001,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"apd" = (
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "ape" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"apf" = (
-/turf/simulated/wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "apg" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -6060,9 +6022,7 @@
 /obj/item/grenade/flashbang,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "api" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east bump";
@@ -6552,33 +6512,25 @@
 /obj/item/tape/random,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aqz" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/stock_parts/cell/crap,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aqA" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/firealarm_electronics,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aqB" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aqC" = (
 /obj/structure/rack{
 	dir = 1
@@ -6590,9 +6542,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aqI" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -7018,24 +6968,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "arJ" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "arK" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "arO" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -7111,9 +7055,7 @@
 "arU" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "arV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
@@ -7671,9 +7613,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "atf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -7686,9 +7626,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "atg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7696,10 +7634,11 @@
 /obj/effect/landmark/spawner/xeno,
 /obj/item/cigbutt,
 /obj/item/cigbutt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "ath" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -7714,21 +7653,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "atj" = (
 /obj/item/cigbutt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"atk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "atl" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -7768,9 +7697,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "atp" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7889,8 +7816,11 @@
 /area/security/main)
 "atF" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/flashlight,
+/obj/item/toy/crayon/white,
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "atG" = (
@@ -7914,9 +7844,7 @@
 /obj/item/poster/random_official,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "atJ" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -8196,16 +8124,14 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/girder,
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "aus" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -8213,9 +8139,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aut" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -8223,9 +8147,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auu" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -8233,9 +8155,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auv" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -8251,44 +8171,32 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aux" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auB" = (
 /obj/item/bucket_sensor,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auC" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auD" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
@@ -8296,9 +8204,7 @@
 "auE" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -8331,15 +8237,11 @@
 "auI" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auJ" = (
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "auL" = (
 /obj/structure/chair,
 /obj/item/restraints/handcuffs,
@@ -8893,9 +8795,7 @@
 /obj/effect/landmark/spawner/xeno,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "avR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8917,15 +8817,11 @@
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "avT" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "avU" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -8933,9 +8829,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "avV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8951,9 +8845,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "avX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8968,9 +8860,7 @@
 	},
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "avZ" = (
 /obj/structure/chair{
 	dir = 4
@@ -9005,17 +8895,13 @@
 "awe" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "awf" = (
 /obj/machinery/light,
 /obj/effect/landmark/spawner/xeno,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "awg" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
@@ -9240,9 +9126,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "awF" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -9316,9 +9200,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "awL" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
@@ -9426,9 +9308,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "awX" = (
 /obj/effect/landmark/spawner/xeno,
 /obj/effect/decal/cleanable/dirt,
@@ -9482,9 +9362,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "axf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9566,9 +9444,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "axl" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -9576,17 +9452,13 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "axn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "axq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -9595,9 +9467,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "axr" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -9673,9 +9543,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "axx" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -10181,9 +10049,7 @@
 "ayB" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "ayC" = (
 /obj/structure/chair{
 	dir = 4
@@ -10196,6 +10062,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "ayF" = (
@@ -10444,9 +10311,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "azj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -10584,9 +10449,7 @@
 	},
 /obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "azC" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = -25
@@ -10688,9 +10551,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "azL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10712,9 +10573,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "azO" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -10727,9 +10586,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "azP" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -10753,9 +10610,7 @@
 "azQ" = (
 /obj/item/stack/sheet/cardboard,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "azR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
@@ -10897,11 +10752,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
 "aAg" = (
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aAh" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -11082,9 +10934,7 @@
 "aAA" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aAB" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -11228,18 +11078,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aAU" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/shoes/rainbow,
 /obj/item/clothing/under/rainbow,
 /obj/item/clothing/head/soft/rainbow,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aAV" = (
 /obj/structure/chair{
 	dir = 1
@@ -11270,9 +11116,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aAY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11288,9 +11132,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aBa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12273,9 +12115,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aDp" = (
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating/airless,
@@ -12733,7 +12573,7 @@
 "aEf" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aEg" = (
@@ -12763,9 +12603,7 @@
 "aEj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aEk" = (
 /obj/item/bikehorn/rubberducky,
 /obj/effect/landmark/spawner/xeno,
@@ -13129,9 +12967,7 @@
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aEV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13523,8 +13359,8 @@
 	name = "\improper Mining Office"
 	})
 "aFP" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aFQ" = (
@@ -13661,9 +13497,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aGk" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -14155,17 +13989,13 @@
 /obj/item/coin/silver,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aHn" = (
 /obj/structure/closet,
 /obj/item/poster/random_contraband,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aHr" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -14226,9 +14056,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aHw" = (
 /obj/machinery/shower{
 	dir = 8
@@ -14519,9 +14347,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aHZ" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -14705,9 +14531,15 @@
 /turf/simulated/floor/mineral/tranquillite,
 /area/crew_quarters/sleep)
 "aIu" = (
-/obj/structure/lattice,
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
 "aIv" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -14850,11 +14682,8 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "aIJ" = (
-/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aIN" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -14917,9 +14746,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aIV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16652,8 +16479,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aMN" = (
-/turf/space,
-/area/chapel/main)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "aMP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16983,18 +16811,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aNn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aNo" = (
 /turf/simulated/wall,
 /area/security/processing)
@@ -17413,9 +17237,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aOy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17426,9 +17248,7 @@
 	req_one_access_txt = "12;63;48;50"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aOA" = (
 /turf/simulated/wall,
 /area/storage/primary)
@@ -17563,9 +17383,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aOX" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow,
@@ -17968,9 +17786,7 @@
 	opacity = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aPS" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -17995,9 +17811,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aPW" = (
 /obj/machinery/atm{
 	pixel_y = -32
@@ -19901,9 +19715,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aUv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -20212,9 +20024,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aVl" = (
 /turf/simulated/wall,
 /area/quartermaster/qm)
@@ -20261,9 +20071,7 @@
 /mob/living/simple_animal/mouse,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aVr" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Starboard"
@@ -20519,7 +20327,7 @@
 /area/crew_quarters/locker)
 "aVP" = (
 /obj/structure/chair/stool{
-	pixel_y = 8
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -20743,9 +20551,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aWr" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -21439,9 +21245,7 @@
 "aYb" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aYg" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
@@ -21475,9 +21279,7 @@
 	sortType = 2
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aYl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21489,9 +21291,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aYn" = (
 /obj/machinery/light{
 	dir = 1
@@ -21524,9 +21324,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aYq" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -21571,9 +21369,7 @@
 "aYt" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aYv" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -21859,9 +21655,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "aYY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -22365,9 +22159,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bac" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/workboots,
@@ -22874,9 +22666,7 @@
 /obj/item/toolbox_tiles/sensor,
 /obj/machinery/light_construct/small,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bbk" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Network Access";
@@ -23526,9 +23316,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bcH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -23539,9 +23327,7 @@
 	req_one_access_txt = "12;63;48;50"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bcI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24148,9 +23934,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bei" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -24700,9 +24484,7 @@
 	req_one_access_txt = "12;48;50;1"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bfl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -25360,9 +25142,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bgB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -25371,9 +25151,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bgC" = (
 /obj/machinery/telepad_cargo,
 /obj/effect/decal/warning_stripes/south,
@@ -25574,9 +25352,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bgZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -25999,9 +25775,7 @@
 /obj/item/cigbutt,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bic" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -26097,9 +25871,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bil" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -26245,9 +26017,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "biD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26777,9 +26547,7 @@
 	req_one_access_txt = "12;27;37"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bjF" = (
 /obj/structure/closet/toolcloset,
 /obj/item/radio/intercom{
@@ -28952,9 +28720,7 @@
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bod" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -28965,9 +28731,7 @@
 	req_one_access_txt = "12;48;50;1"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "boe" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -30015,9 +29779,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bql" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -30289,9 +30051,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "bqR" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -33359,9 +33119,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bwr" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NW"
@@ -33506,10 +33264,9 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "bwI" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/maintenance/fpmaint)
 "bwL" = (
 /obj/structure/transit_tube,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33545,7 +33302,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bwR" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -34020,14 +33777,10 @@
 	name = "\improper MiniSat Central Foyer"
 	})
 "bxG" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/maintenance/fpmaint)
 "bxH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -35190,9 +34943,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bzK" = (
 /turf/simulated/wall,
 /area/library)
@@ -35476,9 +35227,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bAp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
@@ -36091,9 +35840,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bBO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37100,9 +36847,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bDM" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -37877,9 +37622,7 @@
 	name = "Port Emergency Storage"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bFp" = (
 /turf/simulated/wall,
 /area/security/vacantoffice)
@@ -37931,9 +37674,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bFv" = (
 /obj/machinery/photocopier{
 	pixel_y = 3
@@ -38190,9 +37931,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bFY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
@@ -38229,9 +37968,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bGc" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
@@ -38716,9 +38453,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bHe" = (
 /obj/machinery/atmospherics/unary/thermomachine/heater/on,
 /turf/simulated/floor/plasteel{
@@ -38832,9 +38567,7 @@
 /obj/item/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bHq" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -38952,9 +38685,15 @@
 	},
 /area/bridge)
 "bHE" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
+/area/security/brig)
 "bHG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -40361,9 +40100,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bKz" = (
 /obj/machinery/light{
 	dir = 8
@@ -40413,6 +40150,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"bKH" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "bKL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -40924,9 +40665,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bLH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40948,9 +40687,7 @@
 /obj/structure/closet/crate,
 /obj/item/poster/random_official,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bLL" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi';
@@ -41470,9 +41207,7 @@
 	req_one_access_txt = "12;37"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bMM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43105,9 +42840,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bQz" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -43646,27 +43379,19 @@
 "bRD" = (
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bRE" = (
 /obj/machinery/vending/hatdispenser,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bRF" = (
 /obj/machinery/vending/shoedispenser,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bRG" = (
 /obj/machinery/vending/autodrobe,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bRH" = (
 /obj/structure/rack{
 	dir = 8;
@@ -43675,9 +43400,7 @@
 /obj/effect/landmark/costume,
 /obj/effect/landmark/costume,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bRI" = (
 /obj/structure/rack{
 	dir = 8;
@@ -43687,9 +43410,7 @@
 /obj/effect/landmark/costume,
 /obj/effect/landmark/costume,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bRJ" = (
 /obj/structure/bookcase{
 	name = "bookcase (Religious)"
@@ -44508,9 +44229,7 @@
 /obj/structure/table,
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bTq" = (
 /obj/machinery/light/small,
 /obj/structure/table,
@@ -44540,9 +44259,7 @@
 /obj/item/rack_parts,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bTs" = (
 /obj/machinery/light/small,
 /obj/machinery/power/apc{
@@ -45058,9 +44775,7 @@
 	},
 /obj/item/clothing/mask/horsehead,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bUI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -45143,7 +44858,7 @@
 "bUR" = (
 /obj/machinery/door/airlock/welded,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bUS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -45413,7 +45128,7 @@
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bVs" = (
 /obj/structure/table,
 /obj/machinery/door_control{
@@ -45582,7 +45297,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bVL" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -45643,11 +45358,11 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bVR" = (
-/obj/machinery/vending/suitdispenser,
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
+/obj/item/lighter/random,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bVS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -45722,7 +45437,7 @@
 /obj/item/trash/tapetrash,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bVY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -45762,11 +45477,11 @@
 /obj/item/clothing/suit/storage/labcoat/mad,
 /obj/item/clothing/glasses/science,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bWa" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bWb" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -24
@@ -45813,9 +45528,7 @@
 "bWi" = (
 /obj/item/trash/candy,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bWj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Vacant Office Maintenance";
@@ -45827,19 +45540,15 @@
 /obj/structure/closet,
 /obj/item/flashlight,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bWl" = (
 /turf/simulated/wall/rust,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bWm" = (
 /obj/structure/rack,
 /obj/item/storage/box,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bWn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
@@ -46400,20 +46109,20 @@
 "bXC" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bXD" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bXE" = (
 /obj/structure/table,
 /obj/item/reagent_containers/syringe,
 /obj/item/storage/pill_bottle/random_drug_bottle,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bXF" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-14"
@@ -46429,7 +46138,7 @@
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bXH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -46443,9 +46152,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bXI" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -46454,9 +46161,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bXJ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -46468,9 +46173,7 @@
 "bXK" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bXL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46759,7 +46462,7 @@
 "bYq" = (
 /obj/item/mounted/frame/apc_frame,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bYr" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -46851,9 +46554,7 @@
 "bYx" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bYy" = (
 /obj/machinery/vending/coffee,
 /obj/structure/sign/double/map/left{
@@ -47019,7 +46720,7 @@
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "bYR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47034,9 +46735,7 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bYU" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -47063,9 +46762,7 @@
 /mob/living/simple_animal/mouse,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bYX" = (
 /obj/structure/cable/yellow,
 /obj/machinery/door/poddoor{
@@ -47440,7 +47137,7 @@
 "bZO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "bZP" = (
 /turf/simulated/wall,
 /area/maintenance/portsolar)
@@ -47463,9 +47160,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "bZS" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/portsolar)
@@ -47544,9 +47239,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "cae" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -47566,9 +47259,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "caf" = (
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -47793,17 +47484,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "caJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "caK" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -47816,9 +47499,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "caL" = (
 /obj/machinery/firealarm{
 	name = "north bump";
@@ -47913,6 +47594,15 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
+"caV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "caW" = (
 /obj/item/trash/candy,
 /obj/item/clothing/accessory/stethoscope,
@@ -48647,9 +48337,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "ccC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -48663,9 +48351,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "ccD" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -48908,9 +48594,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cdp" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -49104,9 +48788,7 @@
 /obj/item/cigbutt,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cdE" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -49129,9 +48811,7 @@
 /obj/item/poster/random_contraband,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cdI" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/extinguisher_cabinet{
@@ -49325,7 +49005,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cel" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
@@ -49461,7 +49141,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "ceE" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -49592,9 +49272,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "ceU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable{
@@ -49981,7 +49659,7 @@
 "cfE" = (
 /obj/machinery/constructable_frame,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cfF" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
@@ -50126,7 +49804,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cfV" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable/yellow{
@@ -50141,7 +49819,7 @@
 "cfY" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cfZ" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -50236,9 +49914,7 @@
 /obj/item/cigbutt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cgn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/spawner/window/reinforced,
@@ -50247,9 +49923,7 @@
 "cgo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cgp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -50429,9 +50103,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "cgI" = (
 /obj/structure/closet/paramedic,
 /obj/machinery/firealarm{
@@ -50586,9 +50258,7 @@
 "cgU" = (
 /obj/item/vending_refill/cola,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cgV" = (
 /obj/machinery/door/window/eastright{
 	dir = 1;
@@ -50742,9 +50412,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "chr" = (
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_y = 3
@@ -51639,7 +51307,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cjj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -52393,7 +52061,7 @@
 "ckP" = (
 /obj/item/healthanalyzer,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "ckQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -52605,7 +52273,7 @@
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "clp" = (
 /obj/structure/cable/yellow,
 /obj/effect/spawner/window/reinforced,
@@ -52784,7 +52452,7 @@
 "clN" = (
 /obj/item/storage/box,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "clO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -52821,7 +52489,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "clV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53052,7 +52720,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cmz" = (
 /turf/simulated/wall/r_wall,
 /area/medical/research)
@@ -53235,16 +52903,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_barrier/obstruction,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cmZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/south,
+/obj/item/cigbutt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fore)
 "cna" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -53666,8 +53329,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cnQ" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
@@ -54891,12 +54555,12 @@
 /obj/structure/rack,
 /obj/item/stack/packageWrap,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cqp" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cqq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -54906,7 +54570,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "cqr" = (
 /obj/machinery/atmospherics/binary/pump{
 	on = 1
@@ -54993,15 +54657,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cqE" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/item/hatchet,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cqF" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -55011,7 +54673,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cqG" = (
 /obj/item/reagent_containers/glass/bottle/toxin{
 	pixel_x = 4;
@@ -55023,7 +54685,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cqH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -55043,7 +54705,7 @@
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/syringe,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cqI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -55301,7 +54963,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "crr" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -55530,7 +55192,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "crS" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -55541,7 +55203,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "crT" = (
 /obj/machinery/camera{
 	c_tag = "Research and Development";
@@ -55568,7 +55230,7 @@
 /area/toxins/lab)
 "crU" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "crV" = (
 /obj/item/retractor,
 /obj/item/cautery,
@@ -55741,7 +55403,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "csh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55776,7 +55438,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "csk" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -55803,7 +55465,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "csm" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -56327,7 +55989,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "ctb" = (
 /obj/machinery/door/airlock{
 	name = "Research Emergency Storage";
@@ -56418,7 +56080,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "ctm" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -56465,7 +56127,7 @@
 "ctr" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cts" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -56964,15 +56626,15 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cuH" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cuI" = (
 /obj/structure/bed,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cuJ" = (
 /obj/structure/mineral_door/wood{
 	name = "The Gobbetting Barmaid"
@@ -57641,7 +57303,7 @@
 "cvW" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cvX" = (
 /obj/structure/extinguisher_cabinet{
 	name = "north bump";
@@ -57657,7 +57319,7 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cvZ" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
@@ -57892,7 +57554,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cwH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -57913,7 +57575,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cwJ" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -58068,13 +57730,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cxj" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cxk" = (
 /obj/item/toy/cards/deck,
 /obj/structure/table/wood,
@@ -58418,7 +58080,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cxU" = (
 /turf/simulated/wall,
 /area/crew_quarters/hor)
@@ -58512,7 +58174,7 @@
 /obj/item/restraints/handcuffs/cable/white,
 /obj/item/gun/syringe,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cyf" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin{
@@ -58520,18 +58182,18 @@
 	},
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cyg" = (
 /obj/machinery/iv_drip,
 /obj/item/roller,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cyh" = (
 /obj/structure/rack,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cyi" = (
 /obj/machinery/light_construct/small,
 /obj/item/toy/cards/deck,
@@ -58818,7 +58480,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/bed/roller,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cyU" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/warning_stripes/north,
@@ -59437,7 +59099,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cAd" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59451,7 +59113,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cAe" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
@@ -61026,7 +60688,7 @@
 	req_one_access_txt = "8;12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cDb" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -61382,7 +61044,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cDN" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -61446,7 +61108,7 @@
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cDY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -61528,9 +61190,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cEh" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -61671,7 +61331,7 @@
 "cEB" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cEC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -61756,7 +61416,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cEN" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -61923,7 +61583,7 @@
 	},
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cFd" = (
 /turf/simulated/wall,
 /area/medical/medbreak)
@@ -62156,7 +61816,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cFH" = (
 /turf/simulated/wall,
 /area/toxins/mixing{
@@ -63066,9 +62726,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cHs" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -63514,9 +63172,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cIj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -64354,15 +64010,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cJW" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
+"cJX" = (
+/turf/simulated/wall,
+/area/maintenance/asmaint)
 "cJY" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
@@ -64644,7 +64301,7 @@
 "cKG" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cKH" = (
 /obj/item/circular_saw,
 /obj/item/FixOVein,
@@ -65105,7 +64762,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/remains/robot,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cLC" = (
 /obj/structure/closet,
 /obj/item/assembly/prox_sensor{
@@ -65117,7 +64774,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cLD" = (
 /obj/structure/chair{
 	dir = 4
@@ -65295,7 +64952,7 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cLX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -65544,7 +65201,7 @@
 /obj/item/clothing/mask/gas,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cMy" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -66652,24 +66309,18 @@
 /obj/structure/sign/biohazard{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cOt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cOw" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cOx" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -67608,7 +67259,7 @@
 /obj/item/flashlight,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cQn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -67758,12 +67409,9 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cQE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cQF" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -67775,7 +67423,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cQG" = (
 /obj/structure/rack,
 /obj/item/crowbar/red,
@@ -67804,7 +67452,7 @@
 "cQI" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cQJ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -67834,7 +67482,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cQM" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
@@ -67930,9 +67578,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "cQU" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/botanic_leather,
@@ -67941,7 +67587,7 @@
 /obj/item/storage/belt/botany,
 /obj/item/storage/backpack/satchel_hyd,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cQW" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboardsolar)
@@ -68056,6 +67702,15 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cRn" = (
@@ -68222,7 +67877,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cRE" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery 1 North"
@@ -68263,7 +67918,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cRI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -68362,7 +68017,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cRQ" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -68651,7 +68306,7 @@
 	req_one_access_txt = "7;12;47"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cSu" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xeno_blastdoor";
@@ -68948,7 +68603,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cSZ" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -69111,7 +68766,7 @@
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/hydroponics,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cTp" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -69313,7 +68968,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cTO" = (
 /obj/structure/chair{
 	dir = 4
@@ -69796,12 +69451,12 @@
 "cUK" = (
 /obj/item/seeds/berry,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cUL" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cUN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/spawner/xeno,
@@ -69926,7 +69581,7 @@
 /obj/machinery/biogenerator,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cVf" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -69953,7 +69608,7 @@
 /obj/item/seeds/grass,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cVi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -69969,7 +69624,7 @@
 /obj/item/seeds/glowshroom,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cVk" = (
 /turf/simulated/wall,
 /area/hallway/secondary/exit{
@@ -70027,20 +69682,20 @@
 /obj/item/seeds/carrot,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cVp" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/plant_analyzer,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cVq" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/glowshroom,
 /obj/item/seeds/corn,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cVr" = (
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
@@ -70449,7 +70104,7 @@
 "cWq" = (
 /obj/structure/chair,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cWt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -70952,7 +70607,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cXz" = (
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plasteel{
@@ -71296,8 +70951,15 @@
 	name = "\improper Departure Lounge"
 	})
 "cYg" = (
-/turf/space,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/restraints/handcuffs/cable/zipties/used,
+/obj/item/trash/tapetrash,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "cYh" = (
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/simple_animal/parrot/Poly,
@@ -71334,7 +70996,7 @@
 /obj/item/seeds/glowshroom,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cYr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71379,7 +71041,7 @@
 /obj/item/seeds/ambrosia,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cYx" = (
 /obj/structure/chair{
 	dir = 1
@@ -71861,7 +71523,7 @@
 /obj/item/cultivator,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cZK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -71897,7 +71559,7 @@
 /obj/item/seeds/watermelon,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "cZO" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psych Office";
@@ -71992,7 +71654,7 @@
 /obj/item/seeds/berry,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "daa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -73517,6 +73179,11 @@
 "dek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "del" = (
@@ -74141,9 +73808,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "dgx" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -74227,6 +73892,11 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"dhe" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "dhf" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
@@ -74306,15 +73976,11 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dhq" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/trash/spentcasing,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fore)
 "dhr" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -74347,7 +74013,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "dhx" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -74428,7 +74094,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "dhF" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74444,7 +74110,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "dhI" = (
 /mob/living/simple_animal/bot/cleanbot{
 	name = "Mopfficer Sweepsky";
@@ -74561,7 +74227,7 @@
 /obj/item/clothing/suit/apron,
 /obj/item/clothing/mask/surgical,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "dwC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -74576,6 +74242,20 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
+"dxo" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall/r_wall,
+/area/maintenance/starboard)
+"dxZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "dAs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -74788,10 +74468,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "dVK" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -74835,6 +74517,15 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"dXP" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/landmark/start/engineer,
+/turf/simulated/floor/plasteel,
+/area/engine/break_room)
 "dYi" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -74927,6 +74618,10 @@
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"egT" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -74959,7 +74654,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "eiF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -74990,6 +74685,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
+"erh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/trash/can,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "erv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -75009,6 +74713,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"euN" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "rampbottom"
+	},
+/area/maintenance/aft)
 "evR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -75061,6 +74770,13 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"eIf" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "eIg" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -75090,8 +74806,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "eKV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -75105,7 +74824,7 @@
 /obj/structure/girder,
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "eMs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -75191,16 +74910,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "fcP" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "ffD" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -75354,6 +75071,17 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
+"ftF" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "rampbottom"
+	},
+/area/maintenance/aft)
 "fvO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -75392,9 +75120,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "fxB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -75409,6 +75135,10 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
+"fzX" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/maintenance/starboard)
 "fBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -75494,7 +75224,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "fPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75535,11 +75265,11 @@
 /area/security/permabrig)
 "fZo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "fZC" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -75684,6 +75414,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"gji" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "gkU" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -75763,9 +75507,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "gtu" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
@@ -75810,6 +75552,13 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"gyU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "gyZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -75836,7 +75585,13 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
+"gAv" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "gAK" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -75893,6 +75648,11 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
+"gKj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/blood_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "gMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75939,6 +75699,10 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
+"gSb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "gSK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -75954,11 +75718,27 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"gVs" = (
+/obj/machinery/vending/suitdispenser,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "gYM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"gZc" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "gZH" = (
 /obj/machinery/light/small,
 /obj/machinery/door_control{
@@ -76041,9 +75821,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "hht" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76086,9 +75864,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "hlZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76243,7 +76019,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "hDK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -76293,6 +76069,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"hHQ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "hIG" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -76342,6 +76122,10 @@
 	},
 /turf/space,
 /area/space)
+"hKe" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "hKu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -76373,10 +76157,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"hLL" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/space/nearstation)
 "hLW" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76389,7 +76169,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
+"hNf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "hNy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -76413,6 +76207,10 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"hSw" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hVe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76566,11 +76364,8 @@
 	})
 "ijy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "ikO" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -76631,7 +76426,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "iof" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76664,14 +76459,16 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"irN" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "isf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "iuh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76705,6 +76502,15 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"ixD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "iyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76739,7 +76545,7 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "iEd" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76791,9 +76597,6 @@
 "iKX" = (
 /obj/item/bedsheet/clown,
 /obj/structure/bed,
-/obj/structure/sign/clown{
-	pixel_x = 32
-	},
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = -32
 	},
@@ -76877,7 +76680,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "iTW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76903,6 +76706,19 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
+"iYX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "iZz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -76910,13 +76726,9 @@
 "jap" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "jaV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76925,7 +76737,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "jbk" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -76942,18 +76754,9 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "jcf" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "jeY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -76963,6 +76766,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
+"jfg" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "maint3";
+	name = "Blast Door";
+	opacity = 0
+	},
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jgD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -77002,6 +76816,11 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"jnz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/blood_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "jos" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -77024,7 +76843,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "juN" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm - Far";
@@ -77085,6 +76904,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"jCP" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "jCT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77177,13 +77006,17 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"jPw" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall/r_wall,
+/area/maintenance/starboard)
 "jPy" = (
 /obj/structure/closet,
 /obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "jQb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -77213,6 +77046,21 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"jZg" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "keY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -77235,11 +77083,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"kgn" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "kgV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"kiY" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/maintenance/asmaint)
+"klt" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "kmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -77254,7 +77115,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "kmF" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -77299,9 +77160,7 @@
 	},
 /obj/item/vending_refill/cigarette,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "kto" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -77675,7 +77534,7 @@
 /obj/effect/landmark/spawner/xeno,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "lio" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -77691,7 +77550,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "ljZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -78119,6 +77978,19 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
+/area/maintenance/asmaint)
+"mCb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/aft)
 "mCS" = (
 /obj/machinery/light/small{
@@ -78173,6 +78045,12 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"mLm" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "mMS" = (
 /obj/machinery/light/small,
 /obj/machinery/door_control{
@@ -78329,9 +78207,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "nbO" = (
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/wall,
@@ -78448,7 +78324,7 @@
 /obj/item/flashlight,
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "nuB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78477,6 +78353,11 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"nxy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "nza" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/warning_stripes/north,
@@ -78541,6 +78422,14 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"nCf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "nEQ" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	name = "Gas to Cooling Loop"
@@ -78577,7 +78466,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "nHB" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -78711,7 +78600,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "oaH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78729,7 +78618,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "ocl" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -78775,7 +78664,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "ofz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78876,14 +78765,12 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "oCE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "oJQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78916,6 +78803,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
+"oQF" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/crew_quarters/toilet{
+	name = "\improper Auxiliary Restrooms"
+	})
 "oRr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -78926,6 +78819,10 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
+"oTn" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/maintenance/starboard)
 "oTM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79054,10 +78951,11 @@
 	},
 /area/security/processing)
 "peo" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/space,
-/area/space)
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/quartermaster/sorting{
+	name = "\improper Warehouse"
+	})
 "pep" = (
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/wall,
@@ -79070,7 +78968,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "peO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/binary/pump{
@@ -79085,7 +78983,7 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "phx" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79165,6 +79063,16 @@
 	icon_state = "vault"
 	},
 /area/chapel/main)
+"pmm" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "pne" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/welded,
@@ -79191,7 +79099,7 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/mask/surgical,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "pru" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79200,7 +79108,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -79300,9 +79208,7 @@
 "pHQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "pJV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -79330,7 +79236,7 @@
 "pMx" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "pMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79402,7 +79308,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "pSL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79482,7 +79388,7 @@
 "qbl" = (
 /obj/effect/spawner/airlock,
 /turf/simulated/wall,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "qbE" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -79565,13 +79471,14 @@
 	},
 /area/medical/research)
 "qob" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/grille{
+	density = 0;
+	icon_state = "brokengrille"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "qor" = (
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel,
@@ -79586,6 +79493,11 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
+"qsk" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/unary/portables_connector,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "qts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -79676,7 +79588,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "qHi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79731,6 +79643,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"qQW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "qRj" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel{
@@ -79834,6 +79755,11 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"rkT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "rlJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -79876,7 +79802,7 @@
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "rnY" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
@@ -79943,9 +79869,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "rwh" = (
 /obj/machinery/door/airlock/engineering/glass{
 	heat_proof = 1;
@@ -79973,6 +79897,12 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
+"rzL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/remains/robot,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "rzT" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80114,9 +80044,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "rHl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80127,7 +80055,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "rIq" = (
 /obj/structure/table,
 /obj/item/clothing/mask/breath{
@@ -80171,6 +80099,10 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"rKx" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "rNt" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm{
@@ -80480,7 +80412,7 @@
 "sEQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "sFz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80518,9 +80450,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "sLs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80578,6 +80508,16 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"sPZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "sRB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -80658,6 +80598,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
+"tfe" = (
+/obj/structure/closet/wardrobe/yellow,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
+"tfq" = (
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "tfV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80704,6 +80652,15 @@
 "tlF" = (
 /obj/structure/lattice,
 /turf/simulated/wall,
+/area/maintenance/asmaint)
+"tmA" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
 /area/maintenance/aft)
 "tpg" = (
 /obj/structure/cable/yellow{
@@ -80854,6 +80811,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
+"tFd" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/maintenance/aft)
 "tKC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80863,7 +80824,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80915,6 +80876,15 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"tTL" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "tUA" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -80934,6 +80904,22 @@
 	icon_state = "vault"
 	},
 /area/chapel/main)
+"tUN" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/maintenance/aft)
+"tVk" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "tVw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -81039,6 +81025,15 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"uga" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "ugy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81141,6 +81136,17 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"uzB" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "chapelparlourshutters";
+	name = "chapel shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "uAA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -81151,7 +81157,7 @@
 	},
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "uBN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -81160,6 +81166,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"uDw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "uEN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -81182,9 +81199,7 @@
 "uKm" = (
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "uLE" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plating,
@@ -81385,9 +81400,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -81561,9 +81574,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "vLL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81664,7 +81675,7 @@
 /area/hallway/primary/fore)
 "vZo" = (
 /turf/simulated/floor/plating,
-/area/space/nearstation)
+/area/maintenance/asmaint)
 "vZU" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 1
@@ -81744,6 +81755,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"wsN" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "wtP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -81941,12 +81957,30 @@
 	icon_state = "grimy"
 	},
 /area/chapel/office)
+"wIs" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "wID" = (
 /obj/structure/sign/directions/evac,
 /turf/simulated/wall,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"wJm" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
+"wJF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/toy/figure/crew,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "wJQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -82063,7 +82097,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
+"xde" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/maintenance/asmaint)
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82138,9 +82176,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/fpmaint)
 "xvi" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82156,11 +82192,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"xwb" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "xxe" = (
 /obj/effect/landmark/spawner/xeno,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/asmaint)
 "xxA" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -82198,6 +82240,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"xEH" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 18;
+	id = "emergency_home";
+	name = "emergency evac bay";
+	width = 29
+	},
+/turf/space,
+/area/space)
 "xFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82218,6 +82271,17 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"xIp" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "xJn" = (
 /obj/structure/rack,
 /obj/item/storage/box/bodybags,
@@ -82348,6 +82412,10 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"ycW" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "yeW" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -82359,7 +82427,7 @@
 /area/hallway/primary/port)
 "ygK" = (
 /obj/structure/chair/stool{
-	pixel_y = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82402,7 +82470,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
+"ykv" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "ykV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82414,6 +82486,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 
@@ -94842,15 +94915,15 @@ arA
 aaa
 aaa
 abq
-apf
-apd
+aAg
+aIJ
 uKm
 abq
 aaa
 abq
-apf
-apf
-apf
+aAg
+aAg
+aAg
 aHk
 aPr
 aLB
@@ -94889,10 +94962,10 @@ kmF
 aWD
 bCx
 dfZ
-apf
-apf
-apf
-apf
+aAg
+aAg
+aAg
+aAg
 aaa
 aaa
 aaa
@@ -95099,12 +95172,12 @@ aaa
 aaa
 abq
 abq
-apf
+aAg
 aDi
-apf
+aAg
 abq
 abq
-apf
+aAg
 aAg
 aHm
 auJ
@@ -95149,7 +95222,7 @@ bLC
 bLD
 nbG
 bXH
-apf
+aAg
 abq
 abq
 abq
@@ -95355,9 +95428,9 @@ abq
 abq
 aaa
 abq
-apf
-apf
-apd
+aAg
+aAg
+aIJ
 auE
 aAA
 alL
@@ -95403,10 +95476,10 @@ uWq
 uWq
 bBv
 dgb
-apf
+aAg
 auJ
 eYE
-apf
+aAg
 aaa
 aaa
 abq
@@ -95609,10 +95682,10 @@ aaa
 aaa
 aaa
 abq
-apf
-apf
+aAg
+aAg
 alL
-apf
+aAg
 azi
 aIU
 aAP
@@ -95660,10 +95733,10 @@ bOf
 ahq
 bRy
 bTm
-apf
+aAg
 bLK
 dgu
-apf
+aAg
 bZP
 bZS
 bZS
@@ -95866,27 +95939,27 @@ aaa
 aaa
 aaa
 abq
-apf
+aAg
 awE
 avQ
 avW
 pHQ
-atk
-atk
-atk
-atk
+ijy
+ijy
+ijy
+ijy
 ijy
 fZo
-fZo
-fZo
-fZo
+nxy
+nxy
+nxy
 bab
-fZo
-fZo
-fZo
-fZo
+nxy
+nxy
+nxy
+nxy
 qob
-fZo
+nxy
 ceT
 vHW
 aYm
@@ -95908,16 +95981,16 @@ bky
 bAE
 bBy
 bDu
-apf
-apf
-apf
-apf
-apf
-apf
+aAg
+aAg
+aAg
+aAg
+aAg
+aAg
 bjE
-apf
-apf
-apf
+aAg
+aAg
+aAg
 aoX
 rvu
 bWm
@@ -96126,28 +96199,28 @@ aaa
 alL
 auC
 avS
-apf
-apf
-apf
-apd
+aAg
+aAg
+bwI
+jcf
 arI
-apd
-apd
-apd
-apd
 aIJ
-apd
+aIJ
+gqF
+aIJ
+aIJ
+aIJ
+jnz
 cgo
-cgo
-apd
-apd
-apd
-apd
-apd
-apd
-apd
+aIJ
+aIJ
+aIJ
+klt
+aqB
+aIJ
+aIJ
 aYb
-apf
+aAg
 bdQ
 bgh
 bdX
@@ -96173,7 +96246,7 @@ bjE
 bgY
 bQy
 bgY
-bgY
+qQW
 cJU
 cJU
 rGT
@@ -96380,34 +96453,34 @@ aaa
 aaa
 aaa
 aaa
-apf
-apf
+aAg
+aAg
 awW
-apf
+aAg
 abq
-apf
-apf
+aAg
+aAg
 alL
-apf
-apf
+bwI
+aAg
 alL
-apf
-apf
-apf
-apf
+aAg
+aAg
+aAg
+aAg
 alL
-apf
-apf
-apf
-apf
-apf
-apf
+aAg
+aAg
+aAg
+aAg
+aAg
+aAg
 alL
-apf
-apf
-apf
-apf
-apf
+aAg
+aAg
+aAg
+aAg
+aAg
 bfj
 bgX
 bgX
@@ -96422,15 +96495,15 @@ bxL
 btm
 btm
 bFJ
-apf
+aAg
 cdn
 aEj
 bKy
-apf
+aAg
 oCE
-apd
+aIJ
 ayB
-auy
+dhe
 auC
 bRD
 cgo
@@ -96664,7 +96737,7 @@ abq
 abq
 aaa
 aaa
-apf
+aAg
 bgA
 bgX
 biv
@@ -96679,16 +96752,16 @@ bfG
 bfG
 bDC
 bDC
-apf
+aAg
 bHd
 aUu
 anE
-apf
+aAg
 aqB
-apd
+aIJ
 bFX
-apd
-apd
+aIJ
+aIJ
 bWi
 cgo
 dgu
@@ -96896,7 +96969,7 @@ aaa
 aaa
 aaa
 aus
-apd
+aIJ
 axk
 abq
 aaa
@@ -96921,7 +96994,7 @@ aaa
 aaa
 aaa
 aaa
-apf
+aAg
 cEg
 bgX
 biw
@@ -96947,13 +97020,13 @@ bFp
 bFp
 bFp
 bFp
-apd
+aIJ
 rvu
-apf
-apd
+aAg
+aIJ
 cgo
 cdF
-apf
+aAg
 abq
 aaa
 abq
@@ -97153,7 +97226,7 @@ aaa
 aaa
 abq
 aus
-apd
+caJ
 axk
 abq
 aaa
@@ -97178,7 +97251,7 @@ aaa
 aaa
 aaa
 abq
-apf
+aAg
 cEg
 bgX
 bix
@@ -97209,8 +97282,8 @@ cQS
 bXK
 cdD
 arU
-apd
-apf
+aIJ
+aAg
 aaa
 aaa
 cmi
@@ -97410,7 +97483,7 @@ aaa
 abq
 abq
 aus
-apd
+caJ
 axk
 abq
 aaa
@@ -97461,13 +97534,13 @@ bRB
 bTn
 bUD
 bFp
-apd
+aIJ
 rvu
 auE
 bWk
 bFX
 bYT
-apf
+aAg
 aaa
 aaa
 cmi
@@ -97667,7 +97740,7 @@ aaa
 aaa
 abq
 aus
-apd
+caJ
 axk
 abq
 aaa
@@ -97718,13 +97791,13 @@ bHf
 bHf
 bUE
 bFp
-apd
+aIJ
 eYE
-apf
-apf
+aAg
+aAg
 auE
-apf
-apf
+aAg
+aAg
 cmi
 cmi
 cmi
@@ -97924,7 +97997,7 @@ aaa
 abq
 abq
 aus
-apd
+aIJ
 axk
 abq
 aaa
@@ -97977,9 +98050,9 @@ bHf
 bWj
 bYx
 vmT
-apd
-apd
-apd
+chy
+chy
+chy
 ckw
 cwt
 chy
@@ -98206,7 +98279,7 @@ aaa
 aaa
 aaa
 abq
-apf
+aAg
 avU
 bgX
 bgX
@@ -98232,9 +98305,9 @@ bHf
 bTn
 bUE
 bFp
-apd
+aIJ
 bYW
-caJ
+ceN
 ceN
 ceN
 ykV
@@ -98436,10 +98509,10 @@ abq
 abq
 abq
 abq
-apf
-apf
+aAg
+aAg
 axe
-apf
+aAg
 abq
 aaa
 abq
@@ -98463,7 +98536,7 @@ aaa
 aaa
 aaa
 abq
-apf
+aAg
 cHr
 bgY
 bgY
@@ -98489,7 +98562,7 @@ bRC
 bTo
 bUF
 bFp
-apd
+aIJ
 cEg
 bZU
 bZU
@@ -98696,7 +98769,7 @@ aaa
 alL
 aAZ
 awf
-apf
+aAg
 abq
 aaa
 abq
@@ -98720,7 +98793,7 @@ abq
 abq
 abq
 abq
-apf
+aAg
 bgB
 azQ
 biC
@@ -98746,7 +98819,7 @@ bFp
 bFp
 bFp
 bFp
-apd
+anE
 hgW
 bZU
 cbs
@@ -98953,7 +99026,7 @@ akt
 akt
 awE
 awe
-apf
+aAg
 abq
 abq
 abq
@@ -99002,9 +99075,9 @@ bBK
 bVR
 bTp
 bUG
-apf
+aAg
 bRD
-cEg
+jCP
 bZU
 cem
 dfi
@@ -99208,12 +99281,12 @@ aoU
 aqr
 arD
 akt
-apf
+aAg
 avW
-apf
-apf
-apf
-apf
+aAg
+aAg
+aAg
+aAg
 aCs
 aFE
 aEM
@@ -99258,9 +99331,9 @@ bOl
 bBK
 bRE
 arJ
-apd
-apf
-cgo
+aIJ
+aAg
+wJF
 avU
 cTa
 cbu
@@ -99269,7 +99342,7 @@ chy
 ceZ
 cfb
 nTF
-bZU
+tUN
 cuV
 ebA
 bZU
@@ -99469,7 +99542,7 @@ auw
 awK
 xuA
 aqB
-apf
+aAg
 aAU
 aCs
 aDv
@@ -99515,9 +99588,9 @@ cBE
 bBK
 bRF
 arU
-apd
+aIJ
 auE
-cgo
+wJF
 avU
 cTa
 ceu
@@ -99526,7 +99599,7 @@ cak
 bgZ
 bZU
 bZU
-bZU
+tUN
 cuV
 dhr
 cod
@@ -99535,7 +99608,7 @@ cod
 cod
 cod
 cod
-cod
+mCb
 cym
 cym
 cAw
@@ -99547,10 +99620,10 @@ cGg
 cJR
 cuV
 cuV
-chy
+euN
 mCS
 chy
-chy
+hSw
 bZU
 abq
 cFv
@@ -99771,10 +99844,10 @@ cgp
 bIU
 bBK
 bRG
-apd
+aIJ
 bib
-apf
-apd
+aAg
+aIJ
 cEg
 cTa
 cbw
@@ -99790,8 +99863,8 @@ chy
 cFQ
 cLU
 crF
-cuV
-cuV
+gKj
+gKj
 chy
 chy
 chy
@@ -99804,7 +99877,7 @@ cIb
 cDT
 ckJ
 ckJ
-tXl
+ftF
 tXl
 ckJ
 cJR
@@ -99982,8 +100055,8 @@ aug
 aoX
 axn
 axn
-apd
-apd
+aIJ
+aIJ
 azO
 aCt
 aDx
@@ -100028,7 +100101,7 @@ bBK
 bOm
 bBK
 bRH
-apd
+aIJ
 auI
 bXK
 bYx
@@ -100041,7 +100114,7 @@ clG
 cJR
 chy
 bZU
-chy
+eIf
 srJ
 coC
 coC
@@ -100230,8 +100303,8 @@ abq
 aaa
 akI
 ajy
-alr
-tvx
+ano
+aIu
 aoV
 aqs
 arG
@@ -100286,20 +100359,20 @@ bPc
 bBK
 bRI
 bRH
-bVR
-apf
+gVs
+aAg
 aDi
 cEg
-apf
-auC
-apf
+bZU
+cfZ
+bZU
 bZU
 cfV
 cjr
 chy
 cTa
-chy
-bgZ
+coD
+tmA
 coC
 cpU
 crG
@@ -100531,25 +100604,25 @@ bfw
 btz
 bVW
 bxX
-apf
+aAg
 arK
 bGb
 bBK
 bBK
+oQF
 bBK
 bBK
 bBK
 bBK
-bBK
-apf
+aAg
 auE
 auE
-apf
-apd
+aAg
+gAv
 cEg
 cgH
-apd
-apd
+chy
+chy
 bZU
 cfW
 cjr
@@ -100579,7 +100652,7 @@ cGo
 cMV
 cEY
 hLt
-bZU
+tUN
 abq
 cHZ
 cHZ
@@ -100750,9 +100823,9 @@ akt
 akt
 akt
 akt
-apf
+aAg
 axn
-apd
+aIJ
 aoX
 aoX
 aOx
@@ -100804,9 +100877,9 @@ bgY
 bgY
 bgY
 bZR
-cgH
-apd
-cgo
+jfg
+chy
+cuV
 cTa
 idx
 dgG
@@ -100836,7 +100909,7 @@ cLi
 cNc
 cEY
 hLt
-bZU
+tUN
 aaa
 aaa
 aaa
@@ -101005,7 +101078,7 @@ ajB
 anC
 aoX
 amu
-apd
+aIJ
 aoX
 aEU
 aHv
@@ -101045,10 +101118,10 @@ bfw
 btA
 bvL
 bxZ
-apf
+aAg
 bBN
-apd
-apd
+aIJ
+aIJ
 bHp
 cgm
 cgo
@@ -101057,19 +101130,19 @@ cgo
 cgo
 auC
 bTr
-apd
-apd
+aIJ
+aIJ
 cgm
 isf
-apf
+bZU
 sJG
-cgo
+cuV
 cTa
 bZU
 bZU
 bZU
 cTa
-chy
+cuV
 bgZ
 coC
 cpV
@@ -101093,7 +101166,7 @@ dxa
 cKL
 cEY
 ube
-bZU
+tFd
 abq
 aaa
 cFv
@@ -101320,13 +101393,13 @@ bzK
 bzK
 bzK
 bzK
-cgo
+cuV
 chy
 chy
 cmi
 chy
-chy
-chy
+cuV
+cuV
 bgZ
 coC
 cpY
@@ -101519,7 +101592,7 @@ apH
 anE
 awe
 bFX
-apd
+aIJ
 aoZ
 gqF
 awZ
@@ -101579,10 +101652,10 @@ bFw
 bzK
 cho
 tXl
-ckJ
+tXl
 rBE
-ckJ
-ckJ
+tXl
+tXl
 ckJ
 iic
 coC
@@ -101778,7 +101851,7 @@ bXK
 aky
 auE
 atf
-apf
+aAg
 ajg
 axr
 ayH
@@ -101834,9 +101907,9 @@ jrE
 bZc
 bZZ
 bzK
-jcf
+ube
 chy
-chy
+cuV
 cmi
 cem
 ciK
@@ -101878,13 +101951,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 cSO
 dfv
 dfv
 dfv
-dfv
+uzB
 cSO
-dfv
 cSO
 cSO
 aaa
@@ -102035,14 +102108,14 @@ auq
 atH
 arI
 apb
-apf
+aAg
 axv
 axs
 alW
 aMc
 caj
-aCu
-aCu
+peo
+peo
 aCu
 aCu
 aCu
@@ -102050,9 +102123,9 @@ aCu
 aCu
 aNa
 hDK
-apf
+aAg
 aPR
-apf
+aAg
 aLK
 aTW
 aLK
@@ -102091,7 +102164,7 @@ bXN
 cgv
 caa
 bzK
-avU
+bgZ
 chx
 bZU
 bZU
@@ -102290,9 +102363,9 @@ alz
 cgU
 auB
 aqy
-apd
+aMN
 atg
-apf
+aAg
 alW
 axt
 aAY
@@ -102309,7 +102382,7 @@ aMH
 aOf
 aOy
 bwq
-apf
+aAg
 aSI
 aTX
 aXt
@@ -102348,7 +102421,7 @@ ehr
 bZe
 cab
 bzK
-avU
+bgZ
 bRD
 bZU
 cfZ
@@ -102545,11 +102618,11 @@ abq
 aky
 aly
 amv
-apd
+aIJ
 aqz
 cgo
 bbj
-apf
+bwI
 alW
 axy
 ajg
@@ -102564,9 +102637,9 @@ ajg
 ajg
 aME
 aNX
-apf
+aAg
 avU
-apf
+aAg
 aWh
 aTY
 aVn
@@ -102605,7 +102678,7 @@ esf
 bHr
 bHr
 bzK
-avU
+bgZ
 auy
 cTa
 cga
@@ -102634,7 +102707,7 @@ cFd
 cwj
 cNJ
 cPy
-bgZ
+xIp
 cuV
 chy
 cHZ
@@ -102804,9 +102877,9 @@ aky
 anI
 aph
 aqA
-apd
+aIJ
 ksz
-auE
+bxG
 caj
 axy
 ajg
@@ -102821,9 +102894,9 @@ aaa
 aKj
 aNa
 hDK
-apf
+aAg
 bik
-apf
+aAg
 aSK
 aTZ
 aVo
@@ -102862,7 +102935,7 @@ dDw
 bZf
 tNG
 bzK
-cEg
+hLt
 ayB
 cTa
 cgb
@@ -103078,9 +103151,9 @@ abq
 aGy
 aLV
 aRB
-apf
+aAg
 cEg
-apf
+aAg
 bZa
 aWt
 aXB
@@ -103119,7 +103192,7 @@ bYv
 bZg
 cac
 bzK
-avU
+bgZ
 auC
 bZU
 chB
@@ -103317,10 +103390,10 @@ abq
 abq
 abq
 abq
-apf
+aAg
 aAA
 auE
-apf
+aAg
 alW
 axx
 axT
@@ -103335,18 +103408,18 @@ aaa
 aHj
 aLW
 aNe
-apf
+aAg
 cEg
-apf
-apf
-apf
-apf
-apf
-apf
-apf
-apf
-apf
-apf
+aAg
+aAg
+aAg
+aAg
+aAg
+aAg
+aAg
+aAg
+aAg
+aAg
 bjg
 bhl
 bhl
@@ -103376,7 +103449,7 @@ bzK
 bzK
 cad
 bzK
-avU
+bgZ
 cdT
 cdT
 ceQ
@@ -103573,11 +103646,11 @@ aaa
 aaa
 abq
 aaa
-apf
-apf
+aAg
+aAg
 arK
 ajS
-apf
+aAg
 caj
 axy
 axQ
@@ -103603,7 +103676,7 @@ aYX
 axq
 axq
 azB
-apf
+aAg
 bfD
 bhl
 bhl
@@ -103830,11 +103903,11 @@ aaa
 aaa
 abq
 aaa
-apf
+aAg
 aqB
 arU
 atj
-apf
+aAg
 axz
 axy
 axQ
@@ -103888,8 +103961,8 @@ bUK
 bWx
 bXR
 bzK
-ayB
-apd
+cjn
+chy
 bqQ
 cdT
 chT
@@ -104089,7 +104162,7 @@ abq
 abq
 alL
 aqC
-apd
+aIJ
 auI
 bXK
 awg
@@ -104117,7 +104190,7 @@ aYq
 bbV
 aOA
 bgB
-apf
+aAg
 ceY
 bhn
 biT
@@ -104145,8 +104218,8 @@ bzK
 bXL
 bXS
 bzK
-apf
-apf
+bZU
+bZU
 ccC
 cdT
 cfs
@@ -104344,9 +104417,9 @@ aaa
 aaa
 abq
 aaa
-apf
+aAg
 anE
-apd
+aIJ
 ajg
 ajg
 ajg
@@ -104374,7 +104447,7 @@ aRV
 aZC
 aOA
 bcH
-apf
+aAg
 bfG
 bfG
 aAM
@@ -104455,7 +104528,7 @@ mzY
 cSO
 cSO
 cSO
-aMN
+aaa
 abq
 abq
 aaa
@@ -104601,7 +104674,7 @@ aaa
 aaa
 abq
 aaa
-apf
+aAg
 ajg
 ajg
 ajg
@@ -109595,7 +109668,7 @@ wqP
 cZp
 slt
 cZp
-aaa
+xEH
 aaa
 aaa
 aaa
@@ -110353,7 +110426,7 @@ coG
 cIx
 cIx
 cRC
-bZU
+cJX
 deo
 cLS
 cUC
@@ -110610,7 +110683,7 @@ cOR
 cPQ
 cIx
 cSY
-bZU
+cJX
 cUO
 cTT
 cUD
@@ -110866,8 +110939,8 @@ cQk
 cOS
 cpR
 cIx
-coe
-bZU
+jZg
+cJX
 cUG
 nxh
 cUE
@@ -111123,8 +111196,8 @@ pzX
 cOT
 cPS
 cIx
-coe
-bZU
+jZg
+cJX
 cTh
 cTU
 deQ
@@ -111380,8 +111453,8 @@ cQv
 cPR
 cSx
 cIx
-coe
-bZU
+jZg
+cJX
 cTi
 cWo
 cXB
@@ -111638,11 +111711,11 @@ cOX
 cPW
 cSs
 hCZ
-cTa
-bZU
-bZU
+xde
+cJX
+cJX
 qbl
-bZU
+cJX
 abq
 abq
 aaa
@@ -111896,9 +111969,9 @@ cPV
 cIx
 oaH
 iTR
-chy
-mCS
-chy
+vZo
+mLm
+vZo
 aef
 aef
 abq
@@ -112153,9 +112226,9 @@ ikO
 cQP
 cXx
 cTN
-bZU
-bZU
-bZU
+cJX
+cJX
+cJX
 abq
 abq
 abq
@@ -112315,7 +112388,7 @@ akD
 avj
 awI
 akD
-aFg
+bHE
 aGE
 aKc
 aBn
@@ -112407,10 +112480,10 @@ cNY
 cOV
 cPo
 cQO
-crU
+cIx
 pQx
 qFg
-bZU
+cJX
 abq
 abq
 aaa
@@ -112664,10 +112737,10 @@ ckz
 cOe
 clC
 cIx
-crU
+cIx
 cRH
-bZU
-bZU
+cJX
+cJX
 aaa
 abq
 aaa
@@ -112887,13 +112960,13 @@ nza
 beo
 acw
 bbg
-bZU
-bZU
-bZU
-bZU
-bZU
-bZU
-crU
+aoG
+aoG
+aoG
+aoG
+aoG
+aoG
+axh
 bVk
 cqB
 crO
@@ -113144,13 +113217,13 @@ pyX
 vNb
 bdb
 bbi
-bZU
+aoG
 cfE
 bVZ
 bXC
 bXE
 bXG
-crU
+axh
 cmz
 cmz
 cmz
@@ -113401,11 +113474,11 @@ caM
 bek
 bdb
 bbi
-bZU
+aoG
 bVI
 ckP
 bXD
-chy
+asJ
 bYq
 bWl
 bVl
@@ -113658,15 +113731,15 @@ cbj
 bek
 bfJ
 cej
-bZU
+aoG
 bVX
 bWa
-chy
-chy
+asJ
+asJ
 bYQ
-bZU
-chy
-cuV
+aoG
+asJ
+aEx
 crS
 cta
 cic
@@ -113694,8 +113767,8 @@ cPc
 cPc
 cOp
 cSt
-bZU
-bZU
+cJX
+cJX
 aaa
 abq
 aaa
@@ -113915,16 +113988,16 @@ bbr
 bel
 cdE
 bZu
-bZU
-bZU
+aoG
+aoG
 bWl
 bUR
 bWl
 bWl
-bZU
+aoG
 ntm
 cqp
-crU
+axh
 cmz
 cvX
 ptn
@@ -113950,9 +114023,9 @@ cOj
 cPd
 cPZ
 cOp
-bgZ
+wJm
 cvY
-cmi
+bKH
 aaa
 aaa
 aaa
@@ -114172,16 +114245,16 @@ bNp
 bek
 bqR
 cek
-bwI
+buH
 bwP
-bHE
-bHE
-dhq
-cjl
-cjl
+lUo
+lUo
+bwR
+caV
+caV
 bVr
 cqq
-cNZ
+dxZ
 ctb
 cur
 cvC
@@ -114208,8 +114281,8 @@ cPe
 cQa
 cOp
 ljT
-cwt
-cmi
+hKe
+bKH
 aaa
 aaa
 aaa
@@ -114433,11 +114506,11 @@ bZu
 bZu
 bZu
 bZu
-bgZ
-bZO
+azy
+qAm
 cqo
-cfY
-cMY
+hWr
+gSb
 ctE
 cmz
 cus
@@ -114464,9 +114537,9 @@ cOl
 cPf
 dcd
 cOp
-bgZ
-cuV
-cmi
+wJm
+cOt
+bKH
 aaa
 aaa
 aaa
@@ -114690,7 +114763,7 @@ cfG
 cgM
 cio
 bZu
-bgZ
+azy
 cmz
 cmz
 cmz
@@ -114721,13 +114794,13 @@ cJL
 cPg
 cKN
 cOp
-bgZ
-bZU
-bZU
-bZU
-bZU
-bZU
-bZU
+wJm
+cJX
+cJX
+cJX
+cJX
+cJX
+cJX
 aaa
 cNz
 cJg
@@ -114899,7 +114972,7 @@ alW
 alW
 alW
 alW
-alW
+tfe
 ajg
 aQz
 aQC
@@ -114978,13 +115051,13 @@ cOn
 cPh
 cQd
 cOp
-bgZ
-bZU
+wJm
+cJX
 cVe
-chy
-chy
+vZo
+vZo
 cYm
-bZU
+cJX
 aaa
 cNz
 cJg
@@ -115204,7 +115277,7 @@ cfB
 cgO
 ciq
 bZu
-hLt
+bwO
 cmz
 cnG
 coS
@@ -115235,13 +115308,13 @@ cOo
 cQq
 cQe
 cOp
-bgZ
-cTa
+wJm
+xde
 cVj
-cuV
-cuV
+cOt
+cOt
 cZJ
-bZU
+cJX
 aaa
 cNz
 cJg
@@ -115461,7 +115534,7 @@ baj
 cgP
 baj
 bZv
-bgZ
+azy
 cmz
 cny
 cnI
@@ -115492,13 +115565,13 @@ cOp
 cOp
 cOp
 cOp
-bgZ
-cPT
+wJm
+agK
 cVg
-cuV
-chy
+cOt
+vZo
 cYw
-bZU
+cJX
 aaa
 cNz
 jhQ
@@ -115659,7 +115732,7 @@ auD
 avn
 caj
 caj
-alW
+cmZ
 caj
 caj
 alW
@@ -115718,7 +115791,7 @@ cfC
 cgQ
 ciZ
 bZv
-cmZ
+bec
 cmA
 cnI
 coU
@@ -115748,14 +115821,14 @@ cEK
 cln
 clN
 crq
-chy
-bgZ
-cPT
-cPT
+vZo
+wJm
+agK
+agK
 cmy
 lif
-bZU
-bZU
+cJX
+cJX
 aaa
 cNz
 cNz
@@ -115916,8 +115989,8 @@ alW
 alW
 alW
 ayE
-caj
-caj
+cYg
+dhq
 aFP
 alW
 alW
@@ -115932,7 +116005,7 @@ aOZ
 aQC
 aQC
 aTo
-ygK
+gZc
 aVQ
 aTo
 cuE
@@ -116007,12 +116080,12 @@ dVw
 cxT
 cRP
 clT
-cPT
+agK
 cVo
-cuV
+cOt
 cUK
 cZN
-bZU
+cJX
 aaa
 aaa
 aaa
@@ -116232,7 +116305,7 @@ uzt
 cgS
 cjf
 bZv
-bgZ
+azy
 cmB
 cmB
 cmB
@@ -116260,16 +116333,16 @@ cNy
 cPm
 cEK
 cOs
-hLt
-chy
-chy
-ckw
-bZU
+tVk
+vZo
+vZo
+tfq
+cJX
 cVq
 dhG
-cuV
+cOt
 cZY
-bZU
+cJX
 aaa
 aaa
 aaa
@@ -116489,7 +116562,7 @@ cdh
 cgT
 cjf
 bZv
-hLt
+bwO
 cmB
 cnK
 cnK
@@ -116517,16 +116590,16 @@ cEK
 cEK
 cEK
 cOt
-hLt
-bZU
+tVk
+cJX
 bZO
-cTa
-bZU
+xde
+cJX
 cVp
-chy
+vZo
 cUL
 cYw
-bZU
+cJX
 aaa
 aaa
 aaa
@@ -116746,7 +116819,7 @@ cdh
 bYA
 chm
 bZv
-hLt
+sPZ
 cmB
 cnK
 coW
@@ -116770,20 +116843,20 @@ cHO
 cEK
 cEK
 crU
-cdN
-cjn
+hHQ
+irN
 oBI
 jaV
 eKz
 bZO
 cQU
 cTo
-bZU
-bZU
-ckD
-bZU
-bZU
-bZU
+cJX
+cJX
+wIs
+cJX
+cJX
+cJX
 aaa
 aaa
 aaa
@@ -117003,7 +117076,7 @@ cde
 edg
 cjf
 bZv
-bgZ
+bwO
 cmB
 cnK
 cnK
@@ -117020,25 +117093,25 @@ crU
 crU
 crU
 crU
-cfZ
-bZU
+ycW
+cJX
 cHP
 cIM
 cKt
-bZU
+cJX
 cKG
 cLB
-chy
+vZo
 kmv
-bZU
+cJX
 fOU
 cQI
-cuV
-cuV
-cdO
-ceE
+cOt
+cOt
+kgn
+cQE
 cWq
-cmi
+bKH
 aaa
 aaa
 aaa
@@ -117216,7 +117289,7 @@ aBI
 aBI
 aVr
 aQC
-bxG
+bxs
 jCi
 aVV
 aTo
@@ -117260,7 +117333,7 @@ cfD
 bYC
 cjZ
 bZv
-bgZ
+azy
 cmB
 cnL
 coY
@@ -117275,7 +117348,7 @@ cmB
 cfY
 cvW
 dhw
-bZU
+cJX
 cAc
 dhE
 cFG
@@ -117284,12 +117357,12 @@ cHM
 cIL
 hLW
 ceD
-ceN
-ceN
+pmm
+pmm
 mBa
-cTa
+xde
 fOU
-bZU
+cJX
 cQW
 cQW
 cQW
@@ -117517,7 +117590,7 @@ cdh
 bYB
 cjf
 bZv
-bgZ
+azy
 cmB
 cnM
 cnK
@@ -117529,24 +117602,24 @@ eiF
 cha
 cyO
 cmB
-clP
+ykv
 cDX
-bZU
-cTa
-dVK
+cJX
+xde
+gji
 nHr
-bZU
+cJX
 cHQ
 cJd
 cKu
-bZU
+cJX
 fcP
-cuV
-chy
-chy
+cOt
+vZo
+vZo
 cmY
 eif
-chy
+vZo
 cQW
 cRQ
 cUd
@@ -117774,7 +117847,7 @@ cdh
 bYB
 ckS
 bZv
-bgZ
+azy
 cmB
 cnN
 cnK
@@ -117786,11 +117859,11 @@ clS
 cha
 cyS
 cmB
-cTa
+xde
 cfU
-bZU
-chy
-dVK
+cJX
+vZo
+gji
 iob
 cFH
 cFH
@@ -117800,9 +117873,9 @@ cFH
 cFH
 cLC
 cMx
-bZU
+cJX
 cOw
-clG
+iYX
 cQL
 cQX
 cTp
@@ -118031,7 +118104,7 @@ imQ
 gaa
 cku
 bZv
-hLt
+bwO
 cmB
 cnK
 cnK
@@ -118044,21 +118117,21 @@ cyb
 cyR
 cmB
 cAc
-chP
-ceN
-ceN
+uDw
+pmm
+pmm
 cFc
-bZU
+cJX
 cFH
 cJo
 cJe
 cJi
 cJx
 cFH
-bZU
-bZU
-bZU
-cOx
+cJX
+cJX
+cJX
+qsk
 cQF
 cQl
 cSQ
@@ -118288,7 +118361,7 @@ cfM
 cgl
 cll
 bZv
-bgZ
+bwO
 cmB
 cmB
 cmB
@@ -118300,12 +118373,12 @@ csz
 cmB
 cmB
 cmB
-dVK
-ckD
-cqp
-bZU
-bZU
-bZU
+gji
+wIs
+wsN
+cJX
+cJX
+cJX
 bGQ
 cHS
 cJu
@@ -118314,9 +118387,9 @@ cMr
 cFH
 abq
 abq
-bZU
-bZU
-bgZ
+cJX
+cJX
+wJm
 pMx
 cQW
 cQW
@@ -118546,22 +118619,22 @@ cgd
 bZv
 bZv
 cnO
-ckJ
-ckJ
-ckJ
-ckJ
+aQS
+aGW
+tTL
+nCf
 csg
-chP
-chP
+uDw
+uDw
 cxe
-ceN
-chP
-chP
+pmm
+uDw
+hNf
 cAd
-chy
+vZo
 cEB
 cDa
-chy
+vZo
 cEM
 cEN
 cHS
@@ -118572,9 +118645,9 @@ cFH
 abq
 aaa
 abq
-bZU
-srJ
-bZU
+cJX
+uga
+cJX
 aaa
 abq
 aaa
@@ -118803,23 +118876,23 @@ bZC
 chr
 bZv
 azy
-asJ
+aEx
 asJ
 bcj
-cwt
-csh
-chy
-kIq
-chy
-chy
-chy
-chy
-chy
-cuV
+hKe
+ixD
+vZo
+gyU
+cOt
+vZo
+rzL
+rkT
+vZo
+cOt
 wXT
-bZU
-cFe
-bZU
+cJX
+xwb
+cJX
 cFK
 xtA
 cJw
@@ -118829,9 +118902,9 @@ cFH
 abq
 aaa
 abq
-bZU
-bgZ
-bZU
+cJX
+wJm
+cJX
 aaa
 abq
 abq
@@ -119060,23 +119133,23 @@ bZB
 cgV
 bZv
 azy
-asJ
+aEx
 arr
 aoG
-bZU
+cJX
 ctl
-bZU
-bZU
-bZU
-bZU
-cTa
-bZU
-bZU
-cmi
-bZU
+cJX
+kiY
+kiY
+cJX
+xde
+cJX
+cJX
+bKH
+cJX
 iDw
 cDM
-bZU
+cJX
 cFJ
 cJv
 cKw
@@ -119323,16 +119396,16 @@ bYG
 crR
 csj
 cwF
-bZU
+cJX
 cyT
 phf
 cyT
-cPT
+agK
 abq
 abq
-bZU
-bZU
-cFe
+cJX
+cJX
+xwb
 pMx
 cFM
 cBN
@@ -119582,15 +119655,15 @@ gzu
 oeY
 aur
 pes
-chy
+vZo
 rnT
-bZU
+cJX
 qyO
 fnT
-bZU
-bZU
-lFQ
-bZU
+cJX
+cJX
+rKx
+cJX
 abq
 abq
 abq
@@ -119822,8 +119895,8 @@ bVB
 bXp
 bEG
 xLf
-asJ
-aoG
+aEx
+fzX
 aoG
 aoG
 mXN
@@ -119834,20 +119907,20 @@ cnQ
 aEE
 coN
 aoG
-bZU
-bZU
-bZU
-bZU
+cJX
+cJX
+cJX
+cJX
 rHl
 eMr
-bZU
-bZU
+cJX
+cJX
 qRj
 mOB
-bZU
-hLL
+cJX
+tlF
 vZo
-hLL
+tlF
 abq
 aaa
 abq
@@ -120079,7 +120152,7 @@ bnc
 bXq
 bEG
 caI
-asJ
+aEx
 bdl
 wWO
 bYG
@@ -120098,7 +120171,7 @@ cuG
 cji
 xxe
 cye
-bZU
+cJX
 tlF
 tlF
 tlF
@@ -120336,11 +120409,11 @@ bVD
 bXr
 bEG
 azy
-asJ
+aEx
 bdl
 asJ
 pne
-azy
+bwO
 cis
 buC
 cmx
@@ -120349,13 +120422,13 @@ asJ
 coQ
 buC
 cqF
-chy
-cdK
+vZo
+egT
 jtr
-csh
+ixD
 cuH
 cyf
-bZU
+cJX
 aaa
 abq
 aaa
@@ -120593,11 +120666,11 @@ bVE
 bEG
 bEG
 azy
-asJ
+aEx
 bdl
 iKX
 qAm
-azy
+bwO
 cir
 buC
 clR
@@ -120606,13 +120679,13 @@ asJ
 coO
 buC
 cqE
-chy
-chy
+vZo
+vZo
 sEQ
 pru
-chy
+vZo
 cyg
-cmi
+bKH
 aaa
 abq
 aaa
@@ -120813,7 +120886,7 @@ bac
 aoG
 aoG
 bbG
-aoG
+oTn
 bbG
 aoG
 aoG
@@ -120850,11 +120923,11 @@ bWT
 bNF
 aGW
 ofz
-asJ
+aEx
 aoG
 aoG
 aoG
-azy
+bwO
 cfK
 cfK
 cfK
@@ -120864,12 +120937,12 @@ cfK
 cfK
 cqH
 nZf
-chy
+vZo
 cuH
 uBl
-chy
+vZo
 cyg
-bZU
+cJX
 aaa
 abq
 aaa
@@ -121061,8 +121134,8 @@ aEy
 gip
 aEx
 aLp
-aoG
-aoG
+fzX
+fzX
 aLp
 asJ
 asJ
@@ -121110,8 +121183,8 @@ tbK
 lUo
 lmY
 bwE
-asJ
-azy
+aEx
+bwO
 cfK
 ciD
 cka
@@ -121126,7 +121199,7 @@ cuI
 cwI
 cxj
 cyh
-bZU
+cJX
 aaa
 abq
 aaa
@@ -121331,7 +121404,7 @@ aQS
 aQS
 aGW
 aGW
-aGW
+erh
 aGW
 ofz
 asJ
@@ -121358,8 +121431,8 @@ bLO
 bkj
 bFh
 axh
-axh
-axh
+dxo
+jPw
 brR
 axh
 bYG
@@ -121376,14 +121449,14 @@ cly
 cmF
 cnJ
 cfK
-bZU
-bZU
-bZU
-cmi
-bZU
-cmi
-bZU
-bZU
+cJX
+cJX
+cJX
+bKH
+cJX
+bKH
+cJX
+cJX
 abq
 abq
 abq
@@ -123915,7 +123988,7 @@ aWw
 deM
 dhn
 dhF
-gkU
+dXP
 bxn
 bjN
 bjN
@@ -126189,7 +126262,7 @@ aaa
 abq
 aaa
 aaa
-ano
+aaa
 apg
 ans
 ans
@@ -126221,7 +126294,7 @@ aKT
 tgE
 pUc
 kKa
-cYg
+aaa
 aaa
 aaa
 aaa
@@ -126444,7 +126517,7 @@ abq
 aaa
 aaa
 abq
-ano
+aaa
 apg
 apg
 gRw
@@ -126478,7 +126551,7 @@ aKT
 bfz
 pUc
 rYj
-cYg
+aaa
 aaa
 aaa
 aaa
@@ -126958,7 +127031,7 @@ abq
 aaa
 aaa
 abq
-ano
+aaa
 apg
 apg
 apg
@@ -127258,7 +127331,7 @@ aaa
 wAP
 bwF
 bsN
-peo
+cmL
 cmL
 cmL
 cmL
@@ -129025,7 +129098,7 @@ aaa
 abq
 aef
 aCj
-aIu
+abq
 abd
 abd
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4748,6 +4748,12 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/armoury)
+"alV" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "alW" = (
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -6939,12 +6945,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"art" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "arw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -10431,15 +10431,6 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"azg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "azh" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -11492,10 +11483,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
-"aBK" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "aBL" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -12785,16 +12772,6 @@
 /area/crew_quarters/locker/locker_toilet{
 	name = "\improper Restrooms"
 	})
-"aEl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "aEm" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
@@ -65556,6 +65533,16 @@
 /area/toxins/mixing{
 	name = "\improper Toxins Lab"
 	})
+"cMw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.3-Escape-3";
+	location = "9.2-Escape-2"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "cMx" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/mask/gas,
@@ -73935,9 +73922,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"dfN" = (
-/turf/space,
-/area/chapel/main)
 "dfO" = (
 /obj/structure/sign/lifestar,
 /turf/simulated/wall,
@@ -74476,18 +74460,6 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
-"djf" = (
-/obj/item/flashlight/lantern{
-	pixel_y = 7
-	},
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "djx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -74509,6 +74481,14 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"dmh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard,
+/obj/item/radio/off,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "dmU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -74518,17 +74498,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
-"dnm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "dnu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -74582,6 +74551,12 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
+"dvN" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "dwC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -74596,11 +74571,27 @@
 	icon_state = "white"
 	},
 /area/medical/surgery2)
-"dyz" = (
+"dxv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
+"dyW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "dAs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -74613,26 +74604,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"dAy" = (
-/obj/structure/bookcase{
-	name = "Holy Bookcase"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+"dAE" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/maintenance/aft)
 "dAH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"dBm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=9.3-Escape-3";
-	location = "9.2-Escape-2"
+"dAJ" = (
+/obj/machinery/door/window/eastleft{
+	name = "Coffin Storage";
+	req_access_txt = "22"
 	},
-/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/chapel/main)
+"dBX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -74691,13 +74686,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"dFP" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
+"dGb" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "dGT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -74732,14 +74725,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"dJp" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-24"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+"dIk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "dKL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74763,15 +74755,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
-"dMv" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/pennywise,
-/obj/item/toy/syndicateballoon,
-/obj/item/clothing/shoes/clown_shoes,
-/obj/item/clothing/mask/gas/clown_hat/pennywise,
-/obj/item/coin/clown,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+"dMn" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "dMV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -74789,17 +74781,11 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
-"dPM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+"dQs" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "dRN" = (
 /obj/machinery/light{
 	dir = 4
@@ -74821,19 +74807,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"dSk" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "dTK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -74898,6 +74871,13 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
+"dZd" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/space/nearstation)
 "dZe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/warning_stripes/west,
@@ -74923,15 +74903,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
-"eaK" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/trash/candy,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "ebA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -74966,6 +74937,18 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"ecc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/closet/crate,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "edg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -74985,6 +74968,13 @@
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"efY" = (
+/obj/structure/closet,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -75007,6 +74997,29 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"eic" = (
+/obj/machinery/atm{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "eiF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -75022,10 +75035,25 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
+"ekm" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "elK" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
 /area/security/permabrig)
+"emU" = (
+/obj/structure/closet/coffin,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "eoq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75045,6 +75073,14 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"ery" = (
+/obj/structure/closet/coffin,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "esf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75056,10 +75092,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"eub" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/maintenance/starboard)
 "evR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -75071,29 +75103,9 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"eze" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
+"eCr" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"ezX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/door/airlock/welded,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "eEV" = (
@@ -75126,19 +75138,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"eHD" = (
-/obj/machinery/power/apc{
-	name = "Chapel Office APC";
-	pixel_y = -25
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "eIg" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -75162,10 +75161,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
-"eLN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "eMs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -75180,15 +75175,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"eOH" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "ePy" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75246,23 +75232,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"eXe" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"eXi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "eYE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -75280,6 +75249,21 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"fba" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth (Chaplain)";
+	req_access_txt = "22"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
+"fed" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "ffD" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -75287,6 +75271,18 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/hor)
+"ffT" = (
+/obj/item/flashlight/lantern{
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "fga" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/door/window/northleft{
@@ -75352,20 +75348,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"flN" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "fmg" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
+"fmL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "fmP" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
@@ -75440,6 +75438,16 @@
 	icon_state = "dark"
 	},
 /area/engine/break_room)
+"fyH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "fyS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -75448,33 +75456,12 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
-"fAn" = (
-/obj/effect/landmark/spawner/xeno,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"fAA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "fBO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/security/warden)
-"fCI" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "fCO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -75510,16 +75497,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"fFl" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "fGt" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75536,16 +75513,6 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"fKC" = (
-/obj/item/storage/fancy/crayons,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "fOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -75570,6 +75537,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
+"fWe" = (
+/obj/machinery/light/small,
+/obj/machinery/door_control{
+	id = "chapelparlourshutters";
+	name = "Window Shutter Control";
+	pixel_y = -25
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "fWW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75598,16 +75576,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"fZA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "fZC" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -75700,6 +75668,12 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"geM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "gfB" = (
 /obj/structure/window/plasmareinforced,
 /obj/machinery/power/rad_collector{
@@ -75711,6 +75685,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"ggY" = (
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "gid" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -75860,18 +75849,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
-"gHb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;5;39;6"
-	},
+"gIr" = (
+/obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/chapel/main)
 "gIN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -75884,6 +75870,22 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
+"gIO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "gKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -75895,19 +75897,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
-"gMN" = (
-/obj/structure/sign/atmosplaque{
-	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
-	icon_state = "kiddieplaque";
-	name = "Remembrance Plaque";
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "gMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75939,14 +75928,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
-"gPh" = (
-/obj/machinery/door/morgue{
-	name = "Chapel Garden"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/main)
 "gQu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -75957,16 +75938,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
+"gQJ" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "gRw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
-"gSF" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/bed/roller,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/cleanable/blood,
+"gRx" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "gSK" = (
@@ -75984,17 +75967,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"gUS" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
-"gXv" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "gYM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/warning_stripes/east,
@@ -76041,6 +76013,13 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"hgn" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hgN" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -76093,6 +76072,12 @@
 	icon_state = "floorgrime"
 	},
 /area/security/brig)
+"hiN" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/mask/surgical,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hiO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -76170,15 +76155,6 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"hob" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hqN" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -76187,12 +76163,6 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"hsU" = (
-/obj/structure/lattice,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/turf/space,
-/area/space/nearstation)
 "huo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -76226,12 +76196,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"hyl" = (
-/obj/structure/chair,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "hAg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -76289,6 +76253,9 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"hEy" = (
+/turf/space,
+/area/chapel/main)
 "hEA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -76300,11 +76267,19 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"hGL" = (
-/obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/decal/warning_stripes/south,
+"hGk" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "hHE" = (
@@ -76430,17 +76405,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"hTM" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hVe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76457,17 +76421,24 @@
 /area/quartermaster/miningdock{
 	name = "\improper Mining Office"
 	})
-"hVX" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+"hVz" = (
+/obj/structure/chair{
+	dir = 4
 	},
-/area/chapel/main)
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "hWr" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"hXY" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "hYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76484,12 +76455,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
-"hZq" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hZZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76545,24 +76510,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"ieo" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"ifq" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"ifA" = (
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "ihM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76570,12 +76517,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
-"ihY" = (
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkblue"
-	},
-/area/space/nearstation)
 "iip" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76604,6 +76545,22 @@
 	},
 /turf/space,
 /area/space)
+"iiU" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ijt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -76753,16 +76710,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"iDW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "iEd" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76791,28 +76738,43 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
-"iIk" = (
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"iNt" = (
-/obj/item/candle,
-/obj/machinery/light_switch{
-	name = "custom placement";
-	pixel_x = 6;
-	pixel_y = 24
+"iHH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/machinery/door_control{
-	id = "chapelescapeshutters";
-	name = "Side Windows Shutter Control";
-	pixel_x = -6;
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"iHM" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "chapel"
 	},
 /area/chapel/main)
+"iIk" = (
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"iJi" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/double/map/right{
+	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
+	icon_state = "map-right-MS";
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "iNu" = (
 /obj/structure/reagent_dispensers/beerkeg/nuke{
 	name = "Nanotrasen-brand nuclear fizz-sion explosive"
@@ -76882,6 +76844,40 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
+"iUx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"iVQ" = (
+/obj/machinery/mecha_part_fabricator{
+	dir = 1;
+	id = "0";
+	name = "counterfeit fabricator";
+	req_access = "0"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"iWh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "iWv" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -76890,6 +76886,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
+"iXI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "iXL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76901,15 +76915,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"iZY" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "jap" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -76937,6 +76942,13 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"jdO" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "jeY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -76970,13 +76982,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"jjD" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "jlB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76992,12 +76997,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
-"jmX" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "jrE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77025,6 +77024,17 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
+"jyw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77050,16 +77060,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"jEC" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/flashlight,
-/obj/item/storage/box/lights/mixed,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "jGr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -77080,19 +77080,6 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"jJy" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"jJP" = (
-/obj/structure/closet/coffin,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/chapel/main)
 "jJV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77158,6 +77145,25 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
+"jSQ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium";
+	req_access_txt = "27"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
+"jTM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jUV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -77166,6 +77172,24 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"jWU" = (
+/obj/item/bedsheet/clown,
+/obj/structure/bed,
+/obj/structure/sign/clown{
+	pixel_x = 32
+	},
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"jYx" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jZd" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_y = -32
@@ -77201,10 +77225,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"kkA" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "kmF" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"kmU" = (
+/obj/structure/bookcase{
+	name = "Holy Bookcase"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "knc" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
@@ -77248,17 +77290,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"ksM" = (
-/obj/item/bedsheet/clown,
-/obj/structure/bed,
-/obj/structure/sign/clown{
-	pixel_x = 32
-	},
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "kto" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -77294,31 +77325,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"kug" = (
-/obj/item/candle,
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
-"kuM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
-"kuY" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "kvG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -77354,6 +77360,13 @@
 /obj/machinery/message_server,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/server)
+"kwY" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/storage/labcoat/mortician,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "kxf" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -77376,20 +77389,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
-"kAJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "kBa" = (
 /obj/machinery/door_control{
 	id = "maint1";
@@ -77483,29 +77482,24 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
-"kNS" = (
-/obj/machinery/atm{
-	pixel_y = 32
+"kRL" = (
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/chapel/main)
 "kSC" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -77524,6 +77518,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"kUy" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "kWg" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
@@ -77549,6 +77549,11 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"kXh" = (
+/obj/effect/landmark/spawner/xeno,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "kXs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -77560,15 +77565,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"kYx" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "kZl" = (
 /obj/structure/table/wood,
 /obj/item/lipstick{
@@ -77590,15 +77586,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
-"lag" = (
-/obj/structure/sign/vacuum{
-	pixel_x = 32
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "law" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -77619,6 +77606,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"leq" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/driver_button{
+	id_tag = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -4;
+	pixel_y = -26
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "leu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77641,6 +77643,13 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"lgl" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "lgr" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -77696,11 +77705,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"lnu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/welded,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+"lnx" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "lpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77737,6 +77749,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"lyK" = (
+/obj/machinery/light/small,
+/obj/machinery/door_control{
+	id = "chapelspaceshutters";
+	name = "Space Window Shutter Control";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "custom placement";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "lBy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77769,11 +77800,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
-"lFa" = (
-/obj/structure/rack,
-/obj/item/storage/box/bodybags,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "lFH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -77790,20 +77816,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab)
-"lGf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "lGk" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -77849,6 +77861,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
+"lIy" = (
+/obj/machinery/door/poddoor{
+	id_tag = "chapelgun";
+	name = "Chapel Launcher Door";
+	protected = 0
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "lIR" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -77859,6 +77880,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"lMO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "lOU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77892,19 +77918,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
-"lVE" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/door_control{
-	id = "maint3";
-	name = "Blast Door Control C";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "lWo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77914,37 +77927,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
-"lXl" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"lXA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/closet/crate,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"lYm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/girder,
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "mcP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -77954,6 +77936,10 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"mdk" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "mea" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -77971,6 +77957,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"meo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "mfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77978,6 +77974,13 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
+"mgd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "mhq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -78013,14 +78016,6 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"mli" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "mmk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78078,22 +78073,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"mtS" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
-"mtV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "myY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
@@ -78101,21 +78080,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"mzl" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "custom placement";
-	pixel_x = 28
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "mAa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78138,6 +78102,17 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"mBw" = (
+/obj/item/reagent_containers/food/drinks/bottle/holywater{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/organ/internal/heart,
+/obj/structure/closet/secure_closet/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/office)
 "mDj" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -78178,6 +78153,17 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
+"mGR" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "mKy" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -78185,21 +78171,33 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"mNv" = (
+"mKQ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"mLG" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"mMU" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "mOc" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78222,6 +78220,19 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"mRb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "mRP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -78232,6 +78243,18 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay3)
+"mTf" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "mVG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -78262,11 +78285,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"mXi" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "mXy" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
@@ -78330,17 +78348,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"neO" = (
-/obj/machinery/light/small,
-/obj/machinery/door_control{
-	id = "chapelparlourshutters";
-	name = "Window Shutter Control";
-	pixel_y = -25
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "neT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/warning_stripes/north,
@@ -78348,13 +78355,6 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
-"ngK" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "nhK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78395,6 +78395,23 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
+"nkL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel - Funeral Parlour";
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "nnI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -78427,6 +78444,13 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"ntb" = (
+/obj/structure/lattice,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "nuB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78474,11 +78498,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"nAn" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+"nDX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard)
 "nEQ" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	name = "Gas to Cooling Loop"
@@ -78500,6 +78531,24 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"nFB" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "nFC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/binary/valve/digital{
@@ -78521,6 +78570,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
+"nIv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "nIZ" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -78542,15 +78597,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"nMl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "nMx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -78569,6 +78615,15 @@
 /area/turret_protected/aisat_interior{
 	name = "\improper MiniSat Central Foyer"
 	})
+"nPF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "nRh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -78586,11 +78641,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"nTO" = (
-/obj/structure/closet/coffin,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/chapel/main)
 "nUW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78654,13 +78704,13 @@
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/server)
-"oeg" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+"oeo" = (
+/obj/item/candle,
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/chapel/main)
 "oeP" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -78707,7 +78757,30 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"okx" = (
+"onG" = (
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/airlock/s_to_n,
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarport)
+"orm" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/crew_quarters/locker)
+"ovJ" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/space/nearstation)
+"owG" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
 /obj/machinery/light/small{
@@ -78722,44 +78795,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"olR" = (
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/space/nearstation)
-"onG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/effect/spawner/airlock/s_to_n,
-/turf/simulated/floor/plating,
-/area/maintenance/auxsolarport)
-"oot" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"orm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/locker)
 "oxC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -78771,6 +78806,16 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
+"oyQ" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "oCE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -78778,34 +78823,12 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"oET" = (
-/obj/machinery/door/poddoor{
-	id_tag = "chapelgun";
-	name = "Chapel Launcher Door";
-	protected = 0
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/chapel/main)
-"oHm" = (
-/obj/machinery/light/small,
-/obj/machinery/door_control{
-	id = "chapelspaceshutters";
-	name = "Space Window Shutter Control";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "custom placement";
-	pixel_x = 6;
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
+"oFs" = (
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "oJQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78820,6 +78843,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
+"oMV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"oOo" = (
+/obj/structure/table,
+/obj/item/candle,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "oOs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -78838,14 +78879,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
-"oQE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard,
-/obj/item/radio/off,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "oRr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -78856,26 +78889,6 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
-"oSh" = (
-/obj/machinery/door/morgue{
-	name = "Relic Closet";
-	req_access_txt = "22"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/office)
-"oSX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "oTM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78995,6 +79008,11 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"pdq" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "pef" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -79003,16 +79021,6 @@
 	icon_state = "red"
 	},
 /area/security/processing)
-"pej" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "peo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -79054,24 +79062,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/cmo)
-"piG" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "pjn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -79109,30 +79099,18 @@
 	icon_state = "brown"
 	},
 /area/hallway/primary/port)
+"plf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "plu" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"plZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "pmh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -79141,6 +79119,20 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"pov" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "ppw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -79153,29 +79145,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/virology)
-"pqF" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
-"prF" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "ptc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -79216,6 +79185,14 @@
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"pxY" = (
+/obj/machinery/door/morgue{
+	name = "Chapel Garden"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/main)
 "pyX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79293,15 +79270,13 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"pLj" = (
-/obj/machinery/light/small{
-	dir = 8
+"pMd" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/chapel/main)
 "pMx" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall,
@@ -79337,14 +79312,6 @@
 	},
 /area/quartermaster/sorting{
 	name = "\improper Warehouse"
-	})
-"pNQ" = (
-/obj/structure/table,
-/obj/item/candle,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
 	})
 "pQx" = (
 /obj/structure/cable/yellow{
@@ -79417,27 +79384,6 @@
 	icon_state = "dark"
 	},
 /area/maintenance/starboard)
-"pVQ" = (
-/obj/structure/noticeboard{
-	desc = "A memorial wall for pinning up momentos";
-	name = "memorial board";
-	pixel_y = 32
-	},
-/obj/item/storage/bible,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/chapel/main)
-"pWB" = (
-/obj/item/reagent_containers/food/drinks/bottle/holywater{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/organ/internal/heart,
-/obj/structure/closet/secure_closet/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/chapel/office)
 "pXV" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79451,6 +79397,12 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/lawoffice)
+"pYF" = (
+/obj/structure/lattice,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/turf/space,
+/area/space/nearstation)
 "qaB" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79487,6 +79439,18 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/construction)
+"qdr" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "qee" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79564,19 +79528,25 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"qsa" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"qpY" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/flashlight,
+/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"qsE" = (
-/obj/machinery/door/window/eastleft{
-	name = "Coffin Storage";
-	req_access_txt = "22"
+"qte" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/item/trash/candy,
 /turf/simulated/floor/plating,
-/area/chapel/main)
+/area/maintenance/aft)
 "qts" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -79660,21 +79630,6 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"qFs" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
-"qGq" = (
-/obj/structure/girder,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "qHi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79702,30 +79657,6 @@
 	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/starboard)
-"qKp" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"qKK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "qME" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79765,6 +79696,13 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"qSr" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "qTK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -79794,10 +79732,40 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
+"rax" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "raV" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"rbF" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"rcT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "rdz" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -79849,21 +79817,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rkK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "rlJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -79899,6 +79852,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
+"roo" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "rpg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -79922,27 +79880,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rsW" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
-"rto" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "rvu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79997,16 +79934,18 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"rBA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+"rAh" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
 	})
 "rDe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -80131,9 +80070,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "rIq" = (
@@ -80215,18 +80151,19 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"rSn" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"rPn" = (
+/obj/machinery/power/apc{
+	name = "Chapel Office APC";
+	pixel_y = -25
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "rTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -80253,6 +80190,17 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
+/area/chapel/main)
+"rVr" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "chapelspaceshutters";
+	name = "chapel shutters";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/chapel/main)
 "rVv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -80319,12 +80267,36 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"sdl" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/mask/surgical,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+"seq" = (
+/obj/structure/closet/secure_closet/chaplain,
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
+"sgt" = (
+/obj/item/candle,
+/obj/machinery/light_switch{
+	name = "custom placement";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/structure/table/wood,
+/obj/machinery/door_control{
+	id = "chapelescapeshutters";
+	name = "Side Windows Shutter Control";
+	pixel_x = -6;
+	pixel_y = 25
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -80352,40 +80324,10 @@
 	icon_state = "dark"
 	},
 /area/space/nearstation)
-"slA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
-"slH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+"skx" = (
+/obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/space/nearstation)
 "soT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -80418,6 +80360,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"spq" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-24"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "spv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
@@ -80443,6 +80393,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"stc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "svF" = (
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
@@ -80491,6 +80450,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
+"sDm" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"sDK" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "sFz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80503,28 +80477,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
-"sHs" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"sIN" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "sJe" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -80540,6 +80492,21 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"sJU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "sLs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80574,10 +80541,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"sOG" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/maintenance/aft)
 "sOJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -80589,24 +80552,6 @@
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
 	})
-"sQS" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "sRB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -80619,12 +80564,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"sXf" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "sYp" = (
 /obj/structure/chair{
 	dir = 1
@@ -80636,14 +80575,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"taB" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "tbK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -80663,16 +80594,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"tef" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "teE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80710,6 +80631,14 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"thp" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "thC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -80721,6 +80650,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
+"thL" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "tjR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80730,12 +80667,33 @@
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
+"tkc" = (
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "custom placement";
+	pixel_x = 28
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "tlh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
+"tok" = (
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tpg" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -80751,22 +80709,13 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"trh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Office";
-	req_access_txt = "27"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+"tqh" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "tvk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -80820,6 +80769,19 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
+"tyi" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/door_control{
+	id = "maint3";
+	name = "Blast Door Control C";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "tAk" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80881,24 +80843,25 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
-"tFv" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"tKO" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/double/map/right{
-	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
-	icon_state = "map-right-MS";
-	pixel_y = 32
+"tKb" = (
+/obj/machinery/door/morgue{
+	name = "Relic Closet";
+	req_access_txt = "22"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault"
+	icon_state = "cult"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
+/area/chapel/office)
+"tLv" = (
+/obj/item/storage/fancy/crayons,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "tNG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80965,17 +80928,6 @@
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"tYz" = (
-/obj/structure/closet/secure_closet/chaplain,
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "tYX" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -81012,12 +80964,17 @@
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"udo" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
+"uca" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
 /area/chapel/main)
 "udB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -81057,22 +81014,6 @@
 	icon_state = "dark"
 	},
 /area/security/hos)
-"uhi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Crematorium";
-	req_access_txt = "27"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
-"uhV" = (
-/obj/structure/lattice,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "uhY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81114,18 +81055,6 @@
 /obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"usg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "uuE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -81155,6 +81084,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
+"uvW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "uzt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -81180,6 +81118,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"uCn" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Office";
+	req_access_txt = "27"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "uEN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -81188,14 +81142,12 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
-"uGA" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"uHP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -81203,12 +81155,22 @@
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboard)
+"uKb" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "uKm" = (
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/wall,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"uKz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/maintenance/starboard)
 "uLE" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plating,
@@ -81242,10 +81204,10 @@
 	icon_state = "white"
 	},
 /area/medical/medbay3)
-"uNl" = (
-/obj/effect/landmark/damageturf,
+"uNa" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/space/nearstation)
+/area/maintenance/starboard)
 "uOL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -81304,14 +81266,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"uWh" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
+"uWa" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "uWq" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -81328,13 +81287,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/atmos)
-"uZU" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "vaE" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -81348,32 +81300,32 @@
 "vaO" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry)
-"vdn" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+"vdH" = (
+/obj/structure/chair,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
+/area/chapel/main)
+"veH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"veA" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/chapel/main)
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "vfe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -81403,18 +81355,6 @@
 	icon_state = "redfull"
 	},
 /area/security/main)
-"vgT" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"vhD" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "vjp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -81444,15 +81384,24 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"vnD" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+"voO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/starboardsolar)
+"vrD" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/under/pennywise,
+/obj/item/toy/syndicateballoon,
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/clothing/mask/gas/clown_hat/pennywise,
+/obj/item/coin/clown,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -81550,15 +81499,11 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"vCu" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
+"vCo" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "vCR" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -81597,6 +81542,21 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
+"vFB" = (
+/obj/structure/sign/directions/evac,
+/turf/simulated/wall,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
+"vHf" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "vHA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -81615,27 +81575,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
-	})
-"vIk" = (
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
-"vJy" = (
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
 	})
 "vLL" = (
 /obj/structure/cable/yellow{
@@ -81679,6 +81618,30 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
+"vPN" = (
+/obj/structure/sign/atmosplaque{
+	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
+	icon_state = "kiddieplaque";
+	name = "Remembrance Plaque";
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"vRN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "vRY" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -81703,6 +81666,16 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"vTG" = (
+/obj/structure/noticeboard{
+	desc = "A memorial wall for pinning up momentos";
+	name = "memorial board";
+	pixel_y = 32
+	},
+/obj/item/storage/bible,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "vUD" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -81722,21 +81695,6 @@
 "vZo" = (
 /turf/simulated/floor/plating,
 /area/space/nearstation)
-"vZw" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/driver_button{
-	id_tag = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -4;
-	pixel_y = -26
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/chapel/main)
 "vZU" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 1
@@ -81762,15 +81720,20 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
-"wfL" = (
-/obj/structure/cable{
-	d1 = 4;
+"wgB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboardsolar)
+/area/maintenance/aft)
 "whC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -81778,13 +81741,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"wkP" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/storage/labcoat/mortician,
-/obj/item/clothing/mask/surgical,
-/obj/item/storage/box/bodybags,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "wma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/spawner/window/reinforced,
@@ -81807,11 +81763,6 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
-"wrX" = (
-/obj/effect/landmark/spawner/xeno,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "wsx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81953,6 +81904,12 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"wDa" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "wEq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81983,19 +81940,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
-"wGj" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "wHZ" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -82004,21 +81948,15 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"wJL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"wIw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "wJQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -82030,23 +81968,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"wRi" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel - Funeral Parlour";
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "wRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82081,15 +82002,6 @@
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
-"wTV" = (
-/obj/machinery/mecha_part_fabricator{
-	dir = 1;
-	id = "0";
-	name = "counterfeit fabricator";
-	req_access = "0"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "wUE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82108,12 +82020,26 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
-"xcZ" = (
-/obj/machinery/light/small{
+"xdY" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82134,17 +82060,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
-"xho" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "chapelspaceshutters";
-	name = "chapel shutters";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/chapel/main)
 "xhx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82175,6 +82090,15 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
+"xqE" = (
+/obj/structure/sign/vacuum{
+	pixel_x = 32
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit{
+	name = "\improper Departure Lounge"
+	})
 "xrG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -82247,15 +82171,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
-"xFH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"xEy" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "xFR" = (
@@ -82278,6 +82201,35 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"xHm" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"xIS" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "xJB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82290,6 +82242,18 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"xKX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -82307,12 +82271,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"xOW" = (
-/obj/structure/sign/directions/evac,
-/turf/simulated/wall,
-/area/hallway/secondary/exit{
-	name = "\improper Departure Lounge"
-	})
 "xSh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82327,6 +82285,22 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
+	},
+/area/chapel/main)
+"xUZ" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/chapel/main)
+"xXJ" = (
+/obj/structure/chair,
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
 	},
 /area/chapel/main)
 "xYR" = (
@@ -82346,6 +82320,11 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/solar/starboard)
+"yaf" = (
+/obj/effect/landmark/spawner/xeno,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "yag" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82356,6 +82335,15 @@
 "yaq" = (
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"yaE" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "yaQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -82372,6 +82360,15 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
+"yeQ" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/chapel/main)
 "yeW" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -97472,7 +97469,7 @@ apf
 aaa
 aaa
 cmi
-qKp
+mdk
 cmi
 bZU
 cpu
@@ -98238,7 +98235,7 @@ bYW
 caJ
 ceN
 ceN
-wGj
+mRb
 chP
 ceN
 xJB
@@ -98755,7 +98752,7 @@ bWo
 cdJ
 ceO
 cTa
-kYx
+uvW
 ckD
 chy
 ebA
@@ -99031,7 +99028,7 @@ bZU
 bZU
 cOx
 cqS
-tFv
+uWa
 bZU
 cNa
 cNP
@@ -99549,7 +99546,7 @@ cJR
 cuV
 cuV
 chy
-hZq
+uKb
 chy
 chy
 bZU
@@ -99786,7 +99783,7 @@ chw
 ckH
 bZU
 cuV
-eaK
+qte
 chy
 cFQ
 cLU
@@ -99797,7 +99794,7 @@ chy
 chy
 chy
 czf
-xcZ
+geM
 cBX
 cFT
 ckD
@@ -99805,8 +99802,8 @@ cIb
 cDT
 ckJ
 ckJ
-hob
-hob
+stc
+stc
 ckJ
 cJR
 bZU
@@ -100554,7 +100551,7 @@ apd
 bZU
 cfW
 cjr
-wTV
+iVQ
 cTa
 chy
 bgZ
@@ -100811,7 +100808,7 @@ cgo
 cTa
 idx
 dgG
-oQE
+dmh
 cTa
 chy
 bgZ
@@ -101063,7 +101060,7 @@ apd
 cgm
 isf
 apf
-lVE
+tyi
 cgo
 cTa
 bZU
@@ -101093,7 +101090,7 @@ cKA
 dxa
 cKL
 cEY
-uGA
+mKQ
 bZU
 abq
 aaa
@@ -101579,13 +101576,13 @@ bZW
 bFw
 bzK
 cho
-hob
+stc
 ckJ
-prF
+vRN
 ckJ
 ckJ
 ckJ
-lXA
+ecc
 coC
 cpX
 crV
@@ -101835,7 +101832,7 @@ jrE
 bZc
 bZZ
 bzK
-dSk
+rAh
 chy
 chy
 cmi
@@ -102138,12 +102135,12 @@ cRh
 cRh
 cRh
 cSO
-jJP
+ery
 cWn
 cWn
-nTO
+emU
 cSO
-veA
+yeQ
 dfv
 abq
 aaa
@@ -102386,21 +102383,21 @@ dfR
 dfU
 cRg
 cHZ
-lFa
+roo
 chy
 bZU
 cSI
 cTy
 cUg
-okx
+owG
 cUg
 cSO
 cVM
 cVM
-qsE
+dAJ
 cVM
 cSO
-gPh
+pxY
 cSO
 abq
 aaa
@@ -102650,14 +102647,14 @@ cSJ
 cTz
 cUh
 cUN
-mli
+plf
 cSO
 cSO
-vIk
+ggY
 cVR
 cVR
 dbX
-neO
+fWe
 cSO
 abq
 aaa
@@ -102901,12 +102898,12 @@ dfV
 dgH
 cHZ
 cuV
-eXi
+uHP
 bZU
 cRh
 cRh
 cRh
-uhi
+jSQ
 cRh
 cSO
 cWp
@@ -102914,7 +102911,7 @@ cWO
 cWN
 cWN
 cYk
-hyl
+vdH
 dfv
 abq
 aaa
@@ -103149,7 +103146,7 @@ cFd
 cLw
 cNL
 cPy
-uGA
+mKQ
 chy
 chy
 cHZ
@@ -103158,20 +103155,20 @@ cMR
 cHZ
 cHZ
 cuV
-eXi
+uHP
 bZU
 cSK
 cTA
-fKC
+tLv
 cZs
-tYz
+seq
 cSO
-gMN
+vPN
 cWO
-rsW
+xUZ
 cWN
 cYk
-hVX
+xXJ
 dfv
 abq
 aaa
@@ -103415,20 +103412,20 @@ day
 lrA
 bZU
 cFe
-iDW
+fyH
 bZU
 cSL
 cTB
 cUk
 cUP
-eOH
+sDK
 cSO
-pVQ
+vTG
 cWO
 cYk
-wRi
+nkL
 cYk
-gUS
+kUy
 dfv
 abq
 aaa
@@ -103633,7 +103630,7 @@ bXy
 cgt
 bzK
 caK
-lGf
+pov
 ccB
 cdT
 cfa
@@ -103678,14 +103675,14 @@ deI
 cWR
 cUl
 cZt
-eHD
+rPn
 cSO
 cSO
-sQS
+kRL
 cYk
 cSO
 cYl
-vZw
+leq
 cSO
 abq
 aaa
@@ -103922,14 +103919,14 @@ cNM
 cPy
 cRo
 cyE
-qKp
+mdk
 bZU
 cZw
 daM
 dby
 bZU
 chy
-fAA
+jTM
 bZU
 cZs
 cTD
@@ -103943,7 +103940,7 @@ cYk
 cSO
 dbc
 dag
-oET
+lIy
 abq
 aaa
 aaa
@@ -104188,15 +104185,15 @@ cPy
 svF
 csh
 bZU
-oSh
+tKb
 cRh
 cRh
 cRh
-iZY
+fba
 cSO
-slA
+iXI
 dgg
-dJp
+spq
 cSO
 cSO
 cSO
@@ -104443,20 +104440,20 @@ daO
 cRV
 cPy
 chy
-eXi
+uHP
 bZU
-pWB
+mBw
 cRh
 cUn
 cUT
-mzl
+tkc
 cSO
 cSO
-trh
+uCn
 cSO
 cSO
 cSO
-dfN
+hEy
 abq
 abq
 aaa
@@ -104700,18 +104697,18 @@ daN
 cRu
 cPy
 ckw
-eXi
+uHP
 bZU
 cRh
 cRh
-uWh
+thp
 cRh
 cRh
 cSO
 cYk
 dgg
 dhj
-dAy
+kmU
 cSO
 aaa
 aaa
@@ -104956,18 +104953,18 @@ daP
 daP
 dbG
 cPy
-nAn
-eXi
+vCo
+uHP
 bZU
 deL
-taB
+thL
 deN
 cSO
 cSO
 dfw
 xUe
 dhi
-vCu
+mMU
 cVA
 cSO
 aaa
@@ -105213,19 +105210,19 @@ cZO
 cYC
 cRU
 cRU
-jJy
-eXi
+dGb
+uHP
 bZU
-kug
+oeo
 deN
 deN
 cZX
 cVU
 cWz
 jQZ
-rto
+uca
 jQZ
-ngK
+pMd
 cSO
 aaa
 aaa
@@ -105471,19 +105468,19 @@ daU
 cRX
 cRU
 coD
-eXi
+uHP
 bZU
 ktX
 lUv
 deY
 cVw
 cUY
-mtS
+jdO
 xUe
 cXm
 cXJ
 dhl
-xho
+rVr
 aaa
 aaa
 aaa
@@ -105728,19 +105725,19 @@ daQ
 dbH
 der
 dek
-fZA
+oMV
 bZU
 cTK
-art
+nIv
 deN
 cVz
-fCI
-dFP
+alV
+qSr
 jQZ
-pqF
+qdr
 cYk
 dhl
-xho
+rVr
 aaa
 aaa
 aaa
@@ -105990,14 +105987,14 @@ cSS
 cTJ
 deP
 dfo
-usg
+dyW
 fPa
 fPa
 fPa
 cXn
 cXK
-gUS
-xho
+kUy
+rVr
 aaa
 aaa
 aaa
@@ -106242,19 +106239,19 @@ daV
 dbN
 cRU
 chy
-mNv
+hGk
 bZU
 cTK
-azg
+wIw
 deN
-mtS
+jdO
 cUY
-mtS
+jdO
 xUe
-kuY
+gIr
 cYk
 dhl
-xho
+rVr
 aaa
 aaa
 aaa
@@ -106504,14 +106501,14 @@ bZU
 rUJ
 cUs
 cUZ
-dFP
-fCI
-dFP
+qSr
+alV
+qSr
 jQZ
 wzo
-djf
+ffT
 dhl
-xho
+rVr
 aaa
 aaa
 aaa
@@ -106758,8 +106755,8 @@ cRU
 cuV
 dVK
 bZU
-iNt
-azg
+sgt
+wIw
 deN
 cVA
 cVa
@@ -106767,7 +106764,7 @@ cVA
 xUe
 cVA
 xUe
-oHm
+lyK
 cSO
 aaa
 aaa
@@ -107013,18 +107010,18 @@ ckJ
 ckJ
 ckJ
 ckJ
-kAJ
+wgB
 bZU
 cSO
 cUt
-udo
+mgd
 cSO
 cSO
-qFs
+iHM
 jQZ
 cZC
 cZR
-vnD
+yaE
 cSO
 aaa
 aaa
@@ -107270,12 +107267,12 @@ chy
 bZU
 bZU
 bZU
-gHb
+mTf
 bZU
 cVs
 cWi
 cXc
-pNQ
+oOo
 cSO
 cSO
 cSO
@@ -107530,15 +107527,15 @@ cSr
 cTq
 cTO
 cWb
-dnm
-flN
+dBX
+hVz
 cUv
 dau
-ieo
+wDa
 cXc
 cYf
 cZp
-pLj
+dMn
 cZp
 aaa
 aaa
@@ -107784,16 +107781,16 @@ cdN
 cVk
 cQM
 pue
-dPM
+iUx
 cVc
 cRt
-dnm
+dBX
 cRt
 nej
 cRt
 cRt
 cTr
-ifA
+tok
 cTX
 cTX
 cTX
@@ -108039,20 +108036,20 @@ cYW
 cQh
 cjn
 cVk
-eXe
+lnx
 cTg
 cSk
 gnZ
 cTQ
-rBA
+iHH
 cSo
 gTp
 cRt
 cRt
 cXb
-ifA
+tok
 cZp
-ifA
+tok
 cZp
 aaa
 aaa
@@ -108293,13 +108290,13 @@ cmw
 diT
 com
 cIm
-rSn
+xIS
 chy
 cVk
 cVk
 cRv
 cRt
-vJy
+oFs
 cRt
 cRt
 cRt
@@ -108307,7 +108304,7 @@ cRt
 cRt
 cRt
 cTr
-ifA
+tok
 cTX
 cTX
 cTX
@@ -108564,7 +108561,7 @@ cTW
 cUu
 cRt
 cTr
-ifA
+tok
 cTX
 aaa
 aaa
@@ -108811,7 +108808,7 @@ bgZ
 chy
 cVk
 bYy
-qKK
+xdY
 cTr
 cUz
 cTR
@@ -108821,7 +108818,7 @@ cUz
 dap
 cRt
 cTr
-jjD
+tqh
 cTX
 aaa
 aaa
@@ -109065,10 +109062,10 @@ cVv
 cot
 cIm
 clu
-wkP
+kwY
 cVk
-tKO
-qKK
+iJi
+xdY
 cTt
 cUv
 cUv
@@ -109078,7 +109075,7 @@ cUv
 cWb
 cRt
 cTr
-ifA
+tok
 cTX
 aaa
 aaa
@@ -109323,9 +109320,9 @@ cIm
 cIm
 cNV
 bZU
-xOW
+vFB
 cVk
-kNS
+eic
 cRt
 cRt
 cRt
@@ -109335,7 +109332,7 @@ cRt
 cRt
 cRt
 cTr
-ifA
+tok
 cTX
 cTX
 cTX
@@ -109581,8 +109578,8 @@ cNS
 cNW
 cON
 cPN
-uZU
-plZ
+mLG
+veH
 cRt
 nej
 cRt
@@ -109591,10 +109588,10 @@ cRt
 cVc
 cRt
 cRt
-dBm
-ifA
+cMw
+tok
 cZp
-kuM
+vHf
 cZp
 aaa
 aaa
@@ -109849,7 +109846,7 @@ cVC
 cRt
 cRt
 cTr
-ifA
+tok
 cTX
 cTX
 cTX
@@ -110106,9 +110103,9 @@ dac
 dat
 cUB
 cXM
-lag
+xqE
 cZp
-ifA
+tok
 cZp
 aaa
 aaa
@@ -110366,7 +110363,7 @@ cTX
 cVk
 cTX
 cTX
-uhV
+ntb
 aaa
 aaa
 aaa
@@ -111638,7 +111635,7 @@ ryN
 cOX
 cPW
 cSs
-eze
+iiU
 cTa
 bZU
 bZU
@@ -111895,10 +111892,10 @@ cQv
 cOW
 cPV
 cIx
-piG
+nFB
 iTR
 chy
-hZq
+uKb
 chy
 aef
 aef
@@ -113923,7 +113920,7 @@ bUR
 bWl
 bWl
 bZU
-jEC
+qpY
 cqp
 crU
 cmz
@@ -114208,7 +114205,7 @@ cPi
 cPe
 cQa
 cOp
-lXl
+xKX
 cwt
 cmi
 aaa
@@ -114948,7 +114945,7 @@ cfA
 cgN
 cip
 bZu
-fFl
+ekm
 cmz
 cnh
 cpT
@@ -115754,7 +115751,7 @@ bgZ
 cPT
 cPT
 cmy
-wrX
+yaf
 bZU
 bZU
 aaa
@@ -115976,7 +115973,7 @@ cbO
 cgR
 ciC
 cjV
-pej
+kkA
 cmz
 cnF
 coV
@@ -116004,7 +116001,7 @@ cKE
 cOc
 cQg
 cQE
-tef
+oyQ
 cxT
 cRP
 clT
@@ -116773,9 +116770,9 @@ cEK
 crU
 cdN
 cjn
-oot
+iWh
 jaV
-vdn
+xHm
 bZO
 cQU
 cTo
@@ -117030,9 +117027,9 @@ bZU
 cKG
 cLB
 chy
-wJL
+rax
 bZU
-oSX
+jyw
 cQI
 cuV
 cuV
@@ -117287,9 +117284,9 @@ hLW
 ceD
 ceN
 ceN
-rkK
+sJU
 cTa
-oSX
+jyw
 bZU
 cQW
 cQW
@@ -117535,18 +117532,18 @@ cDX
 bZU
 cTa
 dVK
-dyz
+lMO
 bZU
 cHQ
 cJd
 cKu
 bZU
-vhD
+jYx
 cuV
 chy
 chy
 cmY
-xFH
+fmL
 chy
 cQW
 cRQ
@@ -117792,7 +117789,7 @@ cfU
 bZU
 chy
 dVK
-vgT
+gQJ
 cFH
 cFH
 cHY
@@ -118580,7 +118577,7 @@ aaa
 abq
 aaa
 cOy
-wfL
+voO
 xZq
 aaa
 abq
@@ -118810,14 +118807,14 @@ bcj
 cwt
 csh
 chy
-xcZ
+geM
 chy
 chy
 chy
 chy
 chy
 cuV
-gXv
+pdq
 bZU
 cFe
 bZU
@@ -119326,7 +119323,7 @@ csj
 cwF
 bZU
 cyT
-gSF
+hgn
 cyT
 cPT
 abq
@@ -119570,7 +119567,7 @@ cdi
 aGW
 aGW
 aGW
-slH
+gIO
 clq
 clq
 aQS
@@ -119578,19 +119575,19 @@ bal
 asJ
 coM
 aoG
-hGL
-nMl
-qsa
-lYm
+efY
+nPF
+dvN
+dIk
 pes
 chy
-sXf
+rbF
 bZU
-uNl
-ihY
+skx
+ovJ
 bZU
 bZU
-qKp
+mdk
 bZU
 abq
 abq
@@ -119827,7 +119824,7 @@ asJ
 aoG
 aoG
 aoG
-ezX
+dxv
 aEx
 aEx
 asJ
@@ -119840,11 +119837,11 @@ bZU
 bZU
 bZU
 rHl
-qGq
+hXY
 bZU
 bZU
-olR
-hsU
+dZd
+pYF
 bZU
 hLL
 vZo
@@ -120082,7 +120079,7 @@ bEG
 caI
 asJ
 bdl
-dMv
+vrD
 bYG
 azy
 asI
@@ -120093,16 +120090,16 @@ aoG
 aoG
 buC
 cLV
-sdl
-sIN
+hiN
+xEy
 cuG
 cji
-fAn
+kXh
 cye
 bZU
-sOG
-sOG
-sOG
+dAE
+dAE
+dAE
 abq
 aef
 aaa
@@ -120340,7 +120337,7 @@ azy
 asJ
 bdl
 asJ
-lnu
+eCr
 azy
 cis
 buC
@@ -120352,7 +120349,7 @@ buC
 cqF
 chy
 cdK
-hTM
+mGR
 csh
 cuH
 cyf
@@ -120596,8 +120593,8 @@ bEG
 azy
 asJ
 bdl
-ksM
-eub
+jWU
+uKz
 azy
 cir
 buC
@@ -120609,8 +120606,8 @@ buC
 cqE
 chy
 chy
-eLN
-mtV
+gRx
+rcT
 chy
 cyg
 cmi
@@ -120864,7 +120861,7 @@ cfK
 cfK
 cfK
 cqH
-ifq
+sDm
 chy
 cuH
 uBl
@@ -121108,8 +121105,8 @@ brg
 tbK
 tbK
 tbK
-aBK
-mXi
+uNa
+dQs
 bwE
 asJ
 azy
@@ -121368,7 +121365,7 @@ bYG
 aoG
 aoG
 cdm
-aEl
+meo
 ofz
 cfK
 chs
@@ -121624,7 +121621,7 @@ uLE
 bVL
 aoG
 azp
-sHs
+nDX
 asJ
 bcj
 cfK
@@ -122135,7 +122132,7 @@ bqN
 rDF
 axh
 asJ
-jmX
+fed
 aoG
 cSa
 cdp
@@ -122906,7 +122903,7 @@ asJ
 bVL
 uqy
 aXP
-oeg
+lgl
 bCM
 bCM
 cds

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8967,10 +8967,10 @@
 	name = "Port Maintenance"
 	})
 "avX" = (
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/obj/structure/closet/crate,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -26577,15 +26577,12 @@
 	},
 /area/storage/tech)
 "bib" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil{
-	pixel_x = -1;
-	pixel_y = -3
-	},
-/obj/item/wrench,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/cigbutt,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "bic" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -44234,23 +44231,19 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bRD" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
 "bRE" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/machinery/vending/hatdispenser,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
 "bRF" = (
-/obj/structure/closet,
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/vending/shoedispenser,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -45107,6 +45100,7 @@
 	pixel_y = -2
 	},
 /obj/structure/table,
+/obj/item/clothing/mask/cigarette/pipe,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -45651,8 +45645,11 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bUG" = (
-/obj/structure/table,
-/obj/item/clothing/mask/cigarette/pipe,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/horsehead,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -46419,11 +46416,8 @@
 /turf/simulated/floor/plating,
 /area/security/vacantoffice)
 "bWk" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/mask/horsehead,
+/obj/structure/closet,
+/obj/item/flashlight,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -46446,12 +46440,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "bWo" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "bWp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47633,21 +47625,10 @@
 	name = "E.V.A. Storage"
 	})
 "bYT" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
+/obj/effect/decal/cleanable/cobweb2,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -48214,16 +48195,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "cak" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "can" = (
 /obj/machinery/firealarm{
 	name = "north bump";
@@ -48410,7 +48384,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -48692,23 +48665,19 @@
 /area/maintenance/portsolar)
 "cbq" = (
 /obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/stack/sheet/glass{
+	amount = 12
+	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/area/maintenance/aft)
 "cbr" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;5;39;25;28"
+/obj/structure/closet,
+/obj/item/stack/sheet/metal{
+	amount = 34
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/extinguisher/mini,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cbs" = (
@@ -49219,7 +49188,12 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/spawner/blob,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "ccz" = (
@@ -49737,11 +49711,6 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
-"cdH" = (
-/obj/structure/closet,
-/obj/item/flashlight,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cdI" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/extinguisher_cabinet{
@@ -50260,13 +50229,11 @@
 	},
 /area/hallway/primary/port)
 "ceZ" = (
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;5;39;25;28"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -50280,18 +50247,20 @@
 	name = "Medbay Storage"
 	})
 "cfb" = (
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage Room";
+	req_access_txt = "12"
 	},
-/obj/item/clothing/suit/storage/labcoat,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/breath/medical,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cfc" = (
-/obj/item/cigbutt,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cfd" = (
@@ -50739,12 +50708,22 @@
 "cfV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluegrid,
 /area/maintenance/aft)
 "cfW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/bluegrid,
 /area/maintenance/aft)
 "cfY" = (
@@ -51399,12 +51378,13 @@
 	name = "\improper Toxins Lab"
 	})
 "chw" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/item/stack/cable_coil{
+	pixel_x = -1;
+	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/item/wrench,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "chx" = (
@@ -51418,11 +51398,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "chz" = (
-/obj/structure/closet/crate,
-/obj/item/coin/silver,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/screwdriver{
+	pixel_y = 6
+	},
+/obj/item/crowbar,
+/obj/item/storage/pill_bottle,
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
 /area/maintenance/aft)
 "chB" = (
 /obj/item/cigbutt,
@@ -51563,14 +51550,14 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "chS" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/machinery/light_construct,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
 /area/maintenance/aft)
 "chT" = (
 /obj/structure/noticeboard{
@@ -51966,11 +51953,11 @@
 	},
 /area/maintenance/incinerator)
 "ciK" = (
-/obj/item/trash/semki,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "ciL" = (
@@ -52211,16 +52198,13 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "cjg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room";
-	req_access_txt = "12"
+/obj/structure/bed/roller,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cjh" = (
 /obj/machinery/door/firedoor,
@@ -52246,11 +52230,14 @@
 	},
 /area/medical/reception)
 "cjk" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/glass{
-	amount = 12
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/clothing/suit/storage/labcoat,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/breath/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cjl" = (
@@ -52302,24 +52289,10 @@
 	name = "counterfeit fabricator";
 	req_access = "0"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cjs" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/item/cigbutt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cjt" = (
@@ -52329,18 +52302,6 @@
 /area/medical/medbay2{
 	name = "Medbay Storage"
 	})
-"cju" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/metal{
-	amount = 34
-	},
-/obj/item/extinguisher/mini,
-/obj/machinery/light_construct{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cjv" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/decal/cleanable/dirt,
@@ -52803,29 +52764,8 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
-"ckv" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "ckw" = (
-/obj/structure/girder,
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "ckx" = (
@@ -52855,14 +52795,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
-"ckA" = (
-/obj/structure/rack,
-/obj/item/stack/rods{
-	amount = 23
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "ckB" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -53453,16 +53385,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"clU" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -55864,12 +55786,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/aft)
-"crd" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "crf" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -63464,18 +63380,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/medical/cryo)
-"cGZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/structure/grille,/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "maint grille or trash spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cHa" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -64840,23 +64744,6 @@
 /area/toxins/mixing{
 	name = "\improper Toxins Lab"
 	})
-"cJy" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/iv_bag,
-/obj/item/reagent_containers/iv_bag,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/dropper,
-/obj/structure/sign/biohazard{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/aft)
 "cJz" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/decal/warning_stripes/north,
@@ -65269,8 +65156,10 @@
 	name = "\improper Toxins Lab"
 	})
 "cKC" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/warning_stripes/east,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Surplus Storeroom";
+	req_access_txt = "12"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cKD" = (
@@ -66645,20 +66534,6 @@
 /area/medical/research)
 "cNa" = (
 /obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/storage/backpack/duffel/medical,
-/obj/item/flashlight/pen{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/aft)
-"cNb" = (
-/obj/structure/table,
 /obj/item/retractor,
 /obj/item/hemostat,
 /obj/item/healthanalyzer,
@@ -66964,17 +66839,24 @@
 	},
 /area/medical/medbay3)
 "cNO" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
 /area/maintenance/aft)
 "cNP" = (
-/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/iv_bag,
+/obj/item/reagent_containers/iv_bag,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/dropper,
+/obj/structure/sign/biohazard{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -67528,15 +67410,6 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
-"cOJ" = (
-/obj/structure/bed/roller,
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/maintenance/aft)
 "cOL" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -67931,23 +67804,16 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
-"cPF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Surplus Storeroom";
-	req_access_txt = "12"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cPG" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/screwdriver{
-	pixel_y = 6
+/obj/item/storage/backpack/duffel/medical,
+/obj/item/flashlight/pen{
+	pixel_x = 4;
+	pixel_y = 3
 	},
-/obj/item/crowbar,
-/obj/item/storage/pill_bottle,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -70187,24 +70053,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/medbay3)
-"cUb" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/trash/cheesie,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "cUd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -72891,18 +72739,6 @@
 /obj/structure/closet/secure_closet/psychiatrist,
 /turf/simulated/floor/wood,
 /area/medical/psych)
-"dan" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "dap" = (
 /obj/item/radio/beacon,
 /obj/effect/decal/warning_stripes/north,
@@ -74518,12 +74354,6 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/maintcentral)
-"deH" = (
-/obj/machinery/vending/shoedispenser,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "deI" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -74544,12 +74374,6 @@
 	icon_state = "grimy"
 	},
 /area/chapel/office)
-"deJ" = (
-/obj/machinery/vending/hatdispenser,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "deL" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -75053,11 +74877,6 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
 /obj/item/radio/off,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -77060,8 +76879,8 @@
 "idx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -77214,6 +77033,8 @@
 "isf" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -78830,6 +78651,11 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "nUW" = (
@@ -81839,8 +81665,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -95990,10 +95818,10 @@ bKy
 apf
 atj
 apd
-aoX
+ayB
 auy
 auC
-aoX
+bRD
 cgo
 rvu
 caw
@@ -96508,8 +96336,8 @@ bFp
 bFp
 bFp
 bFp
-aoX
-bYT
+apd
+rvu
 apf
 apd
 cgo
@@ -96765,7 +96593,7 @@ bRA
 bHh
 bTo
 bFp
-aqB
+apd
 cQS
 bXK
 cdD
@@ -97022,12 +96850,12 @@ bRB
 bTn
 bUD
 bFp
-ayB
+apd
 rvu
 apf
-apd
+bWk
 bFX
-apd
+bYT
 apf
 aaa
 aaa
@@ -97282,12 +97110,12 @@ bFp
 apd
 rvu
 apf
-cbq
 apf
 apf
 apf
-aaa
-aaa
+apf
+cmi
+cmi
 cmi
 chy
 cmi
@@ -97537,15 +97365,15 @@ bHf
 bHf
 bWj
 bYx
-cUb
-apf
-apf
-apf
-cdH
-bZU
-bZU
-bZU
-cmi
+eYE
+apd
+apd
+apd
+ckw
+chy
+chy
+chy
+chy
 sRB
 lcL
 bZU
@@ -97793,16 +97621,16 @@ bHf
 bTn
 bUE
 bFp
-auy
+apd
 bYW
 caJ
-cbr
-dan
+ceN
+ceN
 ceN
 chP
 ceN
 xJB
-ckv
+ceN
 ceN
 cof
 bZU
@@ -97822,10 +97650,10 @@ bZU
 bgZ
 crl
 bZU
-aaa
-abq
-aaa
-aaa
+bZU
+bZU
+bZU
+bZU
 aaa
 aaa
 cFv
@@ -98050,7 +97878,7 @@ bRC
 bTo
 bUF
 bFp
-auC
+apd
 avU
 bZU
 bZU
@@ -98058,9 +97886,9 @@ bZU
 bZU
 bZU
 bZU
-bZU
+bgZ
 ckw
-bZU
+chy
 coe
 bZU
 cpy
@@ -98079,11 +97907,11 @@ bZU
 cEL
 cDB
 bZU
+chz
+chS
+cjg
 bZU
 bZU
-bZU
-bZU
-aaa
 aaa
 cHZ
 cIT
@@ -98307,17 +98135,17 @@ bFp
 bFp
 bFp
 bFp
-apf
+apd
 hgW
 bZU
 cbs
-cuV
+bWo
 cdJ
 ceO
 bZU
-chy
+bgZ
 ckw
-bZU
+chy
 ebA
 bZU
 cpS
@@ -98338,8 +98166,8 @@ bZU
 bZU
 cPG
 cNO
-cOJ
-bZU
+chy
+cjs
 bZU
 aaa
 cHZ
@@ -98560,21 +98388,21 @@ bBK
 bOX
 bOk
 bBK
-bRD
+bVR
 bTp
 bUG
-bWk
 apf
-bfl
+bRD
+avU
 bZU
 cem
 dfi
 dgC
 cfm
 bZU
-chy
 bgZ
-bZU
+ckw
+cuV
 ebA
 bZU
 cpA
@@ -98595,7 +98423,7 @@ cdN
 bZU
 cNa
 cNP
-chy
+cjk
 cfc
 bZU
 aaa
@@ -98820,18 +98648,18 @@ bBK
 bRE
 arJ
 apd
-deJ
 apf
+apd
 avU
 bZU
 cbu
 ceE
 chy
-cEB
-cfU
+ceZ
+cfb
 nTF
-clu
-bZU
+ckw
+cuV
 ebA
 bZU
 bZU
@@ -98850,9 +98678,9 @@ cuV
 bgZ
 clP
 bZU
-cNb
-cJy
-cfb
+bZU
+bZU
+cPT
 cKC
 bZU
 aaa
@@ -99077,18 +98905,18 @@ bBK
 bRF
 arU
 apd
-deH
 apf
+apd
 avU
 bZU
 ceu
 cHV
-chy
-chy
+cak
+bgZ
 bZU
 bZU
-cjg
 bZU
+cuV
 dhr
 cod
 cod
@@ -99106,12 +98934,12 @@ ckJ
 ckJ
 cGg
 cJR
-bZU
-bZU
-bZU
-cPT
-cPF
-bZU
+chy
+chy
+chy
+chy
+chy
+chy
 bZU
 abq
 cFv
@@ -99333,21 +99161,21 @@ bIU
 bBK
 bRG
 apd
-atj
-crd
+bib
 apf
+apd
 avU
 bZU
 cbw
 ccx
-cdN
-chS
-bZU
-ckH
-cEL
-bZU
+cbq
 bgZ
-coD
+chw
+ckH
+bZU
+cuV
+bgZ
+chy
 cFQ
 cLU
 crF
@@ -99364,7 +99192,7 @@ ckD
 cIb
 cDT
 ckJ
-cGZ
+ckJ
 ckJ
 ckJ
 ckJ
@@ -99590,19 +99418,19 @@ bOm
 bBK
 bRH
 apd
-apd
 auI
 bXK
-cak
+bYx
+avU
 bZU
 bZU
 bZU
-bZU
-bZU
-bZU
-bib
+cbr
 bgZ
+chy
+chy
 bZU
+chy
 srJ
 coC
 coC
@@ -99848,18 +99676,18 @@ bBK
 bRI
 bRH
 bVR
-bWm
 apf
+apd
 avU
 apf
 auC
 apf
 ceT
 cfV
-cjs
-ckJ
-clT
+chy
+chy
 bZU
+chy
 bgZ
 coC
 cpU
@@ -100106,7 +99934,7 @@ apf
 apf
 apf
 apf
-apf
+apd
 avU
 cgH
 cgU
@@ -100115,8 +99943,8 @@ ceU
 cfW
 cjr
 chy
-ckA
 bZU
+chy
 bgZ
 coC
 coy
@@ -100356,7 +100184,7 @@ bgY
 bgY
 bAo
 bgY
-aSM
+bgY
 bgY
 bgY
 bAo
@@ -100372,8 +100200,8 @@ ceV
 idx
 dgG
 cuV
-clU
 bZU
+chy
 bgZ
 coC
 cpW
@@ -100609,7 +100437,7 @@ bxZ
 apf
 bBN
 apd
-aoX
+apd
 bHp
 cgm
 cgo
@@ -100618,8 +100446,8 @@ cgo
 cgo
 auC
 bTr
-aoX
-bWo
+apd
+apd
 cgm
 isf
 apf
@@ -100627,10 +100455,10 @@ apf
 apf
 bZU
 bZU
-cju
-cjk
 bZU
 bZU
+bZU
+chy
 bgZ
 coC
 cpV
@@ -100883,12 +100711,12 @@ bzK
 bzK
 avX
 chy
-bZU
-bZU
-bZU
-bZU
-bZU
-hLt
+chy
+chy
+chy
+chy
+chy
+bgZ
 coC
 cpY
 crE
@@ -101139,12 +100967,12 @@ bZW
 bFw
 bzK
 cho
-cQL
-ceZ
-chw
 ckJ
 ckJ
-cGZ
+ckJ
+ckJ
+ckJ
+ckJ
 clT
 coC
 cpX
@@ -101396,9 +101224,9 @@ bZc
 bZZ
 bzK
 avU
-chz
-bZU
-cfY
+chy
+cjn
+cdN
 cem
 ciK
 cmX
@@ -101910,7 +101738,7 @@ bZe
 cab
 bzK
 avU
-aoX
+bRD
 bZU
 cfZ
 dhf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> Expands the maintenance tunnels on MetaStation, done via reshuffling the existing rooms where possible, as well as the chapel/escape and engineering by 1-2 tiles. To fill some of the gaps made, added some maintenance rooms.

Please note that there will still be 1 tile wide maintenance tunnels on the map, however they are now the minority instead of the majority as lots of the tunnels don't actually connect and more or less weave between pre-established departments.

In addition, if there are any areas that need an obvious change or can be improved from what is provided, please comment it as this is really my first time redesigning a major station component.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->One of the major gripes with MetaStation is that it's maintenance is significantly narrow. By doing this expansion, I'm hoping to bring it more in line as best as I can.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. --> Go view MapDiffBot.

## Changelog
:cl:
tweak: Expands MetaStation maintenance tunnels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
