### PR TITLE
Blacklists Plasmamen Envirosuits From Washing Machines

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -233,6 +233,9 @@
 		istype(W,/obj/item/bedsheet))
 
 		//YES, it's hardcoded... saves a var/can_be_washed for every single clothing item.
+		if( istype(W,/obj/item/clothing/under/plasmaman ) )
+			to_chat(user, "This item does not fit.")
+			return
 		if( istype(W,/obj/item/clothing/suit/space ) )
 			to_chat(user, "This item does not fit.")
 			return
@@ -246,9 +249,6 @@
 			to_chat(user, "This item does not fit.")
 			return
 		if( istype(W,/obj/item/clothing/suit/bomb_suit ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if( istype(W,/obj/item/clothing/suit/armor ) )
 			to_chat(user, "This item does not fit.")
 			return
 		if( istype(W,/obj/item/clothing/suit/armor ) )


### PR DESCRIPTION
## What Does This PR Do
Fixes #17789 by blacklisting envirosuits from washing machines. No more invisible envirosuits.

Removes a duplicate entry for the armour blacklist in the washing machine code.

## Why It's Good For The Game
Fixes bugs

## Changelog
:cl: Bmon
fix: Envirosuits can no longer be put in washing machines which broke their sprite before
/:cl: