### PR TITLE
Fixes the honkmensional tear's leader spawn and dchat announcement

### DIFF
--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -9,6 +9,9 @@
 	name = "dimensional tear"
 	announceWhen = 6
 	endWhen = 10
+	var/notify_title = "Dimensional Rift"
+	var/notify_image = "hellhound"
+
 	var/obj/effect/tear/TE
 
 /datum/event/tear/setup()
@@ -18,8 +21,8 @@
 	var/turf/T = pick(get_area_turfs(impact_area))
 	if(T)
 		// Give ghosts some time to jump there before it begins.
-		var/image/alert_overlay = image('icons/mob/animal.dmi', "hellhound")
-		notify_ghosts("\A [src] is about to open in [get_area(T)].", title = "Dimensional Rift", source = T, alert_overlay = alert_overlay, action = NOTIFY_FOLLOW)
+		var/image/alert_overlay = image('icons/mob/animal.dmi', notify_image)
+		notify_ghosts("\A [src] is about to open in [get_area(T)].", title = notify_title, source = T, alert_overlay = alert_overlay, action = NOTIFY_FOLLOW)
 		addtimer(CALLBACK(src, .proc/spawn_tear, T), 4 SECONDS)
 
 		// Energy overload; we mess with machines as an early warning and for extra spookiness.
@@ -48,30 +51,21 @@
 	pixel_x = -106
 	pixel_y = -96
 
+	var/list/possible_mobs = list(
+		/mob/living/simple_animal/hostile/netherworld,
+		/mob/living/simple_animal/hostile/netherworld/migo,
+		/mob/living/simple_animal/hostile/faithless)
+
 /obj/effect/tear/Initialize(mapload)
 	. = ..()
 	// Sound cue to warn people nearby.
 	playsound(get_turf(src), 'sound/magic/drum_heartbeat.ogg', 100)
-
-	// Portal opening animation.
-	var/atom/movable/overlay/animation = new(loc)
-	animation.pixel_x = pixel_x
-	animation.pixel_y = pixel_y
-	animation.icon_state = "newtear"
-	animation.icon = 'icons/effects/tear.dmi'
-	animation.master = src
-	QDEL_IN(animation, 1.5 SECONDS)
 
 	// We spawn the minions first, then the boss.
 	addtimer(CALLBACK(src, .proc/spawn_mobs), 2 SECONDS)
 	addtimer(CALLBACK(src, .proc/spawn_leader), 5 SECONDS)
 
 /obj/effect/tear/proc/spawn_mobs()
-	var/list/possible_mobs = list(
-		/mob/living/simple_animal/hostile/netherworld,
-		/mob/living/simple_animal/hostile/netherworld/migo,
-		/mob/living/simple_animal/hostile/faithless)
-
 	// We break some of those flickering consoles from earlier.
 	// Mirrors as well, for the extra bad luck.
 	for(var/obj/machinery/computer/C in range(6, src))

--- a/code/modules/events/tear_honk.dm
+++ b/code/modules/events/tear_honk.dm
@@ -1,25 +1,23 @@
 /datum/event/tear/honk
-	var/obj/effect/tear/honk/HE //i could just inherit but its being finicky.
+	name = "honkmensional tear"
+	notify_title = "Honkmensional Tear"
+	notify_image = "clowngoblin"
+	var/obj/effect/tear/honk/HE
+
+/datum/event/tear/honk/spawn_tear(location)
+	HE = new /obj/effect/tear/honk(location)
 
 /datum/event/tear/honk/announce()
 	GLOB.event_announcement.Announce("A Honknomoly has opened. Expected location: [impact_area.name].", "Honknomoly Alert", 'sound/items/airhorn.ogg')
-
-/datum/event/tear/honk/start()
-	var/turf/T = pick(get_area_turfs(impact_area))
-	if(T)
-		HE = new /obj/effect/tear/honk(T.loc)
 
 /datum/event/tear/honk/end()
 	if(HE)
 		qdel(HE)
 
 /obj/effect/tear/honk
-	name = "Honkmensional Tear"
+	name = "honkmensional tear"
 	desc = "A tear in the dimensional fabric of sanity."
+	possible_mobs = list(/mob/living/simple_animal/hostile/retaliate/clown/goblin)
 
-/obj/effect/tear/honk/spawn_mobs()
-	for(var/i in 1 to 6)
-		var/mob/living/simple_animal/hostile/retaliate/clown/goblin/G = new(get_turf(src))
-		if(prob(50))
-			for(var/j = 1, j <= rand(1, 3), j++)
-				step(G, pick(NORTH, SOUTH, EAST, WEST))
+/obj/effect/tear/honk/spawn_leader()
+	return


### PR DESCRIPTION
## What Does This PR Do
1. The hellhound no longer spawns during a honknomoly event (and kills the clown goblins)
2. Honknamoly events are now properly announced
3. Cleans up code

## Why It's Good For The Game
When I did #17629 I was not aware of its subtype and I inadvertently broke it.

This subtype also didn't get announced.

## Images of changes

https://user-images.githubusercontent.com/33333517/168895704-a12c1058-6b14-4047-8bbf-1d3dd06a6e37.mp4

## Changelog
:cl:
fix: The honkmensional tear no longer spawns a hellhound.
fix: The honkmensional tear is now properly announced to ghosts.
/:cl:
