### PR TITLE
Trying to pull an already-pulled object stops the pull

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -226,7 +226,7 @@
 	set name = "Pull"
 	set category = "Object"
 
-	if(istype(AM) && Adjacent(AM))
+	if(istype(AM) && Adjacent(AM) && AM != pulling)
 		start_pulling(AM, show_message = TRUE)
 	else
 		stop_pulling()


### PR DESCRIPTION
## What does this PR do?
Made it so ctrl-clicking (or using the pull verb on) a thing you're already pulling will make you stop pulling said thing.

## Why it's good for the game
I have to use my mouse less.

## Changelog
:cl:
tweak: Trying to pull something you're already pulling will now stop pulling said thing.
/:cl:
