### PR TITLE
Locks some really gamebreaking verbs to Maints

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -40,10 +40,11 @@
 #define R_MENTOR		16384
 #define R_PROCCALL		32768
 #define R_VIEWRUNTIMES	65536
+#define R_MAINTAINER	131072
 
-#define R_MAXPERMISSION 65536 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+#define R_MAXPERMISSION 131072 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
-#define R_HOST			131071 // Sum of all permissions to allow easy setting
+#define R_HOST			262141 // Sum of all permissions to allow easy setting
 
 #define ADMIN_QUE(user,display) "<a href='?_src_=holder;adminmoreinfo=[user.UID()]'>[display]</a>"
 #define ADMIN_FLW(user,display) "<a href='?_src_=holder;adminplayerobservefollow=[user.UID()]'>[display]</a>"

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -213,6 +213,7 @@
 	if(rights & R_MOD)			. += "[seperator]+MODERATOR"
 	if(rights & R_MENTOR)		. += "[seperator]+MENTOR"
 	if(rights & R_VIEWRUNTIMES)	. += "[seperator]+VIEWRUNTIMES"
+	if(rights & R_MAINTAINER)	. += "[seperator]+MAINTAINER"
 	return .
 
 /proc/ui_style2icon(ui_style)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2094,22 +2094,3 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	output["CONTENT"] = content
 
 	return output
-
-
-/proc/is_maintainer(mob/user)
-	#ifdef TESTING // Account for local test mode
-	return TRUE
-	#endif
-
-	// Check if this user is a maint, or on a test server
-	var/ip_check = (user.client.address == "127.0.0.1" || user.client.address == null)
-
-	var/rank_check = FALSE
-
-	if(user.client.holder)
-		rank_check = (findtext(user.client.holder.rank, "Maintainer") > 0) // Accounts for "Maintainers", "Maintainer", "Host & Maintainer", etc
-
-	if(ip_check || rank_check)
-		return TRUE
-
-	return FALSE

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -48,11 +48,7 @@ SUBSYSTEM_DEF(jobs)
 
 
 /datum/controller/subsystem/jobs/proc/Debug(text)
-	if(!GLOB.debug2)
-		return 0
 	job_debug.Add(text)
-	return 1
-
 
 /datum/controller/subsystem/jobs/proc/GetJob(rank)
 	if(!occupations.len)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1003,8 +1003,6 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	return
 
 /atom/vv_edit_var(var_name, var_value)
-	if(!GLOB.debug2)
-		admin_spawned = TRUE
 	. = ..()
 	switch(var_name)
 		if("light_power", "light_range", "light_color")

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -186,8 +186,7 @@
 
 		var/took = stop_watch(watch)
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
-		if(GLOB.debug2)
-			log_world("## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds.")
+		log_world("## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds.")
 
 		//Machines which report explosions.
 		for(var/array in GLOB.doppler_arrays)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -35,6 +35,7 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 				if("mentor")					rights |= R_MENTOR
 				if("proccall")					rights |= R_PROCCALL
 				if("viewruntimes")				rights |= R_VIEWRUNTIMES
+				if("maintainer")				rights |= R_MAINTAINER
 
 		GLOB.admin_ranks[rankname] = rights
 		previous_rights = rights

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -88,7 +88,6 @@ GLOBAL_LIST_INIT(admin_verbs_event, list(
 	/client/proc/cmd_admin_dress,
 	/client/proc/cmd_admin_gib_self,
 	/client/proc/drop_bomb,
-	/client/proc/cinematic,
 	/client/proc/one_click_antag,
 	/client/proc/cmd_admin_add_freeform_ai_law,
 	/client/proc/cmd_admin_add_random_ai_law,
@@ -145,7 +144,6 @@ GLOBAL_LIST_INIT(admin_verbs_server, list(
 	))
 GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/cmd_admin_list_open_jobs,
-	/client/proc/Debug2,
 	/client/proc/cmd_debug_make_powernets,
 	/client/proc/debug_controller,
 	/client/proc/cmd_debug_mob_lists,
@@ -156,11 +154,9 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/toggledebuglogs,
 	/client/proc/cmd_display_del_log,
 	/client/proc/cmd_display_del_log_simple,
-	/client/proc/debugNatureMapGenerator,
 	/client/proc/check_bomb_impacts,
 	/client/proc/test_movable_UI,
 	/client/proc/test_snap_UI,
-	/client/proc/cinematic,
 	/proc/machine_upgrade,
 	/client/proc/map_template_load,
 	/client/proc/map_template_upload,
@@ -225,6 +221,14 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 	/client/proc/resolveAllAdminTickets,
 	/client/proc/resolveAllMentorTickets
 ))
+// In this list are verbs that should ONLY be executed by maintainers, aka people who know how badly this will break the server
+// If you are adding something here, you MUST justify it
+GLOBAL_LIST_INIT(admin_verbs_maintainer, list(
+	/client/proc/ticklag, // This adjusts the server tick rate and is VERY easy to hard lockup the server with
+	/client/proc/debugNatureMapGenerator, // This lags like hell, and is very easy to nuke half the server with
+	/client/proc/vv_by_ref, // This allows you to lookup **ANYTHING** in the server memory by spamming refs. Locked for security.
+	/client/proc/cinematic, // This will break everyone's screens in the round. Dont use this for adminbus.
+))
 
 /client/proc/on_holder_add()
 	if(chatOutput && chatOutput.loaded)
@@ -270,6 +274,8 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 			verbs += GLOB.admin_verbs_mentor
 		if(holder.rights & R_PROCCALL)
 			verbs += GLOB.admin_verbs_proccall
+		if(holder.rights & R_MAINTAINER)
+			verbs += GLOB.admin_verbs_maintainer
 		if(holder.rights & R_VIEWRUNTIMES)
 			verbs += /client/proc/view_runtimes
 			verbs += /client/proc/cmd_display_del_log

--- a/code/modules/admin/verbs/cinematic.dm
+++ b/code/modules/admin/verbs/cinematic.dm
@@ -5,6 +5,10 @@
 	set hidden = 1
 	if(!SSticker)
 		return
+
+	if(!check_rights(R_MAINTAINER))
+		return
+
 	switch(cinematic)
 		if("explosion")
 			var/parameter = input(src, "station_missed = ?", "Enter Parameter", 0) as num

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1,22 +1,3 @@
-/client/proc/Debug2()
-	set category = "Debug"
-	set name = "Debug-Game"
-
-	if(!check_rights(R_DEBUG))
-		return
-
-	if(GLOB.debug2)
-		GLOB.debug2 = 0
-		message_admins("[key_name_admin(src)] toggled debugging off.")
-		log_admin("[key_name(src)] toggled debugging off.")
-	else
-		GLOB.debug2 = 1
-		message_admins("[key_name_admin(src)] toggled debugging on.")
-		log_admin("[key_name(src)] toggled debugging on.")
-
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Debug Game") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-
 /* 21st Sept 2010
 Updated by Skie -- Still not perfect but better!
 Stuff you can't do:

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -125,7 +125,8 @@
 	set category = "Debug"
 
 	// It's gated by "Debug Verbs", so might as well gate it to the debug permission
-	if(!check_rights(R_DEBUG))
+	// AA: This seems harmless but is **incredibly** powerful and dangerous. Maints only.
+	if(!check_rights(R_MAINTAINER))
 		return
 
 	var/refstring = clean_input("Which reference?","Ref")

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -543,7 +543,7 @@ GLOBAL_PROTECT(VVmaint_only)
 		if(prompt != "Continue")
 			return FALSE
 	if(param_var_name in GLOB.VVmaint_only)
-		if(!is_maintainer(usr))
+		if(!check_rights(R_MAINTAINER))
 			alert(usr, "Editing this variable is restricted to Maintainers only.", "Error", "Ok")
 			return FALSE
 

--- a/code/modules/admin/verbs/ticklag.dm
+++ b/code/modules/admin/verbs/ticklag.dm
@@ -5,7 +5,7 @@
 	set name = "Set Ticklag"
 	set desc = "Sets a new tick lag. Recommend you don't mess with this too much! Stable, time-tested ticklag value is 0.9"
 
-	if(!check_rights(R_DEBUG))	return
+	if(!check_rights(R_MAINTAINER))	return
 
 	var/newtick = input("Sets a new tick lag. Please don't mess with this too much! The stable, time-tested ticklag value is 0.9","Lag of Tick", world.tick_lag) as num|null
 	//I've used ticks of 2 before to help with serious singulo lags

--- a/code/modules/admin/verbs/toggledebugverbs.dm
+++ b/code/modules/admin/verbs/toggledebugverbs.dm
@@ -9,7 +9,6 @@ GLOBAL_LIST_INIT(admin_verbs_show_debug_verbs, list(
 	/client/proc/count_objects_all,
 	/client/proc/cmd_assume_direct_control,
 	/client/proc/startSinglo,
-	/client/proc/ticklag,
 	/client/proc/cmd_admin_grantfullaccess,
 	/client/proc/cmd_admin_areatest,
 	/client/proc/cmd_admin_rejuvenate,
@@ -17,7 +16,6 @@ GLOBAL_LIST_INIT(admin_verbs_show_debug_verbs, list(
 	/client/proc/forceEvent,
 	/client/proc/admin_redo_space_transitions,
 	/client/proc/make_turf_space_map,
-	/client/proc/vv_by_ref
 ))
 
 // Would be nice to make this a permanent admin pref so we don't need to click it each time

--- a/code/modules/procedural_mapping/mapGenerator.dm
+++ b/code/modules/procedural_mapping/mapGenerator.dm
@@ -146,6 +146,9 @@
 	set name = "Test Nature Map Generator"
 	set category = "Debug"
 
+	if(!check_rights(R_MAINTAINER))
+		return
+
 	var/datum/mapGenerator/nature/N = new()
 	var/startInput = clean_input("Start turf of Map, (X;Y;Z)", "Map Gen Settings", "1;1;1")
 	var/endInput = clean_input("End turf of Map (X;Y;Z)", "Map Gen Settings", "[world.maxx];[world.maxy];[mob ? mob.z : 1]")


### PR DESCRIPTION
## What Does This PR Do
- Adds framework for a Maintainer verb set
- Locks some verbs which currently **really** break the server to Maintainers only (These are not adminbus tools, do not whine)
- Removes `is_maintainer()` and adds it as a separate permission node.

## Why It's Good For The Game
Hacky code bad, `admins breaking the server because they think something is fine when it isnt` bad

## Changelog
N/A