### PR TITLE
Fix blood transfer for slime people

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -571,25 +571,11 @@
 				var/check = reaction_check(A, R)
 				if(!check)
 					continue
-				if(handle_exotic_blood(A, R, method, volume_modifier))
-					continue
 				R.reaction_mob(A, method, R.volume * volume_modifier, show_message)
 			if("TURF")
 				R.reaction_turf(A, R.volume * volume_modifier, R.color)
 			if("OBJ")
 				R.reaction_obj(A, R.volume * volume_modifier)
-
-/datum/reagents/proc/handle_exotic_blood(atom/A, datum/reagent/R, method, volume_modifier)
-	if(!R || !method || method != REAGENT_INGEST)
-		return FALSE
-	if(ishuman(A))
-		var/mob/living/carbon/human/H = A
-		if(R.id == H.dna.species.exotic_blood)
-			H.blood_volume = min(H.blood_volume + round(R.volume * volume_modifier, 0.1), BLOOD_VOLUME_NORMAL)
-			del_reagent(R.id)
-			return TRUE
-	return FALSE
-
 
 /datum/reagents/proc/add_reagent_list(list/list_reagents, list/data = null) // Like add_reagent but you can enter a list. Format it like this: list("toxin" = 10, "beer" = 15)
 	for(var/r_id in list_reagents)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -44,20 +44,27 @@
 	return
 
 /datum/reagent/proc/reaction_mob(mob/living/M, method = REAGENT_TOUCH, volume, show_message = TRUE) //Some reagents transfer on touch, others don't; dependent on if they penetrate the skin or not.
-	if(holder)  //for catching rare runtimes
-		if(method == REAGENT_TOUCH && penetrates_skin)
-			var/block  = M.get_permeability_protection()
-			var/amount = round(volume * (1 - block), 0.1)
-			if(M.reagents)
-				if(amount >= 1)
-					M.reagents.add_reagent(id, amount)
+	if(!holder)  //for catching rare runtimes
+		return
+	if(method == REAGENT_TOUCH && penetrates_skin)
+		var/block  = M.get_permeability_protection()
+		var/amount = round(volume * (1 - block), 0.1)
+		if(M.reagents)
+			if(amount >= 1)
+				M.reagents.add_reagent(id, amount)
 
-		if(method == REAGENT_INGEST) //Yes, even Xenos can get addicted to drugs.
-			var/can_become_addicted = M.reagents.reaction_check(M, src)
-			if(can_become_addicted)
-				if(is_type_in_list(src, M.reagents.addiction_list))
-					to_chat(M, "<span class='notice'>You feel slightly better, but for how long?</span>") //sate_addiction handles this now, but kept this for the feed back.
-		return TRUE
+	if(method == REAGENT_INGEST) //Yes, even Xenos can get addicted to drugs.
+		var/can_become_addicted = M.reagents.reaction_check(M, src)
+		if(can_become_addicted)
+			if(is_type_in_list(src, M.reagents.addiction_list))
+				to_chat(M, "<span class='notice'>You feel slightly better, but for how long?</span>") //sate_addiction handles this now, but kept this for the feed back.
+
+	var/mob/living/carbon/C = M
+	if(method == REAGENT_INGEST && istype(C) && C.get_blood_id() == id)
+		if(id == "blood" && !(data?["blood_type"] in get_safe_blood(C.dna?.blood_type)))
+			C.reagents.add_reagent("toxin", volume * 0.5)
+		else
+			C.blood_volume = min(C.blood_volume + round(volume, 0.1), BLOOD_VOLUME_NORMAL)
 
 /datum/reagent/proc/reaction_obj(obj/O, volume)
 	return

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -49,11 +49,18 @@
 
 /datum/reagent/slimejelly/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(prob(10))
-		to_chat(M, "<span class='danger'>Your insides are burning!</span>")
-		update_flags |= M.adjustToxLoss(rand(2, 6) * REAGENTS_EFFECT_MULTIPLIER, FALSE) // avg 0.4 toxin per cycle, not unreasonable
-	else if(prob(40))
-		update_flags |= M.adjustBruteLoss(-0.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	var/mob/living/carbon/C = M
+	if(istype(C) && C.get_blood_id() == id)
+		// Absorb it; we've handled blood volume update when ingesting it.
+		// We could leave the volume as is, but that looks mildly bad on health scanner
+		// (and also allows for very niche exploits in slime jelly farming)
+		volume = metabolization_rate
+	else
+		if(prob(10))
+			to_chat(M, "<span class='danger'>Your insides are burning!</span>")
+			update_flags |= M.adjustToxLoss(rand(2, 6) * REAGENTS_EFFECT_MULTIPLIER, FALSE) // avg 0.4 toxin per cycle, not unreasonable
+		else if(prob(40))
+			update_flags |= M.adjustBruteLoss(-0.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/slimejelly/on_merge(list/mix_data)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -102,13 +102,9 @@
 
 	if(method == REAGENT_INGEST && iscarbon(M))
 		var/mob/living/carbon/C = M
-		if(C.get_blood_id() == "blood")
-			if((!data || !(data["blood_type"] in get_safe_blood(C.dna.blood_type))))
-				C.reagents.add_reagent("toxin", volume * 0.5)
-			else
-				C.blood_volume = min(C.blood_volume + round(volume, 0.1), BLOOD_VOLUME_NORMAL)
 		if(C.mind?.has_antag_datum(/datum/antagonist/vampire))
 			C.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, C.nutrition + 10))
+	..()
 
 /datum/reagent/blood/on_new(list/data)
 	if(istype(data))


### PR DESCRIPTION
## What Does This PR Do
Actually allows blood transfer for slime people.

## Why It's Good For The Game
#17851 moved the blood volume update from metabolization to ingestion. Which is good, because it allows to treat dead slimes.
However what it also did is delete the original blood container when the transfusion happens. Which makes it completely unusable for IV.
It would have been plain obvious if the PR was tested at all, as that was claimed as *the* thing it was aiming to fix. Shaking my smh.

Anyway, this current PR actually fixes that oversight, and moves all (and not just exotic) blood transfusion logic into a single place.

Also I've tested it, and it does work.

## Images of changes
Blood transfusion on a living person:
![20220601-202202](https://user-images.githubusercontent.com/7831163/171494595-266eaff1-7b8c-421c-acd5-195f3d8251ff.png)


Blood transfusion on a corpse:
![20220601-201643](https://user-images.githubusercontent.com/7831163/171494448-88b189ad-cd0b-422d-a252-f54fd514050a.png)


## Changelog
:cl:
fix: Fix slime jelly blood transfusion not working on dead slimes
/:cl:
