### PR TITLE
Add logs to skipped space ruin and away mission initialization

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -48,10 +48,14 @@ SUBSYSTEM_DEF(mapping)
 	// Pick a random away mission.
 	if(GLOB.configuration.gateway.enable_away_mission)
 		load_away_mission()
+	else
+		log_startup_progress("Skipping away mission...")
 
 	// Seed space ruins
 	if(GLOB.configuration.ruins.enable_space_ruins)
 		handleRuins()
+	else
+		log_startup_progress("Skipping space ruins...")
 
 	// Makes a blank space level for the sake of randomness
 	GLOB.space_manager.add_new_zlevel("Empty Area", linkage = CROSSLINKED, traits = list(REACHABLE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the server log if space ruins and gateway mission are skipped by the config

## Why It's Good For The Game
I like to know if things are going smoothly (Outside of just looking at the extra short load time)

## Images of changes
![faster](https://user-images.githubusercontent.com/80771500/170609824-4a68787a-d79d-4bc8-93f9-a61709f12c34.PNG)

## Changelog
Nothing playerfacing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
