### PR TITLE
Fixed autoadmin when launching the game through Dream Seeker

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -396,8 +396,8 @@
 
 
 /client/proc/is_connecting_from_localhost()
-	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses
-	if(!isnull(address) && (address in localhost_addresses))
+	var/static/list/localhost_addresses = list("127.0.0.1", "::1")
+	if((!address && !world.port) || (address in localhost_addresses))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## What does this PR do
Changed the proc that determines whether someone is connecting through localhost to be aware of the situation in which the game has been started via Dream Seeker.

## Why it's good for the game
It's helpful for testing changes.
