### PR TITLE
Removes karma lock on barber

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -54,12 +54,13 @@
 #define JOB_MIME				(1<<12)
 #define JOB_ASSISTANT			(1<<13)
 #define JOB_EXPLORER			(1<<14)
+#define JOB_BARBER				(1<<15)
 
 #define JOBCAT_KARMA			(1<<3)
 
 #define JOB_NANO				(1<<0)
 // #define JOB_BLUESHIELD		(1<<1) // AA07 2022-02-23 - Moved to ENGSEC (Non karma): Define kept for history sake
-#define JOB_BARBER				(1<<3)
+// #define JOB_BARBER			(1<<3) // AA07 2022-04-07 - Moved to SUPPORT (Non karma): Define kept for history sake
 // #define JOB_MECHANIC			(1<<4) // AA07 2021-10-02 - Removed: Kept for history sake
 // #define JOB_BRIGDOC			(1<<5) // AA07 2021-12-01 - Removed: Kept for history sake
 // #define JOB_JUDGE			(1<<6) // AA07 2021-10-09 - Moved to ENGSEC (Non karma): Define kept for history sake

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -438,10 +438,10 @@
 /datum/job/barber
 	title = "Barber"
 	flag = JOB_BARBER
-	department_flag = JOBCAT_KARMA
+	department_flag = JOBCAT_SUPPORT
 	total_positions = 1
 	spawn_positions = 1
-	is_service = 1
+	is_service = TRUE
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -89,8 +89,7 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 ))
 
 GLOBAL_LIST_INIT(whitelisted_positions, list(
-	"Nanotrasen Representative",
-	"Barber",
+	"Nanotrasen Representative", // your days are numbered
 ))
 
 

--- a/code/modules/karma/karma_packages.dm
+++ b/code/modules/karma/karma_packages.dm
@@ -36,6 +36,7 @@
 	database_id = KARMAPACKAGE_JOB_BARBER
 	friendly_name = "Barber"
 	karma_cost = 5
+	refundable = TRUE
 
 /datum/karma_package/job/brigphys
 	database_id = KARMAPACKAGE_JOB_BRIGPHYSICIAN


### PR DESCRIPTION
## What Does This PR Do
Removes karma lock on barber

The job has 0 requirements (its incredibly simple and should be nice for new players). People who have purchased it will get a 5 karma refund. There aint really much more to say.

## Why It's Good For The Game
The purge must continue.

## Changelog
:cl: AffectedArc07
tweak: Removed the karma cost on Barber. Those who have purchased it will get a 5 karma refund.
/:cl:
