### PR TITLE
Fixes movable window tint buttons

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -515,7 +515,7 @@
 	name = "window tint control"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light0"
-	anchored = 1.0
+	anchored = 1
 	desc = "A remote control switch for polarized windows."
 	var/range = 7
 	var/id = 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -515,7 +515,7 @@
 	name = "window tint control"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light0"
-	anchored = 1
+	anchored = TRUE
 	desc = "A remote control switch for polarized windows."
 	var/range = 7
 	var/id = 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -515,6 +515,7 @@
 	name = "window tint control"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light0"
+	anchored = 1.0
 	desc = "A remote control switch for polarized windows."
 	var/range = 7
 	var/id = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes so that window tint buttons can't be moved.
Fixes #17609
I also have no idea why its 1.0 and not just 1, I stole it from the normal light switch.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Switches are not supposed to move AAAAAHH
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Changelog
:cl:
fix: Window tint switches are now unmovable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
