### PR TITLE
Station state datum no longer points to the incorrect z level

### DIFF
--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -42,7 +42,7 @@
 
 /datum/station_state/proc/count()
 	var/station_zlevel = level_name_to_num(MAIN_STATION)
-	for(var/turf/T in block(locate(1,1,station_zlevel), locate(world.maxx,world.maxy,station_zlevel)))
+	for(var/turf/T in block(locate(1, 1, station_zlevel), locate(world.maxx, world.maxy, station_zlevel)))
 
 		if(istype(T,/turf/simulated/floor))
 			if(!(T:burnt))

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -41,7 +41,8 @@
 
 
 /datum/station_state/proc/count()
-	for(var/turf/T in block(locate(1,1,1), locate(world.maxx,world.maxy,1)))
+	var/station_zlevel = level_name_to_num(MAIN_STATION)
+	for(var/turf/T in block(locate(1,1,station_zlevel), locate(world.maxx,world.maxy,station_zlevel)))
 
 		if(istype(T,/turf/simulated/floor))
 			if(!(T:burnt))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is my first PR
Fixes #17853
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Station integrity will now show correctly at the end of the round
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Station integrity is now calculated correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
