### PR TITLE
Makes shuttles unable to jump and the gateway inoperable while the nuke is active

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -399,9 +399,8 @@ GLOBAL_VAR(bomb_set)
 					message_admins("[key_name_admin(usr)] engaged a nuclear bomb [ADMIN_JMP(src)]")
 					if(!is_syndicate)
 						set_security_level("delta")
-					GLOB.bomb_set = TRUE // There can still be issues with this resetting when there are multiple bombs. Not a big deal though for Nuke
-				else
-					GLOB.bomb_set = TRUE
+				GLOB.bomb_set = TRUE
+				GLOB.the_gateway.toggleoff()
 			else
 				if(!is_syndicate)
 					set_security_level(previous_level)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -114,6 +114,9 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 	if(world.time < wait)
 		to_chat(user, "<span class='notice'>Error: Warpspace triangulation in progress. Estimated time to completion: [round(((wait - world.time) / 10) / 60)] minutes.</span>")
 		return
+	if(is_station_level(z) && GLOB.bomb_set)
+		atom_say("Error: Quarantine protocol enabled.")
+		return
 
 	for(var/obj/machinery/gateway/G in linked)
 		G.active = 1

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -114,7 +114,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 	if(world.time < wait)
 		to_chat(user, "<span class='notice'>Error: Warpspace triangulation in progress. Estimated time to completion: [round(((wait - world.time) / 10) / 60)] minutes.</span>")
 		return
-	if(is_station_level(z) && GLOB.bomb_set)
+	if(GLOB.bomb_set && is_station_level(z))
 		atom_say("Error: Quarantine protocol enabled.")
 		return
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -812,6 +812,9 @@
 		if(!options.Find(destination))//figure out if this translation works
 			message_admins("<span class='boldannounce'>EXPLOIT:</span> [ADMIN_LOOKUPFLW(usr)] attempted to move [src] to an invalid location! [ADMIN_COORDJMP(src)]")
 			return
+		if(GLOB.bomb_set && !(ACCESS_SYNDICATE in req_access))
+			atom_say("Error: Quarantine protocol enabled.")
+			return
 		switch(SSshuttle.moveShuttle(shuttleId, destination, TRUE, usr))
 			if(0)
 				atom_say("Shuttle departing! Please stand away from the doors.")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -812,12 +812,11 @@
 		if(!options.Find(destination))//figure out if this translation works
 			message_admins("<span class='boldannounce'>EXPLOIT:</span> [ADMIN_LOOKUPFLW(usr)] attempted to move [src] to an invalid location! [ADMIN_COORDJMP(src)]")
 			return
-		if(GLOB.bomb_set)
-			if(!(ACCESS_SYNDICATE in req_access))
+		if(GLOB.bomb_set && !(ACCESS_SYNDICATE in req_access) && shuttleId != "whiteship")
+			if(!(ACCESS_CAPTAIN in usr.get_access()))
 				atom_say("Error: Quarantine protocol enabled.")
 				return
-			if(ACCESS_CAPTAIN in usr.get_access())
-				atom_say("Notice: Captain access detected. Overriding quarantine protocol.")
+			atom_say("Notice: Captain access detected. Overriding quarantine protocol.")
 		switch(SSshuttle.moveShuttle(shuttleId, destination, TRUE, usr))
 			if(0)
 				atom_say("Shuttle departing! Please stand away from the doors.")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -812,9 +812,12 @@
 		if(!options.Find(destination))//figure out if this translation works
 			message_admins("<span class='boldannounce'>EXPLOIT:</span> [ADMIN_LOOKUPFLW(usr)] attempted to move [src] to an invalid location! [ADMIN_COORDJMP(src)]")
 			return
-		if(GLOB.bomb_set && !(ACCESS_SYNDICATE in req_access))
-			atom_say("Error: Quarantine protocol enabled.")
-			return
+		if(GLOB.bomb_set)
+			if(!(ACCESS_SYNDICATE in req_access))
+				atom_say("Error: Quarantine protocol enabled.")
+				return
+			if(ACCESS_CAPTAIN in usr.get_access())
+				atom_say("Notice: Captain access detected. Overriding quarantine protocol.")
 		switch(SSshuttle.moveShuttle(shuttleId, destination, TRUE, usr))
 			if(0)
 				atom_say("Shuttle departing! Please stand away from the doors.")


### PR DESCRIPTION
## What Does This PR Do

**This PR is currently being discussed, it is very much subject to change. See the comments.** 

When the nuke gets activated:
- the gateway is turned off
- the gateway cannot be turned on until the nuke is deactivated
- shuttles cannot be moved unless one has captain access
  - syndicate access ships are not affected (nukies, SIT)
  - the whiteship is not affected (it is a neutral shuttle)
  - the trader shuttle gets quarantined too, it physically docked with the station

#### Important: I am aware that during nukie rounds, everyone and their cats have captain access. I am fine with people getting off the station easily, they have a myriad other ways to die. This PR is aimed at making malf AI/biohazard nuking more dangerous and impactful.

## Why It's Good For The Game
- Currently, you can rather easily survive a nuclear blast - just get off station via gateway or the labour/mining shuttle. This PR aims to make it more difficult **but still not impossible**.
- During malf AI, this makes the nuke more of an "it is everyone's problem, we should _really fix it"_ thing rather than the current "oh the AI is malf, guess I jump into the gateway".
- During biohazard nuking, when it is the captain's decision, it makes their role more vital. **If you, as a captain do not communicate with your crew, and instruct them where to go to, you and only you are responsible for their death.**
  - This is our delta message: _"The station's self-destruct mechanism has been engaged. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."_
  - This will hopefully become a reality with this change.

## Images of changes

#### Shuttles
![image](https://user-images.githubusercontent.com/33333517/167457328-18e427a0-a345-4441-aec2-14b12e03921c.png) 
![image](https://user-images.githubusercontent.com/33333517/167457339-939e5441-7d92-47ad-a219-a47e3c4e3283.png)
![image](https://user-images.githubusercontent.com/33333517/167457393-247394e7-d12b-4b79-bbb0-49f99a1e8651.png)
![image](https://user-images.githubusercontent.com/33333517/167457409-436347ff-0f3c-44a7-b4a8-405da4f02700.png)

#### Gateway
![image](https://user-images.githubusercontent.com/33333517/167457436-3a111abe-a098-495c-a2c3-487fc7c2e7f7.png)

#### Nukies, having a _blast_
![image](https://user-images.githubusercontent.com/33333517/167457475-2b1cd10d-6396-4fbe-9df9-c5b73be71e18.png)


## Changelog
:cl:
add: Automated quarantine protocol added when the nuclear device gets activated:
add: The gateway is turned off and cannot be turned on while the nuclear device is active.
add: All shuttles except for syndicate ones and the hospital ship are grounded, and can only be moved with captain level access.
/:cl:
