### PR TITLE
Fix tiny karma-related runtime when running server with no SQL

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -392,7 +392,8 @@
 		to_chat(src,"<span class='boldannounce'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.</big></span>") // Very fucking obvious
 
 	// This happens asyncronously
-	karmaholder.processRefunds(mob)
+	if(karmaholder)
+		karmaholder.processRefunds(mob)
 
 
 /client/proc/is_connecting_from_localhost()


### PR DESCRIPTION
## What Does This PR Do
Fixes this:
```
Runtime in client_procs.dm,395: Cannot execute null.processRefunds().
```

## Why It's Good For The Game
Runtime bad.
Although this is a very minor one, and not affecting prod, it does show up each time I boot up a local server with debugger on (i still haven't gotten around setting up SQL properly)
