### PR TITLE
Fix Experimentor deconstruction, and standardizes into tool procs

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -149,6 +149,8 @@
 
 /obj/machinery/r_n_d/experimentor/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
 	ejectItem()
 	default_deconstruction_crowbar(user, I)
 

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -115,17 +115,7 @@
 	if(shocked)
 		shock(user,50)
 
-	if(default_deconstruction_screwdriver(user, "h_lathe_maint", "h_lathe", O))
-		if(linked_console)
-			linked_console.linked_destroy = null
-			linked_console = null
-		return
-
 	if(exchange_parts(user, O))
-		return
-
-	if(panel_open && istype(O, /obj/item/crowbar))
-		default_deconstruction_crowbar(user, O)
 		return
 
 	if(!checkCircumstances(O))
@@ -157,9 +147,19 @@
 
 	return
 
-/obj/machinery/r_n_d/experimentor/default_deconstruction_crowbar(user, obj/item/O)
+/obj/machinery/r_n_d/experimentor/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
 	ejectItem()
-	..(O)
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/r_n_d/experimentor/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	default_deconstruction_screwdriver(user, "h_lathe_maint", "h_lathe", I)
+	if(linked_console)
+		linked_console.linked_destroy = null
+		linked_console = null
 
 /obj/machinery/r_n_d/experimentor/attack_hand(mob/user)
 	user.set_machine(src)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -148,6 +148,8 @@
 	return
 
 /obj/machinery/r_n_d/experimentor/crowbar_act(mob/user, obj/item/I)
+	if(!panel_open)
+		return
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Goes over the Experimentor so it uses the usual tool procs instead of being part of `attackby`, and fixes the crowbar act as it wasn't actually passing the user, causing a runtime. (Yes, it was pretty much a one line fix but why not)

## Why It's Good For The Game
Fixes #17592.

## Changelog
:cl:
fix: E.X.P.E.R.I-MENTOR can be deconstructed properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
