### PR TITLE
Fix chinstrap icon name.

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories/human/human_facial_hair.dm
+++ b/code/modules/mob/new_player/sprite_accessories/human/human_facial_hair.dm
@@ -60,7 +60,7 @@
 
 /datum/sprite_accessory/facial_hair/chinstrap
 	name = "Chinstrap"
-	icon_state = "chim"
+	icon_state = "chin"
 
 /datum/sprite_accessory/facial_hair/hip
 	name = "Hipster Beard"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a typo in the chinstrap icon state.

## Why It's Good For The Game

How can we possibly deny this beautiful sprite to the people

## Images of changes

![paradise  icons_mob_sprite_accessories_human_human_facial_hair dmi  - Dream Make-13_56_57](https://user-images.githubusercontent.com/59303604/170884706-7c536c19-f831-4964-bcee-9a088710b9b7.png)

## Changelog
:cl:
fix: Chinstrap facial hair now renders properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
