### PR TITLE
Firelock Unweld Grammar

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -34,6 +34,8 @@
 #define WELDER_FLOOR_SLICE_SUCCESS_MESSAGE	to_chat(user, "<span class='notice'>You slice [src] clear of [get_turf(src)]!</span>")
 #define WELDER_ATTEMPT_FLOOR_WELD_MESSAGE	user.visible_message("<span class='notice'>[user] begins welding [src] to [get_turf(src)]...</span>", "<span class='notice'>You begin welding [src] to [get_turf(src)]...</span>", "<span class='warning'>You hear welding.</span>")
 #define WELDER_FLOOR_WELD_SUCCESS_MESSAGE	to_chat(user, "<span class='notice'>You weld [src] to [get_turf(src)]!</span>")
+#define WELDER_ATTEMPT_UNWELD_MESSAGE		user.visible_message("<span class='notice'>[user] begins cutting through the weld on [src]...</span>", "<span class='notice'>You begin cutting through the weld on [src]...</span>", "<span class='warning'>You hear welding.</span>")
+#define WELDER_UNWELD_SUCCESS_MESSAGE		to_chat(user, "<span class='notice'>You finish unwelding [src]!</span>")
 
 //Wrench messages
 #define WRENCH_ANCHOR_MESSAGE				user.visible_message("<span class='notice'>[user] tightens the bolts on [src]!</span>", "<span class='notice'>You tighten the bolts on [src]!</span>", "<span class='warning'>You hear ratcheting.</span>")

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -162,10 +162,10 @@
 		return
 	if(!density) //In case someone opens it while it's getting welded
 		return
-	if(!welded)
-		WELDER_WELD_SUCCESS_MESSAGE
-	else
+	if(welded)
 		WELDER_UNWELD_SUCCESS_MESSAGE
+	else
+		WELDER_WELD_SUCCESS_MESSAGE
 	welded = !welded
 	update_icon()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -154,12 +154,18 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	WELDER_ATTEMPT_WELD_MESSAGE
+	if(!welded)
+		WELDER_ATTEMPT_WELD_MESSAGE
+	else
+		WELDER_ATTEMPT_UNWELD_MESSAGE
 	if(!I.use_tool(src, user, 40, volume = I.tool_volume))
 		return
 	if(!density) //In case someone opens it while it's getting welded
 		return
-	WELDER_WELD_SUCCESS_MESSAGE
+	if(!welded)
+		WELDER_WELD_SUCCESS_MESSAGE
+	else
+		WELDER_UNWELD_SUCCESS_MESSAGE
 	welded = !welded
 	update_icon()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -154,10 +154,10 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	if(!welded)
-		WELDER_ATTEMPT_WELD_MESSAGE
-	else
+	if(welded)
 		WELDER_ATTEMPT_UNWELD_MESSAGE
+	else
+		WELDER_ATTEMPT_WELD_MESSAGE
 	if(!I.use_tool(src, user, 40, volume = I.tool_volume))
 		return
 	if(!density) //In case someone opens it while it's getting welded


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Changes the dialogue when you unweld a firelock to say "unweld" instead of weld again.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bad grammar bad


## Changelog
:cl:
spellcheck: Firelock unweld message now says "unweld" instead of "weld".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
