### PR TITLE
Fixes pride mirror sending you to CC sometimes

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -26,7 +26,7 @@
 		))
 	var/drop_x = 1
 	var/drop_y = 1
-	var/drop_z = 1
+	var/drop_z = 2 // so that it doesn't send you to CC if something fucks up.
 
 /turf/simulated/floor/chasm/Entered(atom/movable/AM)
 	..()
@@ -189,3 +189,10 @@
 
 /turf/simulated/floor/chasm/CanPass(atom/movable/mover, turf/target)
 	return 1
+
+/turf/simulated/floor/chasm/pride/Initialize(mapload)
+	. = ..()
+	drop_x = x
+	drop_y = y
+	var/list/target_z = levels_by_trait(SPAWN_RUINS)
+	drop_z = pick(target_z)

--- a/code/modules/ruins/lavalandruin_code/sin_ruins.dm
+++ b/code/modules/ruins/lavalandruin_code/sin_ruins.dm
@@ -123,11 +123,8 @@
 			fool.monkeyize()
 			fool.forceMove(return_turf)
 			return
-	T.ChangeTurf(/turf/simulated/floor/chasm)
+	T.ChangeTurf(/turf/simulated/floor/chasm/pride)
 	var/turf/simulated/floor/chasm/C = T
-	C.drop_x = T.x
-	C.drop_y = T.y
-	C.drop_z = pick(levels)
 	C.drop(user)
 
 // Envy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Going to CC is bad.

## Why It's Good For The Game
very bad exploit.

## Changelog
:cl:
fix: pride mirror can no longer send you to CC 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
