### PR TITLE
Remove bracket coloring from project settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,6 @@
 	"workbench.editorAssociations": {
 		"*.dmi": "imagePreview.previewEditor"
 	},
-	"editor.bracketPairColorization.enabled": true,
-	"editor.guides.bracketPairs": "active",
 	"gitlens.advanced.blame.customArguments": [
 		"--ignore-revs-file", "${workspaceRoot}/.git-blame-ignore-revs"
 	]


### PR DESCRIPTION
## What Does This PR Do
Removes bracket colorization added in #17631

## Why It's Good For The Game
I understand that some people like those settings, and it makes it easier for them to navigate the code that way.
For me - it's the opposite, i find them extremely distracting, and they *hinder* me.

I had no qualms with that when they were just a recommended extension i could (and did) ignore. It is a one-off prompt when I opened the project for the first time. However now that it is in `.vscode/settings.json`, it is being forced on me. So my two options are: 1) get distracted or 2) have fun fiddling with the settings file each time i check out or commit the code. Neither looks appealing to me.

It's like changing the editor color theme, or the font - it should be left to the individual developer, not set on a project-wide basis.
If you want to have bracket pair colorization, please set that in your user-wide profile (that way you get the benefit of it in non-paradise as well, and for free!)

cc @lewcc
