### PR TITLE
Add "reference in range" option to atom proccall

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -237,10 +237,10 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 				lst += input("Select reference:","Reference",src) as mob|obj|turf|area in world
 
 			if("reference in range")
-				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in range(world.view)
+				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in range(view)
 
 			if("reference in view")
-				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in view(world.view)
+				lst += input("Select reference in view:", "Reference in view", src) as mob|obj|turf|area in view(view)
 
 			if("mob reference")
 				lst += input("Select reference:","Reference",usr) as mob in world

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -236,8 +236,8 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 			if("reference")
 				lst += input("Select reference:","Reference",src) as mob|obj|turf|area in world
 
-			if("reference in view")
-				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in range(world.view, usr)
+			if("reference in range")
+				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in range(world.view)
 
 			if("mob reference")
 				lst += input("Select reference:","Reference",usr) as mob in world

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -215,11 +215,11 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		var/class = null
 		// Make a list with each index containing one variable, to be given to the proc
 		if(src.holder && src.holder.marked_datum)
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","reference in range","mob reference","icon","file","client","mob's area","Marked datum ([holder.marked_datum.type])","CANCEL")
+			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","reference in range","reference in view", "mob reference","icon","file","client","mob's area","Marked datum ([holder.marked_datum.type])","CANCEL")
 			if(holder.marked_datum && class == "Marked datum ([holder.marked_datum.type])")
 				class = "Marked datum"
 		else
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","reference in range","icon","file","client","mob's area","CANCEL")
+			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","reference in range","reference in view","icon","file","client","mob's area","CANCEL")
 		switch(class)
 			if("CANCEL")
 				return null
@@ -238,6 +238,9 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 			if("reference in range")
 				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in range(world.view)
+
+			if("reference in view")
+				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in view(world.view)
 
 			if("mob reference")
 				lst += input("Select reference:","Reference",usr) as mob in world

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -215,11 +215,11 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		var/class = null
 		// Make a list with each index containing one variable, to be given to the proc
 		if(src.holder && src.holder.marked_datum)
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","icon","file","client","mob's area","Marked datum ([holder.marked_datum.type])","CANCEL")
+			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","reference in view","mob reference","icon","file","client","mob's area","Marked datum ([holder.marked_datum.type])","CANCEL")
 			if(holder.marked_datum && class == "Marked datum ([holder.marked_datum.type])")
 				class = "Marked datum"
 		else
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","icon","file","client","mob's area","CANCEL")
+			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","reference in view","icon","file","client","mob's area","CANCEL")
 		switch(class)
 			if("CANCEL")
 				return null
@@ -235,6 +235,9 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 			if("reference")
 				lst += input("Select reference:","Reference",src) as mob|obj|turf|area in world
+
+			if("reference in view")
+				lst += input("Select reference:", "Reference in view", src) as mob|obj|turf|area in range(world.view, usr)
 
 			if("mob reference")
 				lst += input("Select reference:","Reference",usr) as mob in world

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -215,11 +215,11 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		var/class = null
 		// Make a list with each index containing one variable, to be given to the proc
 		if(src.holder && src.holder.marked_datum)
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","reference in view","mob reference","icon","file","client","mob's area","Marked datum ([holder.marked_datum.type])","CANCEL")
+			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","reference in range","mob reference","icon","file","client","mob's area","Marked datum ([holder.marked_datum.type])","CANCEL")
 			if(holder.marked_datum && class == "Marked datum ([holder.marked_datum.type])")
 				class = "Marked datum"
 		else
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","reference in view","icon","file","client","mob's area","CANCEL")
+			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","reference in range","icon","file","client","mob's area","CANCEL")
 		switch(class)
 			if("CANCEL")
 				return null
@@ -237,7 +237,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 				lst += input("Select reference:","Reference",src) as mob|obj|turf|area in world
 
 			if("reference in view")
-				lst += input("Select reference:", "Reference in view", src) as mob|obj|turf|area in range(world.view, usr)
+				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in range(world.view, usr)
 
 			if("mob reference")
 				lst += input("Select reference:","Reference",usr) as mob in world


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds an option in the debug verb "atom proc-call" to get references in range (or view) of the current client for proc parameters.

No player-facing changes, but this should make debugging easier in some cases.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently, if you want to find a reference for a proc's argument, you need to page through every single reference in the game world (generating this list generally freezes the server for a few seconds as well). This should make it a *lot* easier to call a proc on something that you can see, which is probably what you want to do with this verb most of the time anyway.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
