### PR TITLE
Nukes all of the OpenDream warnings

### DIFF
--- a/code/datums/outfits/vv_outfit.dm
+++ b/code/datums/outfits/vv_outfit.dm
@@ -56,10 +56,7 @@
 				continue
 			if(varname in ignored_vars)
 				continue
-			var/vval = I.vars[varname]
-			//Does it even work ?
-			if(vval == initial(I.vars[varname]))
-				continue
+			var/vval = I.vars[varname] // Can't check initial() because it doesn't work on a list index
 			//Only text/numbers and icons variables to make it less weirdness prone.
 			if(!istext(vval) && !isnum(vval) && !isicon(vval))
 				continue

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -1,4 +1,6 @@
 GLOBAL_VAR_INIT(normal_ooc_colour, "#275FC5")
+GLOBAL_VAR_INIT(initial_normal_ooc_colour, "#275FC5") // Can't initial() a global
+
 GLOBAL_VAR_INIT(member_ooc_colour, "#035417")
 GLOBAL_VAR_INIT(mentor_ooc_colour, "#00B0EB")
 GLOBAL_VAR_INIT(moderator_ooc_colour, "#184880")
@@ -129,7 +131,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 
 	if(!check_rights(R_SERVER))	return
 
-	GLOB.normal_ooc_colour = initial(GLOB.normal_ooc_colour)
+	GLOB.normal_ooc_colour = GLOB.initial_normal_ooc_colour
 	message_admins("[key_name_admin(usr)] has reset the default player OOC color")
 	log_admin("[key_name(usr)] has reset the default player OOC color")
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -131,7 +131,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 
 	if(!check_rights(R_SERVER))	return
 
-	GLOB.normal_ooc_colour = GLOB.initial_normal_ooc_colour
+	GLOB.normal_ooc_colour = DEFAULT_PLAYER_OOC_COLOUR 
 	message_admins("[key_name_admin(usr)] has reset the default player OOC color")
 	log_admin("[key_name(usr)] has reset the default player OOC color")
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -1,5 +1,5 @@
-GLOBAL_VAR_INIT(normal_ooc_colour, "#275FC5")
-GLOBAL_VAR_INIT(initial_normal_ooc_colour, "#275FC5") // Can't initial() a global
+#define DEFAULT_PLAYER_OOC_COLOUR "#275FC5"
+GLOBAL_VAR_INIT(normal_ooc_colour, DEFAULT_PLAYER_OOC_COLOUR )
 
 GLOBAL_VAR_INIT(member_ooc_colour, "#035417")
 GLOBAL_VAR_INIT(mentor_ooc_colour, "#00B0EB")

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -1,4 +1,4 @@
-#define DEFAULT_PLAYER_OOC_COLOUR "#275FC5"
+#define DEFAULT_PLAYER_OOC_COLOUR "#275FC5" // Can't initial() a global so we store the default in a macro instead
 GLOBAL_VAR_INIT(normal_ooc_colour, DEFAULT_PLAYER_OOC_COLOUR )
 
 GLOBAL_VAR_INIT(member_ooc_colour, "#035417")

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -116,7 +116,8 @@
 				if(!thing)
 					continue
 				var/datum/D = thing
-				if(D.vv_edit_var(variable, initial(D.vars[variable])) != FALSE)
+				// This originally did initial(D.vars[variable]) but initial() doesn't work on a list index
+				if(D.vv_edit_var(variable, D.vars[variable]) != FALSE)
 					accepted++
 				else
 					rejected++

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -632,7 +632,8 @@ GLOBAL_PROTECT(VVmaint_only)
 			return
 
 		if(VV_RESTORE_DEFAULT)
-			var_new = initial(O.vars[variable])
+			// This originally did initial(O.vars[variable]) but initial() doesn't work on a list index
+			var_new = O.vars[variable]
 
 		if(VV_TEXT)
 			var/list/varsvars = vv_parse_text(O, var_new)

--- a/code/modules/awaymissions/maploader/writer.dm
+++ b/code/modules/awaymissions/maploader/writer.dm
@@ -172,20 +172,10 @@
 	if(!use_json)
 		for(var/V in A.vars)
 			CHECK_TICK
-			if((!issaved(A.vars[V])) || (A.vars[V] == initial(A.vars[V])))
-				continue
-
+			// Can't check issaved() or initial() because they don't work on a list index
 			attributes += var_to_dmm(A.vars[V], V)
 	else
 		var/list/to_encode = A.serialize()
-		// We'll want to write out vars that are important to the editor
-		// So that the map is legible as before
-		for(var/T in A.map_important_vars())
-			// Save vars that are important for the map editor, so that
-			// json-encoded maps are legible for standard editors
-			if(A.vars[T] != initial(A.vars[T]))
-				to_encode -= T
-				attributes += var_to_dmm(A.vars[T], T)
 
 		// Remove useless info
 		to_encode -= "type"

--- a/code/modules/buildmode/submodes/variable_edit.dm
+++ b/code/modules/buildmode/submodes/variable_edit.dm
@@ -45,7 +45,7 @@
 			to_chat(user, "<span class='warning'>[initial(object.name)] does not have a var called '[varholder]'</span>")
 	if(right_click)
 		if(object.vars.Find(varholder))
-			var/reset_value = initial(object.vars[varholder])
+			var/reset_value = object.vars[varholder] // Can't use initial() on a list index so just hope for the best I guess
 			if(!object.vv_edit_var(varholder, reset_value))
 				to_chat(user, "<span class='warning'>Your edit was rejected by [object].</span>")
 				return

--- a/code/modules/persistence/persistence.dm
+++ b/code/modules/persistence/persistence.dm
@@ -45,8 +45,7 @@
 /atom/serialize()
 	var/list/data = ..()
 	for(var/thing in vars_to_save())
-		if(vars[thing] != initial(vars[thing]))
-			data[thing] = vars[thing]
+		data[thing] = vars[thing] // Can't check initial() because it doesn't work on a list index
 	return data
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
I got tired of seeing these warnings every time I compile Paradise in OpenDream:
```
Warning at code\game\verbs\ooc.dm:132:40: calling initial() on a global returns the current value
Warning at code\modules\admin\verbs\massmodvar.dm:115:42: calling initial() on a list index returns the current value
Warning at code\modules\admin\verbs\modifyvariables.dm:620:24: calling initial() on a list index returns the current value
Warning at code\modules\persistence\persistence.dm:48:34: calling initial() on a list index returns the current value
Warning at code\modules\awaymissions\maploader\writer.dm:175:19: calling issaved() on a list index is always false
Warning at code\modules\awaymissions\maploader\writer.dm:175:56: calling initial() on a list index returns the current value
Warning at code\modules\awaymissions\maploader\writer.dm:186:30: calling initial() on a list index returns the current value
Warning at code\modules\buildmode\submodes\variable_edit.dm:48:37: calling initial() on a list index returns the current value
Warning at code\datums\outfits\vv_outfit.dm:61:25: calling initial() on a list index returns the current value
```

So I fixed them with as little effort as possible.

And yes the behavior described in the OpenDream warnings matches the BYOND behavior as far as we can tell. BYOND just doesn't throw a warning.

## Changelog
:cl:
fix: Admins can now actually reset the OOC color when they change it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
