### PR TITLE
[GBP no update] Computers have keyboards when powered

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -84,7 +84,7 @@
 	if(!(stat & BROKEN) && light)
 		underlays += emissive_appearance(icon, "[icon_state]_light_mask")
 
-	if(!icon_keyboard)
+	if(icon_keyboard)
 		add_overlay("[icon_keyboard]")
 
 /obj/machinery/computer/power_change()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the logic so computers with keyboards have the their overlays applied.

## Why It's Good For The Game
Fixes #17699. My keyboards

## Changelog
:cl:
fix: Powered computers have their associated keyboards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
