### PR TITLE
Removes "toxin bottle" from Nanomed Plus

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1191,7 +1191,7 @@
 					/obj/item/reagent_containers/glass/bottle/charcoal = 4, /obj/item/reagent_containers/glass/bottle/epinephrine = 4, /obj/item/reagent_containers/glass/bottle/diphenhydramine = 4,
 					/obj/item/reagent_containers/glass/bottle/salicylic = 4, /obj/item/reagent_containers/glass/bottle/potassium_iodide =3, /obj/item/reagent_containers/glass/bottle/saline = 5,
 					/obj/item/reagent_containers/glass/bottle/morphine = 4, /obj/item/reagent_containers/glass/bottle/ether = 4, /obj/item/reagent_containers/glass/bottle/atropine = 3,
-					/obj/item/reagent_containers/glass/bottle/oculine = 2, /obj/item/reagent_containers/glass/bottle/toxin = 4, /obj/item/reagent_containers/syringe/antiviral = 6,
+					/obj/item/reagent_containers/glass/bottle/oculine = 2, /obj/item/reagent_containers/syringe/antiviral = 6,
 					/obj/item/reagent_containers/syringe/insulin = 6, /obj/item/reagent_containers/syringe/calomel = 10, /obj/item/reagent_containers/syringe/heparin = 4, /obj/item/reagent_containers/hypospray/autoinjector = 5, /obj/item/reagent_containers/food/pill/salbutamol = 10,
 					/obj/item/reagent_containers/food/pill/mannitol = 10, /obj/item/reagent_containers/food/pill/mutadone = 5, /obj/item/stack/medical/bruise_pack/advanced = 4, /obj/item/stack/medical/ointment/advanced = 4, /obj/item/stack/medical/bruise_pack = 4,
 					/obj/item/stack/medical/splint = 4, /obj/item/reagent_containers/glass/beaker = 4, /obj/item/reagent_containers/dropper = 4, /obj/item/healthanalyzer = 4,


### PR DESCRIPTION
## What Does This PR Do
Removes the "toxin bottle" from the NanoMed Plus vendor. This thing:

![image](https://user-images.githubusercontent.com/33333517/166083517-fb8916a4-9608-4aa3-8b4e-c9b50cc7c534.png)


## Why It's Good For The Game
1) It may have served a purpose before, it does not have a purpose now. The only thing you can make from "toxin" is pest killer.
2) It confuses new doctors.
3) NanoMed Plus vendors are already bloated.
4) If you need antag stuff, you can hack them and get infinitely better drugs. "Toxin" as an antag item it is not viable.

## Images of changes
It is no longer in the list.
![image](https://user-images.githubusercontent.com/33333517/166083619-5bcb6ec3-57be-4db4-b263-5f2b6d66a516.png)


## Changelog
:cl:
del: Removed "toxin bottle" from the NanoMed Plus vendor.
/:cl:
