### PR TITLE
Stops me from having a heart attack looking at defib code, and cleans it up.

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -21,9 +21,9 @@
 	var/powered = FALSE //if there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
 	var/obj/item/twohanded/shockpaddles/paddles
 	var/obj/item/stock_parts/cell/high/cell = null
-	var/safety = TRUE //if you can zap people with the defibs on harm mode
+	var/safety = TRUE //if this is FALSE you can zap people with the defibs on harm mode
 	var/combat = FALSE //can we revive through space suits?
-	var/heart_attack = FALSE //can it give instant heart attacks when zapped on harm intent with combat?
+	var/heart_attack = FALSE //if TRUE it always cause heart attacks if it is a combat defib.
 	base_icon_state = "defibpaddles"
 	var/obj/item/twohanded/shockpaddles/paddle_type = /obj/item/twohanded/shockpaddles
 
@@ -237,6 +237,7 @@
 	paddle_type = /obj/item/twohanded/shockpaddles/syndicate
 	combat = TRUE
 	safety = FALSE
+	heart_attack = TRUE
 
 /obj/item/defibrillator/compact/combat/loaded/Initialize(mapload)
 	. = ..()
@@ -251,7 +252,6 @@
 	paddle_type = /obj/item/twohanded/shockpaddles/advanced
 	combat = TRUE
 	safety = TRUE
-	heart_attack = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //Objective item, better not have it destroyed.
 
 	var/next_emp_message //to prevent spam from the emagging message on the advanced defibrillator
@@ -377,7 +377,7 @@
 			H.Weaken(5)
 			playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 			H.emote("gasp")
-			if(!H.undergoing_cardiac_arrest() && (prob(10) || (defib.combat && !defib.heart_attack) || prob(10) && (defib.combat && defib.heart_attack))) // Your heart explodes.
+			if(!H.undergoing_cardiac_arrest() && (prob(10) || (defib.combat && defib.heart_attack) || prob(10) && (defib.combat))) // If the victim is not having a heart attack, and a 10% chance passes, or the defib has heart attack variable to TRUE while being a combat defib, or if another 10% chance passes with combat being TRUE
 				H.set_heartattack(TRUE)
 			SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 			add_attack_logs(user, M, "Stunned with [src]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->


## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Comments the safety variable to indicate it must be FALSE to be used to attack with.
Changes / comments the heart_attack variable to cause heart attacks 100% of the time when true... rather then when it is FALSE.

Removes an unnecessary defib.heart_attack check (which would now be !defib.heart_attack), as combat defibs always have heart_attack true or false, and since we already checked if it is true, we don't need to check if it is false, just that it is combat.
Also comments it, so it is easier to read what is happening in that large if statement.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No player changes, just makes the code cleaner and commented.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
