### PR TITLE
Removes unused latejoin spawners

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5886,7 +5886,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6321,7 +6320,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8998,7 +8996,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -10000,12 +9997,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"axY" = (
-/obj/effect/landmark/spawner/late/cryo,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/sleep)
 "axZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -10673,7 +10664,6 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = -25
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -19489,7 +19479,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26934,7 +26923,6 @@
 /area/quartermaster/office)
 "biO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -36491,7 +36479,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/landmark/spawner/late/cyborg,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
@@ -49075,7 +49062,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/spawner/late/gateway,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -49084,7 +49070,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/spawner/late/gateway,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -49687,7 +49672,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/landmark/spawner/late/gateway,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -77886,7 +77870,6 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = -25
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -116240,7 +116223,7 @@ avv
 aoE
 apN
 awa
-axY
+aKM
 azC
 avv
 axS

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -17380,7 +17380,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aPL" = (
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
@@ -17542,7 +17541,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
@@ -17944,7 +17942,6 @@
 /area/maintenance/electrical)
 "aQZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
@@ -17986,7 +17983,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
@@ -18488,7 +18484,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
@@ -19874,7 +19869,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/landmark/spawner/late/gateway,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -21350,7 +21344,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/landmark/spawner/late/cryo,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
@@ -25348,7 +25341,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/spawner/late/gateway,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"
@@ -25361,7 +25353,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/spawner/late/gateway,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "vault"
@@ -76253,7 +76244,6 @@
 	pixel_y = 30
 	},
 /obj/effect/decal/warning_stripes/north,
-/obj/effect/landmark/spawner/late/cyborg,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkbluecorners"

--- a/code/_globalvars/mapping.dm
+++ b/code/_globalvars/mapping.dm
@@ -21,9 +21,6 @@ GLOBAL_LIST(global_map) // This is the array of zlevels | list(list(1,5),list(4,
 GLOBAL_LIST_EMPTY(wizardstart)
 GLOBAL_LIST_EMPTY(newplayer_start)
 GLOBAL_LIST_EMPTY(latejoin)
-GLOBAL_LIST_EMPTY(latejoin_gateway)
-GLOBAL_LIST_EMPTY(latejoin_cryo)
-GLOBAL_LIST_EMPTY(latejoin_cyborg)
 GLOBAL_LIST_EMPTY(prisonwarp)	//prisoners go to these
 GLOBAL_LIST_EMPTY(syndieprisonwarp)	//contractor targets go to these
 GLOBAL_LIST_EMPTY(xeno_spawn)//Aliens spawn at these.
@@ -53,4 +50,3 @@ GLOBAL_LIST_EMPTY(space_ruins_templates)
 GLOBAL_LIST_EMPTY(lava_ruins_templates)
 GLOBAL_LIST_EMPTY(shelter_templates)
 GLOBAL_LIST_EMPTY(shuttle_templates)
-

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -97,28 +97,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/awaystart) //Without this away mission
 	spawner_list = GLOB.latejoin
 	return ..()
 
-/obj/effect/landmark/spawner/late/cryo
-	name = "Late Join Cryo"
-
-/obj/effect/landmark/spawner/late/cryo/Initialize(mapload)
-	spawner_list = GLOB.latejoin_cryo
-	return ..()
-
-/obj/effect/landmark/spawner/late/cyborg
-	name = "Late Join Cyborg"
-	icon_state = "Borg"
-
-/obj/effect/landmark/spawner/late/cyborg/Initialize(mapload)
-	spawner_list = GLOB.latejoin_cyborg
-	return ..()
-
-/obj/effect/landmark/spawner/late/gateway
-	name = "Late Join Gateway"
-
-/obj/effect/landmark/spawner/late/gateway/Initialize(mapload)
-	spawner_list = GLOB.latejoin_gateway
-	return ..()
-
 /obj/effect/landmark/spawner/carp
 	name = "carpspawn"
 	icon_state = "Carp"

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -7,7 +7,6 @@
 	var/be_random_name = FALSE				//whether we are a random name every round
 	var/gender = MALE						//gender of character (well duh)
 	var/age = 30							//age of character
-	var/spawnpoint = "Arrivals Shuttle" 	//where this character will spawn (0-2).
 	var/b_type = "A+"						//blood type (not-chooseable)
 	var/underwear = "Nude"					//underwear type
 	var/undershirt = "Nude"					//undershirt type
@@ -862,7 +861,7 @@
 				icon_state = "[coloured_tail]_s"
 			else
 				icon_state = "[current_species.tail]_s"
-		
+
 		if(icon)
 			var/icon/temp = new(icon, icon_state)
 			if(current_species.bodyflags & HAS_SKIN_COLOR)

--- a/code/modules/client/preference/preferences_spawnpoints.dm
+++ b/code/modules/client/preference/preferences_spawnpoints.dm
@@ -29,29 +29,3 @@ GLOBAL_LIST_EMPTY(spawntypes)
 /datum/spawnpoint/arrivals/New()
 	..()
 	turfs = GLOB.latejoin
-
-/datum/spawnpoint/gateway
-	display_name = "Gateway"
-	msg = "has completed translation from offsite gateway"
-
-/datum/spawnpoint/gateway/New()
-	..()
-	turfs = GLOB.latejoin_gateway
-
-/datum/spawnpoint/cryo
-	display_name = "Cryogenic Storage"
-	msg = "has completed cryogenic revival"
-	disallow_job = list("Cyborg")
-
-/datum/spawnpoint/cryo/New()
-	..()
-	turfs = GLOB.latejoin_cryo
-
-/datum/spawnpoint/cyborg
-	display_name = "Cyborg Storage"
-	msg = "has been activated from storage"
-	restrict_job = list("Cyborg")
-
-/datum/spawnpoint/cyborg/New()
-	..()
-	turfs = GLOB.latejoin_cyborg

--- a/code/modules/client/preference/preferences_spawnpoints.dm
+++ b/code/modules/client/preference/preferences_spawnpoints.dm
@@ -10,17 +10,6 @@ GLOBAL_LIST_EMPTY(spawntypes)
 	var/msg          //Message to display on the arrivals computer.
 	var/list/turfs   //List of turfs to spawn on.
 	var/display_name //Name used in preference setup.
-	var/list/restrict_job = null
-	var/list/disallow_job = null
-
-/datum/spawnpoint/proc/check_job_spawning(job)
-	if(restrict_job && !(job in restrict_job))
-		return 0
-
-	if(disallow_job && (job in disallow_job))
-		return 0
-
-	return 1
 
 /datum/spawnpoint/arrivals
 	display_name = "Arrivals Shuttle"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -242,7 +242,7 @@
 				to_chat(src, alert("You are currently not whitelisted to play [client.prefs.active_character.species]."))
 				return FALSE
 
-		AttemptLateSpawn(href_list["SelectedJob"],client.prefs.active_character.spawnpoint)
+		AttemptLateSpawn(href_list["SelectedJob"])
 		return
 
 	if(!ready && href_list["preference"])
@@ -302,7 +302,7 @@
 	else
 		return 0
 
-/mob/new_player/proc/AttemptLateSpawn(rank, spawning_at)
+/mob/new_player/proc/AttemptLateSpawn(rank)
 	if(src != usr)
 		return 0
 	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
@@ -338,7 +338,6 @@
 
 	//Find our spawning point.
 	var/join_message
-	var/datum/spawnpoint/S
 
 	if(IsAdminJob(rank))
 		if(IsERTSpawnJob(rank))
@@ -349,19 +348,8 @@
 			character.forceMove(pick(GLOB.aroomwarp))
 		join_message = "has arrived"
 	else
-		if(spawning_at)
-			S = GLOB.spawntypes[spawning_at]
-		if(S && istype(S))
-			if(S.check_job_spawning(rank))
-				character.forceMove(pick(S.turfs))
-				join_message = S.msg
-			else
-				to_chat(character, "Your chosen spawnpoint ([S.display_name]) is unavailable for your chosen job. Spawning you at the Arrivals shuttle instead.")
-				character.forceMove(pick(GLOB.latejoin))
-				join_message = "has arrived on the station"
-		else
-			character.forceMove(pick(GLOB.latejoin))
-			join_message = "has arrived on the station"
+		character.forceMove(pick(GLOB.latejoin))
+		join_message = "has arrived on the station"
 
 	character.lastarea = get_area(loc)
 	// Moving wheelchair if they have one


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Latejoin spawners removed. It's code that was unused and I can't imagine anyone deciding to readd it at any point. Something something new mapper bait I dunno. Either way, I can only see this breaking things if someone somehow had a character with their spawn preference set to something other than the arrivals shuttle, but that seems unlikely. Yes I could technically go ahead and just make all latejoins automatically spawn at arrivals instead of checking through prefs, but... that's a bit more effort and outside what I'm trying to achieve.
Blah blah blah I tested it it doesn't break everything, shouldn't runtime because VScode didn't screech at me about anything.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Dunno. Is it?

## Changelog
If players notice these changes, something has gone horribly wrong.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
