### PR TITLE
Fix - Contractor targets are stripped of suit accessories when extracted

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -410,7 +410,7 @@
 			stuff_to_transfer += I
 
 	// Remove accessories from the suit if present
-	if(H.w_uniform?.accessories.len)
+	if(length(H.w_uniform?.accessories))
 		for(var/obj/item/clothing/accessory/A in H.w_uniform.accessories)
 			A.on_removed(H)
 			H.w_uniform.accessories -= A

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -409,6 +409,14 @@
 		if(M.unEquip(I))
 			stuff_to_transfer += I
 
+	// Remove accessories from the suit if present
+	if(H.w_uniform?.accessories.len)
+		for(var/obj/item/clothing/accessory/A in H.w_uniform.accessories)
+			A.on_removed(H)
+			H.w_uniform.accessories -= A
+			H.unEquip(A)
+			stuff_to_transfer += A
+
 	// Transfer it all (or drop it if not possible)
 	for(var/i in stuff_to_transfer)
 		var/obj/item/I = i


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check on the contractor extraction for the undersuit's accessories. If present, they're removed and added to the belongings for the closet. No exceptions are made to cut down on checks, so that includes ties and scarves.

## Why It's Good For The Game
Fixes #17461.

## Images of changes
https://user-images.githubusercontent.com/80771500/161867171-e1f67584-8fa3-477f-a431-95ce5ea0f315.mp4

## Changelog
:cl:
fix: Extracted contractor targets have their suit accessories removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
