### PR TITLE
Removes obsolete check in update_revive (thus fixing SR revival of people dead to tox)

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -128,11 +128,6 @@
 /mob/living/silicon/robot/drone/pick_module()
 	return
 
-/mob/living/silicon/robot/drone/can_be_revived()
-	. = ..()
-	if(emagged)
-		return FALSE
-
 /mob/living/silicon/robot/drone/detailed_examine()
 	return "Drones are player-controlled synthetics which are lawed to maintain the station and not \
 			interact with anyone else, except for other drones. They hold a wide array of tools to build, repair, maintain, and clean. \

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -33,16 +33,11 @@
 		update_canmove()
 	return 1
 
-/mob/living/proc/can_be_revived()
-	. = TRUE
-
 // death() is used to make a mob die
 
 // handles revival through other means than cloning or adminbus (defib, IPC repair)
 /mob/living/proc/update_revive(updating = TRUE)
 	if(stat != DEAD)
-		return 0
-	if(!can_be_revived())
 		return 0
 	create_attack_log("<font color='red'>Came back to life at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Came back to life", ATKLOG_ALL)

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -35,9 +35,6 @@
 
 /mob/living/proc/can_be_revived()
 	. = TRUE
-	// if(health <= min_health)
-	if(health <= HEALTH_THRESHOLD_DEAD)
-		return FALSE
 
 // death() is used to make a mob die
 
@@ -52,7 +49,7 @@
 	log_game("[key_name(src)] came back to life at [atom_loc_line(get_turf(src))]")
 	stat = CONSCIOUS
 	GLOB.dead_mob_list -= src
-	GLOB.alive_mob_list += src
+	GLOB.alive_mob_list |= src
 	if(mind)
 		remove_from_respawnable_list()
 	timeofdeath = null


### PR DESCRIPTION
## What Does This PR Do
Allows one to successfully use strange reagent on dead people with more than 200 tox damage on them.

## Why It's Good For The Game
Currently, if you have a dead person with more than 200 toxins damage on them, you can't revive them via SR. If you try to - nothing happens, the person is not revived, their death timer is not reset. This is weird, because:
- you can't purge toxins damage out of dead people
- SR does check for the kinds of damage it cares about (brute, burn) and gibs the patient if it doesn't like them
- the chat message clearly states "Steve Nanotrasen seems to rise from the dead!"
This latter one especially indicates that this is more of a bugfix.

See (behaviour on live, note the "undefibbable" skull on medhud):  
![image](https://user-images.githubusercontent.com/7831163/171497306-db2967a5-7537-4776-ad02-a5e39478e001.png)


## Technical details
All the callsites of `update_reviving` proc already check for target's health, and only ever try to revive when the health is above the "good" threshold (latter depends on the kind of reviving performed). So this health check in `can_be_revived` is not adding any value.

## Changelog
:cl:
fix: SR now works on people with > 200 tox damage
/:cl:
