### PR TITLE
Fix TGUI deprecation warnings

### DIFF
--- a/tgui/packages/tgui/styles/functions.scss
+++ b/tgui/packages/tgui/styles/functions.scss
@@ -18,9 +18,9 @@
     @return null;
   }
   @if math.unit($value) == '%' {
-    @return $value / 100%;
+    @return math.div($value, 100%);
   }
-  @return $value / ($value * 0 + 1);
+  @return math.div($value, ($value * 0 + 1));
 }
 
 //  Color
@@ -48,11 +48,11 @@
 
   @each $name, $value in $colors {
     $adjusted: 0;
-    $value: $value / 255;
+    $value: math.div($value, 255);
     @if $value < 0.03928 {
-      $value: $value / 12.92;
+      $value: math.div($value, 12.92);
     } @else {
-      $value: ($value + 0.055) / 1.055;
+      $value: math.div(($value + 0.055), 1.055);
       $value: math.pow($value, 2.4);
     }
     $colors: map.merge(


### PR DESCRIPTION
Like this one
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($value, 12.92) or calc($value / 12.92)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
53 │       $value: $value / 12.92;
   │               ^^^^^^^^^^^^^^
   ╵
    styles\functions.scss 53:15          luminance()
    styles\components\Button.scss 16:15  button-color()
    styles\components\Button.scss 107:3  load-css()
    stdin 22:3                           root stylesheet
```
and friends.

I'm not sure if that slipped through the cracks in #17809, or it's just due to normal nodejs update churn, but regardless, these warnings are mildly annoying, and easy to fix.