### PR TITLE
Fixes gun cabinet icons breaking with less than 3 guns

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -23,26 +23,27 @@
 /obj/structure/closet/secure_closet/guncabinet/update_overlays()
 	cut_overlays()
 	if(!opened)
-		var/lazors = 0
-		var/shottas = 0
+		var/lasers = 0
+		var/ballistics = 0
 		for(var/obj/item/gun/G in contents)
 			if(istype(G, /obj/item/gun/energy))
-				lazors++
-			if(istype(G, /obj/item/gun/projectile/))
-				shottas++
-		if(lazors || shottas)
+				lasers++
+			if(istype(G, /obj/item/gun/projectile))
+				ballistics++
+		if(lasers || ballistics)
 			for(var/i = 0 to 2)
+				if(!lasers && !ballistics) //This may seem redundant but needed here to prevent adding the gun overlay without guns
+					continue
 				var/image/gun = image(icon(icon))
-
-				if(lazors > 0 && (shottas <= 0 || prob(50)))
-					lazors--
+				if(lasers && (!ballistics || prob(50)))
+					lasers--
 					gun.icon_state = "laser"
-				else if(shottas > 0)
-					shottas--
+				else if(ballistics)
+					ballistics--
 					gun.icon_state = "projectile"
 
 				gun.pixel_x = i*4
-				overlays += gun
+				add_overlay(gun)
 
 		add_overlay("door")
 		if(broken)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes the issue with the new gun cabinet sprites when they are closed with less than 3 guns in them.
I also slightly tidy up the code while I am there, but not by much.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The cabinets used to apply an overlay of the default sprite if less than 3 guns were present, this looked really wack and glitchy.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Fixed gun cabinet sprites breaking with less than 3 guns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
