### PR TITLE
Prevent solid objects from turret deployment.

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -624,7 +624,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	// check if anything's preventing us from raising
 	var/turf/T = get_turf(src)
 	for(var/atom/A in T.contents)
-		if(A==src)
+		if(A == src)
 			continue
 		if(A.density)
 			return

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -623,7 +623,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		return
 	// check if anything's preventing us from raising
 	var/turf/T = get_turf(src)
-	for(var/atom/A in T.contents)
+	for(var/atom/A in T)
 		if(A == src)
 			continue
 		if(A.density)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -621,6 +621,14 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		return
 	if(stat & BROKEN)
 		return
+	// check if anything's preventing us from raising
+	var/turf/T = get_turf(src)
+	for(var/atom/A in T.contents)
+		if(A==src)
+			continue
+		if(A.density)
+			return
+
 	set_raised_raising(raised, TRUE)
 	playsound(get_turf(src), 'sound/effects/turret/open.wav', 60, 1)
 	update_icon()


### PR DESCRIPTION
## What Does This PR Do
Prevents solid objects on top of undeployed turrets from said turrets getting deployed.
Fixes #17302
Fixes #17418
Alternative to PR #17590

Note that this includes all solid objects including grilles, borgos, mobs, surgical trays, closed lockers, janicarts and the P.A.C.M.A.N.s and Air supply canisters conveniently placed right in the satellite antechamber.

## Why It's Good For The Game
See the abovementioned bugs.
As for #17590, I don't have strong opinions on it. It might be a good addition to the game as a whole, but it does not fully fix the "turret can shoot from beneath things fully protecting it" issue (because, again, movable furniture exists).

## Images of changes
Grille:
![20220425-062011-dreamseeker](https://user-images.githubusercontent.com/7831163/165034555-1a77e16e-4f65-4bd5-b06f-a0d63d1a3233.gif)
Pacman:
![20220425-065725-dreamseeker](https://user-images.githubusercontent.com/7831163/165036383-3f1c10c3-8c87-4baf-96f1-1cdac8587d86.gif)

## Changelog
:cl:
fix: Turrets will no longer deploy when a solid object is present on top of them.
/:cl:

