### PR TITLE
Fix - Ruptured canisters use the proper icon and won't process atmos

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -149,8 +149,8 @@ update_flag
 (note: colors has to be applied every icon update)
 */
 
-	if(destroyed)
-		overlays = 0
+	if(stat & BROKEN)
+		cut_overlays()
 		icon_state = text("[]-1", canister_color["prim"])//yes, I KNOW the colours don't reflect when the can's borked, whatever.
 		return
 
@@ -160,27 +160,23 @@ update_flag
 	if(check_change()) //Returns 1 if no change needed to icons.
 		return
 
-	overlays.Cut()
+	cut_overlays()
 
 	for(var/C in canister_color)
 		if(C == "prim")
 			continue
 		if(canister_color[C] == "none")
 			continue
-		overlays.Add(canister_color[C])
+		add_overlay(canister_color[C])
 
 	if(update_flag & 1)
-		overlays += "can-open"
-	if(update_flag & 2)
-		overlays += "can-connector"
+		add_overlay("can-open")
 	if(update_flag & 4)
-		overlays += "can-o0"
-	if(update_flag & 8)
-		overlays += "can-o1"
+		add_overlay("can-o0")
 	else if(update_flag & 16)
-		overlays += "can-o2"
+		add_overlay("can-o2")
 	else if(update_flag & 32)
-		overlays += "can-o3"
+		add_overlay("can-o3")
 
 	update_flag &= ~68 //the flag 64 represents change, not states. As such, we have to reset them to be able to detect a change on the next go.
 	return
@@ -222,7 +218,7 @@ update_flag
 		holding = null
 
 /obj/machinery/portable_atmospherics/canister/process_atmos()
-	if(destroyed)
+	if(stat & BROKEN)
 		return
 
 	..()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -171,8 +171,12 @@ update_flag
 
 	if(update_flag & 1)
 		add_overlay("can-open")
+	if(update_flag & 2)
+		add_overlay("can-connector")
 	if(update_flag & 4)
 		add_overlay("can-o0")
+	if(update_flag & 8)
+		add_overlay("can-o1")
 	else if(update_flag & 16)
 		add_overlay("can-o2")
 	else if(update_flag & 32)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the canister's icon handling and atmos process to properly detect when it's ruptured

## Why It's Good For The Game
Better to know which can is the offender if it's actually ruptured.

## Images of changes
![Atmos](https://user-images.githubusercontent.com/80771500/167745448-ceda204a-f618-4c67-bba1-6129c16847b0.PNG)

## Changelog
:cl:
fix: Ruptured canisters show up as such
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
