### PR TITLE
Fixes narsie and other singularities getting shuttle crushed

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -61,6 +61,8 @@
 #define RAD_PROTECT_CONTENTS_2	16384
 /// should this object be allowed to be contaminated
 #define RAD_NO_CONTAMINATE_2	32768
+/// Prevents shuttles from deleting the item
+#define IMMUNE_TO_SHUTTLECRUSH_2 (1<<16)
 
 //Reagent flags
 #define REAGENT_NOREACT			1

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -6,6 +6,7 @@
 	anchored = TRUE
 	density = TRUE
 	layer = MASSIVE_OBJ_LAYER
+	flags_2 = IMMUNE_TO_SHUTTLECRUSH_2
 	light_range = 6
 	appearance_flags = LONG_GLIDE
 	var/current_size = 1

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -85,7 +85,7 @@
 	icon_state = "darkmatter"
 	density = TRUE
 	anchored = TRUE
-	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2
+	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2 | IMMUNE_TO_SHUTTLECRUSH_2
 	light_range = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	base_icon_state = "darkmatter"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -618,7 +618,7 @@
 			if(!AM.anchored)
 				step(AM, dir)
 			else
-				if(AM.simulated) // Don't qdel lighting overlays, they are static
+				if(AM.simulated && !istype(AM, /obj/singularity)) // Don't qdel lighting overlays, they are static
 					qdel(AM)
 
 //used by shuttle subsystem to check timers

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -595,6 +595,8 @@
 		for(var/atom/movable/AM in T1)
 			if(AM.pulledby)
 				AM.pulledby.stop_pulling()
+			if(AM.flags_2 & IMMUNE_TO_SHUTTLECRUSH_2)
+				continue
 			if(ismob(AM))
 				var/mob/M = AM
 				if(M.buckled)
@@ -618,7 +620,7 @@
 			if(!AM.anchored)
 				step(AM, dir)
 			else
-				if(AM.simulated && !istype(AM, /obj/singularity)) // Don't qdel lighting overlays, they are static
+				if(AM.simulated) // Don't qdel lighting overlays, they are static
 					qdel(AM)
 
 //used by shuttle subsystem to check timers


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds a check to flag any singulo (teslas and narsie included) or SM shards from being destroyed by shuttle crushing

## Why It's Good For The Game
Singularities don't tend to break when you ram into them, nor would an eldritch god.

Fixes #17621 
Fixes #12068 

## Changelog
:cl:
Fix: shuttlecrushing won't destroy singularities, teslas, supermatters and narsie.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
