### PR TITLE
Makes the feral cat grenade not spawn the cats in nullspace

### DIFF
--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -7,6 +7,7 @@
 	origin_tech = "materials=3;magnets=4"
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
+	var/flash_viewers = TRUE
 	spawner_type = /mob/living/simple_animal/hostile/viscerator
 
 /obj/item/grenade/spawnergrenade/prime() // Prime now just handles the two loops that query for people in lockers and people who can see it.
@@ -15,8 +16,9 @@
 		// Make a quick flash
 		var/turf/T = get_turf(src)
 		playsound(T, 'sound/effects/phasein.ogg', 100, 1)
-		for(var/mob/living/carbon/C in viewers(T, null))
-			C.flash_eyes()
+		if(flash_viewers)
+			for(var/mob/living/carbon/C in viewers(T, null))
+				C.flash_eyes()
 
 		for(var/i in 1 to deliveryamt)
 			var/atom/movable/x = new spawner_type(T)
@@ -48,20 +50,4 @@
 	spawner_type = /mob/living/simple_animal/hostile/feral_cat
 	deliveryamt = 5
 	origin_tech = "materials=3;magnets=4;syndicate=3"
-
-/obj/item/grenade/spawnergrenade/feral_cats/prime()			//Own proc for this because the regular one would flash people which was dumb.
-	update_mob()
-	if(spawner_type && deliveryamt)
-		var/turf/T = get_turf(src)
-		playsound(T, 'sound/effects/phasein.ogg', 100, 1)
-
-		for(var/i=1, i<=deliveryamt, i++)
-			var/atom/movable/x = new spawner_type
-			x.loc = T
-			if(prob(50))
-				for(var/j = 1, j <= rand(1, 3), j++)
-					step(x, pick(NORTH,SOUTH,EAST,WEST))
-
-
-	qdel(src)
-	return
+	flash_viewers = FALSE


### PR DESCRIPTION
## What Does This PR Do
Removes the weird custom logic of feral cats. Thus fixing them spawning in null space.
The not flashing part was the only difference. That is now an option using a variable.

Fixes:
```
Runtime in unsorted.dm,1932: Simple animal being instantiated in nullspace
   proc name: stack trace (/datum/proc/stack_trace)
   usr: The feral cat () (/mob/living/simple_animal/hostile/feral_cat)
```

## Why It's Good For The Game
Bug fix b gut

## Changelog
NA