### PR TITLE
Adds tiny fans to the Gamma Armoury

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -6062,6 +6062,7 @@
 /area/shuttle/trade/sol)
 "uR" = (
 /obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/gamma/space)
 "uT" = (


### PR DESCRIPTION
## What Does This PR Do
Adds two tiny fans to both sides of the Gamma Armoury.

## Why It's Good For The Game
This has been talked about in the mapping channel a few times. Not all maps can or want to have a giant two-sided cutout in the middle of the Brig to support both sides of the Gamma Armoury. Delta, the up and coming Shepard station and the currently test merged version of Meta don't and the door leads straight to space. This adds tiny fans to the Gamma Armoury to stop baldies from spacing it.

## Images of changes
![image](https://user-images.githubusercontent.com/92271472/171259335-eba54ed2-28dc-4ade-8ec5-ceb6e65c3859.png)

## Changelog
:cl: Bmon
add: Tiny fans added to the Gamma Armoury! Stop spacing it.
/:cl: