### PR TITLE
Smoothen the camera for orbiters

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -145,6 +145,7 @@
 		orbiter.loc = target_loc
 		// Setting loc directly doesn't fire COMSIG_MOVABLE_MOVED, so we need to do it ourselves
 		SEND_SIGNAL(orbiter, COMSIG_MOVABLE_MOVED, current_loc, target_loc, null)
+	orbiter.animate_movement = SYNC_STEPS
 
 /**
  * End the orbit and clean up our transformation.
@@ -158,6 +159,7 @@
 		return
 
 	if(orbiter)
+		orbiter.animate_movement = SLIDE_STEPS
 		if(!QDELETED(parent))
 			SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_STOP, orbiter)
 


### PR DESCRIPTION
## What Does This PR Do
Ever noticed how choppy the camera feels when orbiting someone? Especially compared to how smooth the movement is when you're in control of your character?
Well, this PR makes orbiting just as smooth

## Why It's Good For The Game
feels good

## Images of changes
See the screengrab. I VV the setting to what we currently have on live to show the difference. Then put it back to what is in the PR

https://user-images.githubusercontent.com/7831163/170897743-7c3c3872-b419-4f54-a7de-5f7ff0d01943.mp4



## Changelog
:cl:
fix: Orbiter movement is now smooth
/:cl:

