### PR TITLE
Stops CC / ussp special lights from runtiming on deconstruct

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -239,7 +239,6 @@
 
 /obj/machinery/light/spot
 	name = "spotlight"
-	fitting = "large tube"
 	light_type = /obj/item/light/tube/large
 	brightness_range = 12
 	brightness_power = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Removes the fitting = "large tube" variable adjustment from the light tubes in the spotlight special lights, to prevent runtime on deconstruction, as "large tube" is not one of the switch options.

The light tube frame will be normal after reconstruction, rather than a spotlight variant (that does not exist), as the frame doesn't do anything special other than having a brighter light in it, which ones can not obtain the bulbs for without removing from another spotlight. The larger bulbs can be put in a normal light frame anyway currently.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Runtimes are bad.

## Changelog
:cl:
fix: Fixed a runtime on deconstructing CC lights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
