### PR TITLE
fixes firelocks et al. preventing the movement of air (revisited)

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -278,6 +278,14 @@ SUBSYSTEM_DEF(air)
 			T.excited_group.garbage_collect()
 
 /datum/controller/subsystem/air/proc/add_to_active(turf/simulated/T, blockchanges = 1)
+	if(!initialized)
+		/* it makes no sense to "activate" turfs before setup_allturfs is
+		   called, as setup_allturfs would simply cull the list incorrectly.
+		   only /turf/simulated/Initialize_Atmos() is blessed enough to
+		   activate turfs during this phase of initialization, as it happens
+		   post-cull and inlines the logic (perhaps incorrectly) */
+		return
+
 	if(istype(T) && T.air)
 		T.excited = 1
 		active_turfs |= T
@@ -290,11 +298,8 @@ SUBSYSTEM_DEF(air)
 			add_to_active(S)
 
 /datum/controller/subsystem/air/proc/setup_allturfs(list/turfs_to_init = block(locate(1, 1, 1), locate(world.maxx, world.maxy, world.maxz)))
-	var/list/active_turfs = src.active_turfs
-
-	// Clear active turfs - faster than removing every single turf in the world
-	// one-by-one, and Initalize_Atmos only ever adds `src` back in.
-	active_turfs.Cut()
+	if(active_turfs.len)
+		log_debug("failed sanity check: active_turfs is not empty before initialization ([active_turfs.len])")
 
 	for(var/thing in turfs_to_init)
 		var/turf/T = thing

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -7,7 +7,10 @@
 		smoothTurfs = turfs
 
 	log_debug("Setting up atmos")
-	if(SSair)
+	/* setup_allturfs is superfluous during server initialization because
+	   air subsystem will call subsequently call setup_allturfs with _every_
+	   turf in the world */
+	if(SSair && SSair.initialized)
 		SSair.setup_allturfs(turfs)
 	log_debug("\tTook [stop_watch(subtimer)]s")
 


### PR DESCRIPTION
certain objects like firelocks, single-pane windows, windoors, and potentially others would prevent the movement of air until they were "woken up" by opening/closing the firelock, breathing on it or removing/adding the floor tile underneath.

image attached demonstrates this, with the plasma being very secure and stable within its region and never moving passed the firelock.

![fix_atmos_firelocks](https://user-images.githubusercontent.com/16431567/160660440-aee7993d-8a42-4d37-81fa-90a082cc0dd3.png)

:cl: anon
fix: firelocks and others no longer prevent movement of air until "awoken" after server intializations
/:cl:

this is a different approach to the original pr https://github.com/ParadiseSS13/Paradise/pull/15720