### PR TITLE
Surgery on napping people wakes them up.

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -402,6 +402,7 @@
 	id = "sleeping"
 	tick_interval = 2 SECONDS
 	needs_update_stat = TRUE
+	var/voluntary = FALSE
 
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(!iscarbon(owner))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -406,6 +406,10 @@
 	/// As opposed to being hard knocked out with N2O or similar.
 	var/voluntary = FALSE
 
+/datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, set_duration, voluntary = FALSE)
+	..()
+	src.voluntary = voluntary
+
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(!iscarbon(owner))
 		return

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -402,6 +402,8 @@
 	id = "sleeping"
 	tick_interval = 2 SECONDS
 	needs_update_stat = TRUE
+	/// Whether we decided to take a nap on our own.
+	/// As opposed to being hard knocked out with N2O or similar.
 	var/voluntary = FALSE
 
 /datum/status_effect/incapacitating/sleeping/tick()

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -103,8 +103,9 @@
 // HELPER PROCS //
 //////////////////
 
-/mob/living/proc/apply_status_effect(effect, ...) //applies a given status effect to this mob, returning the effect if it was successful
-	. = FALSE
+/// Applies a given status effect to this mob, returning the effect if it was successful or null otherwise
+/mob/living/proc/apply_status_effect(effect, ...)
+	. = null
 	var/datum/status_effect/S1 = effect
 	LAZYINITLIST(status_effects)
 	for(var/datum/status_effect/S in status_effects)
@@ -121,7 +122,8 @@
 	S1 = new effect(arguments)
 	. = S1
 
-/mob/living/proc/remove_status_effect(effect, ...) //removes all of a given status effect from this mob, returning TRUE if at least one was removed
+/// Removes all of a given status effect from this mob, returning TRUE if at least one was removed
+/mob/living/proc/remove_status_effect(effect, ...)
 	. = FALSE
 	var/list/arguments = args.Copy(2)
 	if(status_effects)
@@ -131,15 +133,17 @@
 				qdel(S)
 				. = TRUE
 
-/mob/living/proc/has_status_effect(effect) //returns the effect if the mob calling the proc owns the given status effect
-	. = FALSE
+/// Returns the effect if the mob calling the proc owns the given status effect, or null otherwise
+/mob/living/proc/has_status_effect(effect)
+	. = null
 	if(status_effects)
 		var/datum/status_effect/S1 = effect
 		for(var/datum/status_effect/S in status_effects)
 			if(initial(S1.id) == S.id)
 				return S
 
-/mob/living/proc/has_status_effect_list(effect) //returns a list of effects with matching IDs that the mod owns; use for effects there can be multiple of
+/// Returns a list of effects with matching IDs that the mod owns; use for effects there can be multiple of
+/mob/living/proc/has_status_effect_list(effect)
 	. = list()
 	if(status_effects)
 		var/datum/status_effect/S1 = effect

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -402,6 +402,7 @@
 	var/datum/status_effect/incapacitating/sleeping/S = IsSleeping()
 	if(S)
 		S.duration = -1
+		S.voluntary = FALSE
 	else
 		S = apply_status_effect(STATUS_EFFECT_SLEEPING, -1)
 	return S

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -380,7 +380,7 @@
 		S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount)
 	return S
 
-/mob/living/proc/SetSleeping(amount, ignore_canstun = FALSE)
+/mob/living/proc/SetSleeping(amount, ignore_canstun = FALSE, voluntary = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
 		return
 	if(status_flags & GODMODE)
@@ -392,6 +392,10 @@
 		S.duration = amount + world.time
 	else if(amount > 0)
 		S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount)
+		if(voluntary)
+			S.voluntary = TRUE
+	if(!voluntary && S)
+		S.voluntary = FALSE
 	return S
 
 /mob/living/proc/PermaSleeping() /// used for admin freezing.

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -391,9 +391,7 @@
 	if(S)
 		S.duration = amount + world.time
 	else if(amount > 0)
-		S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount)
-		if(voluntary)
-			S.voluntary = TRUE
+		S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount, voluntary)
 	if(!voluntary && S)
 		// Only set it one way (true => false)
 		// Otherwise if we are hard knocked out, and then try to nap, we'd be

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -395,6 +395,9 @@
 		if(voluntary)
 			S.voluntary = TRUE
 	if(!voluntary && S)
+		// Only set it one way (true => false)
+		// Otherwise if we are hard knocked out, and then try to nap, we'd be
+		// treated as "just lightly napping" and woken up by trivial stuff.
 		S.voluntary = FALSE
 	return S
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -407,9 +407,8 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 	if(IsSleeping())
 		to_chat(src, "<span class='notice'>You are already sleeping.</span>")
 		return
-	else
-		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
-			SetSleeping(40 SECONDS, voluntary = TRUE) //Short nap
+	if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
+		SetSleeping(40 SECONDS, voluntary = TRUE) //Short nap
 
 /mob/living/verb/lay_down()
 	set name = "Rest"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -409,7 +409,7 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 		return
 	else
 		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
-			SetSleeping(40 SECONDS) //Short nap
+			SetSleeping(40 SECONDS, voluntary = TRUE) //Short nap
 
 /mob/living/verb/lay_down()
 	set name = "Rest"

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -118,7 +118,11 @@
 
 
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
+	if(M.stat == DEAD) // Operating on dead people is easy
+		return 1
+	var/datum/status_effect/incapacitating/sleeping/S = M.has_status_effect(STATUS_EFFECT_SLEEPING)
+	if(M.stat == UNCONSCIOUS && !(S?.voluntary))
+		// Knocked out for good, not just napping
 		return 1
 	if(HAS_TRAIT(M, TRAIT_NOPAIN))//if you don't feel pain, you can hold still
 		return 1

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -122,7 +122,9 @@
 		return 1
 	var/datum/status_effect/incapacitating/sleeping/S = M.has_status_effect(STATUS_EFFECT_SLEEPING)
 	if(M.stat == UNCONSCIOUS && !(S?.voluntary))
-		// Knocked out for good, not just napping
+		// Either unconscious due to something other than sleep,
+		// or "sleeping" due to being hard knocked out (N2O or similar), rather than just napping.
+		// Either way, not easily woken up.
 		return 1
 	if(HAS_TRAIT(M, TRAIT_NOPAIN))//if you don't feel pain, you can hold still
 		return 1

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -120,7 +120,7 @@
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
 	if(M.stat == DEAD) // Operating on dead people is easy
 		return 1
-	var/datum/status_effect/incapacitating/sleeping/S = M.has_status_effect(STATUS_EFFECT_SLEEPING)
+	var/datum/status_effect/incapacitating/sleeping/S = M.IsSleeping()
 	if(M.stat == UNCONSCIOUS && !(S?.voluntary))
 		// Either unconscious due to something other than sleep,
 		// or "sleeping" due to being hard knocked out (N2O or similar), rather than just napping.

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -115,7 +115,7 @@
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target //typecast to human
 				var/pain_mod = get_pain_modifier(H)
-				var/datum/status_effect/incapacitating/sleeping/S = H.has_status_effect(STATUS_EFFECT_SLEEPING)
+				var/datum/status_effect/incapacitating/sleeping/S = H.IsSleeping()
 				if(S?.voluntary)
 					H.SetSleeping(0) // wake up people who are napping through the surgery
 					if(pain_mod < 0.95)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -114,7 +114,16 @@
 		if(!ispath(surgery.steps[surgery.status], /datum/surgery_step/robotics))//Repairing robotic limbs doesn't hurt, and neither does cutting someone out of a rig
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target //typecast to human
-				prob_chance *= get_pain_modifier(H)//operating on conscious people is hard.
+				var/pain_mod = get_pain_modifier(H)
+				var/datum/status_effect/incapacitating/sleeping/S = H.has_status_effect(STATUS_EFFECT_SLEEPING)
+				if(S?.voluntary)
+					H.SetSleeping(0) // wake up people who are napping through the surgery
+					if(pain_mod < 0.95)
+						to_chat(H, "<span class='danger'>The surgery on your [target_zone] is agonizingly painful, and wrecks you out of your shallow slumber!</span>")
+					else
+						// Still wake people up, but they shouldn't be as alarmed.
+						to_chat(H, "<span class='warning'>The surgery being performed on your [target_zone] wakes you up.</span>")
+				prob_chance *= pain_mod //operating on conscious people is hard.
 
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))


### PR DESCRIPTION
## What Does This PR Do
Wakes up people who use IC->Sleep during the surgery.

## Why It's Good For The Game
The current behavior is "breaking immersion" and - some argue - "powergamey" and/or LRP.

Also the existing code comments imply that it is not desirable, and thus a bug, rather than a feature. See:
https://github.com/ParadiseSS13/Paradise/blob/b316c880bfaad998e0286580aca873a5dd30c908/code/modules/surgery/helpers.dm#L121

The code does not match the comments due to #8248, which fixed a real problem with the previous implementation (but at what cost!). This PR does not reintroduce the issue that #8248 was fixing by being a bit more clever, and distinguishing a "nap" kind of sleep from "being knocked out" kind of sleep.

## Images of changes
Operating on an IC Sleeping farwa:
![20220425-033129-dreamseeker](https://user-images.githubusercontent.com/7831163/165016575-d4f6f8d0-b233-4e98-b1e8-421d6de54897.png)

Operating on the same farwa, but now sedated:
![20220425-033628-dreamseeker](https://user-images.githubusercontent.com/7831163/165016744-35dfdf14-9e48-4052-a2ff-0c00758960d4.png)

## Changelog
:cl:
fix: Surgery on napping people wakes them up.
/:cl: