### PR TITLE
Fix vampire thralls appearing in both the vampire thrall and mindslave section of the Check Antagonists UI

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -47,6 +47,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 /datum/antagonist/Destroy(force, ...)
 	QDEL_LIST(objectives)
+	remove_owner_from_gamemode()
 	GLOB.antagonists -= src
 	if(!silent)
 		farewell()
@@ -59,6 +60,18 @@ GLOBAL_LIST_EMPTY(antagonists)
 	restore_last_hud_and_role()
 	owner = null
 	return ..()
+
+/**
+ * Adds the owner to their respective gamemode's list. For example `SSticker.mode.traitors |= owner`.
+ */
+/datum/antagonist/proc/add_owner_to_gamemode()
+	return
+
+/**
+ * Removes the owner from their respective gamemode's list. For example `SSticker.mode.traitors -= owner`.
+ */
+/datum/antagonist/proc/remove_owner_from_gamemode()
+	return
 
 /**
  * Loops through the owner's `antag_datums` list and determines if this one is blacklisted by any others.
@@ -255,6 +268,7 @@ GLOBAL_LIST_EMPTY(antagonists)
  */
 /datum/antagonist/proc/on_gain()
 	owner.special_role = special_role
+	add_owner_to_gamemode()
 	if(give_objectives)
 		give_objectives()
 	if(!silent)

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -28,13 +28,9 @@
 		owner.som.serv -= owner
 		owner.som.leave_serv_hud(owner)
 	master = null
-	SSticker.mode.implanted[owner] = null
-	SSticker.mode.implanted -= owner
 	return ..()
 
 /datum/antagonist/mindslave/on_gain()
-	SSticker.mode.implanted[owner] = master
-
 	var/datum/mindslaves/slaved = master.som
 	if(!slaved) // If the master didn't already have this, we need to make a new mindslaves datum.
 		slaved = new
@@ -48,6 +44,13 @@
 	set_antag_hud(master.current, "hudmaster")
 	slaved.add_serv_hud(master, "master")
 	return ..()
+
+/datum/antagonist/mindslave/add_owner_to_gamemode()
+	SSticker.mode.implanted[owner] = master
+
+/datum/antagonist/mindslave/remove_owner_from_gamemode()
+	SSticker.mode.implanted[owner] = null
+	SSticker.mode.implanted -= owner
 
 /datum/antagonist/mindslave/give_objectives()
 	var/explanation_text = "Obey every order from and protect [master.current.real_name], the [master.assigned_role ? master.assigned_role : master.special_role]."

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -22,7 +22,6 @@
 		owner.som = new /datum/mindslaves
 
 	owner.som.masters += owner
-	SSticker.mode.traitors |= owner
 	..()
 
 /datum/antagonist/traitor/Destroy(force, ...)
@@ -46,8 +45,13 @@
 		owner.som = null
 
 	owner.current.client.chatOutput?.clear_syndicate_codes()
-	SSticker.mode.traitors -= owner
 	return ..()
+
+/datum/antagonist/traitor/add_owner_to_gamemode()
+	SSticker.mode.traitors |= owner
+
+/datum/antagonist/traitor/remove_owner_from_gamemode()
+	SSticker.mode.traitors -= owner
 
 /datum/antagonist/traitor/add_antag_hud(mob/living/antag_mob)
 	var/is_contractor = LAZYACCESS(GLOB.contractors, owner)

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -32,22 +32,20 @@
 	antag_hud_type = ANTAG_HUD_VAMPIRE
 	antag_hud_name = "vampthrall"
 
-/datum/antagonist/mindslave/thrall/on_gain()
+/datum/antagonist/mindslave/thrall/add_owner_to_gamemode()
 	SSticker.mode.vampire_enthralled += owner
-	..()
 
-/datum/antagonist/mindslave/thrall/Destroy(force, ...)
+/datum/antagonist/mindslave/thrall/remove_owner_from_gamemode()
 	SSticker.mode.vampire_enthralled -= owner
-	return ..()
 
-/datum/antagonist/mindslave/thrall/apply_innate_effects(mob/living/new_body)
-	..()
-	var/datum/mind/M = new_body?.mind || owner
+/datum/antagonist/mindslave/thrall/apply_innate_effects(mob/living/mob_override)
+	mob_override = ..()
+	var/datum/mind/M = mob_override.mind
 	M.AddSpell(new /obj/effect/proc_holder/spell/vampire/thrall_commune)
 
-/datum/antagonist/mindslave/thrall/remove_innate_effects(mob/living/old_body)
-	..()
-	var/datum/mind/M = old_body?.mind || owner
+/datum/antagonist/mindslave/thrall/remove_innate_effects(mob/living/mob_override)
+	mob_override = ..()
+	var/datum/mind/M = mob_override.mind
 	M.RemoveSpell(/obj/effect/proc_holder/spell/vampire/thrall_commune)
 
 /datum/antagonist/vampire/Destroy(force, ...)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some new procs to `/datum/antagonist` so that antag datums can add/remove their owner from their respective gamemode lists. Stops antag datum subtypes from being added to their parent's gamemode list, which is what was happening with thralls and mindslaves.

Also updates args and logic in `/datum/antagonist/mindslave/thrall/apply_innate_effects` and `/datum/antagonist/mindslave/thrall/remove_innate_effects`. This was missed in when I did #17517
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Fix vampire thralls appearing in both the vampire thrall and mindslave section of the Check Antagonists UI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
