### PR TITLE
You can no longer use mech ranged weapons if you have a melee-only martial arts

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -211,7 +211,7 @@
 			if(HAS_TRAIT(L, TRAIT_PACIFISM) && selected.harmful)
 				to_chat(L, "<span class='warning'>You don't want to harm other living beings!</span>")
 				return
-			if(mind?.martial_art?.no_guns)
+			if(user.mind?.martial_art?.no_guns)
 				to_chat(src, "<span class='warning'>[mind.martial_art.no_guns_message]</span>")
 				return
 			selected.action(target, params)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -212,7 +212,7 @@
 				to_chat(L, "<span class='warning'>You don't want to harm other living beings!</span>")
 				return
 			if(user.mind?.martial_art?.no_guns)
-				to_chat(src, "<span class='warning'>[mind.martial_art.no_guns_message]</span>")
+				to_chat(L, "<span class='warning'>[L.mind.martial_art.no_guns_message]</span>")
 				return
 			selected.action(target, params)
 	else if(selected && selected.is_melee())

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -211,6 +211,9 @@
 			if(HAS_TRAIT(L, TRAIT_PACIFISM) && selected.harmful)
 				to_chat(L, "<span class='warning'>You don't want to harm other living beings!</span>")
 				return
+			if(mind?.martial_art?.no_guns)
+				to_chat(src, "<span class='warning'>[mind.martial_art.no_guns_message]</span>")
+				return
 			selected.action(target, params)
 	else if(selected && selected.is_melee())
 		if(isliving(target) && selected.harmful && HAS_TRAIT(L, TRAIT_PACIFISM))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an additional check for martials arts that restrict ranged combat to mechs.
Fixes #17542

## Why It's Good For The Game
A no-ranged restriction should apply to you regardless of being in a mech or not


## Changelog
:cl: Regens
fix: You can no longer fire mech ranged weapons if you are ranged weapons restricted by a martial art, like sleeping carp.
/:cl: