### PR TITLE
Deploying a mining shelter capsule on the station now requires it to be emagged

### DIFF
--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -16,6 +16,14 @@
 	var/datum/map_template/shelter/template
 	var/used = FALSE
 
+/obj/item/survivalcapsule/emag_act()
+	if(!emagged)
+		to_chat(usr, "<span class='warning'>You short out the safeties, allowing it to be placed in the station sector.</span>")
+		emagged = TRUE
+		return
+
+	to_chat(usr, "<span class='warning'>The safeties are already shorted out!</span>")
+
 /obj/item/survivalcapsule/proc/get_template()
 	if(template)
 		return
@@ -34,6 +42,11 @@
 	// Can't grab when capsule is New() because templates aren't loaded then
 	get_template()
 	if(used == FALSE)
+		var/turf/UT = get_turf(usr)
+		if((UT.z == level_name_to_num(MAIN_STATION)) && !emagged)
+			to_chat(usr, "<span class='notice'>Error. Deployment was attempted on the station sector. Deployment aborted.</span>")
+			playsound(usr, 'sound/machines/terminal_error.ogg', 15, TRUE)
+			return
 		loc.visible_message("<span class='warning'>[src] begins to shake. Stand back!</span>")
 		used = TRUE
 		sleep(50)


### PR DESCRIPTION
## What Does This PR Do
Makes it so you need to emag a shelter capsule to deploy it on the station z-level (Z2)

## Why It's Good For The Game
People have started using these to get portable fans on station. People will go this far to get on-station atmos blockers for permanent areas, which is not only incredibly hacky, its just kinda powergamey.

Atom powergamers, cope.

## Changelog
:cl: AffectedArc07
tweak: Deploying a mining shelter capsule on the station now requires it to be emagged
/:cl:
