### PR TITLE
Update link to dmdoc

### DIFF
--- a/.github/AUTODOC_GUIDE.md
+++ b/.github/AUTODOC_GUIDE.md
@@ -3,7 +3,7 @@
 
 [BYOND]: https://secure.byond.com/
 
-[DMDOC]: https://github.com/AffectedArc07/ParaSpacemanDMM/tree/master/src/dmdoc
+[DMDOC]: https://github.com/SpaceManiac/SpacemanDMM/tree/master/crates/dmdoc
 
 [DMDOC] is a documentation generator for DreamMaker, the scripting language
 of the [BYOND] game engine. It produces simple static HTML files based on


### PR DESCRIPTION
## What Does This PR Do
Updates the link to dmdoc tool from https://github.com/AffectedArc07/ParaSpacemanDMM/tree/master/src/dmdoc to https://github.com/SpaceManiac/SpacemanDMM/tree/master/crates/dmdoc
