### PR TITLE
Removes the spirit realm runes ability to summon cult ghosts.

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -57,9 +57,6 @@
 //#define MANIA_DAMAGE_TO_CONVERT 90 //how much damage is required before it'll convert affected targets
 
 #define STATUS_EFFECT_HISWRATH /datum/status_effect/his_wrath //His Wrath.
-
-#define STATUS_EFFECT_SUMMONEDGHOST /datum/status_effect/cultghost //is a cult ghost: can see dead people, can't manifest more ghosts
-
 #define STATUS_EFFECT_CRUSHERMARK /datum/status_effect/crusher_mark //if struck with a proto-kinetic crusher, takes a ton of damage
 
 #define STATUS_EFFECT_SAWBLEED /datum/status_effect/saw_bleed //if the bleed builds up enough, takes a ton of damage

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -23,15 +23,6 @@
 	owner.adjustFireLoss(0.1)
 	owner.adjustToxLoss(0.2)
 
-/datum/status_effect/cultghost //is a cult ghost and can't use manifest runes
-	id = "cult_ghost"
-	duration = -1
-	alert_type = null
-
-/datum/status_effect/cultghost/tick()
-	if(owner.reagents)
-		owner.reagents.del_reagent("holywater") //can't be deconverted
-
 /datum/status_effect/crusher_mark
 	id = "crusher_mark"
 	duration = 300 //if you leave for 30 seconds you lose the mark, deal with it

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -237,7 +237,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 	var/constructs = 0
 	for(var/I in cult)
 		var/datum/mind/M = I
-		if(ishuman(M.current) && !M.current.has_status_effect(STATUS_EFFECT_SUMMONEDGHOST))
+		if(ishuman(M.current))
 			cultists++
 		else if(isconstruct(M.current))
 			constructs++

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -933,9 +933,6 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 		H.see_in_dark = max(H.see_in_dark, 8)
 		H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 
-	if(H.has_status_effect(STATUS_EFFECT_SUMMONEDGHOST))
-		H.see_invisible = SEE_INVISIBLE_OBSERVER
-
 	H.sync_lighting_plane_alpha()
 
 /datum/species/proc/water_act(mob/living/carbon/human/M, volume, temperature, source, method = REAGENT_TOUCH)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -14,10 +14,6 @@
 		if(M == user)
 			return // no self surgery
 
-		if(M.has_status_effect(STATUS_EFFECT_SUMMONEDGHOST))
-			to_chat(user, "<span class='notice'>You realise that a ghost probably doesn't have any useful organs.</span>")
-			return //no cult ghost surgery please
-
 		if(istype(M, /mob/living/carbon/human))
 			H = M
 			affecting = H.get_organ(check_zone(selected_zone))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
title.
also changes the type path of the rune from `manifest` to `spirit` as it no longer manifests anything.
Closes #15392 

## Why It's Good For The Game
Cult is incredibly overloaded, with tons of tools to accomplish their objectives. this results in cultsits not needing to work together to achieve them.

Cult is supposed to be a team antagonist but the ability to create a team on the fly subverts that idea. theres no need to work together.

The removal forces cult to actually act as a team.

It also has the added benefit of preventing the cheese strat where you summon 4 ghosts, send them at security and keep spawning them until they die.

## Changelog
:cl:
del: Cultists can no longer summon ghost cultists using the spirit realm rune.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
