### PR TITLE
Arrival Shuttles: Tiny Fans Edition

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -981,6 +981,7 @@
 	id_tag = "s_docking_airlock"
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/shuttle/arrival/station)
 "ahC" = (
@@ -991,6 +992,7 @@
 	id_tag = "s_docking_airlock"
 	},
 /obj/effect/decal/warning_stripes/west,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/shuttle/arrival/station)
 "ahF" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25465,6 +25465,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
 "biq" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -19731,6 +19731,7 @@
 /area/shuttle/arrival/station)
 "aVX" = (
 /obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
 "aVY" = (


### PR DESCRIPTION
## What Does This PR Do
* Added tiny fans to arrival shuttles, at all current stations.

## Why It's Good For The Game
* Less chance that players will find themselves in an unusable atmosphere when they show up. It's quite friendly.

## Changelog
:cl:
add: Central Command built tiny fans on the arrival shuttles after.. ehh, the past incident.
/:cl: