### PR TITLE
Refactor airlock spawner helpers to use access_txt and use cycle_interior/exterior for the door buttons

### DIFF
--- a/code/game/objects/effects/spawners/airlock_spawner.dm
+++ b/code/game/objects/effects/spawners/airlock_spawner.dm
@@ -33,7 +33,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	var/tiles_in_y_direction = 1
 	var/id_to_link
 	var/radio_frequency = 1379
-	req_access_txt = ACCESS_EXTERNAL_AIRLOCKS
+	req_access_txt = ACCESS_EXTERNAL_AIRLOCKS //If req_one_access_txt is set, this is ignored
 	var/door_name = "external access"
 	var/door_type = /obj/machinery/door/airlock/external/glass
 	var/one_door_interior //For square airlocks, if you set this then a) only one door will spawn, and b) you can choose if the door should go opposite to how it normally goes. Please use the define
@@ -95,7 +95,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 /obj/effect/spawner/airlock/proc/handle_door_stuff(obj/machinery/door/airlock/A, is_this_an_interior_airlock) //This sets up the door vars correctly and then locks it before first use
 	A.set_frequency(radio_frequency)
 	A.id_tag = is_this_an_interior_airlock ? INNER_DOOR_TAG : OUTER_DOOR_TAG
-	A.req_access_txt = "[req_access_txt]"
+	set_access_helper(A)
 	A.name = door_name
 	A.lock()
 
@@ -116,14 +116,14 @@ This spawner places pipe leading up to the interior door, you will need to finis
 		if(WEST)
 			the_button.pixel_x -= 7
 			the_button.pixel_y -= 25
-	the_button.req_access_txt = "[req_access_txt]"
+	set_access_helper(the_button)
 	return the_button
 
 /obj/effect/spawner/airlock/proc/handle_control_placement() //Stick the sensor and controller on the same bit of wall, this will ONLY be unsuitable if airlocks are on both the south and west turfs
 	var/turf/T = get_turf(src)
 	var/obj/machinery/airlock_sensor/AS = new(T)
 	var/obj/machinery/embedded_controller/radio/airlock/airlock_controller/AC = new(T, id_to_link, radio_frequency, OUTER_DOOR_TAG, INNER_DOOR_TAG, AIRPUMP_TAG, SENSOR_TAG)
-	AC.req_access_txt = "[req_access_txt]"
+	set_access_helper(AC)
 	AS.id_tag = SENSOR_TAG
 	AS.set_frequency(radio_frequency)
 	if(interior_direction != WEST && exterior_direction != WEST) //If west wall is free, place stuff there
@@ -201,6 +201,11 @@ This spawner places pipe leading up to the interior door, you will need to finis
 		created_pump.id_tag = AIRPUMP_TAG
 		created_pump.set_frequency(radio_frequency)
 
+/obj/effect/spawner/airlock/proc/set_access_helper(var/obj/I)
+	if(req_one_access_txt == "0")
+		I.req_access_txt = "[req_access_txt]"
+	else
+		I.req_one_access_txt = "[req_one_access_txt]"
 
 //Premade airlocks for mappers, probably won't need all of these but whatever
 /obj/effect/spawner/airlock/s_to_n

--- a/code/game/objects/effects/spawners/airlock_spawner.dm
+++ b/code/game/objects/effects/spawners/airlock_spawner.dm
@@ -33,7 +33,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	var/tiles_in_y_direction = 1
 	var/id_to_link
 	var/radio_frequency = 1379
-	var/required_access = list(ACCESS_EXTERNAL_AIRLOCKS)
+	req_access_txt = ACCESS_EXTERNAL_AIRLOCKS
 	var/door_name = "external access"
 	var/door_type = /obj/machinery/door/airlock/external/glass
 	var/one_door_interior //For square airlocks, if you set this then a) only one door will spawn, and b) you can choose if the door should go opposite to how it normally goes. Please use the define
@@ -79,6 +79,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	var/obj/machinery/access_button/the_button = spawn_button(T, is_this_an_interior_airlock ? interior_direction : exterior_direction)
 	if(one_door_only == DOOR_NORMAL_PLACEMENT) //We only need one door, we are done
 		return
+	the_button.command = "[is_this_an_interior_airlock ? "cycle_interior" : "cycle_exterior"]"
 	if(!(tiles_in_x_direction % 2) && (is_this_an_interior_airlock && north_or_south_interior || !is_this_an_interior_airlock && north_or_south_exterior)) //Handle extra airlock for aesthetics
 		A = new door_type(get_step(T, EAST))
 		handle_door_stuff(A, is_this_an_interior_airlock)
@@ -93,7 +94,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 /obj/effect/spawner/airlock/proc/handle_door_stuff(obj/machinery/door/airlock/A, is_this_an_interior_airlock) //This sets up the door vars correctly and then locks it before first use
 	A.set_frequency(radio_frequency)
 	A.id_tag = is_this_an_interior_airlock ? INNER_DOOR_TAG : OUTER_DOOR_TAG
-	A.req_access = required_access
+	A.req_access_txt = "[req_access_txt]"
 	A.name = door_name
 	A.lock()
 
@@ -114,14 +115,14 @@ This spawner places pipe leading up to the interior door, you will need to finis
 		if(WEST)
 			the_button.pixel_x -= 7
 			the_button.pixel_y -= 25
-	the_button.req_access = required_access
+	the_button.req_access_txt = "[req_access_txt]"
 	return the_button
 
 /obj/effect/spawner/airlock/proc/handle_control_placement() //Stick the sensor and controller on the same bit of wall, this will ONLY be unsuitable if airlocks are on both the south and west turfs
 	var/turf/T = get_turf(src)
 	var/obj/machinery/airlock_sensor/AS = new(T)
 	var/obj/machinery/embedded_controller/radio/airlock/airlock_controller/AC = new(T, id_to_link, radio_frequency, OUTER_DOOR_TAG, INNER_DOOR_TAG, AIRPUMP_TAG, SENSOR_TAG)
-	AC.req_access = required_access
+	AC.req_access_txt = "[req_access_txt]"
 	AS.id_tag = SENSOR_TAG
 	AS.set_frequency(radio_frequency)
 	if(interior_direction != WEST && exterior_direction != WEST) //If west wall is free, place stuff there
@@ -282,22 +283,22 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	tiles_in_y_direction = 3
 
 /obj/effect/spawner/airlock/e_to_w/arrivals
-	required_access = null
+	req_access_txt = null
 
 /obj/effect/spawner/airlock/engineer
-	required_access = list(ACCESS_ENGINE)
+	req_access_txt = ACCESS_ENGINE
 	door_name = "engineering external access"
 /obj/effect/spawner/airlock/e_to_w/engineer
-	required_access = list(ACCESS_ENGINE)
+	req_access_txt = ACCESS_ENGINE
 	door_name = "engineering external access"
 /obj/effect/spawner/airlock/s_to_n/engineer
-	required_access = list(ACCESS_ENGINE)
+	req_access_txt = ACCESS_ENGINE
 	door_name = "engineering external access"
 /obj/effect/spawner/airlock/long/engineer
-	required_access = list(ACCESS_ENGINE)
+	req_access_txt = ACCESS_ENGINE
 	door_name = "engineering external access"
 /obj/effect/spawner/airlock/long/square/engine
-	required_access = list(ACCESS_ENGINE)
+	req_access_txt = ACCESS_ENGINE
 	door_name = "engine external access"
 	icon_state = "2x2_N_to_S_leftdoors"
 	door_type = /obj/machinery/door/airlock/external
@@ -310,17 +311,17 @@ This spawner places pipe leading up to the interior door, you will need to finis
 
 /obj/effect/spawner/airlock/w_to_e/long/square/wide/mining
 	door_name = "mining external access"
-	required_access = list(ACCESS_MINING)
+	req_access_txt = ACCESS_MINING
 /obj/effect/spawner/airlock/long/square/wide/mining
 	door_name = "mining external access"
-	required_access = list(ACCESS_MINING)
+	req_access_txt = ACCESS_MINING
 
 /obj/effect/spawner/airlock/e_to_w/minisat
 	door_name = "minisat external access"
-	required_access = list(ACCESS_MINISAT)
+	req_access_txt = ACCESS_MINISAT
 /obj/effect/spawner/airlock/long/square/e_to_s/telecoms
 	door_name = "telecoms external access"
-	required_access = list(ACCESS_TCOMSAT, ACCESS_EXTERNAL_AIRLOCKS)
+	req_access_txt = "61;13" //ACCESS_TCOMSAT,ACCESS_EXTERNAL_AIRLOCKS
 	door_type = /obj/machinery/door/airlock/external
 
 /obj/effect/spawner/airlock/long/square/three/syndicate
@@ -329,7 +330,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	interior_direction = WEST
 	exterior_direction = NORTH
 	door_name = "ship external access"
-	req_access = list(ACCESS_SYNDICATE)
+	req_access_txt = ACCESS_SYNDICATE
 	door_type = /obj/machinery/door/airlock/external
 
 #undef HALF_X

--- a/code/game/objects/effects/spawners/airlock_spawner.dm
+++ b/code/game/objects/effects/spawners/airlock_spawner.dm
@@ -79,7 +79,6 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	var/obj/machinery/access_button/the_button = spawn_button(T, is_this_an_interior_airlock ? interior_direction : exterior_direction)
 	if(one_door_only == DOOR_NORMAL_PLACEMENT) //We only need one door, we are done
 		return
-	the_button.command = "[is_this_an_interior_airlock ? "cycle_interior" : "cycle_exterior"]"
 	if(!(tiles_in_x_direction % 2) && (is_this_an_interior_airlock && north_or_south_interior || !is_this_an_interior_airlock && north_or_south_exterior)) //Handle extra airlock for aesthetics
 		A = new door_type(get_step(T, EAST))
 		handle_door_stuff(A, is_this_an_interior_airlock)
@@ -90,6 +89,8 @@ This spawner places pipe leading up to the interior door, you will need to finis
 		handle_door_stuff(A, is_this_an_interior_airlock)
 		if(one_door_only == DOOR_FLIPPED_PLACEMENT)
 			the_button.forceMove(get_step(the_button, NORTH))
+	if(!one_door_only)
+		the_button.command = "[is_this_an_interior_airlock ? "cycle_interior" : "cycle_exterior"]"
 
 /obj/effect/spawner/airlock/proc/handle_door_stuff(obj/machinery/door/airlock/A, is_this_an_interior_airlock) //This sets up the door vars correctly and then locks it before first use
 	A.set_frequency(radio_frequency)

--- a/code/game/objects/effects/spawners/airlock_spawner.dm
+++ b/code/game/objects/effects/spawners/airlock_spawner.dm
@@ -201,7 +201,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 		created_pump.id_tag = AIRPUMP_TAG
 		created_pump.set_frequency(radio_frequency)
 
-/obj/effect/spawner/airlock/proc/set_access_helper(var/obj/I)
+/obj/effect/spawner/airlock/proc/set_access_helper(obj/I)
 	if(req_one_access_txt == "0")
 		I.req_access_txt = "[req_access_txt]"
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the airlock spawner helpers to use `access_txt` and make it consistent with how access works everywhere else. Usage of `req_one_access_txt` will override `req_access_txt`. If an helper with internal/external doors is used, the door buttons are set to use `cycle_interior`/`cycle_exterior` instead. They currently default to `cycle`, which isn't gamebreaking, but sometimes makes the airlocks not reliably cycle due to getting confused in its states.

## Why It's Good For The Game
Reduce frustration with airlock helpers, restricted to Metastation at the moment.

## Changelog
:cl:
fix: NSS Cerebron/Metastation external airlock buttons reliably cycle airlocks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
