### PR TITLE
Fixes some portal logging.

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -25,7 +25,8 @@
 	GLOB.portals += src
 
 	target = _target
-	creation_obj_data = list(creation_object.UID(), "[creation_object.name]") // Store the name incase the object is deleted.
+	if(creation_object)
+		creation_obj_data = list(creation_object.UID(), "[creation_object.name]") // Store the name incase the object is deleted.
 	creation_mob_ckey = creation_mob?.ckey
 
 	if(lifespan > 0)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -139,7 +139,7 @@ Frequency:
 		return
 	var/T = L[t1]
 	user.show_message("<span class='notice'>Locked In.</span>", 2)
-	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(src), T, src, user)
+	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(src), T, src, creation_mob = user)
 	try_move_adjacent(P)
 	active_portals++
 	add_fingerprint(user)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -109,7 +109,7 @@ Frequency:
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/active_portals = 0
 
-/obj/item/hand_tele/attack_self(mob/user as mob)
+/obj/item/hand_tele/attack_self(mob/user)
 	var/turf/current_location = get_turf(user)//What turf is the user on?
 	if(!current_location||!is_teleport_allowed(current_location.z))//If turf was not found or they're somewhere teleproof
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
@@ -139,7 +139,7 @@ Frequency:
 		return
 	var/T = L[t1]
 	user.show_message("<span class='notice'>Locked In.</span>", 2)
-	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(src), T, src)
+	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(src), T, src, user)
 	try_move_adjacent(P)
 	active_portals++
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
hand teleporters properly give their portals a "creator" mob

SSD portals no longer runtime

## Why It's Good For The Game
logging good, runtimes bad


## Changelog
:cl:
fix: teleporting megafauna with hand teleporters is properly logged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
