### PR TITLE
Removes dangerous Mega Clusterbusters

### DIFF
--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -253,10 +253,7 @@
 	payload = /obj/item/grenade/gas/knockout
 
 ////////////Clusterbuster of Clusterbusters////////////
-
-/obj/item/grenade/clusterbuster/mega_fox
-	name = "\improper Mega Troublemaking Grenade."
-	payload = /obj/item/grenade/clusterbuster/fox
+//As a note: be extrodinarily careful about make the payload clusterbusters as it can quickly destroy the MC/Server
 
 /obj/item/grenade/clusterbuster/mega_bang
 	name = "For when stunlocking is just too short."
@@ -266,10 +263,3 @@
 	name = "Mega SyndiWrath."
 	payload = /obj/item/grenade/clusterbuster/syndieminibomb
 
-/obj/item/grenade/clusterbuster/mega_honk_evil
-	name = "\improper Mega Evil Mega Honk Grenade."
-	payload = /obj/item/grenade/clusterbuster/honk_evil
-
-/obj/item/grenade/clusterbuster/mega_emp
-	name = "Electromagnetic Storm"
-	payload = /obj/item/grenade/clusterbuster/emp


### PR DESCRIPTION
## What Does This PR Do
Removes the Mega Troublemaking Grenade, Mega Evil Mega Honk Grenade, and Electromagnetic Storm. 

**Mega Troublemaking Grenade:** From testing, this has spawned up to 700 foxes in a single detonation
**Mega Evil Mega Honk Grenade:** On my test server this spawned 13,000 banana peels, yes thirteen thousand
**Electromagnetic Storm:** In both attempts to test this, I couldn't count the number of EMP blasts because both times it brought the MC to Defcon 1
## Why It's Good For The Game
Each of these grenades will bring the server to its knees and if not force the Master Controller to restart, it will cripple server performance for an indefinite amount of time. There is no prior indication to admins or players that these grenades are capable of doing this to the server, even testing this out in admin testing will destroy server performance.

## Changelog
:cl:
del: Removes fox, banana, and emp MEGA clusterbuster grenades. 
/:cl:
