### PR TITLE
Makes the Ice Cream Machine and the Deep Fryer movable through wrenching

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -140,3 +140,9 @@
 		return FALSE
 	var/obj/item/organ/external/E = I
 	return istype(E.dna.species, /datum/species/vox)
+
+/obj/machinery/cooker/deepfryer/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	default_unfasten_wrench(user, I, 30)

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -256,3 +256,10 @@
 	if(!(flags & NODECONSTRUCT))
 		new /obj/item/stack/sheet/metal(loc, 4)
 	qdel(src)
+
+/obj/machinery/icemachine/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	default_unfasten_wrench(user, I, 30)
+


### PR DESCRIPTION
## What Does This PR Do
This adds the "Wrench_act" interaction for the Ice Cream Machine and the Deep Fryer, allowing both to be unanchored, and thus moved, without being deconstructed.

## Why It's Good For The Game
Previously, the Deep Fryer could not be moved without entirely deconstructing it with a screwdriver and crowbar, and rebuilding it elsewhere, and the Ice cream machine could not  be moved, period; this should hopefully make chefs around the station a little happier.

It is to be noted that the deep fryer and ice cream machine can still be used while unanchored, furthermore, their anchoring takes time, unlike most kitchen machinery which are instant, I believe this to be a good thing, since getting your one-of-a-kind ice cream machine stolen instantly by an assistant would be a bummer.

## Changelog
:cl:
add: The Ice Cream Machine and Deep Fryer can now be moved with a wrench.
/:cl:

