### PR TITLE
Delta: Widen access for public-facing Botany windoor.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -94128,8 +94128,7 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/door/window/eastleft{
-	name = "Hydroponics Desk";
-	req_access_txt = "35"
+	name = "Hydroponics Desk"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Clears the access requirements for the public-facing windoor at the Botany counter.

## Why It's Good For The Game

This is almost certainly meant to be public. AFAIK we don't really have a pattern of "counter with double windoors that both require department access". It occurs to me that this windoor may not actually supposed to be there, to mirror the chef's counter across the hall, and the southern botany counter, but this is the "less intrusive" adjustment.

## Images of changes

![paradise  _maps_map_files_Delta_delta dmm  - StrongDMM-02_38_50](https://user-images.githubusercontent.com/59303604/168974540-40fc41d8-45a6-48b0-b8a6-8b8d73b6cd59.png)

## Changelog
:cl:
tweak: Delta: Botany's north counter now has public access for the public-facing windoor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
