### PR TITLE
Fixes dantalion's thrall commune not having a span class

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
@@ -118,9 +118,9 @@
 	var/title = isvampirethrall(user) ? "Thrall" : "<b>Vampire Master</b>" // if admins give this to a non vampire/thrall it is not my problem
 	var/message = "[user.real_name] ([title]): [input]"
 	for(var/mob/M in targets)
-		to_chat(M, "<span class='shadowling'>[message]</span>")
+		to_chat(M, "<span class='dantalion'>[message]</span>")
 	for(var/mob/M in GLOB.dead_mob_list)
-		to_chat(M, "<span class='shadowling'>([ghost_follow_link(user, ghost=M)]): [message] </span>")
+		to_chat(M, "<span class='dantalion'>([ghost_follow_link(user, ghost=M)]): [message] </span>")
 	log_say("(DANTALION) [input]", user)
 	user.create_log(SAY_LOG, "(DANTALION) [input]")
 

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -319,6 +319,7 @@ h1.alert, h2.alert			{color: #FFF;}
 .noticealien				{color: #00c000;}
 .alertalien				{color: #00c000; font-weight: bold;}
 .terrorspider				{color: #CF52FA;}
+.dantalion				{color: #8b2c5e;}
 
 
 .sinister				{color: #800080;	font-weight: bold;	font-style: italic;} /* /vg/ */

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -316,6 +316,7 @@ h1.alert, h2.alert			{color: #000000;}
 .noticealien				{color: #00c000;}
 .alertalien				{color: #00c000; font-weight: bold;}
 .terrorspider				{color: #320E32;}
+.dantalion				{color: #6A2148;}
 
 
 .sinister				{color: #800080;	font-weight: bold;	font-style: italic;} /* /vg/ */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Span class got removed by sling removal, rectifies this.

## Why It's Good For The Game
standard text is boring.

## Images of changes
![image](https://user-images.githubusercontent.com/69320440/168332783-9f4a339c-8117-4e80-8d9f-1dea652251a8.png)

![image](https://user-images.githubusercontent.com/69320440/168332882-7016148d-1de0-4837-9132-1debdf3e32ad.png)

(I had to use lightmode to make this, gross)
## Changelog
:cl:
fix: dantalion thrall commune ability has the proper text colours.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
