### PR TITLE
IPCs no longer dismember as easily

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -81,3 +81,4 @@
 #define CAN_WINGDINGS	"can_wingdings"
 #define NO_CLONESCAN 	"no_clone_scan"
 #define NO_HAIR			"no_hair"
+#define ROBOTIC		"robotic"

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -21,7 +21,7 @@
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."
 	death_sounds = list('sound/voice/borg_deathsound.ogg') //I've made this a list in the event we add more sounds for dead robots.
 
-	species_traits = list(IS_WHITELISTED, NO_BLOOD, NO_CLONESCAN, NO_INTORGANS)
+	species_traits = list(IS_WHITELISTED, NO_BLOOD, NO_CLONESCAN, NO_INTORGANS, ROBOTIC)
 	inherent_traits = list(TRAIT_VIRUSIMMUNE, TRAIT_NOBREATH, TRAIT_RADIMMUNE, TRAIT_NOGERMS, TRAIT_NODECAY, TRAIT_NOPAIN, TRAIT_GENELESS) //Computers that don't decay? What a lie!
 	inherent_biotypes = MOB_ROBOTIC | MOB_HUMANOID
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -671,9 +671,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!make_tough)
 		brute_mod = 0.66
 		burn_mod = 0.66		
-		dismember_at_max_damage = TRUE
-		if(owner && (ROBOTIC in owner.dna.species.species_traits))
-			dismember_at_max_damage = FALSE
+		if(owner && !(ROBOTIC in owner.dna.species.species_traits))
+			dismember_at_max_damage = TRUE
 
 	else
 		tough = TRUE

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -671,7 +671,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!make_tough)
 		brute_mod = 0.66
 		burn_mod = 0.66
-		dismember_at_max_damage = TRUE
+		if(!HAS_TRAIT(owner, ROBOTIC)) //prevent machine species from loosing limbs to a single hit
+			dismember_at_max_damage = TRUE
+			return
 	else
 		tough = TRUE
 	// Robot parts also lack bones

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -673,8 +673,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		burn_mod = 0.66		
 		if(owner && (ROBOTIC in owner.dna.species.species_traits))
 			return
-		if(!HAS_TRAIT(owner, ROBOTIC)) //prevent machine species from loosing limbs to a single hit
-			dismember_at_max_damage = TRUE
+		dismember_at_max_damage = TRUE
 
 	else
 		tough = TRUE

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -671,9 +671,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!make_tough)
 		brute_mod = 0.66
 		burn_mod = 0.66		
-		if(owner && (ROBOTIC in owner.dna.species.species_traits))
-			return
 		dismember_at_max_damage = TRUE
+		if(owner && (ROBOTIC in owner.dna.species.species_traits))
+			dismember_at_max_damage = FALSE
 
 	else
 		tough = TRUE

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -670,10 +670,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 	//robot limbs take reduced damage
 	if(!make_tough)
 		brute_mod = 0.66
-		burn_mod = 0.66
+		burn_mod = 0.66		
+		if(owner && (ROBOTIC in owner.dna.species.species_traits))
+			return
 		if(!HAS_TRAIT(owner, ROBOTIC)) //prevent machine species from loosing limbs to a single hit
 			dismember_at_max_damage = TRUE
-			return
+
 	else
 		tough = TRUE
 	// Robot parts also lack bones


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This pr adds a robotic species trait (yes this is another snowflake ipc thing).
Previously ipcs would loose limbs the second they hit 50 damage or 30 damage for hands and feet, meaning that most sources of damage could instantly dismember ipc hands or feet.
This was due to the already in place balancing for robotic limbs to dismember when at max health.
This lack of dismemberment is balanced by the fact that instead of losing the limb you hold on to the damage taken.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having to get your limbs reattached whenever you take damage is not that fun

## Changelog
:cl:
tweak: IPCs will no longer dismember with a single toolbox to the hand
fix: IPCs would sometimes dismember when being repaired, this won't happen now
/:cl:


