### PR TITLE
 Replace IPC starting box with comfy happy box <3 [reopened]

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -73,6 +73,8 @@
 		"is downloading extra RAM!",
 		"is frying their own circuits!",
 		"is blocking their ventilation port!")
+		
+	speciesbox = /obj/item/storage/box/hug
 
 	var/datum/action/innate/change_monitor/monitor
 


### PR DESCRIPTION
## What Does This PR Do
This replaces the starting box for Machines (currently the default O2 survival box) with a very cute happy box. The new machine survival box contains:
* everything an IPC could use to keep themself from dying while in crit
* the courage to keep on trying!

## Why It's Good For The Game
IPCs no longer have to start the round by dumping some organics-themed items out on a table if they want to have an empty storage box.

## Images of changes
![hugs](https://user-images.githubusercontent.com/1126916/161208506-3c2a47b3-ecdb-4636-a20c-761f494ee20e.PNG)
![wow its nothing](https://user-images.githubusercontent.com/1126916/161208526-5c368616-db81-4dfe-8fe5-763eaccecb59.PNG)


:cl: ARMA-993
tweak: IPCs spawn with a happy friendly box
/:cl:
