### PR TITLE
Removes ability to change flavor text while you are unconscious.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -727,7 +727,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/update_flavor_text()
 	set src in usr
 	if(usr != src)
-		to_chat(usr, "<span class='notice'> You can't change the flavor text of this mob")
+		to_chat(usr, "<span class='notice'>You can't change the flavor text of this mob</span>")
 		return
 	if(stat)
 		to_chat(usr, "<span class='notice'>You have to be conscious to change your flavor text </span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -730,14 +730,14 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		to_chat(usr, "<span class='notice'>You can't change the flavor text of this mob</span>")
 		return
 	if(stat)
-		to_chat(usr, "<span class='notice'>You have to be conscious to change your flavor text </span>")
+		to_chat(usr, "<span class='notice'>You have to be conscious to change your flavor text</span>")
 		return
 	
 	var/msg = input(usr,"Set the flavor text in your 'examine' verb. The flavor text should be a physical descriptor of your character at a glance.","Flavor Text",html_decode(flavor_text)) as message|null
 
 	if(msg != null)
 		if(stat)
-			to_chat(usr, "<span class='notice'>You have to be conscious to change your flavor text </span>")
+			to_chat(usr, "<span class='notice'>You have to be conscious to change your flavor text</span>")
 			return
 		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
 		msg = html_encode(msg)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -727,10 +727,18 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/update_flavor_text()
 	set src in usr
 	if(usr != src)
-		to_chat(usr, "No.")
+		to_chat(usr, "<span class='notice'> You can't change the flavor text of this mob")
+		return
+	if(stat)
+		to_chat(usr, "<span class='notice'>You have to be conscious to change your flavor text </span>")
+		return
+	
 	var/msg = input(usr,"Set the flavor text in your 'examine' verb. The flavor text should be a physical descriptor of your character at a glance.","Flavor Text",html_decode(flavor_text)) as message|null
 
 	if(msg != null)
+		if(stat)
+			to_chat(usr, "<span class='notice'>You have to be conscious to change your flavor text </span>")
+			return
 		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
 		msg = html_encode(msg)
 


### PR DESCRIPTION



<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #17651
Also cleans up the (previously useless) check to see if the user of the verb is changing the flavor text of its own source
Shoutout to my bois in coderchat for the help

## Why It's Good For The Game
You shouldn't be able to change your flavor text while you are unconscious

🆑 Regens
fix: You can no longer change flavor text while you are unconscious or dead
/🆑