### PR TITLE
Allows engineering borgs to change painter type.

### DIFF
--- a/code/game/objects/items/devices/painter/painter.dm
+++ b/code/game/objects/items/devices/painter/painter.dm
@@ -97,7 +97,7 @@
   */
 /obj/item/painter/CtrlClick(mob/user)
 	. = ..()
-	if(!ishuman(user)) // Only want human players doing this
+	if(!ishuman(user) && !isrobot(user)) // Only want human players doing this
 		return
 	if(loc != user) // Not being held
 		return

--- a/code/game/objects/items/devices/painter/painter.dm
+++ b/code/game/objects/items/devices/painter/painter.dm
@@ -97,8 +97,6 @@
   */
 /obj/item/painter/CtrlClick(mob/user)
 	. = ..()
-	if(!ishuman(user) && !isrobot(user)) // Only want human/cyborg players doing this
-		return
 	if(loc != user) // Not being held
 		return
 

--- a/code/game/objects/items/devices/painter/painter.dm
+++ b/code/game/objects/items/devices/painter/painter.dm
@@ -97,7 +97,7 @@
   */
 /obj/item/painter/CtrlClick(mob/user)
 	. = ..()
-	if(!ishuman(user) && !isrobot(user)) // Only want human players doing this
+	if(!ishuman(user) && !isrobot(user)) // Only want human/cyborg players doing this
 		return
 	if(loc != user) // Not being held
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows engineering borgs to switch the painter subtype they have.
fixes #17747
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cyborgs should be able to change their painter type as well.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Engineering cyborgs can now change their painter type by ctrl+clicking it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
