### PR TITLE
Improves logging on teleportation portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -6,10 +6,10 @@
 	anchored = TRUE
 
 	var/obj/item/target = null
-	/// The object that created this portal. For example, a wormhole jaunter.
-	var/obj/creation_object
-	/// The mob which was responsible for the creation of the portal. For example, the mob who used the wormhole jaunter.
-	var/mob/creation_mob
+	/// The UID and `name` of the object that created this portal. For example, a wormhole jaunter.
+	var/list/creation_obj_data
+	/// The ckey of the mob which was responsible for the creation of the portal. For example, the mob who used a wormhole jaunter.
+	var/creation_mob_ckey
 
 	var/failchance = 5
 	var/fail_icon = "portal1"
@@ -19,24 +19,23 @@
 	var/ignore_tele_proof_area_setting = FALSE
 	var/one_use = FALSE // Does this portal go away after one teleport?
 
-/obj/effect/portal/New(loc, turf/_target, obj/_creation_object = null, lifespan = 300, mob/_creation_mob = null)
+/obj/effect/portal/New(loc, turf/_target, obj/creation_object = null, lifespan = 300, mob/creation_mob = null)
 	..()
 
 	GLOB.portals += src
 
 	target = _target
-	creation_object = _creation_object
-	creation_mob = _creation_mob
+	creation_obj_data = list(creation_object.UID(), "[creation_object.name]") // Store the name incase the object is deleted.
+	creation_mob_ckey = creation_mob?.ckey
 
 	if(lifespan > 0)
-		spawn(lifespan)
-			qdel(src)
+		QDEL_IN(src, lifespan)
 
 /obj/effect/portal/Destroy()
 	GLOB.portals -= src
-	creation_object.portal_destroyed(src)
-	creation_object = null
-	creation_mob = null
+	var/obj/O = locateUID(creation_obj_data[1])
+	if(!QDELETED(O))
+		O.portal_destroyed(src)
 	target = null
 	return ..()
 
@@ -100,10 +99,11 @@
 
 	if(ismegafauna(M))
 		var/creator_string = ""
-		if(creation_mob && creation_object)
-			creator_string = " created by [key_name_admin(creation_mob)] using \a [creation_object]"
-		else if(creation_object)
-			creator_string = " created by \a [creation_object]"
+		var/obj_name = creation_obj_data[2]
+		if(creation_mob_ckey)
+			creator_string = " created by [key_name_admin(GLOB.directory[creation_mob_ckey])][obj_name ? " using \a [obj_name]" : ""]"
+		else if(obj_name)
+			creator_string = " created by \a [obj_name]"
 		message_admins("[M] has used a portal at [ADMIN_VERBOSEJMP(src)][creator_string].")
 
 	if(prob(failchance))

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -304,7 +304,7 @@
 	U.message_holder("Extraction signal received, agent. [SSmapping.map_datum.fluff_name]'s bluespace transport jamming systems have been sabotaged. "\
 			 	   + "We have opened a temporary portal at your flare location - proceed to the target's extraction by inserting them into the portal.", 'sound/effects/confirmdropoff.ogg')
 	// Open a portal
-	var/obj/effect/portal/redspace/contractor/P = new(get_turf(F), pick(GLOB.syndieprisonwarp), null, 0)
+	var/obj/effect/portal/redspace/contractor/P = new(get_turf(F), pick(GLOB.syndieprisonwarp), F, 0, M)
 	P.contract = src
 	P.contractor_mind = M.mind
 	P.target_mind = contract.target

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -42,7 +42,7 @@
 		to_chat(user, "<span class='notice'>[src] found no beacons in the world to anchor a wormhole to.</span>")
 		return
 	var/chosen_beacon = pick(L)
-	var/obj/effect/portal/jaunt_tunnel/J = new(get_turf(src), get_turf(chosen_beacon), src, 100)
+	var/obj/effect/portal/jaunt_tunnel/J = new(get_turf(src), get_turf(chosen_beacon), src, 100, user)
 	J.emagged = emagged
 	if(adjacent)
 		try_move_adjacent(J)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes admin logging more accurate when megafauna enter portals (`/obj/effect/portal`). Allows the log to include both the mob and object responsible for creating the portal.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins having more accurate logging is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Improves logging on teleportation portals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
