### PR TITLE
Makes check_self_for_injuries lag the client less.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -291,42 +291,47 @@
 
 /mob/living/carbon/proc/check_self_for_injuries()
 	var/mob/living/carbon/human/H = src
-	visible_message( \
-		text("<span class='notice'>[src] examines [].</span>",gender==MALE?"himself":"herself"), \
+	visible_message("<span class='notice'>[src] examines [H.p_them()]selves.</span>", \
 		"<span class='notice'>You check yourself for injuries.</span>" \
 		)
+	var/list/status_list = list()
 
 	var/list/missing = list("head", "chest", "groin", "l_arm", "r_arm", "l_hand", "r_hand", "l_leg", "r_leg", "l_foot", "r_foot")
 	for(var/X in H.bodyparts)
 		var/obj/item/organ/external/LB = X
 		missing -= LB.limb_name
-		var/status = ""
+		var/status
 		var/brutedamage = LB.brute_dam
 		var/burndamage = LB.burn_dam
 
-		if(brutedamage > 0)
-			status = "bruised"
-		if(brutedamage > 20)
-			status = "battered"
-		if(brutedamage > 40)
-			status = "mangled"
+		switch(brutedamage)
+			if(0.1 to 20)
+				status = "bruised"
+			if(20 to 40)
+				status = "bruised"
+			if(40 to INFINITY)
+				status = "mangled"
 		if(brutedamage > 0 && burndamage > 0)
 			status += " and "
-		if(burndamage > 40)
-			status += "peeling away"
 
-		else if(burndamage > 10)
-			status += "blistered"
-		else if(burndamage > 0)
-			status += "numb"
+		switch(burndamage)
+			if(0.1 to 10)
+				status += "numb"
+			if(10 to 40)
+				status += "blistered"
+			if(40 to INFINITY)
+				status += "peeling away"
+
 		if(LB.status & ORGAN_MUTATED)
 			status = "weirdly shapen."
-		if(status == "")
-			status = "OK"
-		to_chat(src, "\t <span class='[status == "OK" ? "notice" : "warning"]'>Your [LB.name] is [status].</span>")
+
+		var/msg = "<span class='notice'>Your [LB.name] is OK.</span>"
+		if(!isnull(status))
+			msg = "<span class='warning'>Your [LB.name] is [status].</span>"
+		status_list += msg
 
 		for(var/obj/item/I in LB.embedded_objects)
-			to_chat(src, "\t <a href='byond://?src=[UID()];embedded_object=[I.UID()];embedded_limb=[LB.UID()]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>")
+			status_list += "<a href='byond://?src=[UID()];embedded_object=[I.UID()];embedded_limb=[LB.UID()]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>"
 
 	for(var/t in missing)
 		to_chat(src, "<span class='boldannounce'>Your [parse_zone(t)] is missing!</span>")
@@ -338,6 +343,10 @@
 			to_chat(src, "<span class='info'>You're completely exhausted.</span>")
 		else
 			to_chat(src, "<span class='info'>You feel fatigued.</span>")
+
+	var/output = status_list.Join("\n")
+	to_chat(src, output)
+
 	if(HAS_TRAIT(H, TRAIT_SKELETONIZED) && (!H.w_uniform) && (!H.wear_suit))
 		H.play_xylophone()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -308,7 +308,7 @@
 			if(0.1 to 20)
 				status = "bruised"
 			if(20 to 40)
-				status = "bruised"
+				status = "battered"
 			if(40 to INFINITY)
 				status = "mangled"
 		if(brutedamage > 0 && burndamage > 0)
@@ -334,15 +334,15 @@
 			status_list += "<a href='byond://?src=[UID()];embedded_object=[I.UID()];embedded_limb=[LB.UID()]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>"
 
 	for(var/t in missing)
-		to_chat(src, "<span class='boldannounce'>Your [parse_zone(t)] is missing!</span>")
+		status_list += "<span class='boldannounce'>Your [parse_zone(t)] is missing!</span>"
 
 	if(H.bleed_rate)
-		to_chat(src, "<span class='danger'>You are bleeding!</span>")
+		status_list +=  "<span class='danger'>You are bleeding!</span>"
 	if(staminaloss)
 		if(staminaloss > 30)
-			to_chat(src, "<span class='info'>You're completely exhausted.</span>")
+			status_list += "<span class='info'>You're completely exhausted.</span>"
 		else
-			to_chat(src, "<span class='info'>You feel fatigued.</span>")
+			status_list += "<span class='info'>You feel fatigued.</span>"
 
 	var/output = status_list.Join("\n")
 	to_chat(src, output)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -291,7 +291,7 @@
 
 /mob/living/carbon/proc/check_self_for_injuries()
 	var/mob/living/carbon/human/H = src
-	visible_message("<span class='notice'>[src] examines [H.p_them()]selves.</span>", \
+	visible_message("<span class='notice'>[src] examines [H.p_them()]self.</span>", \
 		"<span class='notice'>You check yourself for injuries.</span>" \
 		)
 	var/list/status_list = list()
@@ -323,7 +323,7 @@
 				status += "peeling away"
 
 		if(LB.status & ORGAN_MUTATED)
-			status = "weirdly shapen."
+			status = "weirdly shapen"
 
 		var/msg = "<span class='notice'>Your [LB.name] is OK.</span>"
 		if(!isnull(status))
@@ -337,7 +337,7 @@
 		status_list += "<span class='boldannounce'>Your [parse_zone(t)] is missing!</span>"
 
 	if(H.bleed_rate)
-		status_list +=  "<span class='danger'>You are bleeding!</span>"
+		status_list += "<span class='danger'>You are bleeding!</span>"
 	if(staminaloss)
 		if(staminaloss > 30)
 			status_list += "<span class='info'>You're completely exhausted.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
reduces the amount of `to_chats` sent to a client in one proc. reducing the stutter you feel when you accidentally click on yourself with help intent.

## Why It's Good For The Game
less client side lag is good. also less reassigning values.

## Images
![image](https://user-images.githubusercontent.com/69320440/160885818-f33cc252-1e46-4d9b-8b49-bdd112d7133d.png)


## Changelog
no player facing changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
