### PR TITLE
Allow construction of grilles on lattices

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -1,5 +1,5 @@
 GLOBAL_LIST_INIT(rod_recipes, list ( \
-	new /datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor = 1), \
+	new /datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor_or_lattice = 1), \
 	new /datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = 1, on_floor = 1), \
 	null,
 	new /datum/stack_recipe("railing", /obj/structure/railing, 3, time = 10, one_per_turf = 1, on_floor = 1), \

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -210,12 +210,15 @@
 		if(R.on_floor && !istype(get_turf(src), /turf/simulated))
 			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
 			return FALSE
+		if(R.on_floor_or_lattice && !(istype(get_turf(src), /turf/simulated) || locate(/obj/structure/lattice) in get_turf(src)))
+			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor or lattice!</span>")
+			return FALSE
 
 		if(R.cult_structure)
 			if(usr.holy_check())
 				return
 			if(!is_level_reachable(usr.z))
-				to_chat(usr, "<span class='warning'>The energies of this place interfere with the metal shaping!</span>")
+				to_chat(usr, "<span class='warning'>\The energies of this place interfere with the metal shaping!</span>")
 				return
 			if(locate(/obj/structure/cult) in get_turf(src))
 				to_chat(usr, "<span class='warning'>There is a structure here!</span>")

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -11,10 +11,11 @@
 	var/time = 0
 	var/one_per_turf = 0
 	var/on_floor = 0
+	var/on_floor_or_lattice = 0
 	var/window_checks = FALSE
 	var/cult_structure = FALSE
 
-/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0, window_checks = FALSE, cult_structure = FALSE)
+/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0, on_floor_or_lattice = 0, window_checks = FALSE, cult_structure = FALSE)
 	src.title = title
 	src.result_type = result_type
 	src.req_amount = req_amount
@@ -23,6 +24,7 @@
 	src.time = time
 	src.one_per_turf = one_per_turf
 	src.on_floor = on_floor
+	src.on_floor_or_lattice = on_floor_or_lattice
 	src.window_checks = window_checks
 	src.cult_structure = cult_structure
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -146,7 +146,7 @@
 	deconstruct()
 
 /obj/structure/grille/screwdriver_act(mob/user, obj/item/I)
-	if(!(istype(loc, /turf/simulated) || anchored))
+	if(!(anchored || istype(loc, /turf/simulated) || locate(/obj/structure/lattice) in get_turf(src)))
 		return
 	. = TRUE
 	if(shock(user, 90))
@@ -154,8 +154,11 @@
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	anchored = !anchored
+	var/support = locate(/obj/structure/lattice) in get_turf(src)
+	if(!support)
+		support = get_turf(src)
 	user.visible_message("<span class='notice'>[user] [anchored ? "fastens" : "unfastens"] [src].</span>", \
-							"<span class='notice'>You [anchored ? "fasten [src] to" : "unfasten [src] from"] the floor.</span>")
+							"<span class='notice'>You [anchored ? "fasten [src] to" : "unfasten [src] from"] \the [support].</span>")
 
 /obj/structure/grille/proc/build_window(obj/item/stack/sheet/S, mob/user)
 	var/dir_to_set = SOUTHWEST


### PR DESCRIPTION
## What Does This PR Do
Grilles can now be constructed on lattice, and not just on the floor.

## Why It's Good For The Game
It is common to map the exterior of space stations with grilles on lattice.
![20220601-053007-dreamseeker](https://user-images.githubusercontent.com/7831163/171337624-f845f7e3-4ee1-4577-8def-20be0bed391d.png)

However that cannot be reproduced in game.
What's more annoying is that those half-broken grilles cannot be meaningfully rebuilt without building whole plating under them (which ruins the *a e s t h e t i c s*)

This PR fixes that, and makes the maps a bit closer to player-constructible.

## Technical notes

the extra `on_floor_or_lattice` var is somewhat crude, but the alternative to that is creating a whole "allowed support" list, which would need an extra special handling to distinguish between turfs (floors/platings) and floors contents (lattices), and that's just way overkill.
We can revisit and streamline this when we get more kinds of exceptions.

## Images of changes
![20220601-055635-dreamseeker](https://user-images.githubusercontent.com/7831163/171338477-4656d244-e242-44ea-887d-f33a7efc63a1.png)

## Changelog
:cl:
tweak: grilles can now be built on lattices.
/:cl: