### PR TITLE
Fixes certain Nuke Ops bundles using the wrong duffelbag sprite

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -2797,8 +2797,8 @@
 /area/syndicate_mothership)
 "ka" = (
 /obj/structure/rack,
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgun,
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgun,
+/obj/item/storage/backpack/duffel/syndie/shotgun,
+/obj/item/storage/backpack/duffel/syndie/shotgun,
 /obj/item/gun/projectile/automatic/shotgun/bulldog,
 /obj/item/gun/projectile/automatic/shotgun/bulldog,
 /turf/simulated/floor/plasteel/dark,
@@ -3409,7 +3409,7 @@
 /obj/item/storage/backpack/duffel/clown,
 /obj/item/storage/backpack/duffel/captain,
 /obj/item/storage/backpack/duffel/science,
-/obj/item/storage/backpack/duffel/syndie/ammo,
+/obj/item/storage/backpack/duffel/syndie,
 /obj/item/storage/backpack/duffel/syndie/med,
 /turf/simulated/floor/plasteel,
 /area/admin)
@@ -5865,7 +5865,7 @@
 /area/admin)
 "ul" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffel/syndie/surgery_fake,
+/obj/item/storage/backpack/duffel/syndie/med/surgery_fake,
 /obj/item/circular_saw,
 /obj/item/surgicaldrill,
 /obj/item/clothing/gloves/color/latex/nitrile,

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -721,7 +721,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Bulldog - 12g Ammo Duffel Bag"
 	desc = "A duffel bag filled with enough 12g ammo to supply an entire team, at a discounted price."
 	reference = "12ADB"
-	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgun
+	item = /obj/item/storage/backpack/duffel/syndie/shotgun
 	cost = 12 // normally 18
 	gamemodes = list(/datum/game_mode/nuclear)
 
@@ -729,7 +729,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Bulldog - 12g XL Magazine Duffel Bag"
 	desc = "A duffel bag containing three 16 round drum magazines(Slug, Buckshot, Dragon's Breath)."
 	reference = "12XLDB"
-	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
+	item = /obj/item/storage/backpack/duffel/syndie/shotgunXLmags
 	cost = 12 // normally 18
 	gamemodes = list(/datum/game_mode/nuclear)
 
@@ -745,7 +745,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "C-20r - .45 Ammo Duffel Bag"
 	desc = "A duffel bag filled with enough .45 ammo to supply an entire team, at a discounted price."
 	reference = "45ADB"
-	item = /obj/item/storage/backpack/duffel/syndie/ammo/smg
+	item = /obj/item/storage/backpack/duffel/syndie/smg
 	cost = 14 // normally 20
 	gamemodes = list(/datum/game_mode/nuclear)
 
@@ -1324,7 +1324,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Syndicate Surgery Duffelbag"
 	desc = "The Syndicate surgery duffelbag comes with a full set of surgery tools, a straightjacket and a muzzle. The bag itself is also made of very light materials and won't slow you down while it is equipped."
 	reference = "SSDB"
-	item = /obj/item/storage/backpack/duffel/syndie/surgery
+	item = /obj/item/storage/backpack/duffel/syndie/med/surgery
 	cost = 2
 
 /datum/uplink_item/device_tools/bonerepair

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -149,7 +149,7 @@
 				/obj/item/dnascrambler = 1,
 				/obj/item/storage/backpack/satchel_flat = 2,
 				/obj/item/storage/toolbox/syndicate = 2,
-				/obj/item/storage/backpack/duffel/syndie/surgery_fake = 2,
+				/obj/item/storage/backpack/duffel/syndie/med/surgery_fake = 2,
 				/obj/item/storage/belt/military/traitor = 2,
 				/obj/item/storage/box/syndie_kit/space = 2,
 				/obj/item/multitool/ai_detect = 2,

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -238,7 +238,7 @@
 		/obj/item/storage/pill_bottle/happy = 1,
 		/obj/item/storage/pill_bottle/zoom = 1,
 		/obj/item/storage/pill_bottle/random_drug_bottle = 2,
-		/obj/item/storage/backpack/duffel/syndie/surgery = 1,
+		/obj/item/storage/backpack/duffel/syndie/med/surgery = 1,
 		/obj/item/clothing/shoes/chameleon/noslip = 1,
 		/obj/item/storage/belt/military = 1,
 		/obj/item/clothing/under/chameleon = 1,

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -434,8 +434,6 @@
 /obj/item/storage/backpack/duffel/syndie/med/surgery
 	name = "surgery duffelbag"
 	desc = "A suspicious looking duffelbag for holding surgery tools."
-	icon_state = "duffel-syndimed"
-	item_state = "duffel-syndimed"
 
 /obj/item/storage/backpack/duffel/syndie/med/surgery/populate_contents()
 	new /obj/item/scalpel(src)
@@ -453,8 +451,6 @@
 /obj/item/storage/backpack/duffel/syndie/med/surgery_fake //for maint spawns
 	name = "surgery duffelbag"
 	desc = "A suspicious looking duffelbag for holding surgery tools."
-	icon_state = "duffel-syndimed"
-	item_state = "duffel-syndimed"
 
 /obj/item/storage/backpack/duffel/syndie/med/surgery_fake/populate_contents()
 	new /obj/item/scalpel(src)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -340,8 +340,8 @@
 /obj/item/storage/backpack/duffel/syndie
 	name = "suspicious looking duffelbag"
 	desc = "A large duffelbag for holding extra tactical supplies."
-	icon_state = "duffel-syndimed"
-	item_state = "duffel-syndimed"
+	icon_state = "duffel-syndiammo"
+	item_state = "duffel-syndiammo"
 	origin_tech = "syndicate=1"
 	silent = TRUE
 	slowdown = 0
@@ -350,27 +350,23 @@
 /obj/item/storage/backpack/duffel/syndie/med
 	name = "suspicious duffelbag"
 	desc = "A black and red duffelbag with a red and white cross sewn onto it."
+	icon_state = "duffel-syndimed"
+	item_state = "duffel-syndimed"
 
-/obj/item/storage/backpack/duffel/syndie/ammo
-	name = "suspicious duffelbag"
-	desc = "A black and red duffelbag with a patch depicting shotgun shells sewn onto it."
-	icon_state = "duffel-syndiammo"
-	item_state = "duffel-syndiammo"
-
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgun
+/obj/item/storage/backpack/duffel/syndie/shotgun
 	desc = "A large duffelbag, packed to the brim with Bulldog shotgun ammo."
 
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgun/populate_contents()
+/obj/item/storage/backpack/duffel/syndie/shotgun/populate_contents()
 	for(var/i in 1 to 6)
 		new /obj/item/ammo_box/magazine/m12g(src)
 	new /obj/item/ammo_box/magazine/m12g/buckshot(src)
 	new /obj/item/ammo_box/magazine/m12g/buckshot(src)
 	new /obj/item/ammo_box/magazine/m12g/dragon(src)
 
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
+/obj/item/storage/backpack/duffel/syndie/shotgunXLmags
 	desc = "A large duffelbag, containing three types of extended drum magazines."
 
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags/populate_contents()
+/obj/item/storage/backpack/duffel/syndie/shotgunXLmags/populate_contents()
 	new /obj/item/ammo_box/magazine/m12g/XtrLrg(src)
 	new /obj/item/ammo_box/magazine/m12g/XtrLrg/buckshot(src)
 	new /obj/item/ammo_box/magazine/m12g/XtrLrg/dragon(src)
@@ -393,10 +389,10 @@
 	new /obj/item/clothing/suit/hooded/explorer(src)
 
 
-/obj/item/storage/backpack/duffel/syndie/ammo/smg
+/obj/item/storage/backpack/duffel/syndie/smg
 	desc = "A large duffel bag, packed to the brim with C-20r magazines."
 
-/obj/item/storage/backpack/duffel/syndie/ammo/smg/populate_contents()
+/obj/item/storage/backpack/duffel/syndie/smg/populate_contents()
 	for(var/i in 1 to 10)
 		new /obj/item/ammo_box/magazine/smgm45(src)
 
@@ -435,13 +431,13 @@
 	for(var/i in 1 to 3)
 		new /obj/item/grenade/plastic/c4/x4(src)
 
-/obj/item/storage/backpack/duffel/syndie/surgery
+/obj/item/storage/backpack/duffel/syndie/med/surgery
 	name = "surgery duffelbag"
 	desc = "A suspicious looking duffelbag for holding surgery tools."
 	icon_state = "duffel-syndimed"
 	item_state = "duffel-syndimed"
 
-/obj/item/storage/backpack/duffel/syndie/surgery/populate_contents()
+/obj/item/storage/backpack/duffel/syndie/med/surgery/populate_contents()
 	new /obj/item/scalpel(src)
 	new /obj/item/hemostat(src)
 	new /obj/item/retractor(src)
@@ -454,13 +450,13 @@
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 
-/obj/item/storage/backpack/duffel/syndie/surgery_fake //for maint spawns
+/obj/item/storage/backpack/duffel/syndie/med/surgery_fake //for maint spawns
 	name = "surgery duffelbag"
 	desc = "A suspicious looking duffelbag for holding surgery tools."
 	icon_state = "duffel-syndimed"
 	item_state = "duffel-syndimed"
 
-/obj/item/storage/backpack/duffel/syndie/surgery_fake/populate_contents()
+/obj/item/storage/backpack/duffel/syndie/med/surgery_fake/populate_contents()
 	new /obj/item/scalpel(src)
 	new /obj/item/hemostat(src)
 	new /obj/item/retractor(src)

--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -26,7 +26,7 @@
 		/obj/item/storage/belt/military/traitor,
 		/obj/item/clothing/shoes/chameleon/noslip,
 		/obj/item/storage/toolbox/syndicate,
-		/obj/item/storage/backpack/duffel/syndie/surgery,
+		/obj/item/storage/backpack/duffel/syndie/med/surgery,
 		/obj/item/multitool/ai_detect,
 		/obj/item/encryptionkey/binary,
 		/obj/item/jammer,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a slight visual issue with certain nukie bundles using the medical duffelbag sprite rather than the regular one. Specifically, it changes the sprite for the Bulldog, C20r, C4 and X4 bundles to no longer use the medical duffelbag sprite.

The PR itself removes the "ammo" subtype of the syndi duffel and makes that sprite the base one for all the duffelbags. It also changes the surgery duffels to actually use the "med" subtype which they didn't do before and removes some redundant code from doing this.

The map edit is from the centcom map having a few syndi duffels on it, which needed updating following the changes.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer will nuke ops be confused as to why their SMG came in a medical backpack.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
fix: Fixes certain nuke ops bundles using an incorrect duffelbag sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
