### PR TITLE
Add a config option to persistently override the map loaded

### DIFF
--- a/code/controllers/configuration/sections/system_configuration.dm
+++ b/code/controllers/configuration/sections/system_configuration.dm
@@ -26,8 +26,8 @@
 	var/internal_ip = "127.0.0.1"
 	/// Are we using an external handler for TOS
 	var/external_tos_handler = FALSE
-	/// Whether to load test_tiny instead of the normal map
-	var/load_test_map = FALSE
+	/// Map datum of the map to use, overriding the defaults, and `data/next_map.txt`
+	var/override_map = null
 
 /datum/configuration_section/system_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
@@ -47,4 +47,4 @@
 	CONFIG_LOAD_STR(instance_id, data["instance_id"])
 	CONFIG_LOAD_STR(internal_ip, data["internal_ip"])
 
-	CONFIG_LOAD_BOOL(load_test_map, data["load_test_map"])
+	CONFIG_LOAD_STR(override_map, data["override_map"])

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -126,9 +126,14 @@ SUBSYSTEM_DEF(mapping)
 
 // Loads in the station
 /datum/controller/subsystem/mapping/proc/loadStation()
-	if(GLOB.configuration.system.load_test_map)
-		log_startup_progress("Loading test map, overridden by configuration.")
-		map_datum = new /datum/map/test_tiny
+	if(GLOB.configuration.system.override_map)
+		log_startup_progress("Station map overridden by configuration to [GLOB.configuration.system.override_map].")
+		var/map_datum_path = text2path(GLOB.configuration.system.override_map)
+		if(map_datum_path)
+			map_datum = new map_datum_path
+		else
+			to_chat(world, "<span class='narsie'>ERROR: The map datum specified to load is invalid. Falling back to... cyberiad probably?</span>")
+
 	ASSERT(map_datum.map_path)
 	if(!fexists(map_datum.map_path))
 		// Make a VERY OBVIOUS error

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -742,8 +742,10 @@ instance_id = "paradise_main"
 internal_ip = "127.0.0.1"
 # Are we handling TOS consents on an external service?
 external_tos_handler = false
-# Whether to load test_tiny instead of the normal map.
-load_test_map = false
+# Path to the map datum to load, overriding the defaults and `data/next_map.txt`.
+# Do not use in production.
+# Comment out to disable.
+#override_map = "/datum/map/test_tiny"
 
 
 ################################################################


### PR DESCRIPTION
## What Does This PR Do
Expands upon the framework introduced by @DamianX's #17704, and adds a config option to load any map by datum name, and not only the `test_tiny`

## Why It's Good For The Game
Currently there is no persistent way to set the map being loaded.
That means, that a mapper working on a map needs to remember to create `data/next_map.txt` (one way or another) *each time they restart the server*, which can be annoying.

By making that a persistent config option, the amount of such hassle is reduced (and you now only need to edit the config when you *change* the map you're working on, which is much rarer).

(The alternative to this is, of course, remove the deletion of `./data/next_map.txt` file, but i'm 100% sure that would break things in prod, so i don't even want to try)

Tested, with and without option set; works as one would expect.

## Changelog
N/A; players should not notice anything different at all.