### PR TITLE
Mark ui_data procs as SHOULD_NOT_SLEEP(TRUE)

### DIFF
--- a/code/modules/economy/utils.dm
+++ b/code/modules/economy/utils.dm
@@ -16,7 +16,6 @@
 /obj/proc/get_card_account(obj/item/card/I)
 	if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/C = I
-		var/attempt_pin=0
 		var/datum/money_account/D = get_money_account(C.associated_account_number)
 		if(D)
 			return D
@@ -27,7 +26,6 @@
 		var/obj/item/card/id/I=H.get_idcard()
 		if(!I || !istype(I))
 			return null
-		var/attempt_pin=0
 		var/datum/money_account/D = get_money_account(I.associated_account_number)
 		return D
 	else if(issilicon(src))

--- a/code/modules/economy/utils.dm
+++ b/code/modules/economy/utils.dm
@@ -13,21 +13,15 @@
 		return acct
 
 
-/obj/proc/get_card_account(obj/item/card/I, mob/user=null, terminal_name="", transaction_purpose="", require_pin=0)
-	if(terminal_name=="")
-		terminal_name=src.name
+/obj/proc/get_card_account(obj/item/card/I)
 	if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/C = I
 		var/attempt_pin=0
 		var/datum/money_account/D = get_money_account(C.associated_account_number)
-		if(require_pin && user)
-			attempt_pin = input(user,"Enter pin code", "Transaction") as num
-			if(D.remote_access_pin != attempt_pin)
-				return null
 		if(D)
 			return D
 
-/mob/proc/get_worn_id_account(require_pin=0, mob/user=null)
+/mob/proc/get_worn_id_account()
 	if(ishuman(src))
 		var/mob/living/carbon/human/H=src
 		var/obj/item/card/id/I=H.get_idcard()
@@ -35,10 +29,6 @@
 			return null
 		var/attempt_pin=0
 		var/datum/money_account/D = get_money_account(I.associated_account_number)
-		if(require_pin && user)
-			attempt_pin = input(user,"Enter pin code", "Transaction") as num
-			if(D.remote_access_pin != attempt_pin)
-				return null
 		return D
 	else if(issilicon(src))
 		return GLOB.station_account

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -29,6 +29,11 @@
  * * mob/user - The mob interacting with the UI.
  */
 /datum/proc/ui_data(mob/user)
+	// Two good reasons why it shouldn't:
+	// 1) this is polled several times a second, so sleeping means more running threads, needlessly tanking performance
+	// 2) if you try to sleep, you get fun bugs ranging from BSOD to uninteractable white windows, to windows straight up vanishing.
+	// Just don't.
+	SHOULD_NOT_SLEEP(TRUE)
 	return list() // Not implemented.
 
 /**
@@ -43,6 +48,7 @@
  * * mob/user - The mob interacting with the UI.
  */
 /datum/proc/ui_static_data(mob/user)
+	SHOULD_NOT_SLEEP(TRUE)
 	return list()
 
 /**


### PR DESCRIPTION
## What Does This PR Do
Adds `SHOULD_NOT_SLEEP(TRUE)` on `ui_data` and `ui_static_data` calls (and makes the existing "sleeping" calls not do that)

Credit to @DamianX  for the idea

## Why It's Good For The Game
Catches a rare, but - evidently - very real bugs.


## Changelog
No user-facing changes.