### PR TITLE
Fixes a slight oversight with the chat colours PR

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -1,5 +1,5 @@
-#define DEFAULT_PLAYER_OOC_COLOUR "#275FC5" // Can't initial() a global so we store the default in a macro instead
-GLOBAL_VAR_INIT(normal_ooc_colour, DEFAULT_PLAYER_OOC_COLOUR )
+#define DEFAULT_PLAYER_OOC_COLOUR "#075FE5" // Can't initial() a global so we store the default in a macro instead
+GLOBAL_VAR_INIT(normal_ooc_colour, DEFAULT_PLAYER_OOC_COLOUR)
 
 GLOBAL_VAR_INIT(member_ooc_colour, "#035417")
 GLOBAL_VAR_INIT(mentor_ooc_colour, "#00B0EB")

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -252,7 +252,7 @@ em				{font-style: normal;font-weight: bold;}
 				{color: #638500;}
 .darkmblue 			{color: #6685f5;}
 .prefix				{font-weight: bold;}
-.ooc				{color: #fbd608;font-weight: bold;}
+.ooc				{font-weight: bold;}
 .looc				{color: #6699CC;}
 .adminobserverooc			{color: #0099cc;font-weight: bold;}
 .adminooc			{color: #b82e00;font-weight: bold;}

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -264,7 +264,7 @@ em				{font-style: normal;font-weight: bold;}
 .playerreply			{color: #8800bb;font-weight: bold;}
 .pmsend				{color: #6685f5;}
 .name				{font-weight: bold;}
-.say				{color: #a4bad6}
+.say				{color: #E8EBED}
 .yell				{font-weight: bold;}
 .siliconsay			{font-family: 'Courier New', Courier, monospace;}
 .deadsay				{color: #e2c1ff;}


### PR DESCRIPTION
## What Does This PR Do
Fixes a slight oversight in #17903 

The new CSS rule for the OOC colour removed any custom colouring and broke the ingame change verb.
![image](https://user-images.githubusercontent.com/25063394/173071526-d37398f5-dd4b-4fd9-bb6f-2c7ad3b530e3.png)

The default OOC colour has also been tweaked to make it more vibrant

## Why It's Good For The Game
Yes

## Changelog
N/A, hotfix