### PR TITLE
Fluff ID sprite

### DIFF
--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1703,5 +1703,10 @@
 	item_color = "kikerimask"
 	species_restricted = list("Vox")
 
+/obj/item/id_decal/aa07
+	name = "lifetime ID card decal"
+	desc = "Make your ID look like the property of a nerd. Applies to any ID."
+	decal_icon_state = "lifetimeid"
+
 #undef USED_MOD_HELM
 #undef USED_MOD_SUIT


### PR DESCRIPTION
## What Does This PR Do
Adds an ID modkit for converting an ID to use this sprite
![image](https://user-images.githubusercontent.com/25063394/163458818-f86f2a89-f36b-4fbc-9905-4d6f5ff458bf.png)

2 heads and another maint have signed off on allowing this.

## Why It's Good For The Game
N/A

## Changelog
N/A

---
*making this PR feels wrong and is probably the most self-centered thing I will do this year* 