### PR TITLE
Massively tones down the dizziness status effect

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -207,8 +207,9 @@
 	if(!.)
 		return
 	var/dir = sin(world.time)
-	px_diff = cos(world.time * 3) * min(strength * 0.2, 32) * dir
-	py_diff = sin(world.time * 3) * min(strength * 0.2, 32) * dir
+	var/amplitude = min(strength * 0.003, 32)
+	px_diff = cos(world.time * 3) * amplitude * dir
+	py_diff = sin(world.time * 3) * amplitude * dir
 	owner.client?.pixel_x = px_diff
 	owner.client?.pixel_y = py_diff
 
@@ -307,7 +308,6 @@
 	// THRESHOLD_CONFUSION (80 SECONDS)
 	if(actual_strength >= THRESHOLD_CONFUSION && prob(3.3))
 		owner.AdjustConfused(6 SECONDS / alcohol_resistance, bound_lower = 2 SECONDS, bound_upper = 1 MINUTES)
-		owner.AdjustDizzy(6 SECONDS / alcohol_resistance, bound_lower = 2 SECONDS, bound_upper = 2 MINUTES)
 	// THRESHOLD_SPARK (100 SECONDS)
 	if(is_ipc && actual_strength >= THRESHOLD_SPARK && prob(2.5))
 		do_sparks(3, 1, owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title. brings it more inline with how it used to be

## Why It's Good For The Game
people have complained it made them feel sick. and it was really obnoxious even at lower values.
Also removes the duplicate dizziness from drunkeness.

## Images of changes
new effect roughly 30 seconds after drinking vodka. barely noticable. might even be too far. I would rather the effect be weak than people feel sick playing the game.
![dreamseeker_tHvkFWXs1P](https://user-images.githubusercontent.com/69320440/172490272-4533581c-f38f-40f8-afc6-4f003e332ccd.gif)


## Changelog
:cl:
tweak: tones down dizziness screen movement massively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
