### PR TITLE
Fix a tiny runtime in mmi insertion

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1183,7 +1183,7 @@
 		dir = dir_in
 		log_message("[mmi_as_oc] moved in as pilot.")
 		if(!hasInternalDamage())
-			to_chat(occupant, sound(nominalsound, volume=50))
+			occupant << sound(nominalsound, volume=50)
 		GrantActions(brainmob)
 		return TRUE
 	else


### PR DESCRIPTION
## What Does This PR Do
Prevents a rare and absolutely not game impacting runtime from being triggered.

The code technically works presently. It just over-zealously emits an error *in addition* to normal behaviour - see https://github.com/ParadiseSS13/Paradise/blob/3961ede300ecf985390a33ac00abe438fa998493/goon/code/datums/browserOutput.dm#L284-L304

## Why It's Good For The Game
idk..
ideally i'd do a bigger and better pr with multiple more important runtimes at once, but i'm too tired, so i figured it's better to create this small pr, than not to create any at all.