### PR TITLE
Miners can access Science radio

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -135,17 +135,13 @@
 	icon_state = "com_cypherkey"
 	channels = list("Command" = 1)
 
-/*
-/obj/item/encryptionkey/headset_mine
-	name = "Mining Radio Encryption Key"
-	icon_state = "mine_cypherkey"
-	channels = list("Mining" = 1)
 
-/obj/item/encryptionkey/heads/qm
-	name = "Quartermaster's Encryption Key"
-	icon_state = "qm_cypherkey"
-	channels = list("Cargo" = 1, "Mining" = 1)
-*/
+/obj/item/encryptionkey/headset_mining
+	name = "mining radio encryption key"
+	icon_state = "cargo_cypherkey"
+	channels = list("Supply" = 1, "Science" = 1)
+
+
 /obj/item/encryptionkey/headset_cargo
 	name = "Supply Radio Encryption Key"
 	icon_state = "cargo_cypherkey"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -251,6 +251,7 @@
 	name = "mining radio headset"
 	desc = "Headset used by shaft miners."
 	icon_state = "mine_headset"
+	ks2type = /obj/item/encryptionkey/headset_mining
 
 /obj/item/radio/headset/headset_service
 	name = "service radio headset"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the Science (:n) channel to mining radio headsets
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mining needs science, and science needs mining. Science needs materials and mining needs upgraded equipment and Ripleys. Allows for better co-ordination between Science and Mining, like a scientist making bombs for lavaland or miners asking about slime potions
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Miners can now access the Science radio channel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
