### PR TITLE
Allows multitool to change exofab output dir

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -69,6 +69,9 @@
 		return
 	if(I.flags & ABSTRACT)
 		return
+	var/obj/machinery/machine_parent = parent
+	if(machine_parent.panel_open)
+		return
 	if((I.flags_2 & (HOLOGRAM_2 | NO_MAT_REDEMPTION_2)) || (tc && !is_type_in_typecache(I, tc)))
 		to_chat(user, "<span class='warning'>[parent] won't accept [I]!</span>")
 		return

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -69,9 +69,6 @@
 		return
 	if(I.flags & ABSTRACT)
 		return
-	var/obj/machinery/machine_parent = parent
-	if(machine_parent.panel_open)
-		return
 	if((I.flags_2 & (HOLOGRAM_2 | NO_MAT_REDEMPTION_2)) || (tc && !is_type_in_typecache(I, tc)))
 		to_chat(user, "<span class='warning'>[parent] won't accept [I]!</span>")
 		return

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -25,6 +25,8 @@
 	var/list/categories = null
 	/// Unused. Ensures backwards compatibility with some maps.
 	var/id = null
+	/// Defines what direction this thing spits out it's produced parts
+	var/output_dir = SOUTH
 	// Variables
 	/// Production time multiplier. A lower value means faster production. Updated by [CheckParts()][/atom/proc/CheckParts].
 	var/time_coeff = 1
@@ -87,6 +89,14 @@
 	materials.retrieve_all()
 	QDEL_NULL(local_designs)
 	return ..()
+
+/obj/machinery/mecha_part_fabricator/multitool_act(mob/user, obj/item/I)
+	if(!panel_open)
+		return
+	if(!I.tool_start_check(src, user, 0))
+		return
+	output_dir = turn(output_dir, -90)
+	to_chat(user, "<span class='notice'>You change [src] to output to the [dir2text(output_dir)].</span>")
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	var/coef_mats = 0
@@ -196,12 +206,12 @@
   */
 /obj/machinery/mecha_part_fabricator/proc/build_design_timer_finish(datum/design/D, list/final_cost)
 	// Spawn the item (in a lockbox if restricted) OR mob (e.g. IRC body)
-	var/atom/A = new D.build_path(get_step(src, SOUTH))
+	var/atom/A = new D.build_path(get_step(src, output_dir))
 	if(istype(A, /obj/item))
 		var/obj/item/I = A
 		I.materials = final_cost
 		if(D.locked)
-			var/obj/item/storage/lockbox/research/large/L = new(get_step(src, SOUTH))
+			var/obj/item/storage/lockbox/research/large/L = new(get_step(src, output_dir))
 			I.forceMove(L)
 			L.name += " ([I.name])"
 			L.origin_tech = I.origin_tech

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -93,6 +93,7 @@
 /obj/machinery/mecha_part_fabricator/multitool_act(mob/user, obj/item/I)
 	if(!panel_open)
 		return
+	. = TRUE
 	if(!I.tool_start_check(src, user, 0))
 		return
 	output_dir = turn(output_dir, -90)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes hitting an unscrewed exofab with a multitool change its output-dir in 90degree increments.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hardcoded to the south no more, be free to shove your exofabs in a corner and forget about them!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
tweak: Hitting an exofab with a multitool while it is unscrewed now changes output direction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
