### PR TITLE
Makes the Notice Mech'd Robotic Brains Receive Bigger

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1171,7 +1171,7 @@
 		if(istype(mmi_as_oc, /obj/item/mmi/robotic_brain))
 			var/obj/item/mmi/robotic_brain/R = mmi_as_oc
 			if(R.imprinted_master)
-				to_chat(brainmob, "<span class='biggerdanger'><FONT size = 3><B>Your imprint to [R.imprinted_master] has been temporarily disabled. You should help the crew and not commit harm.</B></FONT></span>")
+				to_chat(brainmob, "<span class='biggerdanger'>Your imprint to [R.imprinted_master] has been temporarily disabled. You should help the crew and not commit harm.</span>")
 		mmi_as_oc.loc = src
 		mmi_as_oc.mecha = src
 		Entered(mmi_as_oc)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1171,7 +1171,7 @@
 		if(istype(mmi_as_oc, /obj/item/mmi/robotic_brain))
 			var/obj/item/mmi/robotic_brain/R = mmi_as_oc
 			if(R.imprinted_master)
-				to_chat(brainmob, "<span class='notice'>Your imprint to [R.imprinted_master] has been temporarily disabled. You should help the crew and not commit harm.</span>")
+				to_chat(brainmob, "<span class='warning'><FONT size = 3><B>Your imprint to [R.imprinted_master] has been temporarily disabled. You should help the crew and not commit harm.</B></FONT></span>")
 		mmi_as_oc.loc = src
 		mmi_as_oc.mecha = src
 		Entered(mmi_as_oc)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1171,7 +1171,7 @@
 		if(istype(mmi_as_oc, /obj/item/mmi/robotic_brain))
 			var/obj/item/mmi/robotic_brain/R = mmi_as_oc
 			if(R.imprinted_master)
-				to_chat(brainmob, "<span class='warning'><FONT size = 3><B>Your imprint to [R.imprinted_master] has been temporarily disabled. You should help the crew and not commit harm.</B></FONT></span>")
+				to_chat(brainmob, "<span class='biggerdanger'><FONT size = 3><B>Your imprint to [R.imprinted_master] has been temporarily disabled. You should help the crew and not commit harm.</B></FONT></span>")
 		mmi_as_oc.loc = src
 		mmi_as_oc.mecha = src
 		Entered(mmi_as_oc)


### PR DESCRIPTION
## What Does This PR Do
This PR does exactly what the title says. It makes the notice that robotic brains receive when placed into a mech of any kind bigger and more obvious so they're aware they are _not_ slaved.

## Why It's Good For The Game
As it stands now most robotic brains inside mechs do not realize that they're actually lawed to help the station and not commit harm and their enslavement to their owner is severed temporarily upon being put into the mech. This creates a whole host of problems from time to time, especially involving non-antags creating 'slaved' mechs to run about and do things or 'slaved' mechs to go and hunt down antags.

Note; This doesn't add the notice to your memory or notes, I'm not quite sure how to do that but if it's preferred to add it as well I'd be happy to take instruction on how to do so.

## Images of changes
![biggerdanger](https://user-images.githubusercontent.com/12178527/163527537-d5fce5f6-48b6-4dc2-af37-b65cabb29b37.png)

## Changelog
:cl:
tweak: The notice robotic brains receive when being placed into a mech is now much more obvious and hard to miss.
/:cl:
