### PR TITLE
Fixes the captains medal being deleted when cryoing

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -412,8 +412,7 @@
 	// Remove accessories from the suit if present
 	if(length(H.w_uniform?.accessories))
 		for(var/obj/item/clothing/accessory/A in H.w_uniform.accessories)
-			A.on_removed(H)
-			H.w_uniform.accessories -= A
+			H.w_uniform.detach_accessory(A, null)
 			H.unEquip(A)
 			stuff_to_transfer += A
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -737,6 +737,13 @@ BLIND     // can't see anything
 
 	return FALSE
 
+/obj/item/clothing/under/proc/detach_accessory(obj/item/clothing/accessory/A, mob/user)
+	accessories -= A
+	A.on_removed(user)
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		H.update_inv_w_uniform()
+
 /obj/item/clothing/under/examine(mob/user)
 	. = ..()
 	switch(sensor_mode)
@@ -802,10 +809,8 @@ BLIND     // can't see anything
 		return
 	if(!Adjacent(user))
 		return
-	A.on_removed(user)
-	accessories -= A
+	detach_accessory(A, user)
 	to_chat(user, "<span class='notice'>You remove [A] from [src].</span>")
-	usr.update_inv_w_uniform()
 
 /obj/item/clothing/under/emp_act(severity)
 	if(accessories.len)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -16,10 +16,14 @@
 	..()
 	inv_overlay = image("icon" = 'icons/obj/clothing/ties_overlay.dmi', "icon_state" = "[item_color? "[item_color]" : "[icon_state]"]")
 
+/obj/item/clothing/accessory/Moved(atom/OldLoc, Dir, Forced)
+	. = ..()
+	if(has_suit)
+		has_suit.detach_accessory(src, null)
+
 /obj/item/clothing/accessory/Destroy()
 	if(has_suit)
-		has_suit.accessories -= src
-		on_removed(null)
+		has_suit.detach_accessory(src, null)
 	return ..()
 
 //when user attached an accessory to S

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -702,9 +702,7 @@
 						if(!thief_mode)
 							usr.visible_message("<span class='danger'>\The [usr] takes \the [A] off of \the [src]'s [U]!</span>", \
 												"<span class='danger'>You take \the [A] off of \the [src]'s [U]!</span>")
-						A.on_removed(usr)
-						U.accessories -= A
-						update_inv_w_uniform()
+						U.detach_accessory(A, usr)
 
 	if(href_list["criminal"])
 		if(hasHUD(usr, EXAMINE_HUD_SECURITY_WRITE))


### PR DESCRIPTION
## What Does This PR Do
Cryoing as captain now won't delete your medal if you wear it as an accessory.

## Why It's Good For The Game
Bug fix

## Changelog
:cl:
fix: Cryoing as captain now won't delete your medal if you wear it as an accessory
/:cl: