### PR TITLE
Removes a redundant loop in client/New()

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -381,12 +381,6 @@
 
 	Master.UpdateTickRate()
 
-	// Check total playercount
-	var/playercount = 0
-	for(var/mob/M in GLOB.player_list)
-		if(M.client)
-			playercount += 1
-
 	// Tell clients about active testmerges
 	if(world.TgsAvailable() && length(GLOB.revision_info.testmerges))
 		to_chat(src, GLOB.revision_info.get_testmerge_chatmessage(TRUE))


### PR DESCRIPTION
## What Does This PR Do
Removes a redundant loop in `client/New()`.

Yes I webedited this. Blame charlie.

## Why It's Good For The Game
This is expense for no purpose on `client/New()`. I am utterly surprised the compiler didnt pick up on this.

## Changelog
N/A
