### PR TITLE
Fix - Wormholes do not affect transit tubes

### DIFF
--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -44,7 +44,7 @@
 /obj/effect/portal/wormhole/can_teleport(atom/movable/M)
 	. = ..()
 
-	if(istype(M, /obj/singularity))
+	if(istype(M, /obj/singularity) || istype(M, /obj/structure/transit_tube_pod))
 		. = FALSE
 
 /obj/effect/portal/wormhole/teleport(atom/movable/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the transit tube pod as an exclusion to the wormhole teleport.

## Why It's Good For The Game
Fixes #17570.

## Images of changes
![SeriesofTubes](https://user-images.githubusercontent.com/80771500/161654339-364865b0-6b0b-472e-9ee1-8f11cafa5ec6.png)

## Changelog
:cl:
fix: Transit tube pods do not get teleported by wormholes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
