### PR TITLE
Remove the extra newly-introduced jank with diagonal movement

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -172,7 +172,8 @@
 	var/atom/oldloc = loc
 
 	if(loc != newloc)
-		glide_for(movetime)
+		if(movetime > 0)
+			glide_for(movetime)
 		if(!(direct & (direct - 1))) //Cardinal move
 			. = ..(newloc, direct) // don't pass up movetime
 		else //Diagonal move, split it into cardinal moves
@@ -181,45 +182,45 @@
 			// The `&& moving_diagonally` checks are so that a forceMove taking
 			// place due to a Crossed, Bumped, etc. call will interrupt
 			// the second half of the diagonal movement, or the second attempt
-			// at a first half if ..() fails because we hit something.
+			// at a first half if the cardinal Move() fails because we hit something.
 			if(direct & NORTH)
 				if(direct & EAST)
-					if(..(get_step(src,  NORTH),  NORTH) && moving_diagonally)
+					if(Move(get_step(src,  NORTH),  NORTH) && moving_diagonally)
 						first_step_dir = NORTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  EAST),  EAST)
-					else if(moving_diagonally && ..(get_step(src,  EAST),  EAST))
+						. = Move(get_step(src,  EAST),  EAST)
+					else if(moving_diagonally && Move(get_step(src,  EAST),  EAST))
 						first_step_dir = EAST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  NORTH),  NORTH)
+						. = Move(get_step(src,  NORTH),  NORTH)
 				else if(direct & WEST)
-					if(..(get_step(src,  NORTH),  NORTH) && moving_diagonally)
+					if(Move(get_step(src,  NORTH),  NORTH) && moving_diagonally)
 						first_step_dir = NORTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  WEST),  WEST)
-					else if(moving_diagonally && ..(get_step(src,  WEST),  WEST))
+						. = Move(get_step(src,  WEST),  WEST)
+					else if(moving_diagonally && Move(get_step(src,  WEST),  WEST))
 						first_step_dir = WEST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  NORTH),  NORTH)
+						. = Move(get_step(src,  NORTH),  NORTH)
 			else if(direct & SOUTH)
 				if(direct & EAST)
-					if(..(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
+					if(Move(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
 						first_step_dir = SOUTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  EAST),  EAST)
-					else if(moving_diagonally && ..(get_step(src,  EAST),  EAST))
+						. = Move(get_step(src,  EAST),  EAST)
+					else if(moving_diagonally && Move(get_step(src,  EAST),  EAST))
 						first_step_dir = EAST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  SOUTH),  SOUTH)
+						. = Move(get_step(src,  SOUTH),  SOUTH)
 				else if(direct & WEST)
-					if(..(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
+					if(Move(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
 						first_step_dir = SOUTH
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  WEST),  WEST)
-					else if(moving_diagonally && ..(get_step(src,  WEST),  WEST))
+						. = Move(get_step(src,  WEST),  WEST)
+					else if(moving_diagonally && Move(get_step(src,  WEST),  WEST))
 						first_step_dir = WEST
 						moving_diagonally = SECOND_DIAG_STEP
-						. = ..(get_step(src,  SOUTH),  SOUTH)
+						. = Move(get_step(src,  SOUTH),  SOUTH)
 			if(moving_diagonally == SECOND_DIAG_STEP)
 				if(!.)
 					setDir(first_step_dir)


### PR DESCRIPTION
## What Does This PR Do
Fixup to #17872 
Makes lights, orbiting ghosts, and probably other things properly follow their source when the latter moves diagonally

Tested: 
- bumping into doors
- slipping on things
- walking with light on
- orbiting a diagonally moving monkey

Probably GBP no update (but i still have no idea how that thing works)

## Technical details

TURNS OUT, that all the `step(Ref, Dir)` does is call `Ref.Move(get_step(Ref, Dir), Dir)`.
And while replacing `step()` with `Move()` works, replacing it with `..()` doesn't, since that doesn't call self (nor the child procs) again! (but the former two alternatives do).
That, and i missed a sneaky return at the end of the `if(diagonal)` block, which should have hinted me at what's going on. Turns out it is there for a very good reason.
Oh well.

Anyhow, I'm leaving `step` replaced with `Move` here, since that means a bit less BYOND arcane.

And the reason `step` ignored glide_size was because it was getting override in recursive Move, because `movetime` was being set to its default of `0` because it was not passed at all.
So now we just don't adjust the `glide_size` if we don't need to. And given how carefully it's being dealt with (i.e. only ever set in `glide_for` and mandatorily unset to its `initial` after the glide is done), there's no reason to fear it would ever get broken (right?)

## Changelog
🆑 
fix: Fixed lights, orbiting ghosts, and probably other things not properly react to players moving diagonally
/:cl:
