### PR TITLE
Minor refactor examine to code, move held items up in the Examine display

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -46,70 +46,53 @@
 	else
 		msg += ", a<b><font color='[examine_color]'> [lowertext(displayed_species)]</font></b>!\n"
 
-	//uniform
-	if(w_uniform && !skipjumpsuit && !(w_uniform.flags & ABSTRACT))
-		//Ties
-		var/tie_msg
-		if(istype(w_uniform,/obj/item/clothing/under))
-			var/obj/item/clothing/under/U = w_uniform
-			if(U.accessories.len)
-				tie_msg += " with [english_accessory_list(U)]"
+	// All the things wielded/worn that can be reasonably described with a common template:
+	var/list/message_parts = list(
+		list("[p_are()] holding", l_hand, "in", "left hand"),
+		list("[p_are()] holding", r_hand, "in", "right hand"),
+		list("[p_are()] wearing", !skipjumpsuit && w_uniform, null, null),
+		list("[p_are()] wearing", head, "on", "head"),
+		list("[p_are()] wearing", wear_suit, null, null),
+		list("[p_are()] carrying", !skipsuitstorage && s_store, "on", wear_suit && wear_suit.name),
+		list("[p_have()]", back, "on", "back"),
+		list("[p_have()]", !skipgloves && gloves, "on", "hands"),
+		list("[p_have()]", belt, "about", "waist"),
+		list("[p_are()] wearing", !skipshoes && shoes, "on", "feet"),
+		list("[p_have()]", !skipmask && wear_mask, "on", "face"),
+		list("[p_have()]", glasses, "covering", "eyes"),
+		list("[p_have()]", !skipears && l_ear, "on", "left ear"),
+		list("[p_have()]", !skipears && r_ear, "on", "right ear"),
+		list("[p_are()] wearing", wear_id, null, null),
+	)
+	for(var/parts in message_parts)
+		var/action = parts[1]
+		var/obj/item/item = parts[2]
+		var/preposition = parts[3]
+		var/limb_name = parts[4]
 
-		if(w_uniform.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] wearing [bicon(w_uniform)] [w_uniform.gender==PLURAL?"some":"a"] [w_uniform.blood_color != "#030303" ? "blood-stained":"oil-stained"] [w_uniform.name][tie_msg]!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_are()] wearing [bicon(w_uniform)] \a [w_uniform][tie_msg].\n"
-
-	//head
-	if(head && !(head.flags & ABSTRACT))
-		if(head.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] wearing [bicon(head)] [head.gender==PLURAL?"some":"a"] [head.blood_color != "#030303" ? "blood-stained":"oil-stained"] [head.name] on [p_their()] head!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_are()] wearing [bicon(head)] \a [head] on [p_their()] head.\n"
-
-	//suit/armour
-	if(wear_suit && !(wear_suit.flags & ABSTRACT))
-		if(wear_suit.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] wearing [bicon(wear_suit)] [wear_suit.gender==PLURAL?"some":"a"] [wear_suit.blood_color != "#030303" ? "blood-stained":"oil-stained"] [wear_suit.name]!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_are()] wearing [bicon(wear_suit)] \a [wear_suit].\n"
-
-		//suit/armour storage
-		if(s_store && !skipsuitstorage)
-			if(s_store.blood_DNA)
-				msg += "<span class='warning'>[p_they(TRUE)] [p_are()] carrying [bicon(s_store)] [s_store.gender==PLURAL?"some":"a"] [s_store.blood_color != "#030303" ? "blood-stained":"oil-stained"] [s_store.name] on [p_their()] [wear_suit.name]!</span>\n"
+		if (item && !(item.flags & ABSTRACT))
+			var/item_words = item.name
+			if (item.blood_DNA)
+				item_words = "[item.blood_color != "#030303" ? "blood-stained":"oil-stained"] [item_words]"
+			var/submsg = "[p_they(TRUE)] [action] [bicon(item)] \a [item_words]"
+			if (limb_name)
+				submsg += " [preposition] [p_their()] [limb_name]"
+			if (item.blood_DNA)
+				submsg = "<span class='warning'>[submsg]!</span>\n"
 			else
-				msg += "[p_they(TRUE)] [p_are()] carrying [bicon(s_store)] \a [s_store] on [p_their()] [wear_suit.name].\n"
-
-	//back
-	if(back && !(back.flags & ABSTRACT))
-		if(back.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [bicon(back)] [back.gender==PLURAL?"some":"a"] [back.blood_color != "#030303" ? "blood-stained":"oil-stained"] [back] on [p_their()] back.</span>\n"
+				submsg = "[submsg].\n"
+			msg += submsg
+			continue
 		else
-			msg += "[p_they(TRUE)] [p_have()] [bicon(back)] \a [back] on [p_their()] back.\n"
-
-	//left hand
-	if(l_hand && !(l_hand.flags & ABSTRACT))
-		if(l_hand.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] holding [bicon(l_hand)] [l_hand.gender==PLURAL?"some":"a"] [l_hand.blood_color != "#030303" ? "blood-stained":"oil-stained"] [l_hand.name] in [p_their()] left hand!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_are()] holding [bicon(l_hand)] \a [l_hand] in [p_their()] left hand.\n"
-
-	//right hand
-	if(r_hand && !(r_hand.flags & ABSTRACT))
-		if(r_hand.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] holding [bicon(r_hand)] [r_hand.gender==PLURAL?"some":"a"] [r_hand.blood_color != "#030303" ? "blood-stained":"oil-stained"] [r_hand.name] in [p_their()] right hand!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_are()] holding [bicon(r_hand)] \a [r_hand] in [p_their()] right hand.\n"
-
-	//gloves
-	if(gloves && !skipgloves && !(gloves.flags & ABSTRACT))
-		if(gloves.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [bicon(gloves)] [gloves.gender==PLURAL?"some":"a"] [gloves.blood_color != "#030303" ? "blood-stained":"oil-stained"] [gloves.name] on [p_their()] hands!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_have()] [bicon(gloves)] \a [gloves] on [p_their()] hands.\n"
-	else if(blood_DNA)
-		msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [hand_blood_color != "#030303" ? "blood-stained":"oil-stained"] hands!</span>\n"
+			// no items worn, thus revealing the skin
+			switch (limb_name)
+				if ("hands")
+					if (blood_DNA)
+						msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [hand_blood_color != "#030303" ? "blood-stained":"oil-stained"] hands!</span>\n"
+				if ("eyes")
+					if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
+						msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glowing an unnatural red!</span>\n"
+			continue
 
 	//handcuffed?
 	if(handcuffed)
@@ -119,52 +102,6 @@
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(handcuffed)] restrained with cable!</span>\n"
 		else
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(handcuffed)] handcuffed!</span>\n"
-
-	//belt
-	if(belt)
-		if(belt.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [bicon(belt)] [belt.gender==PLURAL?"some":"a"] [belt.blood_color != "#030303" ? "blood-stained":"oil-stained"] [belt.name] about [p_their()] waist!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_have()] [bicon(belt)] \a [belt] about [p_their()] waist.\n"
-
-	//shoes
-	if(shoes && !skipshoes && !(shoes.flags & ABSTRACT))
-		if(shoes.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] wearing [bicon(shoes)] [shoes.gender==PLURAL?"some":"a"] [shoes.blood_color != "#030303" ? "blood-stained":"oil-stained"] [shoes.name] on [p_their()] feet!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_are()] wearing [bicon(shoes)] \a [shoes] on [p_their()] feet.\n"
-	else if(blood_DNA)
-		msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [feet_blood_color != "#030303" ? "blood-stained":"oil-stained"] feet!</span>\n"
-
-
-	//mask
-	if(wear_mask && !skipmask && !(wear_mask.flags & ABSTRACT))
-		if(wear_mask.blood_DNA)
-			msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [bicon(wear_mask)] [wear_mask.gender==PLURAL?"some":"a"] [wear_mask.blood_color != "#030303" ? "blood-stained":"oil-stained"] [wear_mask.name] on [p_their()] face!</span>\n"
-		else
-			msg += "[p_they(TRUE)] [p_have()] [bicon(wear_mask)] \a [wear_mask] on [p_their()] face.\n"
-
-	//eyes
-	if(!skipeyes)
-		if(glasses && !(glasses.flags & ABSTRACT))
-			if(glasses.blood_DNA)
-				msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [bicon(glasses)] [glasses.gender==PLURAL?"some":"a"] [glasses.blood_color != "#030303" ? "blood-stained":"oil-stained"] [glasses] covering [p_their()] eyes!</span>\n"
-			else
-				msg += "[p_they(TRUE)] [p_have()] [bicon(glasses)] \a [glasses] covering [p_their()] eyes.\n"
-		else if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
-			msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glowing an unnatural red!</span>\n"
-
-	//left ear
-	if(l_ear && !skipears)
-		msg += "[p_they(TRUE)] [p_have()] [bicon(l_ear)] \a [l_ear] on [p_their()] left ear.\n"
-
-	//right ear
-	if(r_ear && !skipears)
-		msg += "[p_they(TRUE)] [p_have()] [bicon(r_ear)] \a [r_ear] on [p_their()] right ear.\n"
-
-	//ID
-	if(wear_id)
-		msg += "[p_they(TRUE)] [p_are()] wearing [bicon(wear_id)] \a [wear_id].\n"
 
 	//Jitters
 	switch(jitteriness)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -50,8 +50,8 @@
 	var/list/message_parts = list(
 		list("[p_are()] holding", l_hand, "in", "left hand"),
 		list("[p_are()] holding", r_hand, "in", "right hand"),
-		list("[p_are()] wearing", !skipjumpsuit && w_uniform, null, null),
 		list("[p_are()] wearing", head, "on", "head"),
+		list("[p_are()] wearing", !skipjumpsuit && w_uniform, null, null),
 		list("[p_are()] wearing", wear_suit, null, null),
 		list("[p_are()] carrying", !skipsuitstorage && s_store, "on", wear_suit && wear_suit.name),
 		list("[p_have()]", back, "on", "back"),


### PR DESCRIPTION
## What Does This PR Do
The original goal of this PR was to move the items held in hands to either the top of the examine list or the bottom of it.
But looking at the code as it was, was a pain. So I had to remove the gratuitous duplication therein to actually make the change.
Also, while at it, reorder the hats from being between jumpsuit and armor, to preceding both.

## Why It's Good For The Game
When i'm examining someone, I usually don't care about their shoes, but I *do* care about the held item(s), as those are often important, small, and occasionally hidden, depending on the direction the person is looking. Having the held items be listed in the midst of other clutter between the jumpsuit and the belt *makes some sense*, of course, but does not make for good gameplay.

Also, code duplication bad. Doubly so when the duplicates all have very tiny changes between each other.

## Images of changes
![20220424-024128-dreamseeker](https://user-images.githubusercontent.com/7831163/164953826-8440d89f-32d0-4336-b784-7840f2623016.png)



## Changelog
:cl:
tweak: items held in hands are now displayed at the top in the Examine list
/:cl: