### PR TITLE
Add random critter crate, remove the unused crate subtype and tweak the animal hospital lavaland ruin to use new random crate

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -597,13 +597,13 @@
 /turf/simulated/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "bE" = (
-/obj/structure/closet/crate/critter,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/closet/critter/random,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/animal_hospital)
 "bF" = (

--- a/code/game/objects/structures/crates_lockers/closets/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/crittercrate.dm
@@ -1,6 +1,0 @@
-/obj/structure/closet/crate/critter
-	name = "critter crate"
-	desc = "A crate which can sustain life for a while."
-	icon_state = "critter"
-	open_door_sprite = null
-	material_drop = /obj/item/stack/sheet/wood

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -40,8 +40,7 @@
 	name = "unmarked crate"
 	desc = "A crate designed for safe transport of animals. The contents are a mystery."
 
-/obj/structure/closet/critter/random/Initialize(mapload)
-	. = ..()
+/obj/structure/closet/critter/random/populate_contents()
 	content_mob = pick(/mob/living/simple_animal/pet/dog/corgi,
 	/mob/living/simple_animal/pet/dog/corgi/Lisa,
 	/mob/living/simple_animal/cow,

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -5,7 +5,7 @@
 	icon_opened = "critter_open"
 	icon_closed = "critter"
 	open_door_sprite = null
-	var/already_opened = 0
+	var/already_opened = FALSE
 	var/content_mob = null
 	var/amount = 1
 	open_sound = 'sound/machines/wooden_closet_open.ogg'
@@ -15,26 +15,45 @@
 
 /obj/structure/closet/critter/can_open()
 	if(welded)
-		return 0
-	return 1
+		return
+	return TRUE
 
 /obj/structure/closet/critter/open()
 	if(!can_open())
-		return 0
+		return
 
 	if(content_mob == null) //making sure we don't spawn anything too eldritch
-		already_opened = 1
+		already_opened = TRUE
 		return ..()
 
 	if(content_mob != null && already_opened == 0)
 		for(var/i = 1, i <= amount, i++)
 			new content_mob(loc)
-		already_opened = 1
+		already_opened = TRUE
 	. = ..()
 
 /obj/structure/closet/critter/close()
 	..()
-	return 1
+	return TRUE
+
+/obj/structure/closet/critter/random
+	name = "unmarked crate"
+	desc = "A crate designed for safe transport of animals. The contents are a mystery."
+
+/obj/structure/closet/critter/random/Initialize(mapload)
+	. = ..()
+	content_mob = pick(/mob/living/simple_animal/pet/dog/corgi,
+	/mob/living/simple_animal/pet/dog/corgi/Lisa,
+	/mob/living/simple_animal/cow,
+	/mob/living/simple_animal/pig,
+	/mob/living/simple_animal/hostile/retaliate/goat,
+	/mob/living/simple_animal/turkey,
+	/mob/living/simple_animal/chick,
+	/mob/living/simple_animal/pet/cat,
+	/mob/living/simple_animal/pet/dog/pug,
+	/mob/living/simple_animal/pet/dog/fox,
+	/mob/living/simple_animal/deer,
+	/mob/living/simple_animal/bunny)
 
 /obj/structure/closet/critter/corgi
 	name = "corgi crate"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1133,7 +1133,6 @@
 #include "code\game\objects\structures\crates_lockers\walllocker.dm"
 #include "code\game\objects\structures\crates_lockers\closets\cardboardbox.dm"
 #include "code\game\objects\structures\crates_lockers\closets\coffin.dm"
-#include "code\game\objects\structures\crates_lockers\closets\crittercrate.dm"
 #include "code\game\objects\structures\crates_lockers\closets\fireaxe.dm"
 #include "code\game\objects\structures\crates_lockers\closets\fitness.dm"
 #include "code\game\objects\structures\crates_lockers\closets\gimmick.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The `/obj/structure/closet/crate/critter` object is removed as it is fully deprecated by `/obj/structure/closet/critter`, and otherwise was just visually a critter crate, not in function.

At the same time, this adds a `random` subtype and replaces the `/obj/structure/closet/crate/critter` in the animal hospital.

## Why It's Good For The Game
Fixes #17535, at the same time allow for random crates to be mapped in, or spawned. The crate subtype is removed as it otherwise is just a regular crate.

## Images of changes
https://user-images.githubusercontent.com/80771500/160451241-922f7242-db91-4c38-b50f-74b976856b68.mp4

## Changelog
:cl:
fix: Critter crate in animal hospital is visible, and will spawn a random animal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
