### PR TITLE
Prevents legless people from using Krav Maga legsweep

### DIFF
--- a/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
+++ b/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
@@ -5,6 +5,9 @@
 /datum/martial_combo/krav_maga/leg_sweep/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	if(target.stat || target.IsWeakened())
 		return FALSE
+	if(!user.get_num_legs())
+		to_chat(user, "<span class='warning'>You suddenly notice you have no legs with which to sweep - how did that happen?!</span>")
+		return MARTIAL_COMBO_DONE_CLEAR_COMBOS
 	user.do_attack_animation(target, ATTACK_EFFECT_KICK)
 	target.visible_message("<span class='warning'>[user] leg sweeps [target]!</span>", \
 					  	"<span class='userdanger'>[user] leg sweeps you!</span>")

--- a/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
+++ b/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
@@ -8,6 +8,9 @@
 	if(!user.get_num_legs())
 		to_chat(user, "<span class='warning'>You suddenly notice you have no legs with which to sweep - how did that happen?!</span>")
 		return MARTIAL_COMBO_DONE_CLEAR_COMBOS
+	if(!target.get_num_legs())
+		to_chat(user, "<span class='warning'>[target] has no legs to sweep!</span>")
+		return MARTIAL_COMBO_DONE_CLEAR_COMBOS
 	user.do_attack_animation(target, ATTACK_EFFECT_KICK)
 	target.visible_message("<span class='warning'>[user] leg sweeps [target]!</span>", \
 					  	"<span class='userdanger'>[user] leg sweeps you!</span>")

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -42,6 +42,9 @@
 	if(owner.incapacitated())
 		to_chat(owner, "<span class='warning'>You can't use Krav Maga while you're incapacitated.</span>")
 		return
+	if(!owner.get_num_legs())
+		to_chat(owner, "<span class='warning'>You can't leg sweep someone if you have no legs.</spawn>")
+		return
 	to_chat(owner, "<b><i>Your next attack will be a Leg Sweep.</i></b>")
 	owner.visible_message("<span class='danger'>[owner] assumes the Leg Sweep stance!</span>")
 	var/mob/living/carbon/human/H = owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes #17752
Prevents people without any legs from using the leg sweep Krav Maga move. This is done both by preventing people from queuing the move with no legs, and by canceling the move if someone with no legs who somehow had it queued attempts to use it.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As humorous as it may be to be leg swept by a person without legs, and as niche as the situation may be, inconsistency is bad.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Attempting to use leg sweep with no legs:
![KravNoLegs](https://user-images.githubusercontent.com/71326864/169906969-0b64555c-e70b-4e58-b76d-45723f81400c.JPG)
Clicking someone with leg sweep queued while not having legs:
![KravNoLegs2](https://user-images.githubusercontent.com/71326864/169907064-94ecc953-60e7-4972-8fb9-5e1cf78dca65.JPG)

## Changelog
:cl:
fix: Fixed leg sweep working for people with no legs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
