### PR TITLE
VV tweaks + security fix

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2094,3 +2094,22 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	output["CONTENT"] = content
 
 	return output
+
+
+/proc/is_maintainer(mob/user)
+	#ifdef TESTING // Account for local test mode
+	return TRUE
+	#endif
+
+	// Check if this user is a maint, or on a test server
+	var/ip_check = (user.client.address == "127.0.0.1" || user.client.address == null)
+
+	var/rank_check = FALSE
+
+	if(user.client.holder)
+		rank_check = (findtext(user.client.holder.rank, "Maintainer") > 0) // Accounts for "Maintainers", "Maintainer", "Host & Maintainer", etc
+
+	if(ip_check || rank_check)
+		return TRUE
+
+	return FALSE

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -7,6 +7,10 @@
 
 	if(!check_rights(R_VAREDIT))	return
 
+	// Make sure we can actually edit this var
+	if(!vv_varname_lockcheck(var_name))
+		return FALSE
+
 	if(A && A.type)
 		if(typesof(A.type))
 			switch(input("Strict object type detection?") as null|anything in list("Strictly this type","This type and subtypes", "Cancel"))

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -1,7 +1,17 @@
-GLOBAL_LIST_INIT(VVlocked, list("vars", "var_edited", "client", "firemut", "ishulk", "telekinesis", "xray", "ka", "virus", "viruses", "cuffed", "last_eaten", "unlock_content")) // R_DEBUG
+GLOBAL_LIST_INIT(VVlocked, list("client", "firemut", "ishulk", "telekinesis", "xray", "ka", "virus", "viruses", "cuffed", "last_eaten", "unlock_content")) // R_DEBUG
 GLOBAL_LIST_INIT(VVicon_edit_lock, list("icon", "icon_state", "overlays", "underlays", "resize")) // R_EVENT | R_DEBUG
 GLOBAL_LIST_INIT(VVckey_edit, list("key", "ckey")) // R_EVENT | R_DEBUG
 GLOBAL_LIST_INIT(VVpixelmovement, list("step_x", "step_y", "step_size", "bound_height", "bound_width", "bound_x", "bound_y")) // R_DEBUG + warning
+// Stuff that can break the server in weird ways and shouldnt be messed with unless you actually know what you are doing
+GLOBAL_LIST_INIT(VVmaint_only, list("vars", "var_edited", "contents"))
+
+// Protect ALL these
+GLOBAL_PROTECT(VVlocked)
+GLOBAL_PROTECT(VVicon_edit_lock)
+GLOBAL_PROTECT(VVckey_edit)
+GLOBAL_PROTECT(VVpixelmovement)
+GLOBAL_PROTECT(VVmaint_only)
+
 /client/proc/vv_get_class(var_value)
 	if(isnull(var_value))
 		. = VV_NULL
@@ -532,6 +542,11 @@ GLOBAL_LIST_INIT(VVpixelmovement, list("step_x", "step_y", "step_size", "bound_h
 		var/prompt = alert(usr, "Editing this var may irreparably break tile gliding for the rest of the round. THIS CAN'T BE UNDONE", "DANGER", "ABORT ", "Continue", " ABORT")
 		if(prompt != "Continue")
 			return FALSE
+	if(param_var_name in GLOB.VVmaint_only)
+		if(!is_maintainer(usr))
+			alert(usr, "Editing this variable is restricted to Maintainers only.", "Error", "Ok")
+			return FALSE
+
 	return TRUE
 
 /client/proc/modify_variables(atom/O, param_var_name = null, autodetect_class = 0)


### PR DESCRIPTION
## What Does This PR Do

Adds a VV check list for variables that you shouldn't edit unless you **truly** know what you are doing. I am tired of people editing an atom's `contents` list to add things when you should use `forceMove` to ensure registrations are fully updated alongside everything else. It is truly annoying to see people going all "yeah just do this this works fine" and then causing 300 runtimes, so this is what happens.

This PR also fixes a critical VV vulnerability where MassModVars will not check the variables you are editing to ensure you can edit it. **This is bad**.

## Why It's Good For The Game

- Exploits bad
- People breaking things because they dont listen is bad

## Changelog
:cl: AffectedArc07
tweak: Tweaked VV logic to reduce the amount of accidental breakages
fix: Fixed a security vulnerability in VV code
/:cl:
