### PR TITLE
Ash storms are no longer audible on mining/labor shuttles when in transit or docked on station

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -82,7 +82,7 @@ SUBSYSTEM_DEF(weather)
     var/datum/weather/A
     for(var/V in processing)
         var/datum/weather/W = V
-        if((z in W.impacted_z_levels) && W.area_type == active_area.type)
+        if((z in W.impacted_z_levels) && W.area_type == active_area)
             A = W
             break
     return A

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -30,13 +30,28 @@
 	var/datum/looping_sound/weak_outside_ashstorm/sound_wo = new(list(), FALSE, TRUE)
 	var/datum/looping_sound/weak_inside_ashstorm/sound_wi = new(list(), FALSE, TRUE)
 
-/datum/weather/ash_storm/telegraph()
-	. = ..()
+/datum/weather/ash_storm/proc/is_shuttle_docked()
+	var/obj/docking_port/mobile/M = SSshuttle.getShuttle("mining")
+	var/obj/docking_port/stationary/S = M.get_docked()
+
+	if(S.id == "mining_away")
+		return TRUE
+	else
+		return FALSE
+
+/datum/weather/ash_storm/proc/update_eligible_areas()
 	var/list/inside_areas = list()
 	var/list/outside_areas = list()
 	var/list/eligible_areas = list()
 	for(var/z in impacted_z_levels)
 		eligible_areas += GLOB.space_manager.areas_in_z["[z]"]
+
+	// Don't play storm audio if the shuttle is not at the mining station
+	var/isShuttleDocked = is_shuttle_docked()
+
+	if(isShuttleDocked == FALSE)
+		eligible_areas -= get_areas(/area/shuttle/mining)
+
 	for(var/i in 1 to eligible_areas.len)
 		var/area/place = eligible_areas[i]
 		if(place.outdoors)
@@ -50,29 +65,46 @@
 	sound_wo.output_atoms = outside_areas
 	sound_wi.output_atoms = inside_areas
 
-	sound_wo.start()
-	sound_wi.start()
+/datum/weather/ash_storm/proc/update_audio()
+	switch(stage)
+		if(STARTUP_STAGE)
+			sound_wo.start()
+			sound_wi.start()
+
+		if(MAIN_STAGE)
+			sound_wo.stop()
+			sound_wi.stop()
+
+			sound_ao.start()
+			sound_ai.start()
+
+		if(WIND_DOWN_STAGE)
+			sound_ao.stop()
+			sound_ai.stop()
+
+			sound_wo.start()
+			sound_wi.start()
+
+		if(END_STAGE)
+			sound_wo.stop()
+			sound_wi.stop()
+
+/datum/weather/ash_storm/telegraph()
+	. = ..()
+	update_eligible_areas()
+	update_audio()
 
 /datum/weather/ash_storm/start()
 	. = ..()
-	sound_wo.stop()
-	sound_wi.stop()
-
-	sound_ao.start()
-	sound_ai.start()
+	update_audio()
 
 /datum/weather/ash_storm/wind_down()
 	. = ..()
-	sound_ao.stop()
-	sound_ai.stop()
-
-	sound_wo.start()
-	sound_wi.start()
+	update_audio()
 
 /datum/weather/ash_storm/end()
 	. = ..()
-	sound_wo.stop()
-	sound_wi.stop()
+	update_audio()
 
 /datum/weather/ash_storm/proc/is_ash_immune(atom/L)
 	while(L && !isturf(L))

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -34,10 +34,7 @@
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
 	var/obj/docking_port/stationary/S = M.get_docked()
 
-	if(S.id == dockId)
-		return TRUE
-	else
-		return FALSE
+	return S.id == dockId
 
 /datum/weather/ash_storm/proc/update_eligible_areas()
 	var/list/inside_areas = list()
@@ -48,11 +45,11 @@
 
 	// Don't play storm audio to shuttles that are not at lavaland
 	var/miningShuttleDocked = is_shuttle_docked("mining", "mining_away")
-	if(miningShuttleDocked == FALSE)
+	if(!miningShuttleDocked)
 		eligible_areas -= get_areas(/area/shuttle/mining)
 
 	var/laborShuttleDocked = is_shuttle_docked("laborcamp", "laborcamp_away")
-	if(laborShuttleDocked == FALSE)
+	if(!laborShuttleDocked)
 		eligible_areas -= get_areas(/area/shuttle/siberia)
 
 	for(var/i in 1 to eligible_areas.len)

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -30,11 +30,11 @@
 	var/datum/looping_sound/weak_outside_ashstorm/sound_wo = new(list(), FALSE, TRUE)
 	var/datum/looping_sound/weak_inside_ashstorm/sound_wi = new(list(), FALSE, TRUE)
 
-/datum/weather/ash_storm/proc/is_shuttle_docked()
-	var/obj/docking_port/mobile/M = SSshuttle.getShuttle("mining")
+/datum/weather/ash_storm/proc/is_shuttle_docked(shuttleId, dockId)
+	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
 	var/obj/docking_port/stationary/S = M.get_docked()
 
-	if(S.id == "mining_away")
+	if(S.id == dockId)
 		return TRUE
 	else
 		return FALSE
@@ -46,11 +46,14 @@
 	for(var/z in impacted_z_levels)
 		eligible_areas += GLOB.space_manager.areas_in_z["[z]"]
 
-	// Don't play storm audio if the shuttle is not at the mining station
-	var/isShuttleDocked = is_shuttle_docked()
-
-	if(isShuttleDocked == FALSE)
+	// Don't play storm audio to shuttles that are not at lavaland
+	var/miningShuttleDocked = is_shuttle_docked("mining", "mining_away")
+	if(miningShuttleDocked == FALSE)
 		eligible_areas -= get_areas(/area/shuttle/mining)
+
+	var/laborShuttleDocked = is_shuttle_docked("laborcamp", "laborcamp_away")
+	if(laborShuttleDocked == FALSE)
+		eligible_areas -= get_areas(/area/shuttle/siberia)
 
 	for(var/i in 1 to eligible_areas.len)
 		var/area/place = eligible_areas[i]

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -529,7 +529,7 @@
 	dir = S1.dir
 
 	//update mining shuttle ash storm audio
-	if(id=="mining")
+	if(id == "mining" || id == "laborcamp")
 		var/mining_zlevel = level_name_to_num(MINING)
 		var/datum/weather/ash_storm/W = SSweather.get_weather(mining_zlevel, /area/lavaland/surface/outdoors)
 		if(W)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -528,6 +528,14 @@
 	loc = S1.loc
 	dir = S1.dir
 
+	//update mining shuttle ash storm audio
+	if(id=="mining")
+		var/mining_zlevel = level_name_to_num(MINING)
+		var/datum/weather/ash_storm/W = SSweather.get_weather(mining_zlevel, /area/lavaland/surface/outdoors)
+		if(W)
+			W.update_eligible_areas()
+			W.update_audio()
+
 	unlockPortDoors(S1)
 
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -529,7 +529,7 @@
 	dir = S1.dir
 
 	//update mining and labor shuttle ash storm audio
-	if(id == "mining" || id == "laborcamp")
+	if(id in list("mining", "laborcamp"))
 		var/mining_zlevel = level_name_to_num(MINING)
 		var/datum/weather/ash_storm/W = SSweather.get_weather(mining_zlevel, /area/lavaland/surface/outdoors)
 		if(W)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -528,7 +528,7 @@
 	loc = S1.loc
 	dir = S1.dir
 
-	//update mining shuttle ash storm audio
+	//update mining and labor shuttle ash storm audio
 	if(id == "mining" || id == "laborcamp")
 		var/mining_zlevel = level_name_to_num(MINING)
 		var/datum/weather/ash_storm/W = SSweather.get_weather(mining_zlevel, /area/lavaland/surface/outdoors)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops playing the ash storm audio on the mining and labor camp shuttles when they are in transit and at the station. Of course, there is still a delay from when it's supposed to stop to when it actually stops because the sound file needs to finish playing, I think. Before this PR, at the beginning of the storm the shuttle areas were being added to a list of areas that play the audio and when the shuttles left lava land, they were never un-marked and kept playing the audio.

Also changed get_weather() in the weather subsystem to use the type of area instead of an instance of an area to get the weather. This proc wasn't used anywhere else in the project and I don't think it makes sense to have it use an instance instead of just passing it the type.

This is only my second PR so I would love any and all feedback. Something didn't feel right about putting the shuttle checks in the middle of shuttle.dm because the code is specifically for the labor shuttle and mining shuttle, but I couldn't find a better place for it. Feedback on that would be appreciated.

Fixes #17870
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hearing the ash storm from the station breaks immersion and gives players information that should not be available from that point.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ash storm audio no longer audible station side/in transit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
