### PR TITLE
Cryoing now won't cause items to try and remove themselves from deleted storages. Runtime fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -167,7 +167,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 		m.unEquip(src, 1)
 	else if(istype(loc, /obj/item/storage))
 		var/obj/item/storage/S = loc
-		S.remove_from_storage(src)
+		if(!QDELETED(S)) // Can happen when the storage gets deleted, thus deleting the contents
+			S.remove_from_storage(src) // Not required to call. Will only cause runtimes
 	QDEL_LIST(actions)
 	master = null
 	return ..()


### PR DESCRIPTION
## What Does This PR Do
Fixes a bug from one of my previous PRs.
An item should not try and remove itself from a storage item which is already being deleted.

```
[2022-04-25T16:06:51] Runtime in storage.dm,263: Cannot modify null.screen_loc.
   proc name: standard orient objs (/obj/item/storage/proc/standard_orient_objs)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (216,146,1) (/turf/simulated/floor/plasteel)
   src: the leather satchel (/obj/item/storage/backpack/satchel)
   src.loc: the floor (216,146,1) (/turf/simulated/floor/plasteel)
   call stack:
   the leather satchel (/obj/item/storage/backpack/satchel): standard orient objs(0, 6, null)
   the leather satchel (/obj/item/storage/backpack/satchel): orient2hud(NAME (/mob/living/carbon/human))
   the leather satchel (/obj/item/storage/backpack/satchel): remove from storage(the officer kit (/obj/item/storage/box/centcomofficer), the floor (216,146,1) (/turf/simulated/floor/plasteel))
   the leather satchel (/obj/item/storage/backpack/satchel): Exited(the officer kit (/obj/item/storage/box/centcomofficer), the floor (216,146,1) (/turf/simulated/floor/plasteel))
   the officer kit (/obj/item/storage/box/centcomofficer): forceMove(the floor (216,146,1) (/turf/simulated/floor/plasteel))
   the officer kit (/obj/item/storage/box/centcomofficer): forceMove(the floor (216,146,1) (/turf/simulated/floor/plasteel))
   the leather satchel (/obj/item/storage/backpack/satchel): remove from storage(the officer kit (/obj/item/storage/box/centcomofficer), null)
   the officer kit (/obj/item/storage/box/centcomofficer): Destroy(0)
   the officer kit (/obj/item/storage/box/centcomofficer): Destroy(0)
   qdel(the officer kit (/obj/item/storage/box/centcomofficer), 0)
   the leather satchel (/obj/item/storage/backpack/satchel): Destroy(0)
   the leather satchel (/obj/item/storage/backpack/satchel): Destroy(0)
   the leather satchel (/obj/item/storage/backpack/satchel): Destroy(0)
   the leather satchel (/obj/item/storage/backpack/satchel): Destroy(0)
   the leather satchel (/obj/item/storage/backpack/satchel): Destroy(0)
   qdel(the leather satchel (/obj/item/storage/backpack/satchel), 0)
   NAME (/mob/living/carbon/human): Destroy(0)
   NAME (/mob/living/carbon/human): Destroy(0)
   qdel(NAME (/mob/living/carbon/human), 0)
   CKEY (/client): admin delete(NAME (/mob/living/carbon/human))
   CKEY (/client): [Admin] Delete(NAME (/mob/living/carbon/human))
```

## Why It's Good For The Game
Fixes a runtime

## Changelog
Only technical