### PR TITLE
Fix: picking up and dropping earmuffs while having earmuffs already equipped no longer removes the deaf trait

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -208,12 +208,12 @@
 		user.Confused(20 SECONDS)
 		user.Weaken(10 SECONDS)
 	else if(slot == slot_wear_suit)
-		ADD_TRAIT(user, TRAIT_GOTTAGOFAST, "cultrobes")
+		ADD_TRAIT(user, TRAIT_GOTTAGOFAST, "cultrobes[UID()]")
 
 /obj/item/clothing/suit/hooded/cultrobes/flagellant_robe/dropped(mob/user)
 	. = ..()
 	if(user)
-		REMOVE_TRAIT(user, TRAIT_GOTTAGOFAST, "cultrobes")
+		REMOVE_TRAIT(user, TRAIT_GOTTAGOFAST, "cultrobes[UID()]")
 
 /obj/item/clothing/head/hooded/flagellant_hood
 	name = "flagellant's robes"

--- a/code/modules/clothing/ears/ears.dm
+++ b/code/modules/clothing/ears/ears.dm
@@ -15,8 +15,8 @@
 /obj/item/clothing/ears/earmuffs/equipped(mob/user, slot)
 	. = ..()
 	if(ishuman(user) && ((slot == slot_l_ear) || (slot == slot_r_ear)))
-		ADD_TRAIT(user, TRAIT_DEAF, CLOTHING_TRAIT)
+		ADD_TRAIT(user, TRAIT_DEAF, "[CLOTHING_TRAIT][UID()]")
 
 /obj/item/clothing/ears/earmuffs/dropped(mob/user)
 	. = ..()
-	REMOVE_TRAIT(user, TRAIT_DEAF, CLOTHING_TRAIT)
+	REMOVE_TRAIT(user, TRAIT_DEAF, "[CLOTHING_TRAIT][UID()]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title. This is quick fix for a potential exploit. Eventually we should have the `clothing_traits` system from TG which handles this automatically.

Edit: Also now does the same thing with Flagellant robes' and it's `TRAIT_GOTTAGOFAST` trait.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a potential exploit
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Picking up and dropping earmuffs while having earmuffs already equipped no longer removes the deaf trait
fix: Losing the TRAIT_GOTTAGOFAST trait from a source other than unequipping flagellant robes while wearing flagellant robes no longer removes that trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
