### PR TITLE
Add a permanent GPS beacon to mining station.

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1214,6 +1214,10 @@
 /area/mine/production)
 "cL" = (
 /obj/machinery/space_heater,
+/obj/item/gps/ruin{
+	gpstag = "BASE0";
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/mine/production)
 "cM" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR adds a permanent GPS beacon to the Lavaland mining station.

There are three basic GPS unit sub-objects: the handheld units ( `/obj/item/gps/{science,engineering,borg,mining,...}`, the anchored "ruin" GPS beacons (`/obj/item/gps/ruin`), and the shelter pod GPS computers (`/obj/item/gps/computer`). The handheld units are what we're trying to replace here and the shelter computers have a large icon that only meshes with the shelter pod walls, making it unsuitable for this, so the ruin beacon seems the most appropriate.

When it is used in ruins, it doesn't appear to be used as a "wart": that is, it's on the wall tile that it appears on. I believe it's safe to simply nudge it onto the wall as with other warts and have it work that way without issue.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently, only the handheld GPS units are what indicate the location of the mining station on the planet. This means that once all of those units are gone, the mining station cannot be found. Although seasoned players have a more instinctive sense of where the base is, less experienced players and players under duress should still be easily locate the base via GPS.

Simply knowing the distance between you and the base, despite knowing generally where it is on Lavaland, is also tactically useful: can I make it back to base before this ash storm hits? Do I have enough health to return myself or should I just fulton from here? With the addition of lava rivers, beelining to the base is also less straightforward.

It also seems fairly reasonable to me that, IC, NT would have a GPS beacon on the base. They're on every space ruin, every shelter pod, and every megafauna, so the lack of one is more unusual than the presence of one.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

Appearance in-game:

![Paradise Station 13-10_21_04](https://user-images.githubusercontent.com/59303604/162624148-d2fb37ac-779f-426c-9f1f-461f5b12d4a5.png)

Appearance on GPS:

![-10_09_30](https://user-images.githubusercontent.com/59303604/162624156-cda27120-72d3-43c9-8185-3a15034837d6.png)

## Changelog
:cl:
add: Mining station now has a permanent GPS beacon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
