### PR TITLE
Tweaks turret deployment

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -616,15 +616,15 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(target(M))
 			return 1
 
-/obj/machinery/porta_turret/proc/check_popUp()
+/obj/machinery/porta_turret/proc/check_pop_up()
 	/// Whitelist to determine what objects can be put over turrets while letting them deploy
 	var/static/list/deployment_whitelist = typecacheof(list(
-	/obj/structure/window/reinforced,
-	/obj/structure/window/basic,
-	/obj/structure/window/plasmabasic,
-	/obj/structure/window/plasmareinforced,
-	/obj/machinery/door/window,
-	/obj/structure/railing,
+		/obj/structure/window/reinforced,
+		/obj/structure/window/basic,
+		/obj/structure/window/plasmabasic,
+		/obj/structure/window/plasmareinforced,
+		/obj/machinery/door/window,
+		/obj/structure/railing,
 	))
 	if(disabled)
 		return
@@ -699,7 +699,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	if(target)
 		last_target = target
 		if(has_cover)
-			check_popUp()				//pop the turret up if it's not already up.
+			check_pop_up()				//pop the turret up if it's not already up.
 		// Set angle
 		set_angle(get_angle(src, target))
 		shootAt(target)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -66,9 +66,7 @@
 	var/scan_range = 7
 	var/always_up = FALSE		//Will stay active
 	var/has_cover = TRUE		//Hides the cover
-	/// Whitelist to determine what objects can be put over turrets
-	var/list/deployment_whitelist = list(/obj/structure/window/reinforced, /obj/structure/window/basic, /obj/structure/window/plasmabasic, /obj/structure/window/plasmareinforced)
-	/// Deployment override to allow turret popup on dense turfs, for admin turrets
+	/// Deployment override to allow turret popup on/under dense turfs/objects, for admin/CC turrets
 	var/deployment_override
 
 
@@ -633,7 +631,15 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(A == src)
 			continue
 		if(A.density)
-			if(is_type_in_list(A, deployment_whitelist))
+			/// Whitelist to determine what objects can be put over turrets while letting them deploy
+			var/static/list/deployment_whitelist = typecacheof(list(
+			/obj/structure/window/reinforced,
+			/obj/structure/window/basic,
+			/obj/structure/window/plasmabasic,
+			/obj/structure/window/plasmareinforced,
+			/obj/machinery/door/window,
+			))
+			if(is_type_in_typecache(A, deployment_whitelist))
 				continue
 			return
 	pop_up()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -436,7 +436,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		controllock = TRUE
 		enabled = FALSE //turns off the turret temporarily
 		sleep(60) //6 seconds for the traitor to gtfo of the area before the turret decides to ruin his shit
-		enabled = TRUE //turns it back on. The cover popUp() popDown() are automatically called in process(), no need to define it here
+		enabled = TRUE //turns it back on. The cover pop_up() pop_down() are automatically called in process(), no need to define it here
 
 /obj/machinery/porta_turret/take_damage(force)
 	if(!raised && !raising)
@@ -509,13 +509,13 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	if(stat & (NOPOWER|BROKEN))
 		if(!always_up)
 			//if the turret has no power or is broken, make the turret pop down if it hasn't already
-			popDown()
+			pop_down()
 		return
 
 	if(!enabled)
 		if(!always_up)
 			//if the turret is off, make it pop down
-			popDown()
+			pop_down()
 		return
 
 	var/list/targets = list()			//list of primary targets
@@ -546,7 +546,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	if(!tryToShootAt(targets))
 		if(!tryToShootAt(secondarytargets)) // if no valid targets, go for secondary targets
 			if(!always_up)
-				popDown() // no valid targets, close the cover
+				pop_down() // no valid targets, close the cover
 
 /obj/machinery/porta_turret/proc/in_faction(mob/living/target)
 	if(!(faction in target.faction))
@@ -626,7 +626,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	if(stat & BROKEN)
 		return
 	if(deployment_override)
-		popUp()
+		pop_up()
 	// check if anything's preventing us from raising
 	var/turf/T = get_turf(src)
 	for(var/atom/A in T)
@@ -636,9 +636,9 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			if(is_type_in_list(A, deployment_whitelist))
 				continue
 			return
-	popUp()
+	pop_up()
 
-/obj/machinery/porta_turret/proc/popUp()	//pops the turret up
+/obj/machinery/porta_turret/proc/pop_up()	//pops the turret up
 	set_raised_raising(raised, TRUE)
 	playsound(get_turf(src), 'sound/effects/turret/open.wav', 60, 1)
 	update_icon()
@@ -652,7 +652,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	set_raised_raising(TRUE, FALSE)
 	update_icon()
 
-/obj/machinery/porta_turret/proc/popDown()	//pops the turret down
+/obj/machinery/porta_turret/proc/pop_down()	//pops the turret down
 	last_target = null
 	if(disabled)
 		return

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -617,6 +617,14 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			return 1
 
 /obj/machinery/porta_turret/proc/check_popUp()
+	/// Whitelist to determine what objects can be put over turrets while letting them deploy
+	var/static/list/deployment_whitelist = typecacheof(list(
+	/obj/structure/window/reinforced,
+	/obj/structure/window/basic,
+	/obj/structure/window/plasmabasic,
+	/obj/structure/window/plasmareinforced,
+	/obj/machinery/door/window,
+	))
 	if(disabled)
 		return
 	if(raising || raised)
@@ -631,14 +639,6 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(A == src)
 			continue
 		if(A.density)
-			/// Whitelist to determine what objects can be put over turrets while letting them deploy
-			var/static/list/deployment_whitelist = typecacheof(list(
-			/obj/structure/window/reinforced,
-			/obj/structure/window/basic,
-			/obj/structure/window/plasmabasic,
-			/obj/structure/window/plasmareinforced,
-			/obj/machinery/door/window,
-			))
 			if(is_type_in_typecache(A, deployment_whitelist))
 				continue
 			return

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -624,6 +624,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	/obj/structure/window/plasmabasic,
 	/obj/structure/window/plasmareinforced,
 	/obj/machinery/door/window,
+	/obj/structure/railing,
 	))
 	if(disabled)
 		return

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -67,7 +67,7 @@
 	var/always_up = FALSE		//Will stay active
 	var/has_cover = TRUE		//Hides the cover
 	/// Deployment override to allow turret popup on/under dense turfs/objects, for admin/CC turrets
-	var/deployment_override
+	var/deployment_override = FALSE
 
 
 /obj/machinery/porta_turret/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Since https://github.com/ParadiseSS13/Paradise/pull/17662 was merged, turrets on certain admin shuttles have not been deploying since they are behind directional windows. These are not the same as fulltile windows and should not logically block turret deployment, as such I have implemented an exceptions whitelist to dense objects that would normally block their deployment. This currently includes all indoors and all directional windows.
Centcomm subclass turrets can also deploy regardless of density.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admin turrets (Centcomm ones) should disregard normal rules since they are often placed in strange places that make it hard for players to kill them.
Also, logically, things that are not actually blocking the turret (directional windows) should be fine for allowing deployment.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked admin turrets to always deploy when needed, regardless of location
fix: Fixed directional windows blocking regular turret deployment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
