### PR TITLE
Adds obstacle check to bounce spells. Fixing lightning and magnetism from going through windows

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -498,18 +498,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 /obj/effect/proc_holder/spell/aoe_turf/write_custom_logs(list/targets, mob/user)
 	add_attack_logs(user, null, "Cast the AoE spell [name]", ATKLOG_ALL)
 
-/obj/effect/proc_holder/spell/proc/los_check(mob/A,mob/B)
-	//Checks for obstacles from A to B
-	var/obj/dummy = new(A.loc)
-	dummy.pass_flags |= PASSTABLE
-	for(var/turf/turf in getline(A,B))
-		for(var/atom/movable/AM in turf)
-			if(!AM.CanPass(dummy,turf,1))
-				qdel(dummy)
-				return 0
-	qdel(dummy)
-	return 1
-
 /obj/effect/proc_holder/spell/proc/can_cast(mob/user = usr, charge_check = TRUE, show_message = FALSE)
 	if(((!user.mind) || !(src in user.mind.spell_list)) && !(src in user.mob_spell_list))
 		if(show_message)

--- a/code/datums/spell_targeting/spell_targeting.dm
+++ b/code/datums/spell_targeting/spell_targeting.dm
@@ -22,6 +22,8 @@
 	var/try_auto_target = FALSE
 	/// Whether or not the spell should use the turf of the user as starting point
 	var/use_turf_of_user = FALSE
+	/// If the spell should do an obstacle check from the user to the target. Windows, for example, will block the spell if this is true.
+	var/use_obstacle_check = FALSE
 
 /**
  * Called when choosing the targets for the parent spell
@@ -78,4 +80,26 @@
 /datum/spell_targeting/proc/valid_target(target, user, obj/effect/proc_holder/spell/spell, check_if_in_range = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 	return istype(target, allowed_type) && (include_user || target != user) && \
-		spell.valid_target(target, user) && (!check_if_in_range || (target in view_or_range(range, use_turf_of_user ? get_turf(user) : user, selection_type)))
+		spell.valid_target(target, user) && (!check_if_in_range || (target in view_or_range(range, use_turf_of_user ? get_turf(user) : user, selection_type))) \
+		&& (!use_obstacle_check || obstacle_check(user, target))
+
+
+/**
+ * Checks if the path from the source to the target is free.
+ * Mobs won't block the path. But any dense object (other than tables) will.
+ *
+ * Arguments:
+ * * source - Where is the spell effect coming from?
+ * * target - Where is the spell effect going?
+ */
+/datum/spell_targeting/proc/obstacle_check(atom/source, atom/target)
+	//Checks for obstacles from A to B
+	var/obj/dummy = new(source.loc)
+	dummy.pass_flags |= PASSTABLE
+	for(var/turf/turf as anything in getline(source, target))
+		for(var/atom/movable/AM in turf)
+			if(!AM.CanPass(dummy, turf, 1))
+				qdel(dummy)
+				return FALSE
+	qdel(dummy)
+	return TRUE

--- a/code/datums/spell_targeting/targeted.dm
+++ b/code/datums/spell_targeting/targeted.dm
@@ -37,12 +37,11 @@
 					for(var/atom/A as anything in possible_targets)
 						if(target)
 							if(get_dist(spell_location, A) < get_dist(spell_location, target))
-								if(spell.los_check(user, A))
-									target = A
-						else
-							if(spell.los_check(user, A))
 								target = A
-			targets += target
+						else
+							target = A
+			if(target)
+				targets += target
 	else if(max_targets > 1)
 		do
 			if(can_hit_target_more_than_once)

--- a/code/datums/spells/charge_up_bounce.dm
+++ b/code/datums/spells/charge_up_bounce.dm
@@ -5,6 +5,13 @@
 /obj/effect/proc_holder/spell/charge_up/bounce
 	var/bounce_hit_sound
 
+/obj/effect/proc_holder/spell/charge_up/bounce/create_new_targeting()
+	var/datum/spell_targeting/click/T = new
+	T.allowed_type = /mob/living
+	T.try_auto_target = FALSE
+	T.use_obstacle_check = TRUE
+	return T
+
 /obj/effect/proc_holder/spell/charge_up/bounce/cast(list/targets, mob/user = usr)
 	var/mob/living/target = targets[1]
 
@@ -55,7 +62,7 @@
 	if(bounces >= 1)
 		var/list/possible_targets = list()
 		for(var/mob/living/M in view(targeting.range, target))
-			if(user == M || target == M && los_check(target, M))
+			if(user == M || target == M && targeting.obstacle_check(target, M))
 				continue
 			possible_targets += M
 		if(!length(possible_targets))


### PR DESCRIPTION
## What Does This PR Do
Fixes a regression introduced by #17235. 
Magnetism and lightning now won't allow spells to be cast on people behind dense objects like windows or machines.

The obstacle check is also available for other spells. But none other use it currently.
I've ported the old method of checking for obstacles over from the `spell` object and put it in the `spell_targeting` datum.

## Why It's Good For The Game
Bug fix

## Changelog
:cl:
fix: The lightning and magnetism spell now won't go through dense objects like windows or machines
/:cl: