### PR TITLE
Allows Vampires to drain Slime People

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -447,7 +447,7 @@
 	//Vampire code
 	var/datum/antagonist/vampire/V = user?.mind?.has_antag_datum(/datum/antagonist/vampire)
 	if(V && !V.draining && user.zone_selected == "head" && target != user)
-		if((NO_BLOOD in target.dna.species.species_traits) || target.dna.species.exotic_blood || !target.blood_volume)
+		if((NO_BLOOD in target.dna.species.species_traits) || !target.blood_volume)
 			to_chat(user, "<span class='warning'>They have no blood!</span>")
 			return
 		if(target.mind && (target.mind.has_antag_datum(/datum/antagonist/vampire) || target.mind.has_antag_datum(/datum/antagonist/mindslave/thrall)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Vampires will now be able to drain slime people as they are able to drain anyone else with blood.  This is accomplished by removing the check for exotic_blood in the action for vampires draining blood, a tag only presently used by slime people (though has previously been used by Drasks it seems). Shouldn't affect anything except allowing Vamps to drain Slimes.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Not being able to drain slime people is (I believe) a relic from the time slime people had water as blood, and from the way old vampires worked. Now, slime people have delicious jelly to drain, and the way Vampires extract power from people seems to be much more focused on draining their life energy through their blood instead of simply their blood - evidenced by the maximum cap you can reach on draining people. I also believe this change is good for consistency, as other species with blood that should be relatively unique such as the plant-like Dionae or Vox with their nitrogen-based bloodstream instead of oxygen can still be drained by Vampires with no problems.
Additionally, this would mean that any players _with_ blood are now able to be drained by vampires, which is good for consistency - IPCs and Plasmamen escape their draining fate by simple nature of not having blood to drain.
Lastly, noting the popularity of slime person players (especially in positions such as security), it would be a nice chance for vampires to have more targets to extract useful blood - which I believe is a good balance change.

## Changelog
:cl:
tweak: Vampires are now able to drain Slime People
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
 