### PR TITLE
Sets the default FPS to 63

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -277,7 +277,7 @@ CREATE TABLE `player` (
   `volume_mixer` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `lastchangelog` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '0',
   `exp` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `clientfps` smallint(4) DEFAULT '0',
+  `clientfps` smallint(4) DEFAULT '63',
   `atklog` smallint(4) DEFAULT '0',
   `fuid` bigint(20) DEFAULT NULL,
   `fupdate` smallint(4) DEFAULT '0',

--- a/SQL/updates/34-35.sql
+++ b/SQL/updates/34-35.sql
@@ -1,0 +1,4 @@
+# Updates DB from 34 to 35 -hal9000PR
+# Changes DB default for clientFPS to 63
+
+ALTER TABLE `player` CHANGE COLUMN `clientfps` `clientfps` INT(11) DEFAULT '63' AFTER `exp`;

--- a/SQL/updates/34-35.sql
+++ b/SQL/updates/34-35.sql
@@ -1,4 +1,4 @@
 # Updates DB from 34 to 35 -hal9000PR
 # Changes DB default for clientFPS to 63
 
-ALTER TABLE `player` CHANGE COLUMN `clientfps` `clientfps` INT(11) DEFAULT '63' AFTER `exp`;
+ALTER TABLE `player` CHANGE COLUMN `clientfps` `clientfps` smallint(4) DEFAULT '63' AFTER `exp`;

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -367,7 +367,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 34
+#define SQL_VERSION 35
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	var/sound = SOUND_DEFAULT
 	var/UI_style_color = "#ffffff"
 	var/UI_style_alpha = 255
-	var/clientfps = 0
+	var/clientfps = 63
 	var/atklog = ATKLOG_ALL
 	var/fuid							// forum userid
 

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -145,7 +145,7 @@ ipc_screens = [
 # Enable/disable the database on a whole
 sql_enabled = false
 # SQL version. If this is a mismatch, round start will be delayed
-sql_version = 34
+sql_version = 35
 # SQL server address. Can be an IP or DNS name
 sql_address = "127.0.0.1"
 # SQL server port


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title

## Why It's Good For The Game
New players can have a smoother experience without having to wait for someone on the discord to tell them about the FPS option.

## Changelog
:cl:
tweak: new players FPS is defaulted to 63 now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
