### PR TITLE
Adds a visual and audio cue when the sleeper cures addiction

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -127,7 +127,7 @@
 			if(world.timeofday > (R.last_addiction_dose + ADDICTION_SPEEDUP_TIME)) // 2.5 minutes
 				addiction_removal_chance = 10
 			if(prob(addiction_removal_chance))
-				src.visible_message("<span class='notice'>\The [src] pings: Patient's addiction was cured.</span>")
+				visible_message("<span class='notice'>\The [src] pings: Patient's addiction was cured.</span>")
 				playsound(get_turf(src), 'sound/machines/ping.ogg', 50, 0)
 				to_chat(occupant, "<span class='boldnotice'>You no longer feel reliant on [R.name]!</span>")
 				occupant.reagents.addiction_list.Remove(R)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -127,7 +127,7 @@
 			if(world.timeofday > (R.last_addiction_dose + ADDICTION_SPEEDUP_TIME)) // 2.5 minutes
 				addiction_removal_chance = 10
 			if(prob(addiction_removal_chance))
-				visible_message("<span class='notice'>\The [src] pings: Patient's addiction was cured.</span>")
+				atom_say("Patient's addiction was cured.")
 				playsound(get_turf(src), 'sound/machines/ping.ogg', 50, 0)
 				to_chat(occupant, "<span class='boldnotice'>You no longer feel reliant on [R.name]!</span>")
 				occupant.reagents.addiction_list.Remove(R)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -5,7 +5,7 @@
 ////////////
 
 /obj/machinery/sleeper
-	name = "Sleeper"
+	name = "sleeper"
 	icon = 'icons/obj/cryogenic2.dmi'
 	icon_state = "sleeper-open"
 	var/base_icon = "sleeper"
@@ -127,6 +127,8 @@
 			if(world.timeofday > (R.last_addiction_dose + ADDICTION_SPEEDUP_TIME)) // 2.5 minutes
 				addiction_removal_chance = 10
 			if(prob(addiction_removal_chance))
+				src.visible_message("<span class='notice'>\The [src] pings: Patient's addiction was cured.</span>")
+				playsound(get_turf(src), 'sound/machines/ping.ogg', 50, 0)
 				to_chat(occupant, "<span class='boldnotice'>You no longer feel reliant on [R.name]!</span>")
 				occupant.reagents.addiction_list.Remove(R)
 				qdel(R)


### PR DESCRIPTION
## What Does This PR Do
Adds a visual and audio cue when the sleeper successfully cures its occupant.

## Why It's Good For The Game
While the patient is notified about their addictions being cured, doctors are not.

Right now, the only way to check if an addiction was cured is to repeatedly get the patient out and scanning them with a health analyzer.

With this, doctors (or bystanders) will hear if someone's addiction was cured and we may have less **"patient was forgotten inside a sleeper for ten minutes"** cases.

This PR does not change any functionality.

## Images of changes
New variant:
![image](https://user-images.githubusercontent.com/33333517/162773505-3cd8ca00-7e6f-4467-ba44-e339edad61ab.png)

![image](https://user-images.githubusercontent.com/33333517/162773560-f66568fb-dd1a-4f95-98ab-f51f7f126c4b.png)

## Changelog
:cl:
add: The sleeper now notifies nearby people if it cured its occupant's addiction.
/:cl:
