### PR TITLE
"The veil is torn" message fix

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1031,8 +1031,12 @@ structure_check() searches for nearby cultist structures required for the invoca
 	used = TRUE
 	color = COLOR_RED
 	..()
-	SEND_SOUND(world, sound('sound/effects/dimensional_rend.ogg'))
-	to_chat(world, "<span class='cultitalic'><b>The veil... <span class='big'>is...</span> <span class='reallybig'>TORN!!!--</span></b></span>")
+
+	for(var/mob/M in GLOB.player_list)
+		if(!isnewplayer(M)) // exclude people in the lobby
+			SEND_SOUND(M, sound('sound/effects/dimensional_rend.ogg'))
+			to_chat(M, "<span class='cultitalic'><b>The veil... <span class='big'>is...</span> <span class='reallybig'>TORN!!!--</span></b></span>")
+
 	icon_state = "rune_large_distorted"
 	var/turf/T = get_turf(src)
 	sleep(40)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes  "The veil is torn" message no longer visible to lobby players.
#17011, which stopped lobby players from seeing "[cultgod] has risen!", only partially addressed issue #17009

Fixes #17452
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lobby players should not be alerted of the round antagonist. #17011 is pointless if the veil message is still sent to lobby players.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The "veil is torn message" will no longer appear to lobby players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
