### PR TITLE
Makes the admin 'Cryo' button on the AFK player panel respect an area's fast_despawn variable

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2169,19 +2169,36 @@
 			else //robot
 				log_admin("[key_name(usr)] despawned [M] in cryo.")
 				message_admins("[key_name_admin(usr)] despawned [M] in cryo.")
-		else if(cryo_ssd(M))
+		else
+			var/fast_despawn = FALSE
+			if(href_list["fast_despawn"])
+				if(alert(owner, "[M] is an area where players being AFK cryo'd should be despawned immediately. \
+						Do you wish to immediately de-spawn them, or just continue moving them to the cryopod?", "Cryo or De-Spawn", "De-Spawn", "Move to Cryopod") == "De-Spawn")
+					fast_despawn = TRUE
+			if(!cryo_ssd(M))
+				return
+
 			if(human)
 				var/mob/living/carbon/human/H = M
-				log_admin("[key_name(usr)] sent [H.job] [H] to cryo.")
-				message_admins("[key_name_admin(usr)] sent [H.job] [H] to cryo.")
+				var/msg = "[key_name(usr)] [fast_despawn ? "despawned" : "sent"] [H.job] [H] [fast_despawn ? "in" : "to"] cryo."
+				log_admin(msg)
+				message_admins(msg)
 			else
-				log_admin("[key_name(usr)] sent [M] to cryo.")
-				message_admins("[key_name_admin(usr)] sent [M] to cryo.")
+				var/msg = "[key_name(usr)] [fast_despawn ? "despawned" : "sent"] [M] [fast_despawn ? "in" : "to"] cryo."
+				log_admin(msg)
+				message_admins(msg)
+
+			if(fast_despawn)
+				var/obj/machinery/cryopod/P = M.loc // They're already in the cryopod because of `cryo_ssd(M)` above.
+				P.despawn_occupant()
+				return
+
 			if(href_list["cryoafk"]) // Warn them if they are send to storage and are AFK
 				to_chat(M, "<span class='danger'>The admins have moved you to cryo storage for being AFK. Please eject yourself (right click, eject) out of the cryostorage if you want to avoid being despawned.</span>")
 				SEND_SOUND(M, sound('sound/effects/adminhelp.ogg'))
 				if(M.client)
 					window_flash(M.client)
+
 	else if(href_list["FaxReplyTemplate"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1060,7 +1060,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(istype(H.loc, /obj/machinery/cryopod))
 			msg += "<TD><A href='?_src_=holder;cryossd=[H.UID()];cryoafk=1'>De-Spawn</A></TD>"
 		else
-			msg += "<TD><A href='?_src_=holder;cryossd=[H.UID()];cryoafk=1'>Cryo</A></TD>"
+			var/area/A = get_area(H)
+			msg += "<TD><A href='?_src_=holder;cryossd=[H.UID()];cryoafk=1;fast_despawn=[A.fast_despawn]'>Cryo</A></TD>"
 		msg += "</TR>"
 	msg += "</TABLE></BODY></HTML>"
 	src << browse(msg, "window=Player_ssd_afk_check;size=600x300")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently, if an admin chooses to cryo an AFK player, an area's `fast_despawn` var won't be taken into account and they will always be allowed to exit the cryopod and resume playing. Players can exploit this by pretending they're AFK in, for example, perma and then once they're moved to cryo they can exit the pod, essentially using this as an escape method.

This PR adds a pop-up prompt for the admin so that if the AFK player is a `fast_despawn` area, they can choose which option they prefer:

**[Player] is an area where players being AFK cryo'd should be despawned immediately. Do you wish to immediately de-spawn them, or just continue moving them to the cryopod?" Resposne options: 'De-Spawn', or 'Move to Cryo'**

'Move to Cryo' does what it says, moves them to cryopod, and gives them the option to move out of the pod should they no longer be AFK. This functions the same as it does right now on live. 'De-Spawn' moves them to cryo and immediately despawns them, as should happen with a `fast_despawn` area.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
tweak: Gives admins the choice to instantly de-spawn a player when using the 'Cryo' option on the AFK player panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
