### PR TITLE
Ghosts can no longer be stuck visible from the spectral blade

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -78,6 +78,7 @@
 	orbit_data += new_comp.orbit_data
 	new_comp.orbiter_list = list()
 	new_comp.orbit_data = list()
+	QDEL_NULL(new_comp)
 
 /datum/component/orbiter/PostTransfer()
 	if(!isatom(parent) || isarea(parent) || !get_turf(parent))
@@ -448,8 +449,9 @@
 /**
  * Check every object in the hierarchy above ourselves for orbiters, and return the full list of them.
  * If an object is being held in a backpack, returns orbiters of the backpack, the person
+ * If recursive == TRUE, this will also check recursively through any ghosts seen to make sure we find *everything* upstream
  */
-/atom/proc/get_orbiters_up_hierarchy(list/processed, source = TRUE)
+/atom/proc/get_orbiters_up_hierarchy(list/processed, source = TRUE, recursive = FALSE)
 	var/list/output = list()
 	if(!processed)
 		processed = list()
@@ -459,10 +461,14 @@
 	processed += src
 	for(var/atom/movable/atom_orbiter in get_orbiters())
 		if(isobserver(atom_orbiter))
+			if(recursive)
+				output += atom_orbiter.get_orbiters_recursive()
 			output += atom_orbiter
-		if(atom_orbiter.loc != null)
-			output += atom_orbiter.loc.get_orbiters_up_hierarchy(processed, source = FALSE)
 
+	if(loc)
+		output += loc.get_orbiters_up_hierarchy(processed, source = FALSE)
+
+	return output
 
 #undef ORBIT_LOCK_IN
 #undef ORBIT_FORCE_MOVE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some bugs with the spectral blade and orbiting in general. 
- The blade will now only show ghosts if the blade is held in a hand. This means that putting it in a bag or the floor will hide any ghosts that were orbiting it.
- Reworks an internal orbiting proc to actually work instead of being (what I assume to be) incomplete.
  - This was on me
- Fixes orbiting components accidentally adding multiple instances of themselves to atoms
- fixes #17601
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghosts being able to become visible when not attached to the sword causes a whole host of problems (I've heard so much about antags just becoming unclickable), and can lead to a lot of metagaming. Fixing this bug is p important.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ghosts should now not be able to use the spectral blade to become permanently visible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
