### PR TITLE
Reworks exotic blood conversion handling so dead species can regain blood via transfusion

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -336,10 +336,6 @@
 // Return 0 if it shouldn't deplete and do its normal effect
 // Other return values will cause weird badness
 /datum/species/proc/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	if(R.id == exotic_blood)
-		H.blood_volume = min(H.blood_volume + round(R.volume, 0.1), BLOOD_VOLUME_NORMAL)
-		H.reagents.del_reagent(R.id)
-		return FALSE
 	return TRUE
 
 // For special snowflake species effects

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -577,6 +577,11 @@
 				var/check = reaction_check(A, R)
 				if(!check)
 					continue
+				if(ishuman(A) && method == REAGENT_INGEST)
+					var/mob/living/carbon/human/H = A
+					if(R.id == H.dna.species.exotic_blood)
+						H.blood_volume = min(H.blood_volume + round(R.volume * volume_modifier, 0.1), BLOOD_VOLUME_NORMAL)
+						continue //Purges the chemical
 				R.reaction_mob(A, method, R.volume * volume_modifier, show_message)
 			if("TURF")
 				R.reaction_turf(A, R.volume * volume_modifier, R.color)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -591,7 +591,6 @@
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A
 		if(R.id == H.dna.species.exotic_blood)
-			//this is the same formula from the species handle_reagent proc
 			H.blood_volume = min(H.blood_volume + round(R.volume * volume_modifier, 0.1), BLOOD_VOLUME_NORMAL)
 			del_reagent(R)
 			return TRUE

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -592,7 +592,7 @@
 		var/mob/living/carbon/human/H = A
 		if(R.id == H.dna.species.exotic_blood)
 			H.blood_volume = min(H.blood_volume + round(R.volume * volume_modifier, 0.1), BLOOD_VOLUME_NORMAL)
-			del_reagent(R)
+			del_reagent(R.id)
 			return TRUE
 	return FALSE
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -577,16 +577,26 @@
 				var/check = reaction_check(A, R)
 				if(!check)
 					continue
-				if(ishuman(A) && method == REAGENT_INGEST)
-					var/mob/living/carbon/human/H = A
-					if(R.id == H.dna.species.exotic_blood)
-						H.blood_volume = min(H.blood_volume + round(R.volume * volume_modifier, 0.1), BLOOD_VOLUME_NORMAL)
-						continue //Purges the chemical
+				if(handle_exotic_blood(A, R, method, volume_modifier))
+					continue
 				R.reaction_mob(A, method, R.volume * volume_modifier, show_message)
 			if("TURF")
 				R.reaction_turf(A, R.volume * volume_modifier, R.color)
 			if("OBJ")
 				R.reaction_obj(A, R.volume * volume_modifier)
+
+/datum/reagents/proc/handle_exotic_blood(atom/A, datum/reagent/R, method, volume_modifier)
+	if(!R || !method || method != REAGENT_INGEST)
+		return FALSE
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		if(R.id == H.dna.species.exotic_blood)
+			//this is the same formula from the species handle_reagent proc
+			H.blood_volume = min(H.blood_volume + round(R.volume * volume_modifier, 0.1), BLOOD_VOLUME_NORMAL)
+			del_reagent(R)
+			return TRUE
+	return FALSE
+
 
 /datum/reagents/proc/add_reagent_list(list/list_reagents, list/data = null) // Like add_reagent but you can enter a list. Format it like this: list("toxin" = 10, "beer" = 15)
 	for(var/r_id in list_reagents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Moves exotic blood conversion from metabolize, directly to injection, so species with exotic blood can regain it from IV bags / being fed from a glass when dead.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Species with exotic blood being unable to replenish blood is bad. Since species with blood die under 20% blood, if a slime is under 20% blood, they will not be able to regain any blood as they die from having under 20% blood.

With this setup, it works more like normal blood, handled when injected

## Changelog
:cl:
fix: Slimes can now be given slime blood from IV bags when dead to regain blood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
