### PR TITLE
Immovable rod can now cause hull breaches.

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -31,9 +31,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/destination
 	var/notify = TRUE
 	var/move_delay = 1
-	// The base chance to "damage" the floor when passing. This is not guaranteed to cause a full on hull breach.
-	// Chance to expose the tile to space is like 60% of this value.
-	var/floor_rip_chance = 40
 
 /obj/effect/immovablerod/New(atom/start, atom/end, delay)
 	. = ..()
@@ -93,6 +90,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 /obj/effect/immovablerod/event
 	var/tiles_moved = 0
+	// The base chance to "damage" the floor when passing. This is not guaranteed to cause a full on hull breach.
+	// Chance to expose the tile to space is like 60% of this value.
+	var/floor_rip_chance = 40
 
 /obj/effect/immovablerod/event/Move()
 	var/atom/oldloc = loc

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -86,7 +86,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 				"<span class ='danger'>You hear a CLANG!</span>")
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
-			clong.ex_act(2)
+			clong.ex_act(EXPLODE_HEAVY)
 
 /obj/effect/immovablerod/event
 	var/tiles_moved = 0
@@ -101,6 +101,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(prob(floor_rip_chance))
 		var/turf/simulated/floor/T = get_turf(oldloc)
 		if(istype(T))
-			T.ex_act(2)
+			T.ex_act(EXPLODE_HEAVY)
 	if(get_dist(oldloc, loc) > 2 && tiles_moved > 10) // We went on a journey, commit sudoku
 		qdel(src)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -31,6 +31,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/destination
 	var/notify = TRUE
 	var/move_delay = 1
+	// The base chance to "damage" the floor when passing. This is not guaranteed to cause a full on hull breach.
+	// Chance to expose the tile to space is like 60% of this value.
+	var/floor_rip_chance = 40
 
 /obj/effect/immovablerod/New(atom/start, atom/end, delay)
 	. = ..()
@@ -95,5 +98,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/atom/oldloc = loc
 	. = ..()
 	tiles_moved++
+	if(prob(floor_rip_chance))
+		var/turf/simulated/floor/T = get_turf(oldloc)
+		if(istype(T))
+			T.ex_act(2)
 	if(get_dist(oldloc, loc) > 2 && tiles_moved > 10) // We went on a journey, commit sudoku
 		qdel(src)


### PR DESCRIPTION
## What Does This PR Do
Makes the Immovable rod sometimes rip off the floors causing hull breaches, in addition to its current behaviour of decimating walls, machinery, and the haples sods that happen to get in the way.
Also, *I M M E R S I O N* or something.

Credits to W.O.L.F. on discord for the idea.

## Why It's Good For The Game
Makes it slightly more engaging for engineering, and slightly more consequentual for everyone else. The isolated hull breaches are concerning but not immediately threatening.

## Images of changes
![20220426-171210-dreamseeker](https://user-images.githubusercontent.com/7831163/165358611-92aa7bca-156d-49ca-aa80-6ea4ed1ef68c.png)

![20220426-173419-dreamseeker](https://user-images.githubusercontent.com/7831163/165359160-75878e2c-4036-49f6-8da3-0b7d6e8cba5f.png)

## Changelog
:cl:
tweak: Immovable rod now causes hull breaches
/:cl:
