### PR TITLE
Initialize lootdrop spawners and fix Sol trader vehicle spawn to have enough keys

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -8,7 +8,7 @@
 
 /obj/effect/spawner/lootdrop/Initialize(mapload)
 	. = ..()
-	while(!lootcount == 0)
+	while(lootcount)
 		var/lootspawn = pickweight(loot)
 		if(!lootdoubles)
 			loot.Remove(lootspawn)
@@ -236,7 +236,7 @@
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/minerals/Initialize(mapload)
-	while(!lootcount == 0)
+	while(lootcount)
 		var/lootspawn = pickweight(loot)
 		var/obj/item/stack/sheet/S = new lootspawn(get_turf(src))
 		S.amount = 25
@@ -356,7 +356,7 @@
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/vehicle/Initialize(mapload)
-	while(!lootcount == 0)
+	while(lootcount)
 		var/lootspawn = pickweight(loot)
 		var/obj/vehicle/V = new lootspawn(get_turf(src))
 		if(V.key_type)

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -242,7 +242,6 @@
 		S.amount = 25
 		lootcount--
 	. = ..()
-	qdel(src)
 
 /obj/effect/spawner/lootdrop/trade_sol/donksoft
 	name = "3. donksoft gear"
@@ -363,7 +362,6 @@
 			V.inserted_key = new V.key_type(V)
 		lootcount--
 	. = ..()
-	qdel(src)
 
 /obj/effect/spawner/lootdrop/trade_sol/serv
 	name = "10. service gear"

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -3,25 +3,23 @@
 	icon_state = "questionmark"
 	color = "#00FF00"
 	var/lootcount = 1		//how many items will be spawned
-	var/lootdoubles = 1		//if the same item can be spawned twice
+	var/lootdoubles = TRUE		//if the same item can be spawned twice
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
 
-/obj/effect/spawner/lootdrop/New()
-	..()
-	if(loot && loot.len)
-		for(var/i = lootcount, i > 0, i--)
-			if(!loot.len) break
-			var/lootspawn = pickweight(loot)
-			if(!lootdoubles)
-				loot.Remove(lootspawn)
-
-			if(lootspawn)
-				new lootspawn(loc)
+/obj/effect/spawner/lootdrop/Initialize(mapload)
+	. = ..()
+	while(!lootcount == 0)
+		var/lootspawn = pickweight(loot)
+		if(!lootdoubles)
+			loot.Remove(lootspawn)
+		if(lootspawn)
+			new lootspawn(get_turf(src))
+		lootcount--
 	qdel(src)
 
 /obj/effect/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"
-	lootdoubles = 0
+	lootdoubles = FALSE
 
 	loot = list(
 				/obj/item/gun/projectile/automatic/pistol = 8,
@@ -181,8 +179,7 @@
 
 /obj/effect/spawner/lootdrop/crate_spawner // for ruins
 	name = "lootcrate spawner"
-	lootdoubles = 0
-
+	lootdoubles = FALSE
 	loot = list(
 				/obj/structure/closet/crate/secure/loot = 20,
 				"" = 80,
@@ -193,7 +190,6 @@
 /obj/effect/spawner/lootdrop/trade_sol/
 	name = "trader item spawner"
 	lootcount = 6
-	lootdoubles = 1
 	color = "#00FFFF"
 
 
@@ -218,7 +214,6 @@
 
 /obj/effect/spawner/lootdrop/trade_sol/minerals
 	name = "2. minerals"
-	lootdoubles = 1
 	loot = list(
 				// Common stuff you get from mining which isn't already present on the station
 				// Note that plasma and derived hybrid materials are NOT included in this list because plasma is the trader's objective!
@@ -240,20 +235,14 @@
 				/obj/item/stack/sheet/mineral/sandstone = 50
 				)
 
-/obj/effect/spawner/lootdrop/trade_sol/minerals/New()
-	if(loot && loot.len)
-		for(var/i = lootcount, i > 0, i--)
-			if(!loot.len)
-				break
-			var/lootspawn = pickweight(loot)
-			if(!lootdoubles)
-				loot.Remove(lootspawn)
-			if(lootspawn)
-				var/obj/item/stack/sheet/S = new lootspawn(get_turf(src))
-				S.amount = 25
+/obj/effect/spawner/lootdrop/trade_sol/minerals/Initialize(mapload)
+	while(!lootcount == 0)
+		var/lootspawn = pickweight(loot)
+		var/obj/item/stack/sheet/S = new lootspawn(get_turf(src))
+		S.amount = 25
+		lootcount--
 	. = ..()
 	qdel(src)
-
 
 /obj/effect/spawner/lootdrop/trade_sol/donksoft
 	name = "3. donksoft gear"
@@ -366,16 +355,15 @@
 				/obj/vehicle/space/speedbike = 50
 				)
 
-/obj/effect/spawner/lootdrop/trade_sol/vehicle/New()
-	if(!loot.len)
-		return
-	var/lootspawn = pickweight(loot)
-	var/obj/vehicle/V = new lootspawn(get_turf(src))
-	if(V.key_type)
-		new V.key_type(get_turf(src))
+/obj/effect/spawner/lootdrop/trade_sol/vehicle/Initialize(mapload)
+	while(!lootcount == 0)
+		var/lootspawn = pickweight(loot)
+		var/obj/vehicle/V = new lootspawn(get_turf(src))
+		if(V.key_type)
+			V.inserted_key = new V.key_type(V)
+		lootcount--
 	. = ..()
 	qdel(src)
-
 
 /obj/effect/spawner/lootdrop/trade_sol/serv
 	name = "10. service gear"
@@ -423,6 +411,6 @@
 			/obj/item/reagent_containers/food/snacks/bigbiteburger,
 			/obj/item/reagent_containers/food/snacks/superbiteburger)
 
-/obj/effect/spawner/lootdrop/three_course_meal/New()
+/obj/effect/spawner/lootdrop/three_course_meal/Initialize(mapload)
 	loot = list(pick(soups) = 1,pick(salads) = 1,pick(mains) = 1)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Moves lootdrop spawners to `Initialized`, cleaning up the code while at it. The sol vehicle spawner is also fixed so it adds the appropriate key to a vehicle instead of just spawning a single one for the entire batch.

## Why It's Good For The Game
Traders won't have to get an admin to spawn keys.

## Images of changes
![Snowmobile](https://user-images.githubusercontent.com/80771500/162347161-987bd519-814d-45df-af46-0553496486f5.PNG)

## Changelog
:cl:
fix: Sol trader vehicles spawn with keys pre-inserted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
