### PR TITLE
Randomizes the reactive armor in the RD's office

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -114,9 +114,9 @@
 	location_override = "the Captain's Office"
 
 /datum/theft_objective/reactive
-	name = "the reactive teleport armor"
-	typepath = /obj/item/clothing/suit/armor/reactive/teleport
-	protected_jobs = list("Research Director")
+	name = "any type of reactive armor"
+	typepath = /obj/item/clothing/suit/armor/reactive
+	protected_jobs = list("Research Director", "Scientist", "Roboticist") //no one with protolathe access, who will often be handed a core
 	location_override = "the Research Director's Office"
 
 /datum/theft_objective/steal/documents

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -54,7 +54,7 @@
 	new /obj/item/radio/headset/heads/rd(src)
 	new /obj/item/tank/internals/air(src)
 	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/clothing/suit/armor/reactive/teleport(src)
+	new /obj/item/clothing/suit/armor/reactive/random(src)
 	new /obj/item/flash(src)
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -447,9 +447,8 @@
 
 /obj/item/clothing/suit/armor/reactive/random/New()
 	..()
-	var/list/types = subtypesof(/obj/item/clothing/suit/armor/reactive) - /obj/item/clothing/suit/armor/reactive/random
-	var/A = pick(types)
-	new A(loc)
+	var/spawnpath = pick(subtypesof(/obj/item/clothing/suit/armor/reactive) - /obj/item/clothing/suit/armor/reactive/random)
+	new spawnpath(loc)
 	qdel(src)
 
 //All of the armor below is mostly unused

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -442,6 +442,16 @@
 		disable(rand(2, 5))
 		return TRUE
 
+/obj/item/clothing/suit/armor/reactive/random //Spawner for random reactive armor
+	name = "Random Reactive Armor"
+
+/obj/item/clothing/suit/armor/reactive/random/New()
+	..()
+	var/list/types = list(/obj/item/clothing/suit/armor/reactive/teleport, /obj/item/clothing/suit/armor/reactive/fire, /obj/item/clothing/suit/armor/reactive/stealth, /obj/item/clothing/suit/armor/reactive/tesla, /obj/item/clothing/suit/armor/reactive/repulse)
+	var/A = pick(types)
+	new A(loc)
+	qdel(src)
+
 //All of the armor below is mostly unused
 
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -447,7 +447,7 @@
 
 /obj/item/clothing/suit/armor/reactive/random/New()
 	..()
-	var/list/types = list(/obj/item/clothing/suit/armor/reactive/teleport, /obj/item/clothing/suit/armor/reactive/fire, /obj/item/clothing/suit/armor/reactive/stealth, /obj/item/clothing/suit/armor/reactive/tesla, /obj/item/clothing/suit/armor/reactive/repulse)
+	var/list/types = subtypesof(/obj/item/clothing/suit/armor/reactive)
 	var/A = pick(types)
 	new A(loc)
 	qdel(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -447,7 +447,7 @@
 
 /obj/item/clothing/suit/armor/reactive/random/New()
 	..()
-	var/list/types = subtypesof(/obj/item/clothing/suit/armor/reactive)
+	var/list/types = subtypesof(/obj/item/clothing/suit/armor/reactive) - /obj/item/clothing/suit/armor/reactive/random
 	var/A = pick(types)
 	new A(loc)
 	qdel(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -445,8 +445,8 @@
 /obj/item/clothing/suit/armor/reactive/random //Spawner for random reactive armor
 	name = "Random Reactive Armor"
 
-/obj/item/clothing/suit/armor/reactive/random/New()
-	..()
+/obj/item/clothing/suit/armor/reactive/random/Initialize(mapload)
+	. = ..()
 	var/spawnpath = pick(subtypesof(/obj/item/clothing/suit/armor/reactive) - /obj/item/clothing/suit/armor/reactive/random)
 	new spawnpath(loc)
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Adds /obj/item/clothing/suit/armor/reactive/random, which spawns a random reactive armor in it's loc (AKA RD locker)

Replaces the teleport armor in the RD locker to a random reactive armor.

Changes the steal teleport armor objective to steal any reactive armor, which will include armor that is made **and** has a core installed. Scientists / robotics no longer get the armor as an objective, as people often dump the cores at science, not wanting them.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Quite a few people have been talking about the RD armor of late, complaining how it is always a get out of jail free card, especially on a vampire or captain on nukies, so it is now turned into something random, instead of the same teleport armor each shift.

Now instead of always having a teleporting armor that will never send you to a space tile (although it could send you to plating in space), you now only have a one in 5 chance to get the teleport armor, and instead have to work with (or just leave in your locker) some of the other reactive armor types, which have different risks/ benefits, and are generally less of a get out of jail free card. It also will encourage people to not always have the armor on, as tesla, repulse, and pyro armor is going to cause an issue if you are on the bridge and someone throws a donut at you.


## What about space law? Does this mean no one but the RD can wear the other armor types now?

I will point out with (most) high risk items, the head could give them out for certain reasons. Paramedic with the CMO defib. Someone working on the SM instead of the CE. No one arrests security officers with ablative armor, as they have _permission._ Someone can still wear these armors, if the RD gives them permission, who's access is needed for the frame of the armor anyway. As such, this won't change space law for these armors much, unless a security officer is given armor and someone steals it from them, then they could be brigged for grand theft.


## Changelog
:cl:
tweak: The RD starts with a random reactive armor in their locker.
tweak: The steal a reactive teleport armor objective is now for any reactive armor, and is no longer available to scientists and roboticists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
