### PR TITLE
Fixed R&D console bug

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -179,7 +179,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	QDEL_NULL(files)
 	QDEL_NULL(t_disk)
 	QDEL_NULL(d_disk)
-	QDEL_LIST(matching_designs)
+	matching_designs.Cut()
 	if(linked_destroy)
 		linked_destroy.linked_console = null
 		linked_destroy = null


### PR DESCRIPTION
## What Does This PR Do
Fixes the bug where the R&D console would be inoperable until rebuilt. This was introduced in #16609, as the list was meant to be emptied, not have every entry `qdel()`'d. Designs shouldn't be deleted.

## Why It's Good For The Game
Bluescreening bad

## Changelog
:cl: AffectedArc07
fix: Fixed a bug that caused the R&D console to be inoperable 
/:cl:
