### PR TITLE
Makes setting a machine GC properly if not unset properly

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -774,7 +774,7 @@
 	controlling = FALSE
 
 	reset_perspective(null)
-	machine = null
+	unset_machine()
 
 	host.verbs -= /mob/living/carbon/proc/release_control
 	host.verbs -= /mob/living/carbon/proc/punish_host

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -590,10 +590,10 @@
 	GrantBorerActions()
 	RemoveInfestActions()
 	forceMove(get_turf(host))
-	machine = null
+	unset_machine()
 
 	host.reset_perspective(null)
-	host.machine = null
+	host.unset_machine()
 
 	var/mob/living/carbon/H = host
 	H.borer = null

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -171,6 +171,7 @@
 
 /mob/proc/unset_machine()
 	if(machine)
+		UnregisterSignal(machine, COMSIG_PARENT_QDELETING)
 		machine.on_unset_machine(src)
 		machine = null
 
@@ -184,6 +185,7 @@
 	src.machine = O
 	if(istype(O))
 		O.in_use = TRUE
+		RegisterSignal(O, COMSIG_PARENT_QDELETING, .proc/unset_machine)
 
 /obj/item/proc/updateSelfDialog()
 	var/mob/M = src.loc

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -738,21 +738,6 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		if(M)
 			M.transfer_ai(AI_MECH_HACK, src, usr) //Called om the mech itself.
 
-	else if(href_list["faketrack"])
-		var/mob/target = locate(href_list["track"]) in GLOB.mob_list
-		var/mob/living/silicon/ai/A = locate(href_list["track2"]) in GLOB.mob_list
-		if(A && target)
-
-			A.cameraFollow = target
-			to_chat(A, "Now tracking [target.name] on camera.")
-			if(usr.machine == null)
-				usr.machine = usr
-
-			while(cameraFollow == target)
-				to_chat(usr, "Target is not on or near any active cameras on the station. We'll check again in 5 seconds (unless you use the cancel-camera verb).")
-				sleep(40)
-				continue
-
 	else if(href_list["open"])
 		var/mob/target = locate(href_list["open"]) in GLOB.mob_list
 		if(target)


### PR DESCRIPTION
## What Does This PR Do
Alternative to #17520
Related to #17507

Makes setting a machine register on the machine to see if it gets destroyed or not. Fixing all GC issues where a destroyed `machine` does not unset the machine variable on the using mob.

Deletes some unused AI code which used hacky code for setting a machine... which wasn't an `obj`

## Why It's Good For The Game
Improves GC

## Changelog
No functional changes