### PR TITLE
[Ready] AI building fixes: Runtimes when adding AI law modules, Syndicate modules work during building again, Helpful messages for freeform modules.

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -6,7 +6,7 @@
 	icon_state = "0"
 	max_integrity = 500
 	var/state = 0
-	var/datum/ai_laws/laws = null
+	var/datum/ai_laws/laws = new /datum/ai_laws/crewsimov()
 	var/obj/item/circuitboard/aicore/circuit = null
 	var/obj/item/mmi/brain = null
 

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -63,8 +63,20 @@
 
 			if(istype(P, /obj/item/aiModule/freeform))
 				var/obj/item/aiModule/freeform/M = P
+				if(!M.newFreeFormLaw)
+					to_chat(usr, "No law detected on module, please create one.")
+					return
 				laws.add_inherent_law(M.newFreeFormLaw)
 				to_chat(usr, "<span class='notice'>Added a freeform law.</span>")
+				return
+
+			if(istype(P, /obj/item/aiModule/syndicate))
+				var/obj/item/aiModule/syndicate/M = P
+				if(!M.newFreeFormLaw)
+					to_chat(usr, "No law detected on module, please create one.")
+					return
+				laws.add_ion_law(M.newFreeFormLaw)
+				to_chat(usr, "<span class='notice'>Added a hacked law.</span>")
 				return
 
 			if(istype(P, /obj/item/aiModule))
@@ -73,6 +85,8 @@
 					to_chat(usr, "<span class='warning'>This AI module can not be applied directly to AI cores.</span>")
 					return
 				laws = M.laws
+				to_chat(usr, "<span class='notice'>Added [M.laws.name] laws.</span>")
+				return
 
 			if(istype(P, /obj/item/mmi) && !brain)
 				var/obj/item/mmi/M = P

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -188,7 +188,7 @@ AI MODULES
 /****************** New Freeform ******************/
 /obj/item/aiModule/freeform // Slightly more dynamic freeform module -- TLE
 	name = "\improper Freeform AI module"
-	var/newFreeFormLaw = "freeform"
+	var/newFreeFormLaw = ""
 	var/lawpos = 15
 	desc = "A 'freeform' AI module: '<freeform>'"
 	origin_tech = "programming=4;materials=4"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtimes when trying to apply law modules to a partly built AI core.

Note: This is done by making Crewsimov as default lawset for the AI that is being built. 
Crewsimov was chosen because it is used as a default lawset for an AI elsewhere in the code.

Allows syndicate modules to be used on AI during its construction (A feature broken since 2015)

Prevents the user from uploading empty freeform and hacked laws to an AI during construction.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It fixes issue #17934

It reintroduces the ability to subvert an AI with a hacked module during construction.

It makes the usage of freeform modules more user friendly by preventing upload of empty laws.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: uc_guy, Kugamo
fix: It is again possible to purge and add laws to an AI while it is being built.
fix: Syndicate AI modules can again be used during AI construction.
tweak: Helpful messages when trying to use an empty freeform or Syndicate modules on the AI during construction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
