### PR TITLE
Adds gravityboots, from gravitational anomaly core.

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -442,6 +442,19 @@
 	button_icon_state = "jetboot"
 	use_itemicon = FALSE
 
+
+/datum/action/item_action/ghop
+	name = "Gravity jump"
+	desc = "Directs a pulse of gravity in front of the user, pulling them foward rapidly."
+
+/datum/action/item_action/ghop/Trigger()
+	if(!IsAvailable())
+		return FALSE
+
+	var/obj/item/clothing/shoes/magboots/gravity/G = target
+	G.dash(usr)
+
+
 ///prset for organ actions
 /datum/action/item_action/organ_action
 	check_flags = AB_CHECK_CONSCIOUS

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -126,3 +126,147 @@
 			..()
 		else
 			to_chat(user, "<span class='notice'>You poke the gem on [src]. Nothing happens.</span>")
+
+
+/obj/item/clothing/shoes/magboots/gravity
+	name = "Gravitational boots"
+	desc = "Mention experimental, add core stuff."
+	icon_state = "magboots0"
+	origin_tech = "materials=6;magnets=6;engineering=6"
+	actions_types = list(/datum/action/item_action/toggle, /datum/action/item_action/ghop) //In other news, combining magboots with jumpboots is a mess
+	strip_delay = 100
+	put_on_delay = 100
+	var/datum/martial_art/grav_stomp/style = new //Only works with core and cell installed.
+	var/jumpdistance = 5
+	var/jumpspeed = 3
+	var/recharging_rate = 6 SECONDS
+	var/recharging_time = 0 // Time until next dash
+	var/dash_cost = 1000 // Cost to dash.
+	var/power_consumption_rate = 30 // How much power is used by the boots each cycle when magboots are active
+	var/obj/item/assembly/signaler/anomaly/grav/core = null
+	var/obj/item/stock_parts/cell/cell = null
+
+/obj/item/clothing/shoes/magboots/gravity/Destroy()
+	QDEL_NULL(cell)
+	QDEL_NULL(core)
+	return ..()
+
+/obj/item/clothing/shoes/magboots/gravity/examine(mob/user)
+	. = ..()
+	if(core && cell)
+		. += "<span class='notice'>[src] is fully operational!</span>"
+		. += "<span class='notice'>The boots are [round(cell.percent())]% charged.</span>"
+	else if(core)
+		. += "<span class='warning'>It has a gravitational anomaly core installed, but no power cell installed.</span>"
+	else if(cell)
+		. += "<span class='warning'>It has a power installed, but no gravitational anomaly core installed.</span>"
+	else
+		. += "<span class='warning'>It is missing a gravitational anomaly core and a power cell.</span>"
+
+/obj/item/clothing/shoes/magboots/gravity/process()
+	if(cell) //There should be a cell here, but safety first
+		if(cell.charge <= power_consumption_rate * 2 && magpulse)
+			if(istype(loc, /mob/living/carbon/human))
+				var/mob/living/carbon/human/user = loc
+				to_chat(user, "<span class='warning'>[src] has ran out of charge, and turned off!</span>")
+				attack_self(user)
+		else
+			cell.use(power_consumption_rate)
+
+/obj/item/clothing/shoes/magboots/gravity/screwdriver_act(mob/living/user, obj/item/I)
+	if(!cell)
+		to_chat(user, "<span class='warning'>There's no cell installed!</span>")
+		return
+
+	if(magpulse)
+		to_chat(user, "<span class='warning'>Turn off the boots first!</span>")
+		return
+
+	if(!I.use_tool(src, user, volume = I.tool_volume))
+		return
+
+	user.put_in_hands(cell)
+	to_chat(user, "<span class='notice'>You remove [cell] from [src].</span>")
+	cell.update_icon()
+	cell = null
+	update_icon()
+
+/obj/item/clothing/shoes/magboots/gravity/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/stock_parts/cell))
+		if(cell)
+			to_chat(user, "<span class='warning'>[src] already has a cell!</span>")
+			return
+		if(!user.unEquip(I))
+			return
+		I.forceMove(src)
+		cell = I
+		to_chat(user, "<span class='notice'>You install [I] into [src].</span>")
+		update_icon()
+		return
+
+	if(istype(I, /obj/item/assembly/signaler/anomaly/grav))
+		if(core)
+			to_chat(user, "<span class='notice'>[src] already has a [I]!</span>")
+			return
+		if(!user.drop_item())
+			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
+			return
+		to_chat(user, "<span class='notice'>You insert [I] into [src], and [src] starts to warm up.</span>")
+		I.forceMove(src)
+		core = I
+		update_icon()
+	else
+		return ..()
+
+/obj/item/clothing/shoes/magboots/gravity/equipped(mob/user, slot)
+	..()
+	if(!ishuman(user))
+		return
+	if(slot == slot_shoes)
+		var/mob/living/carbon/human/H = user
+		style.teach(H,1)
+
+/obj/item/clothing/shoes/magboots/gravity/dropped(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(H.get_item_by_slot(slot_shoes) == src)
+		style.remove(H)
+		if(magpulse)
+			to_chat(user, "<span class='notice'>As [src] is removed, it deactivates.</span>")
+			attack_self(user)
+
+/obj/item/clothing/shoes/magboots/gravity/item_action_slot_check(slot)
+	if(slot == slot_shoes)
+		return TRUE
+
+/obj/item/clothing/shoes/magboots/gravity/proc/dash(mob/user, action)
+	if(!isliving(user))
+		return
+
+	if(cell)
+		if(cell.charge <= dash_cost)
+			to_chat(user, "<span class='warning'>Your boots do not have enough charge to dash!</span>")
+			return
+	else
+		to_chat(user, "<span class='warning'>Your boots do not have a power cell!</span>")
+		return
+
+	if(!core)
+		to_chat(user, "<span class='warning'>There's no core installed!</span>")
+		return
+
+	if(recharging_time > world.time)
+		to_chat(user, "<span class='warning'>The boot's gravitational pulse needs to recharge still!</span>")
+		return
+
+	var/atom/target = get_edge_target_turf(user, user.dir) //gets the user's direction
+
+	if(user.throw_at(target, jumpdistance, jumpspeed, spin = FALSE, diagonals_first = TRUE))
+		playsound(src, 'sound/effects/stealthoff.ogg', 50, 1, 1)
+		user.visible_message("<span class='warning'>[usr] dashes forward into the air!</span>")
+		recharging_time = world.time + recharging_rate
+		cell.use(dash_cost)
+	else
+		to_chat(user, "<span class='warning'>Something prevents you from dashing forward!</span>")

--- a/code/modules/martial_arts/grav_stomp.dm
+++ b/code/modules/martial_arts/grav_stomp.dm
@@ -1,0 +1,17 @@
+/datum/martial_art/grav_stomp
+	name = "Gravitational Boots"
+
+/datum/martial_art/grav_stomp/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	MARTIAL_ARTS_ACT_CHECK
+	add_attack_logs(A, D, "Melee attacked with [src]")
+	var/picked_hit_type = "kicks"
+	var/bonus_damage = 10
+	if(D.IsWeakened() || D.resting || D.lying)
+		bonus_damage = 15
+		picked_hit_type = "stomps on"
+	A.do_attack_animation(D, ATTACK_EFFECT_KICK)
+	playsound(get_turf(D), 'sound/effects/hit_kick.ogg', 50, 1, -1)
+	D.apply_damage(bonus_damage, BRUTE)
+	D.visible_message("<span class='danger'>[A] [picked_hit_type] [D]!</span>", \
+					  "<span class='userdanger'>[A] [picked_hit_type] you!</span>")
+	return TRUE

--- a/paradise.dme
+++ b/paradise.dme
@@ -1759,6 +1759,7 @@
 #include "code\modules\martial_arts\adminfu.dm"
 #include "code\modules\martial_arts\brawling.dm"
 #include "code\modules\martial_arts\cqc.dm"
+#include "code\modules\martial_arts\grav_stomp.dm"
 #include "code\modules\martial_arts\krav_maga.dm"
 #include "code\modules\martial_arts\martial.dm"
 #include "code\modules\martial_arts\mimejutsu.dm"


### PR DESCRIPTION
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds the gravitational boots. Require a gravitational anomaly core and cell to function, work like a combination of advanced magboots and jump boots, as well as letting the user kick people and stomp on stunned people for extra damage. (10 / 15, which jaws of life can already do anyway)

The boots use energy while on, and more energy when leaping, so it is a perfect upgrade, although with a bluespace cell or yellow power will not matter as much. 15 jumps / 16.6 minutes of power on a 15k cell.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More uses for anomaly cores, rather than just anomaly armor, and rnd deconstruction (which is planned to go away at some point in the future), as well as an anomaly core use that is not a weapon.

Makes a nice upgrade to magboots, having the leap and base magboot functions combined. I had planned a function to negate gravity for the user, but it did not really serve any purpose.

No slowdown on gravitational boots, as if they can make the gravitational boots, I can guarantee you they can slap a red cell on it (which will look ugly anyway)

## Todo:

- [ ] Sprites. Ideally, base state, state with anomaly, with cell, and both, not to mention on. How to visually display a cell / core is attached without being super huge and ugly boots, I still need to figure out. Also vox / drask versions.
- [ ] Add to RND
- [ ] Probably launch the user at the wall / into the ground when emp'd or something, who knows.
- [ ] Proper description on the item as I forgot

## Changelog
:cl:
add: Gravitational boots, producible in RND, which is a highly mobile par of magboots, when combined with a gravitational anomaly core. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
