### PR TITLE
Changes the roller bed size to Normal, allows it to be deployed on adjacent tiles via left click

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -106,12 +106,22 @@
 	desc = "A collapsed roller bed that can be carried around."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
-	w_class = WEIGHT_CLASS_BULKY // Can't be put in backpacks.
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/roller/attack_self(mob/user)
 	var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(user.loc)
 	R.add_fingerprint(user)
 	qdel(src)
+
+/obj/item/roller/afterattack(atom/target, mob/user, proximity, params)
+	if(!proximity)
+		return
+	if(isturf(target))
+		var/turf/T = target
+		if(!T.density)
+			var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(T)
+			R.add_fingerprint(user)
+			qdel(src)
 
 /obj/item/roller/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/roller_holder))


### PR DESCRIPTION
This is a remake of my previous PR, which I had accidentally borked, oops.

## What Does This PR Do
This changes the size of the collapsed roller beds from "Bulky" to "Normal", so as to make them fit inside backpacks.
This also makes them deployable on a targetted turf through the use of a left click, allowing, for instance, to deploy them directly under the person you want to move, without needing to pull said person onto the bed's tile.

## Why It's Good For The Game
The medical roller beds were extremely clunky to use due to requiring the user to hold them in their hand, they are now much less infuriating to use for, say, a paramedic, by leaving both their hands free.

Additionally, deploying roller beds with a left click on an adjacent tile, rather than below yourself is good quality of life that might make the item shine more.

## Changelog
:cl:
tweak: medical roller beds are now normal-sized and can fit in storage items, paramedics rejoice.
add: roller beds can now be deployed on adjacent tiles by left-clicking with the item in your hand.
/:cl:
