### PR TITLE
Fixes the sanity check used by atmos to only be run on init

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -76,6 +76,8 @@ SUBSYSTEM_DEF(air)
 /datum/controller/subsystem/air/Initialize(timeofday)
 	setup_overlays() // Assign icons and such for gas-turf-overlays
 	icon_manager = new() // Sets up icon manager for pipes
+	if(active_turfs.len)
+		log_debug("failed sanity check: active_turfs is not empty before initialization ([active_turfs.len])")
 	setup_allturfs()
 	setup_atmos_machinery(GLOB.machines)
 	setup_pipenets(GLOB.machines)
@@ -298,9 +300,6 @@ SUBSYSTEM_DEF(air)
 			add_to_active(S)
 
 /datum/controller/subsystem/air/proc/setup_allturfs(list/turfs_to_init = block(locate(1, 1, 1), locate(world.maxx, world.maxy, world.maxz)))
-	if(active_turfs.len)
-		log_debug("failed sanity check: active_turfs is not empty before initialization ([active_turfs.len])")
-
 	for(var/thing in turfs_to_init)
 		var/turf/T = thing
 		if(T.blocks_air)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(air)
 /datum/controller/subsystem/air/Initialize(timeofday)
 	setup_overlays() // Assign icons and such for gas-turf-overlays
 	icon_manager = new() // Sets up icon manager for pipes
-	if(active_turfs.len)
+	if(length(active_turfs))
 		log_debug("failed sanity check: active_turfs is not empty before initialization ([active_turfs.len])")
 	setup_allturfs()
 	setup_atmos_machinery(GLOB.machines)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -77,7 +77,7 @@ SUBSYSTEM_DEF(air)
 	setup_overlays() // Assign icons and such for gas-turf-overlays
 	icon_manager = new() // Sets up icon manager for pipes
 	if(length(active_turfs))
-		log_debug("failed sanity check: active_turfs is not empty before initialization ([active_turfs.len])")
+		log_debug("failed sanity check: active_turfs is not empty before initialization ([length(active_turfs)])")
 	setup_allturfs()
 	setup_atmos_machinery(GLOB.machines)
 	setup_pipenets(GLOB.machines)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -77,7 +77,7 @@ SUBSYSTEM_DEF(air)
 	setup_overlays() // Assign icons and such for gas-turf-overlays
 	icon_manager = new() // Sets up icon manager for pipes
 	if(length(active_turfs))
-		log_debug("failed sanity check: active_turfs is not empty before initialization ([length(active_turfs)])")
+		log_debug("Failed sanity check: active_turfs is not empty before initialization ([length(active_turfs)])")
 	setup_allturfs()
 	setup_atmos_machinery(GLOB.machines)
 	setup_pipenets(GLOB.machines)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
A few years ago we added a few lines of code to the atmos controller with intent of increasing performance by forgetting about all currently active turfs to be processed; however this came at the cost of making the setup_allturfs function functionally only expect to be called once, which conflicts with its use in the map loading system for things like mining capsules. As a result, anything loading after atmos init would eliminate all tiles that were processing air at the time, resulting in unusual atmos behavior.

We've since found that this removal is unnecessary, since the active turfs list is normally empty at roundstart, so at this point it's been changed to a sanity check. We can safely move it to atmos init directly instead of having this in a function used in common by multiple systems, remedying this issue.