### PR TITLE
Un-jank diagonal movement

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -181,45 +181,45 @@
 			// The `&& moving_diagonally` checks are so that a forceMove taking
 			// place due to a Crossed, Bumped, etc. call will interrupt
 			// the second half of the diagonal movement, or the second attempt
-			// at a first half if step() fails because we hit something.
+			// at a first half if ..() fails because we hit something.
 			if(direct & NORTH)
 				if(direct & EAST)
-					if(step(src, NORTH) && moving_diagonally)
+					if(..(get_step(src,  NORTH),  NORTH) && moving_diagonally)
 						first_step_dir = NORTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, EAST)
-					else if(moving_diagonally && step(src, EAST))
+						. = ..(get_step(src,  EAST),  EAST)
+					else if(moving_diagonally && ..(get_step(src,  EAST),  EAST))
 						first_step_dir = EAST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, NORTH)
+						. = ..(get_step(src,  NORTH),  NORTH)
 				else if(direct & WEST)
-					if(step(src, NORTH) && moving_diagonally)
+					if(..(get_step(src,  NORTH),  NORTH) && moving_diagonally)
 						first_step_dir = NORTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, WEST)
-					else if(moving_diagonally && step(src, WEST))
+						. = ..(get_step(src,  WEST),  WEST)
+					else if(moving_diagonally && ..(get_step(src,  WEST),  WEST))
 						first_step_dir = WEST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, NORTH)
+						. = ..(get_step(src,  NORTH),  NORTH)
 			else if(direct & SOUTH)
 				if(direct & EAST)
-					if(step(src, SOUTH) && moving_diagonally)
+					if(..(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
 						first_step_dir = SOUTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, EAST)
-					else if(moving_diagonally && step(src, EAST))
+						. = ..(get_step(src,  EAST),  EAST)
+					else if(moving_diagonally && ..(get_step(src,  EAST),  EAST))
 						first_step_dir = EAST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, SOUTH)
+						. = ..(get_step(src,  SOUTH),  SOUTH)
 				else if(direct & WEST)
-					if(step(src, SOUTH) && moving_diagonally)
+					if(..(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
 						first_step_dir = SOUTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, WEST)
-					else if(moving_diagonally && step(src, WEST))
+						. = ..(get_step(src,  WEST),  WEST)
+					else if(moving_diagonally && ..(get_step(src,  WEST),  WEST))
 						first_step_dir = WEST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = step(src, SOUTH)
+						. = ..(get_step(src,  SOUTH),  SOUTH)
 			if(moving_diagonally == SECOND_DIAG_STEP)
 				if(!.)
 					setDir(first_step_dir)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -189,7 +189,7 @@
 			// There would be a bit of visual jank if we try to walk diagonally next to a wall
 			// and the move ends up being cardinal, rather than diagonal,
 			// but that's better than it being jank on every *successful* diagonal move.
-			delay = mob.movement_delay() * 2
+			delay *= 2
 	move_delay += delay
 
 	if(prev_pulling_loc && mob.pulling?.face_while_pulling && (mob.pulling.loc != prev_pulling_loc))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -180,17 +180,22 @@
 	if(mob.pulling)
 		prev_pulling_loc = mob.pulling.loc
 
-	. = mob.SelfMove(n, direct, delay) // The actual movement
+	if(!(direct & (direct - 1))) // cardinal direction
+		. = mob.SelfMove(n, direct, delay)
+	else // diagonal movements take twice as long
+		. = mob.SelfMove(n, direct, delay * 2)
+		if(mob.loc == n)
+			// only incur the extra delay if the move was *actually* diagonal
+			// There would be a bit of visual jank if we try to walk diagonally next to a wall
+			// and the move ends up being cardinal, rather than diagonal,
+			// but that's better than it being jank on every *successful* diagonal move.
+			delay = mob.movement_delay() * 2
+	move_delay += delay
 
 	if(prev_pulling_loc && mob.pulling?.face_while_pulling && (mob.pulling.loc != prev_pulling_loc))
 		mob.setDir(get_dir(mob, mob.pulling)) // Face welding tanks and stuff when pulling
 	else
 		mob.setDir(direct)
-
-	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
-		delay = mob.movement_delay() * 2 //Will prevent mob diagonal moves from smoothing accurately, sadly
-
-	move_delay += delay
 
 	for(var/obj/item/grab/G in mob)
 		if(G.state == GRAB_NECK)


### PR DESCRIPTION
## What Does This PR Do
Makes the diagonal movement smooth with no weird hiccups

Also, while at it, fixes the bug in which moving diagonally while holding someone in your grab lets them escape.

## Why It's Good For The Game
looks good.

## Images of changes
Current behavior, for comparison:
![20220526-183423-dreamseeker](https://user-images.githubusercontent.com/7831163/170553833-f0d41b47-c8ba-4b5c-a96f-4ad10ccef5f2.gif)


With this PR:
![20220526-182946-dreamseeker](https://user-images.githubusercontent.com/7831163/170552992-40417ef0-eece-4228-a25b-01c0374f5a4e.gif)

Caveat: the jank is not completely eliminated, but only just moved to a less noticeable place. If you try to move diagonally while next to a wall you'd get micro-jumps like this:
![20220526-182613-dreamseeker](https://user-images.githubusercontent.com/7831163/170553156-7c303bff-9e32-436d-a9d5-7b75910385eb.gif)
(hard to see at 15fps, but that only strengthens the point). I deem this to be a lesser evil

## Technical details
I had to replace the calls to `step()` with calls to `Move`, since the former does not respect gliding, turns out. But i'm pretty sure the two are otherwise equivalent.
I tested that with obvious things that would interfere with movement (bumping into doors, slipping on water) and those seem to work exactly the same in both cases. So it should have no gameplay impact.
Or rather, if it does somehow have gameplay impact, then our diagonal movement is *already* special/exploitable in those regards, and this PR is only just a fix.

## Changelog
:cl:
fix: Un-jank diagonal movement
/:cl:

