### PR TITLE
Some Tweaks & Fixes For Chameleon Projector

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -5,12 +5,12 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	item_state = "electronic"
-	throwforce = 5.0
+	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "syndicate=4;magnets=4"
-	var/can_use = 1
+	var/can_use = TRUE
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_item = /obj/item/cigbutt
 	var/saved_icon = 'icons/obj/clothing/masks.dmi'
@@ -28,8 +28,9 @@
 /obj/item/chameleon/attack_self()
 	toggle()
 
-/obj/item/chameleon/afterattack(atom/target, mob/user , proximity)
-	if(!proximity) return
+/obj/item/chameleon/afterattack(atom/target, mob/user, proximity)
+	if(!proximity)
+		return
 	if(!check_sprite(target))
 		return
 	if(target.alpha < 255)
@@ -52,7 +53,8 @@
 	return FALSE
 
 /obj/item/chameleon/proc/toggle()
-	if(!can_use || !saved_item) return
+	if(!can_use || !saved_item)
+		return
 	if(active_dummy)
 		eject_all()
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
@@ -66,7 +68,8 @@
 	else
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
 		var/obj/O = new saved_item(src)
-		if(!O) return
+		if(!O)
+			return
 		var/obj/effect/dummy/chameleon/C = new/obj/effect/dummy/chameleon(usr.loc)
 		C.activate(O, usr, saved_icon, saved_icon_state, saved_overlays, saved_underlays, src)
 		qdel(O)
@@ -84,7 +87,7 @@
 		if(delete_dummy)
 			qdel(active_dummy)
 		active_dummy = null
-		can_use = 0
+		can_use = FALSE
 		spawn(50) can_use = 1
 
 /obj/item/chameleon/proc/eject_all()
@@ -97,9 +100,9 @@
 /obj/effect/dummy/chameleon
 	name = ""
 	desc = ""
-	density = 0
-	anchored = 1
-	var/can_move = 1
+	density = FALSE
+	anchored = TRUE
+	var/can_move = TRUE
 	var/obj/item/chameleon/master = null
 
 /obj/effect/dummy/chameleon/proc/activate(obj/O, mob/M, new_icon, new_iconstate, new_overlays, new_underlays, obj/item/chameleon/C)
@@ -151,7 +154,7 @@
 		return // No magical movement!
 
 	if(can_move)
-		can_move = 0
+		can_move = FALSE
 		switch(user.bodytemperature)
 			if(300 to INFINITY)
 				spawn(10) can_move = 1

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -1,5 +1,5 @@
 /obj/item/chameleon
-	name = "chameleon-projector"
+	name = "chameleon projector"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "shield0"
 	flags = CONDUCT
@@ -105,12 +105,12 @@
 
 /obj/effect/dummy/chameleon/attackby()
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon-projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/attack_hand()
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon-projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/attack_animal()
@@ -124,14 +124,14 @@
 
 /obj/effect/dummy/chameleon/ex_act(severity) //no longer bomb-proof
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon-projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
 		spawn()
 			M.ex_act(severity)
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/bullet_act()
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon-projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
 	..()
 	master.disrupt()
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -88,7 +88,7 @@
 			qdel(active_dummy)
 		active_dummy = null
 		can_use = FALSE
-		spawn(50) can_use = 1
+		addtimer(VARSET_CALLBACK(src, can_use, TRUE), 5 SECONDS)
 
 /obj/item/chameleon/proc/eject_all()
 	for(var/atom/movable/A in active_dummy)
@@ -157,15 +157,15 @@
 		can_move = FALSE
 		switch(user.bodytemperature)
 			if(300 to INFINITY)
-				spawn(10) can_move = 1
+				addtimer(VARSET_CALLBACK(src, can_move, TRUE), 1 SECONDS)
 			if(295 to 300)
-				spawn(13) can_move = 1
+				addtimer(VARSET_CALLBACK(src, can_move, TRUE), 1.3 SECONDS)
 			if(280 to 295)
-				spawn(16) can_move = 1
+				addtimer(VARSET_CALLBACK(src, can_move, TRUE), 1.6 SECONDS)
 			if(260 to 280)
-				spawn(20) can_move = 1
+				addtimer(VARSET_CALLBACK(src, can_move, TRUE), 2 SECONDS)
 			else
-				spawn(25) can_move = 1
+				addtimer(VARSET_CALLBACK(src, can_move, TRUE), 2.5 SECONDS)
 		step(src, direction)
 	return
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -30,6 +30,12 @@
 
 /obj/item/chameleon/afterattack(atom/target, mob/user , proximity)
 	if(!proximity) return
+	if(!check_sprite(target))
+		return
+	if(target.alpha < 255)
+		return
+	if(target.invisibility != 0)
+		return
 	if(!active_dummy)
 		if(istype(target,/obj/item) && !istype(target, /obj/item/disk/nuclear))
 			playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
@@ -39,6 +45,11 @@
 			saved_icon_state = target.icon_state
 			saved_overlays = target.overlays
 			saved_underlays = target.underlays
+
+/obj/item/chameleon/proc/check_sprite(atom/target)
+	if(target.icon_state in icon_states(target.icon))
+		return TRUE
+	return FALSE
 
 /obj/item/chameleon/proc/toggle()
 	if(!can_use || !saved_item) return
@@ -136,8 +147,8 @@
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/relaymove(mob/user, direction)
-	if(istype(loc, /turf/space) || !direction)
-		return //No magical space movement!
+	if(!isturf(loc) || istype(loc, /turf/space) || !direction)
+		return // No magical movement!
 
 	if(can_move)
 		can_move = 0

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -48,9 +48,7 @@
 			saved_underlays = target.underlays
 
 /obj/item/chameleon/proc/check_sprite(atom/target)
-	if(target.icon_state in icon_states(target.icon))
-		return TRUE
-	return FALSE
+	return (target.icon_state in icon_states(target.icon))
 
 /obj/item/chameleon/proc/toggle()
 	if(!can_use || !saved_item)
@@ -119,12 +117,12 @@
 
 /obj/effect/dummy/chameleon/attackby()
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your [src] deactivates.</span>")
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/attack_hand()
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your [src] deactivates.</span>")
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/attack_animal()
@@ -138,14 +136,14 @@
 
 /obj/effect/dummy/chameleon/ex_act(severity) //no longer bomb-proof
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your [src] deactivates.</span>")
 		spawn()
 			M.ex_act(severity)
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/bullet_act()
 	for(var/mob/M in src)
-		to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
+		to_chat(M, "<span class='danger'>Your [src] deactivates.</span>")
 	..()
 	master.disrupt()
 


### PR DESCRIPTION
Resolves #15253

## What Does This PR Do
* Masking as invisible objects and missing sprites is no longer available.
* In addition, it is now impossible to get out of the pipe using the projector.

## Why It's Good For The Game
* Exploits are bad. Don't make exploits.

## Changelog
:cl:
fix: You can no longer get out of the pipe with the projector chameleon.
fix: You can no longer disguise yourself as invisible objects (yes, you can find them at the station).
/:cl: