### PR TITLE
Removes "Bracket Pair Colorizer 2" from recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
 		"platymuus.dm-langclient",
 		"EditorConfig.EditorConfig",
 		"dbaeumer.vscode-eslint",
-		"coenraads.bracket-pair-colorizer-2",
 		"eamodio.gitlens"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 		"platymuus.dm-langclient",
 		"EditorConfig.EditorConfig",
 		"dbaeumer.vscode-eslint",
-		"eamodio.gitlens"
+		"eamodio.gitlens",
+		"usernamehw.errorlens"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
 		"*.dmi": "imagePreview.previewEditor"
 	},
 	"editor.bracketPairColorization.enabled": true,
-    "editor.guides.bracketPairs":"active"
+	"editor.guides.bracketPairs": "active",
+	"gitlens.advanced.blame.customArguments": [
+		"--ignore-revs-file", "${workspaceRoot}/.git-blame-ignore-revs"
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
 	"workbench.editorAssociations": {
 		"*.dmi": "imagePreview.previewEditor"
-	}
+	},
+	"editor.bracketPairColorization.enabled": true,
+    "editor.guides.bracketPairs":"active"
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes "Bracket Pair Colorizer 2" from the recommended extensions for VSCode.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This extension is now natively supported by VSCode.
See: https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2
https://code.visualstudio.com/blogs/2021/09/29/bracket-pair-colorization
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
