### PR TITLE
Some malf AI exploit fixes

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -63,6 +63,8 @@
 #define RAD_NO_CONTAMINATE_2	32768
 /// Prevents shuttles from deleting the item
 #define IMMUNE_TO_SHUTTLECRUSH_2 (1<<16)
+/// Prevents malf AI animate + overload ability
+#define NO_MALF_EFFECT_2 (1<<17)
 
 //Reagent flags
 #define REAGENT_NOREACT			1

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -89,10 +89,6 @@
 	button_icon_state = "choose_module"
 	auto_use_uses = FALSE // This is an infinite ability.
 
-/datum/action/innate/ai/choose_modules/Grant(mob/living/L)
-	. = ..()
-	owner_AI.malf_picker = new /datum/module_picker
-
 /datum/action/innate/ai/choose_modules/Trigger()
 	. = ..()
 	owner_AI.malf_picker.use(owner_AI)
@@ -128,7 +124,7 @@
 
 /datum/module_picker/proc/use(mob/user)
 	var/dat
-	dat += {"<B>Select use of processing time: (currently #[processing_time] left.)</B><BR>
+	dat += {"<B>Select use of processing time: (currently [processing_time] left.)</B><BR>
 			<HR>
 			<B>Install Module:</B><BR>
 			<I>The number afterwards is the amount of processing time it consumes.</I><BR>"}
@@ -497,6 +493,9 @@
 	if(!istype(target))
 		to_chat(ranged_ability_user, "<span class='warning'>You can only overload machines!</span>")
 		return
+	if(target.flags_2 & NO_MALF_EFFECT_2)
+		to_chat(ranged_ability_user, "<span class='warning'>That machine can't be overloaded!</span>")
+		return
 
 	ranged_ability_user.playsound_local(ranged_ability_user, "sparks", 50, FALSE, use_reverb = FALSE)
 	attached_action.adjust_uses(-1)
@@ -549,7 +548,7 @@
 	if(!istype(target))
 		to_chat(ranged_ability_user, "<span class='warning'>You can only animate machines!</span>")
 		return
-	if(!target.can_be_overridden())
+	if(target.flags_2 & NO_MALF_EFFECT_2)
 		to_chat(ranged_ability_user, "<span class='warning'>That machine can't be overridden!</span>")
 		return
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -639,9 +639,6 @@ Class Procs:
 /obj/machinery/proc/on_deconstruction()
 	return
 
-/obj/machinery/proc/can_be_overridden()
-	. = 1
-
 /obj/machinery/zap_act(power, zap_flags)
 	if(prob(85) && (zap_flags & ZAP_MACHINE_EXPLOSIVE) && !(resistance_flags & INDESTRUCTIBLE))
 		explosion(src, 1, 2, 4, flame_range = 2, adminlog = FALSE, smoke = FALSE)

--- a/code/modules/atmospherics/machinery/pipes/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipe.dm
@@ -13,6 +13,8 @@
 	buckle_requires_restraints = TRUE
 	buckle_lying = -1
 
+	flags_2 = NO_MALF_EFFECT_2
+
 /obj/machinery/atmospherics/pipe/New()
 	..()
 	//so pipes under walls are hidden

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1014,7 +1014,7 @@
 	if(constructed)
 		to_chat(malf, "<span class='warning'>This APC was only recently constructed, and is not fully linked to station systems. Hacking it would be pointless.</span>")
 		return
-	to_chat(malf, "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.")
+	to_chat(malf, "Beginning override of APC systems. This takes some time, and you can only hack one APC at a time.")
 	malf.malfhack = src
 	malf.malfhacking = addtimer(CALLBACK(malf, /mob/living/silicon/ai/.proc/malfhacked, src), 600, TIMER_STOPPABLE)
 	var/obj/screen/alert/hackingapc/A

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -85,7 +85,7 @@
 	icon_state = "darkmatter"
 	density = TRUE
 	anchored = TRUE
-	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2 | IMMUNE_TO_SHUTTLECRUSH_2
+	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2 | IMMUNE_TO_SHUTTLECRUSH_2 | NO_MALF_EFFECT_2
 	light_range = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	base_icon_state = "darkmatter"


### PR DESCRIPTION
## What Does This PR Do
Fixes the following malf AI exploits:
- Being able to overload and override atmos pipes (not really a machine)
- Being able to overload and override the supermatter crystal (not really a machine either)
- Being able to get infinite points with a shunting exploits

## Why It's Good For The Game
Exploits bad

## Changelog
:cl: AffectedArc07
fix: You can no longer override or overload the SM or atmos pipes as malf AI
fix: You can no longer use a shunting exploit for infinite points as malf AI
/:cl:
