### PR TITLE
Removes midround blob

### DIFF
--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -41,7 +41,8 @@
 
 
 /datum/station_state/proc/count()
-	for(var/turf/T in block(locate(1,1,1), locate(world.maxx,world.maxy,1)))
+	var/station_z = level_name_to_num(MAIN_STATION)
+	for(var/turf/T in block(locate(1, 1, station_z), locate(world.maxx, world.maxy, station_z)))
 
 		if(istype(T,/turf/simulated/floor))
 			if(!(T:burnt))

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -18,7 +18,7 @@
 	var/list/role_weights = list()
 	var/datum/event/event_type
 
-/datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = FALSE, min_event_weight = 0, max_event_weight = INFINITY)
+/datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = FALSE, min_event_weight = 0, max_event_weight = INFINITY, _enabled = TRUE)
 	name = event_name
 	severity = event_severity
 	event_type = type
@@ -26,6 +26,7 @@
 	weight = event_weight
 	min_weight = min_event_weight
 	max_weight = max_event_weight
+	enabled = _enabled
 	if(job_weights)
 		role_weights = job_weights
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -193,7 +193,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	10,						list(ASSIGNMENT_SECURITY =  3), TRUE),	// 4.8% on high pop, 3.4% on low pop
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,	0,			list(ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "APC Overload",	/datum/event/apc_overload,		0),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				30,						list(ASSIGNMENT_ENGINEER =  5), TRUE),	// 6.9% on high pop, 5.5% on low pop
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				30,						list(ASSIGNMENT_ENGINEER =  5), TRUE, _enabled = FALSE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		30,						list(ASSIGNMENT_ENGINEER =  5),	TRUE),	// 6.9% on high pop, 5.5% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",	/datum/event/abductor, 		    20, 					list(ASSIGNMENT_SECURITY =  3), TRUE),	// 5.8% on high pop, 4.5% on low pop
 		//new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), TRUE),


### PR DESCRIPTION
## What Does This PR Do
Alternative to #17305 

This removes it as a midround, keeping it as just the roundstart. After discussion with a head, we deemed that this is a better idea since its a lot easier to balance (lategame states can vastly change)

## Why It's Good For The Game
See most of the reasoning on the other PR, but tldr: Balancing an antag around 2 wildly different game states is very difficult to do

## Changelog
:cl: AffectedArc07
del: Removed midround blob. It is still a roundstart antagonist.
/:cl:
