### PR TITLE
Strange Reagent now resets decaylevel upon successful resurrection

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -788,6 +788,7 @@
 					M.adjustFireLoss(rand(0, 15))
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
+						H.decaylevel = 0
 						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
 						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
 							// Per non-vital body part:


### PR DESCRIPTION
## What Does This PR Do
Strange Reagent now resets the `decaylevel` of humans to `0` upon successful revival.

## Why It's Good For The Game
When you revive long-dead people (so, the ones you are likely to revive with SR), upon examining, they have the line of `Person is rotting and blackened, the skin sloughing off. The smell is indescribably foul.` (or any of its variants)

It's off-putting. Make people un-smelly when they get revived.

I was thinking of making this a surgical procedure (with Synthflesh), but the amount of surgeries we already need after SR revival is, I believe, enough - as long as our SR functions as magical medicine, I feel also resetting the decaylevel is not too much of a buff for it. (It's purely cosmetic.)

I was also thinking of adding this to the unhusking procedure (splash burn husks with 100u Synthflesh) - but resetting `decaylevel` like this could easily lead to f-ckery, especially by coroners/scientists.

This "issue" was pointed out by @hal9000PR (giving credit where its due).

## Images of changes
![image](https://user-images.githubusercontent.com/33333517/162781538-df43ad32-b569-4ea7-bb91-baf9ddda3636.png)

## Changelog
:cl:
add: Strange Reagent now also removes decay upon revival, patients no longer stay "rotting and blackened, their skin sloughing off" after getting resurrected.
/:cl:
