### PR TITLE
[GBP no update] Fixes DS spawning in the SST base.

### DIFF
--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -49,7 +49,7 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 	var/commando_number = COMMANDOS_POSSIBLE //for selecting a leader
 	var/is_leader = TRUE // set to FALSE after leader is spawned
 
-	for(var/obj/effect/landmark/spawner/syndicate_commando/L in GLOB.landmarks_list)
+	for(var/obj/effect/landmark/spawner/ds/L in GLOB.landmarks_list)
 
 		if(commando_number <= 0)
 			break

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -50,8 +50,7 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 	var/is_leader = TRUE // set to FALSE after leader is spawned
 
 	for(var/obj/effect/landmark/spawner/ds/L in GLOB.landmarks_list)
-
-		if(commando_number <= 0)
+		if(!commando_number)
 			break
 
 		if(!length(commando_ghosts))

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -54,45 +54,41 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 	GLOB.sent_syndicate_strike_team = 1
 
 	//Spawns commandos and equips them.
-	for(var/thing in GLOB.landmarks_list)
-		var/obj/effect/landmark/L = thing
-
-		if(syndicate_commando_number <= 0)
+	for(var/obj/effect/landmark/spawner/syndicate_commando/L in GLOB.landmarks_list)
+		if(!syndicate_commando_number)
 			break
 
-		if(L.name == "Syndicate-Commando")
+		if(!length(commando_ghosts))
+			break
 
-			if(!length(commando_ghosts))
-				break
+		var/mob/ghost_mob = pick(commando_ghosts)
+		commando_ghosts -= ghost_mob
 
-			var/mob/ghost_mob = pick(commando_ghosts)
-			commando_ghosts -= ghost_mob
+		if(!ghost_mob || !ghost_mob.key || !ghost_mob.client)
+			continue
 
-			if(!ghost_mob || !ghost_mob.key || !ghost_mob.client)
-				continue
+		var/mob/living/carbon/human/new_syndicate_commando = create_syndicate_death_commando(L, is_leader)
 
-			var/mob/living/carbon/human/new_syndicate_commando = create_syndicate_death_commando(L, is_leader)
+		if(!new_syndicate_commando)
+			continue
 
-			if(!new_syndicate_commando)
-				continue
+		new_syndicate_commando.key = ghost_mob.key
+		new_syndicate_commando.internal = new_syndicate_commando.s_store
+		new_syndicate_commando.update_action_buttons_icon()
 
-			new_syndicate_commando.key = ghost_mob.key
-			new_syndicate_commando.internal = new_syndicate_commando.s_store
-			new_syndicate_commando.update_action_buttons_icon()
+		//So they don't forget their code or mission.
+		if(nuke_code)
+			new_syndicate_commando.mind.store_memory("<B>Nuke Code:</B> <span class='warning'>[nuke_code]</span>.")
+		new_syndicate_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[input]</span>.")
 
-			//So they don't forget their code or mission.
-			if(nuke_code)
-				new_syndicate_commando.mind.store_memory("<B>Nuke Code:</B> <span class='warning'>[nuke_code]</span>.")
-			new_syndicate_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[input]</span>.")
-
-			to_chat(new_syndicate_commando, "<span class='notice'>You are an Elite Syndicate [is_leader ? "<B>TEAM LEADER</B>" : "commando"] in the service of the Syndicate. \nYour current mission is: <span class='userdanger'>[input]</span></span>")
-			new_syndicate_commando.faction += "syndicate"
-			var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
-			opshud.join_hud(new_syndicate_commando.mind.current)
-			set_antag_hud(new_syndicate_commando.mind.current, "hudoperative")
-			new_syndicate_commando.regenerate_icons()
-			is_leader = FALSE
-			syndicate_commando_number--
+		to_chat(new_syndicate_commando, "<span class='notice'>You are an Elite Syndicate [is_leader ? "<B>TEAM LEADER</B>" : "commando"] in the service of the Syndicate. \nYour current mission is: <span class='userdanger'>[input]</span></span>")
+		new_syndicate_commando.faction += "syndicate"
+		var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
+		opshud.join_hud(new_syndicate_commando.mind.current)
+		set_antag_hud(new_syndicate_commando.mind.current, "hudoperative")
+		new_syndicate_commando.regenerate_icons()
+		is_leader = FALSE
+		syndicate_commando_number--
 
 	message_admins("<span class='notice'>[key_name_admin(usr)] has spawned a Syndicate strike squad.</span>", 1)
 	log_admin("[key_name(usr)] used Spawn Syndicate Squad.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue I introduced in https://github.com/ParadiseSS13/Paradise/pull/17849 by being a moron, namely that I refactored `/client/proc/strike_team()` with the SST landmark instead of refactoring `/client/proc/syndicate_strike_team()` with it.

This has now been fixed so that `code\modules\admin\verbs\striketeam.dm` uses the right landmarks, and `code\modules\admin\verbs\striketeam_syndicate.dm` has the refactor it was meant to have applied to it.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
NT DS should spawn in CC, not on the SST base. There is a separate event for SST spawns.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Fixed NT DS spawning at the SST base
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
