### PR TITLE
Fixes accessories not showing up on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -48,28 +48,30 @@
 
 	// All the things wielded/worn that can be reasonably described with a common template:
 	var/list/message_parts = list(
-		list("[p_are()] holding", l_hand, "in", "left hand", null),
-		list("[p_are()] holding", r_hand, "in", "right hand", null),
-		list("[p_are()] wearing", head, "on", "head", null),
+		list("[p_are()] holding", l_hand, "in", "left hand"),
+		list("[p_are()] holding", r_hand, "in", "right hand"),
+		list("[p_are()] wearing", head, "on", "head"),
 		list("[p_are()] wearing", !skipjumpsuit && w_uniform, null, null, length(w_uniform.accessories) && "[english_accessory_list(w_uniform)]"),
-		list("[p_are()] wearing", wear_suit, null, null, null),
-		list("[p_are()] carrying", !skipsuitstorage && s_store, "on", wear_suit && wear_suit.name, null),
-		list("[p_have()]", back, "on", "back", null),
-		list("[p_have()]", !skipgloves && gloves, "on", "hands", null),
-		list("[p_have()]", belt, "about", "waist", null),
-		list("[p_are()] wearing", !skipshoes && shoes, "on", "feet", null),
-		list("[p_have()]", !skipmask && wear_mask, "on", "face", null),
-		list("[p_have()]", glasses, "covering", "eyes", null),
-		list("[p_have()]", !skipears && l_ear, "on", "left ear", null),
-		list("[p_have()]", !skipears && r_ear, "on", "right ear", null),
-		list("[p_are()] wearing", wear_id, null, null, null),
+		list("[p_are()] wearing", wear_suit, null, null),
+		list("[p_are()] carrying", !skipsuitstorage && s_store, "on", wear_suit && wear_suit.name),
+		list("[p_have()]", back, "on", "back"),
+		list("[p_have()]", !skipgloves && gloves, "on", "hands"),
+		list("[p_have()]", belt, "about", "waist"),
+		list("[p_are()] wearing", !skipshoes && shoes, "on", "feet"),
+		list("[p_have()]", !skipmask && wear_mask, "on", "face"),
+		list("[p_have()]", glasses, "covering", "eyes"),
+		list("[p_have()]", !skipears && l_ear, "on", "left ear"),
+		list("[p_have()]", !skipears && r_ear, "on", "right ear"),
+		list("[p_are()] wearing", wear_id, null, null),
 	)
 	for(var/parts in message_parts)
 		var/action = parts[1]
 		var/obj/item/item = parts[2]
 		var/preposition = parts[3]
 		var/limb_name = parts[4]
-		var/accessories = parts[5]
+		var/accessories = null
+		if(length(parts) >= 5)
+			accessories = parts[5]
 
 		if(item && !(item.flags & ABSTRACT))
 			var/item_words = item.name

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -48,36 +48,39 @@
 
 	// All the things wielded/worn that can be reasonably described with a common template:
 	var/list/message_parts = list(
-		list("[p_are()] holding", l_hand, "in", "left hand"),
-		list("[p_are()] holding", r_hand, "in", "right hand"),
-		list("[p_are()] wearing", head, "on", "head"),
-		list("[p_are()] wearing", !skipjumpsuit && w_uniform, null, null),
-		list("[p_are()] wearing", wear_suit, null, null),
-		list("[p_are()] carrying", !skipsuitstorage && s_store, "on", wear_suit && wear_suit.name),
-		list("[p_have()]", back, "on", "back"),
-		list("[p_have()]", !skipgloves && gloves, "on", "hands"),
-		list("[p_have()]", belt, "about", "waist"),
-		list("[p_are()] wearing", !skipshoes && shoes, "on", "feet"),
-		list("[p_have()]", !skipmask && wear_mask, "on", "face"),
-		list("[p_have()]", glasses, "covering", "eyes"),
-		list("[p_have()]", !skipears && l_ear, "on", "left ear"),
-		list("[p_have()]", !skipears && r_ear, "on", "right ear"),
-		list("[p_are()] wearing", wear_id, null, null),
+		list("[p_are()] holding", l_hand, "in", "left hand", null),
+		list("[p_are()] holding", r_hand, "in", "right hand", null),
+		list("[p_are()] wearing", head, "on", "head", null),
+		list("[p_are()] wearing", !skipjumpsuit && w_uniform, null, null, length(w_uniform.accessories) && "[english_accessory_list(w_uniform)]"),
+		list("[p_are()] wearing", wear_suit, null, null, null),
+		list("[p_are()] carrying", !skipsuitstorage && s_store, "on", wear_suit && wear_suit.name, null),
+		list("[p_have()]", back, "on", "back", null),
+		list("[p_have()]", !skipgloves && gloves, "on", "hands", null),
+		list("[p_have()]", belt, "about", "waist", null),
+		list("[p_are()] wearing", !skipshoes && shoes, "on", "feet", null),
+		list("[p_have()]", !skipmask && wear_mask, "on", "face", null),
+		list("[p_have()]", glasses, "covering", "eyes", null),
+		list("[p_have()]", !skipears && l_ear, "on", "left ear", null),
+		list("[p_have()]", !skipears && r_ear, "on", "right ear", null),
+		list("[p_are()] wearing", wear_id, null, null, null),
 	)
 	for(var/parts in message_parts)
 		var/action = parts[1]
 		var/obj/item/item = parts[2]
 		var/preposition = parts[3]
 		var/limb_name = parts[4]
+		var/accessories = parts[5]
 
-		if (item && !(item.flags & ABSTRACT))
+		if(item && !(item.flags & ABSTRACT))
 			var/item_words = item.name
-			if (item.blood_DNA)
+			if(item.blood_DNA)
 				item_words = "[item.blood_color != "#030303" ? "blood-stained":"oil-stained"] [item_words]"
 			var/submsg = "[p_they(TRUE)] [action] [bicon(item)] \a [item_words]"
-			if (limb_name)
+			if(accessories)
+				submsg += " with a [accessories]"
+			if(limb_name)
 				submsg += " [preposition] [p_their()] [limb_name]"
-			if (item.blood_DNA)
+			if(item.blood_DNA)
 				submsg = "<span class='warning'>[submsg]!</span>\n"
 			else
 				submsg = "[submsg].\n"
@@ -85,11 +88,11 @@
 			continue
 		else
 			// no items worn, thus revealing the skin
-			switch (limb_name)
-				if ("hands")
-					if (blood_DNA)
+			switch(limb_name)
+				if("hands")
+					if(blood_DNA)
 						msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [hand_blood_color != "#030303" ? "blood-stained":"oil-stained"] hands!</span>\n"
-				if ("eyes")
+				if("eyes")
 					if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
 						msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glowing an unnatural red!</span>\n"
 			continue

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -77,7 +77,7 @@
 				item_words = "[item.blood_color != "#030303" ? "blood-stained":"oil-stained"] [item_words]"
 			var/submsg = "[p_they(TRUE)] [action] [bicon(item)] \a [item_words]"
 			if(accessories)
-				submsg += " with a [accessories]"
+				submsg += " with [accessories]"
 			if(limb_name)
 				submsg += " [preposition] [p_their()] [limb_name]"
 			if(item.blood_DNA)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
accidental feature removal from #17653
also cleans up the styling between ifs and switches

## Why It's Good For The Game
accidental feature removal bad.

## Images of changes
![image](https://user-images.githubusercontent.com/69320440/166301567-71de657a-838f-4c4a-acf0-d8e57f616f13.png)

## Changelog
:cl:
fix: jumpsuit attachments show up on examine properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
