### PR TITLE
Adds configurable round stats link

### DIFF
--- a/code/controllers/configuration/sections/url_configuration.dm
+++ b/code/controllers/configuration/sections/url_configuration.dm
@@ -28,6 +28,8 @@
 	var/forum_playerinfo_url
 	/// URL for the CentCom Ban DB API
 	var/centcom_ban_db_url
+	/// URL for the stats page
+	var/round_stats_url
 
 /datum/configuration_section/url_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
@@ -45,3 +47,4 @@
 	CONFIG_LOAD_STR(forum_link_url, data["forum_link_url"])
 	CONFIG_LOAD_STR(forum_playerinfo_url, data["forum_playerinfo_url"])
 	CONFIG_LOAD_STR(centcom_ban_db_url, data["centcomm_ban_db_url"])
+	CONFIG_LOAD_STR(round_stats_url, data["round_stats_url"])

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -144,11 +144,17 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	return
 	#endif
 
+	// Send the stats URL if applicable
+	if(GLOB.configuration.url.round_stats_url && GLOB.round_id)
+		var/stats_link = "[GLOB.configuration.url.round_stats_url][GLOB.round_id]"
+		to_chat(world, "<span class='notice'>Stats for this round can be viewed at <a href=\"[stats_link]\">[stats_link]</a></span>")
+
 	// If the server has been gracefully shutdown in TGS, have a 60 seconds grace period for SQL updates and stuff
 	var/secs_before_auto_reconnect = 10
 	if(GLOB.slower_restart)
 		secs_before_auto_reconnect = 60
 		server_announce_global("Reboot will take a little longer due to pending backend changes.")
+
 
 	// Send the reboot banner to all players
 	for(var/client/C in GLOB.clients)

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -781,6 +781,8 @@ donations_url = "https://www.patreon.com/ParadiseStation"
 ban_appeals_url = "https://www.paradisestation.org/forum/55-unban-requests/"
 # URL for the CentComm ban DB. Doesnt change much. Ckey is slapped on the end
 centcomm_ban_db_url = "https://centcom.melonmesa.com/ban/search/"
+# URL for the game stats page, if applicable. Round ID is appended right on the end. Include a trailing slash if necessary.
+#round_stats_url = "https://affectedarc07.github.io/ParaStats/#/round/"
 
 
 ################################################################


### PR DESCRIPTION
## What Does This PR Do
Adds an option in the config to set a link to show stats from that round. This is then shown on reboot so people can look at stats from that round.
![image](https://user-images.githubusercontent.com/25063394/165839824-cbb1c19d-4170-4ec1-b8d9-4bf38050a5f1.png)

The default configured one is the stats page I made for para. An example display is here: https://affectedarc07.github.io/ParaStats/#/round/25968

## Why It's Good For The Game
Stats are nice, and having gamemode info and stuff be viewable is even nicer

## Changelog
:cl: AffectedArc07
add: Added a link on restart to an online stats page for the round that just happened
/:cl:
