### PR TITLE
fixes atmos pda readout

### DIFF
--- a/code/modules/pda/core_apps.dm
+++ b/code/modules/pda/core_apps.dm
@@ -120,7 +120,7 @@
 				list("entry" = "Nitrogen", "units" = "%", "val" = "[round(n2_level*100,0.1)]", "bad_high" = 105, "poor_high" = 85, "poor_low" = 50, "bad_low" = 40),
 				list("entry" = "Carbon Dioxide", "units" = "%", "val" = "[round(co2_level*100,0.1)]", "bad_high" = 10, "poor_high" = 5, "poor_low" = 0, "bad_low" = 0),
 				list("entry" = "Plasma", "units" = "%", "val" = "[round(plasma_level*100,0.01)]", "bad_high" = 0.5, "poor_high" = 0, "poor_low" = 0, "bad_low" = 0),
-				list("entry" = "Other", "units" = "%", "val" = "[round(unknown_level, 0.01)]", "bad_high" = 1, "poor_high" = 0.5, "poor_low" = 0, "bad_low" = 0)
+				list("entry" = "Other", "units" = "%", "val" = "[round(unknown_level*100,0.01)]", "bad_high" = 1, "poor_high" = 0.5, "poor_low" = 0, "bad_low" = 0)
 			)
 
 	if(isnull(results))


### PR DESCRIPTION
:cl: anon
fix: the atmos scan pda app now displays trace gas ratios correctly
/:cl:

before:
![atmos_pda_readout_before](https://user-images.githubusercontent.com/16431567/160662483-2cee7697-ddfc-4f78-b1d6-95f0e54f06d8.png)

after:
![atmos_pda_readout_after](https://user-images.githubusercontent.com/16431567/160662495-9dfac244-97f8-4dd5-a0e6-410632d87a7d.png)

