### PR TITLE
Adds RPD to engineering winter coats

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -452,7 +452,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "coatengineer"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 20, FIRE = 30, ACID = 45)
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/t_scanner, /obj/item/rcd)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/t_scanner, /obj/item/rcd, /obj/item/rpd)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering
 
 /obj/item/clothing/head/hooded/winterhood/engineering


### PR DESCRIPTION
## What Does This PR Do
Adds the RPD and subtypes to allowed items on engineering wintercoats

## Why It's Good For The Game
RPDs are the same size as RCDs, plus it's more convenient for engineering/atmos players to have the RPD on the coat

## Changelog
:cl:
tweak: RPD can now be put in suit slot for engineering and atmospherics wintercoats
/:cl: