### PR TITLE
Robotic lungs can now be configured for vox and plasmamen

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -345,6 +345,39 @@
 	icon_state = "lungs-c"
 	origin_tech = "biotech=4"
 	status = ORGAN_ROBOT
+	var/species_state = "human"
+	var/vox_oxygen_bonus = 0.05 //For upgraded robotic lungs
+
+/obj/item/organ/internal/lungs/cybernetic/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is configured for [species_state] standards of atmosphere.</span>"
+
+/obj/item/organ/internal/lungs/cybernetic/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	switch(species_state)
+		if("human")
+			safe_oxygen_min = 0
+			safe_oxygen_max = vox_oxygen_bonus
+			safe_nitro_min = 16
+			oxy_damage_type = TOX
+			user.show_message("You configure [src] to replace vox lungs.")
+			species_state = "vox"
+		if("vox")
+			safe_oxygen_max = initial(safe_oxygen_max)
+			safe_toxins_min = 16
+			safe_toxins_max = 0
+			safe_nitro_min = initial(safe_nitro_min)
+			oxy_damage_type = OXY
+			user.show_message("You configure [src] to replace plasmamen lungs.")
+			species_state = "plasmamen"
+		if("plasmamen")
+			safe_oxygen_min = initial(safe_oxygen_min)
+			safe_toxins_min = initial(safe_toxins_min)
+			safe_toxins_max = initial(safe_toxins_max)
+			user.show_message("You configure [src] back to default settings.")
+			species_state = "human"
 
 /obj/item/organ/internal/lungs/cybernetic/upgraded
 	name = "upgraded cybernetic lungs"
@@ -354,6 +387,7 @@
 
 	safe_toxins_max = 20
 	safe_co2_max = 20
+	vox_oxygen_bonus = 20
 
 	cold_level_1_threshold = 200
 	cold_level_2_threshold = 140

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -356,14 +356,14 @@
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	switch(species_state)
-		if("human")
+		if("human") // from human to vox
 			safe_oxygen_min = 0
 			safe_oxygen_max = safe_toxins_max
 			safe_nitro_min = 16
 			oxy_damage_type = TOX
 			to_chat(user, "<span class='notice'>You configure [src] to replace vox lungs.</span>")
 			species_state = "vox"
-		if("vox")
+		if("vox") // from vox to plasmamen
 			safe_oxygen_max = initial(safe_oxygen_max)
 			safe_toxins_min = 16
 			safe_toxins_max = 0
@@ -371,7 +371,7 @@
 			oxy_damage_type = OXY
 			to_chat(user, "<span class='notice'>You configure [src] to replace plasmamen lungs.</span>")
 			species_state = "plasmamen"
-		if("plasmamen")
+		if("plasmamen") // from plasmamen to human
 			safe_oxygen_min = initial(safe_oxygen_min)
 			safe_toxins_min = initial(safe_toxins_min)
 			safe_toxins_max = initial(safe_toxins_max)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -346,7 +346,6 @@
 	origin_tech = "biotech=4"
 	status = ORGAN_ROBOT
 	var/species_state = "human"
-	var/vox_oxygen_bonus = 0.05 //For upgraded robotic lungs
 
 /obj/item/organ/internal/lungs/cybernetic/examine(mob/user)
 	. = ..()
@@ -359,10 +358,10 @@
 	switch(species_state)
 		if("human")
 			safe_oxygen_min = 0
-			safe_oxygen_max = vox_oxygen_bonus
+			safe_oxygen_max = safe_toxins_max
 			safe_nitro_min = 16
 			oxy_damage_type = TOX
-			user.show_message("You configure [src] to replace vox lungs.")
+			to_chat(user, "<span class='notice'>You configure [src] to replace vox lungs.</span>")
 			species_state = "vox"
 		if("vox")
 			safe_oxygen_max = initial(safe_oxygen_max)
@@ -370,13 +369,13 @@
 			safe_toxins_max = 0
 			safe_nitro_min = initial(safe_nitro_min)
 			oxy_damage_type = OXY
-			user.show_message("You configure [src] to replace plasmamen lungs.")
+			to_chat(user, "<span class='notice'>You configure [src] to replace plasmamen lungs.</span>")
 			species_state = "plasmamen"
 		if("plasmamen")
 			safe_oxygen_min = initial(safe_oxygen_min)
 			safe_toxins_min = initial(safe_toxins_min)
 			safe_toxins_max = initial(safe_toxins_max)
-			user.show_message("You configure [src] back to default settings.")
+			to_chat(user, "<span class='notice'>You configure [src] back to default settings.</span>")
 			species_state = "human"
 
 /obj/item/organ/internal/lungs/cybernetic/upgraded
@@ -387,7 +386,6 @@
 
 	safe_toxins_max = 20
 	safe_co2_max = 20
-	vox_oxygen_bonus = 20
 
 	cold_level_1_threshold = 200
 	cold_level_2_threshold = 140


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Allows cybernetic and upgraded cybernetic lungs to be configured to vox and plasmamen lung settings. The upgraded lungs will also give vox 20 oxygen as the max oxygen level, similar to the toxin and co2 bonus upgraded lungs already give, but it is **NOT** enough for them to safely breath station oxygen. It will however lower the toxin damage to 1 per cycle.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to properly implant a species lungs into them when no organic replacements are available is good. Currently, nothing stops you from putting robotic lungs into a vox / plasmamen... which ends up being silly. Replacing someones lungs should not magically make them breath a different atmosphere. As such, this PR lets robotic and upgraded lungs be configured to plasmamen and vox settings with a multitool, so they still breath their gas after getting their lungs replaced.

## Changelog
:cl:
add: Cybernetic and upgraded cybernetic lungs can be configured with a multitool for vox or plasmamen settings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
