### PR TITLE
Delay awaymission terrorspider gibbing.

### DIFF
--- a/code/modules/surgery/organs/parasites.dm
+++ b/code/modules/surgery/organs/parasites.dm
@@ -70,14 +70,6 @@
 	egg_progress += pick(0, 1, 2)
 	egg_progress += calc_variable_progress()
 
-	// Detect & stop people attempting to bring a gateway white spider infection back to the main station.
-	if(awaymission_infection)
-		var/turf/T = get_turf(owner)
-		if(istype(T) && !is_away_level(T.z))
-			owner.gib()
-			qdel(src)
-			return
-
 	// Once at least one egg has hatched from you, you'll need help to reach medbay.
 	if(eggs_hatched >= 1)
 		owner.SetConfused(45)
@@ -99,6 +91,16 @@
 	return extra_progress
 
 /obj/item/organ/internal/body_egg/terror_eggs/proc/hatch_egg()
+	// Detect & stop people attempting to bring a gateway white spider infection back to the main station.
+	if(awaymission_infection)
+		var/turf/T = get_turf(owner)
+		if(istype(T) && !is_away_level(T.z))
+			owner.gib()
+			// give a hint of the cause of death
+			new /obj/effect/decal/cleanable/spiderling_remains(T)
+			qdel(src)
+			return
+
 	var/infection_completed = FALSE
 	var/obj/structure/spider/spiderling/terror_spiderling/S = new(get_turf(owner))
 	switch(eggs_hatched)


### PR DESCRIPTION
## What Does This PR Do
Currently, if a person goes into gateway and gets bit by a white spider, they are *immediately* gibbed upon return to the station. This works really well at preventing griefing, but feels very confusing to the player - "what gibbed me?.. huh??..".

This PR:
- delays the gibbing until the spiderlings hatch. So we still don't get the spiderlings on station, but the player has a (slim, really) opportunity to get it surgically removed. and
- adds a "spiderling remains" into the gib pile to hint at the cause of the incident (Example lore: the spiders in the gateway are a sliglty different breed from the midround ones, so they are much more violent to their host, but also happen to be completely unsuited for the conditions on the station). Admittedly it's rather subtle, since those are placed *under* all the gibs, since spiderlings remains is technically a structure. But it's better than nothing? 

This PR was specifically inspired by a certain explorer who got bit by a white, and made the logical decision to immediately head to medbay to get the egg removed. And got gibbed, of course.

## Why It's Good For The Game
Less player confusion. More player agency/counterplay.

It's not fun that you need meta-knowledge about being gibbed on exit.
And even if you have said meta-knowledge, it's also not fun having zero indication about when you're cured of the spider eggs and free to leave once more.  
And even if you can keep track of the amount of spiderlings spawned out of you so far, it's *still* not fun being stuck in gateway for 15 minutes.


## Images of changes
![20220424-004310-dreamseeker](https://user-images.githubusercontent.com/7831163/164950995-329211bb-aaa4-41e4-8944-7539385215ca.png)


## Changelog
:cl:
tweak: Awaymission white spider infection gibs you a bit later now.
/:cl:
