### PR TITLE
Add eslint settings to vscode config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           bash tools/ci/install_dreamchecker.sh
       - name: Run Linters
         run: |
-          find . -name "*.json" -not -path "*/node_modules/*" -print0 | xargs -0 python3 ./tools/ci/json_verifier.py
+          tools/ci/check_json.sh
           tools/ci/build_tgui.sh
           tools/ci/check_grep.sh
           python3 tools/ci/check_line_endings.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,20 @@
 	"editor.guides.bracketPairs": "active",
 	"gitlens.advanced.blame.customArguments": [
 		"--ignore-revs-file", "${workspaceRoot}/.git-blame-ignore-revs"
-	]
+	],
+	// ESLint settings:
+	"eslint.workingDirectories": [
+		"tgui/"
+	],
+	"eslint.rules.customizations": [
+		// We really want to fail the CI builds on styling errors,
+		// but it's better to show them as yellow squigglies in IDE
+		// and thus differentiate from the red typescript ones which
+		// are actually hard errors.
+		{ "rule": "*", "severity": "warn" }
+	],
+	"eslint.format.enable": true,
+	"[javascript]": {
+		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+	},
 }

--- a/tools/ci/check_json.sh
+++ b/tools/ci/check_json.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# We probably could validate literally everything as json5, but let's be cautions for no good reason here.
+find .vscode/ -name "*.json" -print0 | xargs -0 python3 tools/ci/json_verifier.py -5
+find . -name "*.json" -not -path "*/node_modules/*" -and -not -path "./.vscode/*" -print0 | xargs -0 python3 tools/ci/json_verifier.py

--- a/tools/ci/install_build_deps.sh
+++ b/tools/ci/install_build_deps.sh
@@ -7,4 +7,5 @@ source ~/.nvm/nvm.sh
 nvm install $NODE_VERSION
 nvm use $NODE_VERSION
 npm install --global yarn
+python3 -m pip install json5
 

--- a/tools/ci/json_verifier.py
+++ b/tools/ci/json_verifier.py
@@ -1,5 +1,9 @@
 import sys
-import json
+if sys.argv[1] == "-5":
+    import json5 as json
+    sys.argv.pop(1)
+else:
+    import json
 
 if len(sys.argv) <= 1:
     exit(1)

--- a/tools/ci/json_verifier.py
+++ b/tools/ci/json_verifier.py
@@ -1,5 +1,5 @@
 import sys
-if sys.argv[1] == "-5":
+if sys.argv[1:2] == ["-5"]:
     import json5 as json
     sys.argv.pop(1)
 else:


### PR DESCRIPTION
## What Does This PR Do
Adds eslint extension settings to the vscode project config.

## Why It's Good For The Game
I've spent way too much time using my default js formatter extension and getting increasingly annoyed by the fact that its output is different from the one required by eslint, and that i need to remember to `yarn run lint --fix` manually before PR submission.

So i delved into this.
Turns out we have eslint extension in the recommended ones. And i have it installed. But it just doesn't format shit. It's not even an option in the formatter selection. And if you force it to be used anyways, then it fails due to being unable to find `react` module.
Well, that's all because it treats the Paradise/ root as a root of the js project and expects to find `node_modules/` right below it, as any sane JS project would do. But we are not a js project, and all our js stuff lives under `tgui/`. So eslint needs to be told that:
```js
	"eslint.workingDirectories": [
		"tgui/"
	]
```

Well, that worked! But that also meant that any styling issues like a wrong amount of whitespace immediately gave me red squiggles, which is also annoying since that's not a hard error. Except we *want* that to be a hard error for CI purposes... So we have two options basically: either downgrade the severity in vscode, OR downgrade the severity of everything in `.eslintrc` + upgrade it back in the CI via `--max-warnings=0`. I opted for the former as that's less work in the short term.
```js
	"eslint.rules.customizations": [
		{ "rule": "*", "severity": "warn" }
	]
```

So, yay, we have the yellow squigglies. And with one more change, we also have the vscode formatting support:
```js
    "eslint.format.enable": true,
    "[javascript]": {
        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
    },
```

## Images of changes
![20220427-155926-Code](https://user-images.githubusercontent.com/7831163/165561322-cd237dd1-c096-4748-acb4-1423f83b60de.gif)
