### PR TITLE
Fix corgi equipment slots for Lisa and puppies.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -144,15 +144,19 @@
 		return
 	user.set_machine(src)
 
-
 	var/dat = 	"<div align='center'><b>Inventory of [name]</b></div><p>"
-	dat += "<br><B>Head:</B> <A href='?src=[UID()];[inventory_head ? "remove_inv=head'>[html_encode(inventory_head)]" : "add_inv=head'>Nothing"]</A>"
-	dat += "<br><B>Back:</B> <A href='?src=[UID()];[inventory_back ? "remove_inv=back'>[html_encode(inventory_back)]" : "add_inv=back'>Nothing"]</A>"
-	dat += "<br><B>Collar:</B> <A href='?src=[UID()];[pcollar ? "remove_inv=collar'>[pcollar]" : "add_inv=collar'>Nothing"]</A>"
+	dat += get_invslot_content()
 
 	var/datum/browser/popup = new(user, "mob[UID()]", "[src]", 440, 250)
 	popup.set_content(dat)
 	popup.open()
+
+/mob/living/simple_animal/pet/dog/corgi/proc/get_invslot_content()
+	var/dat = "<br><B>Head:</B> <A href='?src=[UID()];[inventory_head ? "remove_inv=head'>[html_encode(inventory_head)]" : "add_inv=head'>Nothing"]</A>"
+	dat += "<br><B>Back:</B> <A href='?src=[UID()];[inventory_back ? "remove_inv=back'>[html_encode(inventory_back)]" : "add_inv=back'>Nothing"]</A>"
+	dat += "<br><B>Collar:</B> <A href='?src=[UID()];[pcollar ? "remove_inv=collar'>[pcollar]" : "add_inv=collar'>Nothing"]</A>"
+
+	return dat
 
 /mob/living/simple_animal/pet/dog/corgi/getarmor(def_zone, type)
 	var/armorval = 0
@@ -615,12 +619,9 @@
 	mob_size = MOB_SIZE_SMALL
 	collar_type = "puppy"
 
-//puppies cannot wear anything.
-/mob/living/simple_animal/pet/dog/corgi/puppy/Topic(href, href_list)
-	if(href_list["remove_inv"] || href_list["add_inv"])
-		to_chat(usr, "<span class='warning'>You can't fit this on [src]!</span>")
-		return
-	..()
+/mob/living/simple_animal/pet/dog/corgi/puppy/get_invslot_content()
+	// Puppies do not have a head or back equipment slot.
+	return "<br><B>Collar:</B> <A href='?src=[UID()];[pcollar ? "remove_inv=collar'>[pcollar]" : "add_inv=collar'>Nothing"]</A>"
 
 /mob/living/simple_animal/pet/dog/corgi/puppy/void		//Tribute to the corgis born in nullspace
 	name = "\improper void puppy"
@@ -653,16 +654,16 @@
 	response_harm   = "kicks"
 	var/turns_since_scan = 0
 
-//Lisa already has a cute bow!
-/mob/living/simple_animal/pet/dog/corgi/Lisa/Topic(href, href_list)
-	if(href_list["remove_inv"] || href_list["add_inv"])
-		to_chat(usr, "<span class='danger'>[src] already has a cute bow!</span>")
-		return
-	..()
-
 /mob/living/simple_animal/pet/dog/corgi/Lisa/Life()
 	..()
 	make_babies()
+
+/mob/living/simple_animal/pet/dog/corgi/Lisa/get_invslot_content()
+	// Lisa already has a cute bow! Only back and collar slots available.
+	var/dat = "<br><B>Back:</B> <A href='?src=[UID()];[inventory_back ? "remove_inv=back'>[html_encode(inventory_back)]" : "add_inv=back'>Nothing"]</A>"
+	dat += "<br><B>Collar:</B> <A href='?src=[UID()];[pcollar ? "remove_inv=collar'>[pcollar]" : "add_inv=collar'>Nothing"]</A>"
+
+	return dat
 
 /mob/living/simple_animal/pet/dog/corgi/Lisa/handle_automated_movement()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

This modifies the specific links available in the equipment slot UI for puppies and Lisa.

Previously all three slots (collar, head, back) appeared to be available, but the internal checks for when we want to restrict a slot (Lisa's head slot, puppy head and back slots) simply checked to see if `add_inv` or `remove_inv` was in the query params, not what specific slots were being manipulated.

Additionally, putting a collar on would work but removing would fail, because putting collars on can be done with an attack, rather than through the equipment UI, which bypasses that check completely.

I fixed this at the UI level, rather than attempting to tweak the existing logic to check for slots, because this removes the need to show any messages at all to the player when it comes to attempting to use restricted slots, and the lack of slots makes its immediately obvious what is unrestricted.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This fixes several bugs:
- Attempting to add or remove from _any_ equip slot on Lisa gave the "Lisa already has a cute bow!" message, preventing equipping in any other slots.
- Adding collars to puppies was possible but it was impossible to remove them, which is a regression from its supertype and I don't see any evidence it was intentional.

This also makes it obvious to the user what slots can be equipped for each animal subtype.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![Paradise Station 13-12_50_58](https://user-images.githubusercontent.com/59303604/162630768-c6eb0762-28c3-4cdf-a8c4-e39eb20a9da4.png)

![Paradise Station 13-12_51_12](https://user-images.githubusercontent.com/59303604/162630773-806c8cd7-28b6-4f8a-bdf8-4ce7a2a80ee4.png)


## Changelog
:cl:
fix: Corgi puppies can now have their collars removed.
tweak: Unavailable equipment slots for corgis are hidden in the UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
