### PR TITLE
[DNM] Removes public syringe guns (reliant on #17816)

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -51551,7 +51551,6 @@
 "csb" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/structure/barricade/wooden,
@@ -62625,7 +62624,6 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/syringes,
-/obj/item/gun/syringe,
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
@@ -87589,7 +87587,6 @@
 "dXZ" = (
 /obj/structure/table/reinforced,
 /obj/structure/bedsheetbin,
-/obj/item/gun/syringe,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/medical/surgery)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2145,7 +2145,6 @@
 	aiControlDisabled = 1;
 	id_tag = "prisonereducation";
 	name = "Prisoner Education Chamber";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /obj/structure/cable/yellow{
@@ -3841,7 +3840,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Armory";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /turf/simulated/floor/plasteel,
@@ -4555,7 +4553,6 @@
 	},
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Office";
-	req_access = null;
 	req_access_txt = "58"
 	},
 /obj/structure/cable/yellow{
@@ -8329,7 +8326,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation Monitoring";
-	req_access = null;
 	req_one_access_txt = "1;4"
 	},
 /turf/simulated/floor/plasteel/grimy,
@@ -11703,7 +11699,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
-	req_access = null;
 	req_access_txt = "4"
 	},
 /turf/simulated/floor/plasteel,
@@ -13434,7 +13429,6 @@
 "aGB" = (
 /obj/machinery/door/airlock/security{
 	name = "Court Cell";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -15154,7 +15148,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Security-Storage Backroom";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -15924,7 +15917,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Court Cell";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -16451,7 +16443,6 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Security-Storage Backroom";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16939,7 +16930,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Brig";
-	req_access = null;
 	req_access_txt = "63; 42"
 	},
 /turf/simulated/floor/plasteel,
@@ -17189,8 +17179,7 @@
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_x = 24;
-	req_access_txt = "10";
-	req_one_access = null
+	req_access_txt = "10"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
@@ -26163,7 +26152,6 @@
 	dir = 8;
 	icon_state = "left";
 	name = "AI Core Door";
-	req_access = null;
 	req_access_txt = "16"
 	},
 /obj/machinery/turretid/lethal{
@@ -26826,7 +26814,6 @@
 /obj/machinery/door/window/southright{
 	dir = 4;
 	name = "AI Core Door";
-	req_access = null;
 	req_access_txt = "16"
 	},
 /turf/simulated/floor/plasteel{
@@ -27070,7 +27057,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
-	req_access = null;
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27948,7 +27934,6 @@
 "bnI" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Four";
-	req_access = null;
 	req_access_txt = "32"
 	},
 /turf/simulated/floor/plating,
@@ -28115,7 +28100,6 @@
 "boa" = (
 /obj/machinery/door/airlock/security{
 	name = "Customs Desk";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /turf/simulated/floor/plasteel,
@@ -30127,7 +30111,6 @@
 "bsj" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34171,7 +34154,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34280,7 +34262,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -34296,7 +34277,6 @@
 "bAg" = (
 /obj/machinery/door/airlock/command{
 	name = "Command Desk";
-	req_access = null;
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35614,7 +35594,6 @@
 "bDl" = (
 /obj/machinery/door/airlock/command{
 	name = "Emergency Escape";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/structure/cable/yellow{
@@ -36031,7 +36010,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Council Chamber";
-	req_access = null;
 	req_access_txt = "19"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -36073,7 +36051,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -36690,7 +36667,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
-	id_tag = null;
 	name = "Vacant Office"
 	},
 /turf/simulated/floor/wood,
@@ -47911,7 +47887,6 @@
 /area/maintenance/starboard)
 "cel" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Paramedic";
 	req_access_txt = "66"
 	},
@@ -47961,7 +47936,6 @@
 /area/hydroponics)
 "ceq" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Paramedic";
 	req_access_txt = "66"
 	},
@@ -50028,9 +50002,7 @@
 	},
 /obj/item/clothing/accessory/stethoscope,
 /obj/item/clothing/accessory/stethoscope,
-/obj/item/gun/syringe,
 /obj/structure/table/glass,
-/obj/item/gun/syringe,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whiteblue"
@@ -50789,7 +50761,6 @@
 /area/maintenance/aft)
 "ckI" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
@@ -52912,7 +52883,6 @@
 "cpD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
@@ -54857,7 +54827,6 @@
 "ctJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medical Reception";
 	req_access_txt = "5"
 	},
@@ -56716,7 +56685,6 @@
 "cye" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable/white,
-/obj/item/gun/syringe,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cyf" = (
@@ -56880,7 +56848,6 @@
 "cyy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
@@ -58141,7 +58108,6 @@
 "cBo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Recovery Ward"
 	},
 /turf/simulated/floor/plasteel/white,
@@ -58818,7 +58784,6 @@
 "cCy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Recovery Ward"
 	},
 /obj/structure/cable/yellow{
@@ -63738,7 +63703,6 @@
 	master_tag = "virology_airlock_control";
 	pixel_x = 10;
 	pixel_y = 25;
-	req_access = null;
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -63928,7 +63892,6 @@
 	tag_airpump = "tox_airlock_apump";
 	tag_chamber_sensor = "tox_airlock_sensor";
 	tag_exterior_door = "tox_airlock_exterior";
-	tag_exterior_sensor = null;
 	tag_interior_door = "tox_airlock_interior"
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
@@ -64341,7 +64304,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Research Division Server Room";
-	req_access = null;
 	req_access_txt = "30"
 	},
 /obj/structure/cable/yellow{
@@ -78675,7 +78637,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -406,7 +406,6 @@
 /area/ruin/unpowered)
 "aW" = (
 /obj/structure/table/reinforced,
-/obj/item/gun/syringe,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2730,7 +2730,6 @@
 "akl" = (
 /obj/machinery/door/airlock/security{
 	name = "Warden's office";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -2833,7 +2832,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -3375,7 +3373,6 @@
 "alL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	id_tag = null;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -7952,8 +7949,7 @@
 	name = "processing tint control";
 	pixel_x = -24;
 	pixel_y = -8;
-	req_access_txt = "63";
-	tag = null
+	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -8567,7 +8563,6 @@
 "awa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	id_tag = null;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -8656,7 +8651,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Prisoner Processing";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -9055,7 +9049,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Execution Room";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/structure/cable{
@@ -9256,7 +9249,6 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -9333,7 +9325,6 @@
 "axI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	id_tag = null;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -9406,7 +9397,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Prisoner Processing";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -10096,7 +10086,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12901,7 +12890,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
-	req_access = null;
 	req_access_txt = "4"
 	},
 /obj/structure/cable{
@@ -15019,7 +15007,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Detective";
-	req_access = null;
 	req_access_txt = "4"
 	},
 /turf/simulated/floor/plasteel/grimy,
@@ -22821,7 +22808,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34150,7 +34136,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
-	req_access = null;
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34189,7 +34174,6 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "captainofficedoor";
 	name = "Captain's Office";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35689,7 +35673,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Paramedic";
 	req_access_txt = "66"
 	},
@@ -38074,7 +38057,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
-	req_access = null;
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -39853,7 +39835,6 @@
 "bOx" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/structure/cable{
@@ -39872,9 +39853,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
-	id_tag = null;
 	name = "Captain's Office";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40777,7 +40756,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -41080,7 +41058,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Paramedic";
 	req_access_txt = "66"
 	},
@@ -41221,11 +41198,6 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/item/gun/syringe,
-/obj/item/gun/syringe{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -41845,7 +41817,6 @@
 "bSt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medbay Reception";
 	req_access_txt = "5"
 	},
@@ -41888,7 +41859,6 @@
 "bSx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Chemistry Lab";
 	req_access_txt = "33"
 	},
@@ -47399,7 +47369,6 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "hopofficedoor";
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47636,7 +47605,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
-	req_access = null;
 	req_access_txt = "30"
 	},
 /obj/structure/cable{
@@ -47862,7 +47830,6 @@
 "cee" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Observation Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47878,7 +47845,6 @@
 "cef" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Observation Room"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -49221,13 +49187,11 @@
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	icon_state = "rightsecure";
-	name = "Server Exterior Door";
-	req_access = null
+	name = "Server Exterior Door"
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
-	name = "Server Interior Door";
-	req_access = null
+	name = "Server Interior Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51759,7 +51723,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Virology Lobby Hallway"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -52301,7 +52264,6 @@
 "cnw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Virology Lobby Hallway"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -55240,7 +55202,6 @@
 "csX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Monkey Pen";
 	req_access_txt = "39"
 	},
@@ -55726,7 +55687,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westright{
 	name = "Engineering Monitoring Station";
-	req_access = null;
 	req_one_access_txt = "11;24;34"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -56350,8 +56310,7 @@
 /area/toxins/mixing)
 "cvf" = (
 /obj/machinery/atmospherics/trinary/mixer{
-	dir = 8;
-	req_access = null
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/mixing)
@@ -56654,7 +56613,6 @@
 "cvO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Isolation B";
 	req_access_txt = "39"
 	},
@@ -56737,7 +56695,6 @@
 "cvX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Secondary Storage";
 	req_access_txt = "5"
 	},
@@ -56851,7 +56808,6 @@
 "cwh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Isolation A";
 	req_access_txt = "39"
 	},
@@ -71624,8 +71580,7 @@
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_y = -24;
-	req_access_txt = "10";
-	req_one_access = null
+	req_access_txt = "10"
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
@@ -76414,7 +76369,6 @@
 /obj/machinery/door/window/southright{
 	dir = 1;
 	name = "AI Core Door";
-	req_access = null;
 	req_access_txt = "16"
 	},
 /turf/simulated/floor/bluegrid,

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -166,6 +166,7 @@
 	new /obj/item/handheld_defibrillator(src)
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/flash(src)
+	new /obj/item/gun/syringe(src)
 	new /obj/item/reagent_containers/hypospray/CMO(src)
 	new /obj/item/organ/internal/cyberimp/eyes/hud/medical(src)
 	new /obj/item/door_remote/chief_medical_officer(src)


### PR DESCRIPTION
## What Does This PR Do
- Removes the public syringe guns from: the three station maps and the abandoned zoo ruin
- Adds a syringe gun to the CMO locker

## Why It's Good For The Game
This PR is reliant on #17816, **please do not merge this PR without that one**. Part 2 of 2 of the rebalancing of syringe guns, part one is #17816.

This change was discussed on Paradise's Discord server, [starting from here](https://discord.com/channels/145533722026967040/145700319819464704/975381887327543386).

As @lewcc stated, syringe guns are insanely powerful weapons, all too readily available, especially for non-antaghunter roles (medical). One ether syringe is capable of roundending a wizard or a cultist (to my experience, the two most griefed antagonists). 

**Most often, syringe guns are used for validhunting,** and though validhunters are dealt with by admins, we should minimise rule-breaking by code whenever possible - plus, if someone gets hit by a syringe, their round is usually already over, even if their assaulter gets dingdong banned for validing.

Questions I received about this:
**Q: Why balance the game around validhunters?**
A: While generally I am against this mindset as well, the syringe gun has no real use at the moment for the average doctor who currently has access to it. Thus, it was moved to the CMO locker. The CMO can still hand out the syringe gun for self-defence (e.g. when cult hits 30%).

**Q: If you move this to the CMO locker, will it just not empower antag CMOs even more?**
A: No, the CMO already has access to the syringe guns. If they wanted to use a syringe gun, they already could.

**Q: What about my syringe gun + perfluo kidnap strategy?**
A: If you are a traitor, you can buy the improved RSG, see #17816. If you are not a traitor, you have inbuilt skills for stunning and muting.

**Q: Why remove it from the space ruin?**
A: The abandoned zoo poses no threat to the explorer, yet rewards them with a powerful weapon.

## Images of changes

## Changelog
:cl:
add: Added a syringe gun to the CMO locker.
del: Removed the syringe guns from all three station maps and the abandoned zoo ruin.
/:cl:
