### PR TITLE
Fixes players assigned the +EVERYTHING rank not receiving the +ADMIN permission

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -44,7 +44,7 @@
 
 #define R_MAXPERMISSION 131072 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
-#define R_HOST			262141 // Sum of all permissions to allow easy setting
+#define R_HOST			262143 // Sum of all permissions to allow easy setting
 
 #define ADMIN_QUE(user,display) "<a href='?_src_=holder;adminmoreinfo=[user.UID()]'>[display]</a>"
 #define ADMIN_FLW(user,display) "<a href='?_src_=holder;adminplayerobservefollow=[user.UID()]'>[display]</a>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a small addition mistake introduced in #17633, `R_HOST` needs to have a value of `262143` instead of `262141`.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Images of changes
Before:
![dreamseeker_bfdNyAli4h](https://user-images.githubusercontent.com/42044220/164600786-1fb12aeb-39cb-4a21-9512-68f1ec2df5c0.png)

After:
![dreamseeker_qwdfhDZBgn](https://user-images.githubusercontent.com/42044220/164600840-392d960b-7c94-4456-b96f-b1c905f107dd.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fixes players assigned the +EVERYTHING rank not receiving the +ADMIN permission
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
