### PR TITLE
Requires the nuclear codes to unanchor an armed nuke

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -362,6 +362,9 @@ GLOBAL_VAR(bomb_set)
 				to_chat(usr, "<span class='warning'>There is nothing to anchor to!</span>")
 				return FALSE
 			else
+				if(!yes_code && anchored && timing)
+					to_chat(usr, "<span class='warning'>The code is required to unanchor [src] when armed!</span>")
+					return
 				anchored = !(anchored)
 				if(anchored)
 					visible_message("<span class='warning'>With a steely snap, bolts slide out of [src] and anchor it to the flooring.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

An armed nuke now needs the codes to unanchor, instead of just the disk.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

To save the station from a soon to be exploding nuke, you had 3 options.

Cut the bolts, no disk or code needed, takes a bunch of time.

Use the disk to open the nuke, fast, 50/50 to kill everyone or save everyone.

Use the disk and codes to defuse, no risk, but hard to do with nukies unless someone kept the paper in their bag.


However, in #15793 , we anchored the nuke by default so nukies did not get their nuke stolen as easy, which was great, but it meant that you no longer need the codes to unanchor the nuke.

This is problematic when the nuke is armed, as it makes it real fast and easy to space in that case, removing the time lock of the first defusal method, and the risk of the second defusal method.

This PR makes it like before, that you need the disk and codes to unanchor an armed nuke, so saving the station fast once again needs the 50/50 coin flip.

## Changelog
:cl:
tweak: The nuclear bomb requires the nuclear codes to unanchor it when it is armed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
