### PR TITLE
Added config entry to toggle lavaland

### DIFF
--- a/code/controllers/configuration/sections/ruin_configuration.dm
+++ b/code/controllers/configuration/sections/ruin_configuration.dm
@@ -1,5 +1,7 @@
 /// Config holder for all things regarding space ruins and lavaland ruins
 /datum/configuration_section/ruin_configuration
+	/// Whether to load the lavaland Z-level
+	var/enable_lavaland = TRUE
 	/// Enable or disable space ruins
 	var/enable_space_ruins = TRUE
 	/// Minimum number of extra zlevels to fill with ruins
@@ -15,6 +17,7 @@
 
 /datum/configuration_section/ruin_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
+	CONFIG_LOAD_BOOL(enable_lavaland, data["enable_lavaland"])
 	CONFIG_LOAD_BOOL(enable_space_ruins, data["enable_space_ruins"])
 	CONFIG_LOAD_NUM(extra_levels_min, data["minimum_zlevels"])
 	CONFIG_LOAD_NUM(extra_levels_max, data["maximum_zlevels"])

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -151,6 +151,9 @@ SUBSYSTEM_DEF(mapping)
 
 // Loads in lavaland
 /datum/controller/subsystem/mapping/proc/loadLavaland()
+	if(!GLOB.configuration.ruins.enable_lavaland)
+		log_startup_progress("Skipping Lavaland...")
+		return
 	var/watch = start_watch()
 	log_startup_progress("Loading Lavaland...")
 	var/lavaland_z_level = GLOB.space_manager.add_new_zlevel(MINING, linkage = SELFLOOPING, traits = list(ORE_LEVEL, REACHABLE, STATION_CONTACT, HAS_WEATHER, AI_OK))

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -60,12 +60,15 @@ SUBSYSTEM_DEF(mapping)
 	// Setup the Z-level linkage
 	GLOB.space_manager.do_transition_setup()
 
-	// Spawn Lavaland ruins and rivers.
-	log_startup_progress("Populating lavaland...")
-	var/lavaland_setup_timer = start_watch()
-	seedRuins(list(level_name_to_num(MINING)), GLOB.configuration.ruins.lavaland_ruin_budget, /area/lavaland/surface/outdoors/unexplored, GLOB.lava_ruins_templates)
-	spawn_rivers(level_name_to_num(MINING))
-	log_startup_progress("Successfully populated lavaland in [stop_watch(lavaland_setup_timer)]s.")
+	if(GLOB.configuration.ruins.enable_lavaland)
+		// Spawn Lavaland ruins and rivers.
+		log_startup_progress("Populating lavaland...")
+		var/lavaland_setup_timer = start_watch()
+		seedRuins(list(level_name_to_num(MINING)), GLOB.configuration.ruins.lavaland_ruin_budget, /area/lavaland/surface/outdoors/unexplored, GLOB.lava_ruins_templates)
+		spawn_rivers(level_name_to_num(MINING))
+		log_startup_progress("Successfully populated lavaland in [stop_watch(lavaland_setup_timer)]s.")
+	else
+		log_startup_progress("Skipping lavaland ruins...")
 
 	// Now we make a list of areas for teleport locs
 	teleportlocs = list()

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -27,10 +27,8 @@
 	GLOB.navigation_computers += src
 	if(access_station)
 		jumpto_ports += list("nav_z[level_name_to_num(MAIN_STATION)]" = 1)
-	if(access_mining)
-		var/mining_zlevel = level_name_to_num(MINING)
-		if(mining_zlevel)
-			jumpto_ports += list("nav_z[mining_zlevel]" = 1)
+	if(access_mining && GLOB.configuration.ruins.enable_lavaland)
+		jumpto_ports += list("nav_z[level_name_to_num(MINING)]" = 1)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/Destroy()
 	GLOB.navigation_computers -= src

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -28,7 +28,9 @@
 	if(access_station)
 		jumpto_ports += list("nav_z[level_name_to_num(MAIN_STATION)]" = 1)
 	if(access_mining)
-		jumpto_ports += list("nav_z[level_name_to_num(MINING)]" = 1)
+		var/mining_zlevel = level_name_to_num(MINING)
+		if(mining_zlevel)
+			jumpto_ports += list("nav_z[mining_zlevel]" = 1)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/Destroy()
 	GLOB.navigation_computers -= src

--- a/code/modules/space_management/level_traits.dm
+++ b/code/modules/space_management/level_traits.dm
@@ -61,7 +61,9 @@ GLOBAL_LIST_INIT(default_map_traits, list(CC_TRANSITION_CONFIG))
 
 /proc/level_name_to_num(name)
 	var/datum/space_level/S = GLOB.space_manager.get_zlev_by_name(name)
-	return S?.zpos
+	if(!S)
+		CRASH("Unknown z-level name: [name]")
+	return S.zpos
 
 /**
   * Proc to get a list of all the linked-together Z-Levels

--- a/code/modules/space_management/level_traits.dm
+++ b/code/modules/space_management/level_traits.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(default_map_traits, list(CC_TRANSITION_CONFIG))
 
 /proc/level_name_to_num(name)
 	var/datum/space_level/S = GLOB.space_manager.get_zlev_by_name(name)
-	return S.zpos
+	return S?.zpos
 
 /**
   * Proc to get a list of all the linked-together Z-Levels

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -607,6 +607,8 @@ redis_connstring = "redis://127.0.0.1/"
 [ruin_configuration]
 # This section contains configuration for all space ruins and lava ruins
 
+# Whether to load the lavaland Z-level.
+enable_lavaland = true
 # Globally enable and disable placing of space ruins. Lava ruins will still place.
 enable_space_ruins = false
 # Minimum number of extra zlevels to generate and fill with ruins


### PR DESCRIPTION
## What Does This PR Do
Added an entry to the configuration file that lets one disable loading Lavaland entirely. This alone brings the time needed to complete initializations from 66~ seconds down to 37~.

## Why It's Good For The Game
Coders get to test things faster.

The rest of the code seems to handle this very well. The mining shuttle console simply reports "missing shuttle", and this seems to cause no runtimes.