### PR TITLE
Atmos Share Optimization

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -205,6 +205,10 @@ What are the archived variables for?
 /datum/gas_mixture/proc/share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
 	if(!sharer)
 		return 0
+	/// Don't make calculations if there is no difference.
+	if(oxygen_archived == sharer.oxygen_archived && carbon_dioxide_archived == sharer.carbon_dioxide_archived && nitrogen_archived == sharer.nitrogen_archived &&\
+	toxins_archived == sharer.toxins_archived && sleeping_agent_archived == sharer.sleeping_agent_archived && agent_b_archived == sharer.agent_b_archived && temperature_archived == sharer.temperature_archived)
+		return 0
 	var/delta_oxygen = QUANTIZE(oxygen_archived - sharer.oxygen_archived) / (atmos_adjacent_turfs + 1)
 	var/delta_carbon_dioxide = QUANTIZE(carbon_dioxide_archived - sharer.carbon_dioxide_archived) / (atmos_adjacent_turfs + 1)
 	var/delta_nitrogen = QUANTIZE(nitrogen_archived - sharer.nitrogen_archived) / (atmos_adjacent_turfs + 1)


### PR DESCRIPTION
## What Does This PR Do
* Now we don't do calculations with proc/share if there is no difference in atmosphere.

## Why It's Good For The Game
* Atmos idle performance is improved by a factor of ~2-3 by adding a check to do certain calculations.

```
This is the data from auto-profiler:
Proc Name   Self CPU Time   Total CPU Time   Real Time   Calls
.../share   0.446           0.525            0.544       33981 [Old]
.../share   0.183           0.205            0.218       11587 [New]
```

## Changelog
No player-facing changes.