### PR TITLE
Remove `jquery.mark.min.js` from the resource list

### DIFF
--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -11,9 +11,9 @@ html, body {
 }
 body {
 	background: #151515;
-    font-family: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 9pt;
-    line-height: 1.2;
+	font-family: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 9pt;
+	line-height: 1.2;
 	overflow-x: hidden;
 	overflow-y: scroll;
 	word-wrap: break-word;
@@ -49,9 +49,9 @@ a.popt {text-decoration: none;}
 	position: fixed;
 	width: 300px;
 	height: 150px;
-text-align: center;
+	text-align: center;
 	left: 50%;
-top: 50%;
+	top: 50%;
 	margin: -75px 0 0 -150px;
 }
 #loading i {display: block; padding-bottom: 3px;}
@@ -69,17 +69,17 @@ font-size: 14px;
 	right: 0;
 	padding: 8px;
 	background: #ddd;
-text-decoration: none;
-    font-variant: small-caps;
-    font-size: 1.1em;
-    font-weight: bold;
+	text-decoration: none;
+	font-variant: small-caps;
+	font-size: 1.1em;
+	font-weight: bold;
 	color: #333;
 }
 #newMessages:hover {background: #ccc;}
 #newMessages i {vertical-align: middle; padding-left: 3px;}
 #ping {
 	position: fixed;
-top: 0;
+	top: 0;
 	right: 40px;
 	width: 45px;
 	background: #ddd;
@@ -90,33 +90,33 @@ top: 0;
 #ping i {display: block; text-align: center;}
 #ping .ms {
 	display: block;
-text-align: center;
-font-size: 8pt;
+	text-align: center;
+	font-size: 8pt;
 	color: #000;
 	padding-top: 2px;
 }
 #options {
 	position: fixed;
-top: 0;
+	top: 0;
 	right: 0;
 }
 #options a {
 	background: #ddd;
-    height: 30px;
+	height: 30px;
 	padding: 5px 0;
 	display: block;
 	color: #333;
-text-decoration: none;
-    line-height: 28px;
-    border-top: 1px solid #b4b4b4;
+	text-decoration: none;
+	line-height: 28px;
+	border-top: 1px solid #b4b4b4;
 }
 #options a:hover {background: #ccc;}
 #options .toggle {
 	width: 40px;
-    background: #ccc;
-    border-top: 0;
-    float: right;
-    text-align: center;
+	background: #ccc;
+	border-top: 0;
+	float: right;
+	text-align: center;
 }
 #options .sub {clear: both; display: none; width: 160px;}
 #options .sub.scroll {overflow-y: scroll;}
@@ -124,33 +124,33 @@ text-decoration: none;
 #options .sub span {
 	display: block;
 	line-height: 30px;
-float: left;
+	float: left;
 }
 #options .sub i {
 	display: block;
 	padding: 0 5px;
-font-size: 1.1em;
+	font-size: 1.1em;
 	width: 22px;
-text-align: center;
+	text-align: center;
 	line-height: 30px;
-float: right;
+	float: right;
 }
 #options .decreaseFont {border-top: 0;}
 
 /* POPUPS */
 .popup {
 	position: fixed;
-top: 50%;
+	top: 50%;
 	left: 50%;
 	background: #ddd;
 }
 .popup .close {
 	position: absolute;
 	background: #aaa;
-top: 0;
+	top: 0;
 	right: 0;
 	color: #333;
-text-decoration: none;
+	text-decoration: none;
 	z-index: 2;
 	padding: 0 10px;
 	height: 30px;
@@ -163,9 +163,9 @@ text-decoration: none;
 	padding: 0 10px;
 	height: 30px;
 	line-height: 30px;
-text-transform: uppercase;
-font-size: 0.9em;
-font-weight: bold;
+	text-transform: uppercase;
+	font-size: 0.9em;
+	font-weight: bold;
 	border-bottom: 2px solid green;
 }
 .popup input {border: 1px solid #999; background: #fff; margin: 0; padding: 5px; outline: none; color: #333;}
@@ -192,7 +192,7 @@ font-weight: bold;
 .contextMenu a {
 	display: block;
 	padding: 2px 5px;
-text-decoration: none;
+	text-decoration: none;
 	color: #333;
 }
 
@@ -228,17 +228,17 @@ text-decoration: none;
 
 /* BADGE */
 .repeatBadge {
-    display: inline-block;
-    min-width: 0.5em;
-    font-size: 0.7em;
-    padding: 0.2em 0.3em;
-    line-height: 1;
-    color: white;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: middle;
-    background-color: crimson;
-    border-radius: 10px;
+	display: inline-block;
+	min-width: 0.5em;
+	font-size: 0.7em;
+	padding: 0.2em 0.3em;
+	line-height: 1;
+	color: white;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: middle;
+	background-color: crimson;
+	border-radius: 10px;
 }
 
 /* OUTPUT COLORS */

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -11,9 +11,9 @@ html, body {
 }
 body {
 	background: #fff;
-    font-family: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 9pt;
-    line-height: 1.2;
+	font-family: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 9pt;
+	line-height: 1.2;
 	overflow-x: hidden;
 	overflow-y: scroll;
 	word-wrap: break-word;
@@ -69,9 +69,9 @@ a.popt {text-decoration: none;}
 	padding: 8px;
 	background: #ddd;
 	text-decoration: none;
-    font-variant: small-caps;
-    font-size: 1.1em;
-    font-weight: bold;
+	font-variant: small-caps;
+	font-size: 1.1em;
+	font-weight: bold;
 	color: #333;
 }
 #newMessages:hover {background: #ccc;}
@@ -99,21 +99,21 @@ a.popt {text-decoration: none;}
 }
 #options a {
 	background: #ddd;
-    height: 30px;
+	height: 30px;
 	padding: 5px 0;
 	display: block;
 	color: #333;
 	text-decoration: none;
-    line-height: 28px;
-    border-top: 1px solid #b4b4b4;
+	line-height: 28px;
+	border-top: 1px solid #b4b4b4;
 }
 #options a:hover {background: #ccc;}
 #options .toggle {
 	width: 40px;
-    background: #ccc;
-    border-top: 0;
-    float: right;
-    text-align: center;
+	background: #ccc;
+	border-top: 0;
+	float: right;
+	text-align: center;
 }
 #options .sub {clear: both; display: none; width: 160px;}
 #options .sub.scroll {overflow-y: scroll;}
@@ -225,17 +225,17 @@ a.popt {text-decoration: none;}
 
 /* BADGE */
 .repeatBadge {
-    display: inline-block;
-    min-width: 0.5em;
-    font-size: 0.7em;
-    padding: 0.2em 0.3em;
-    line-height: 1;
-    color: white;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: middle;
-    background-color: crimson;
-    border-radius: 10px;
+	display: inline-block;
+	min-width: 0.5em;
+	font-size: 0.7em;
+	padding: 0.2em 0.3em;
+	line-height: 1;
+	color: white;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: middle;
+	background-color: crimson;
+	border-radius: 10px;
 }
 
 /* OUTPUT COLORS */

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -103,13 +103,13 @@ if (typeof String.prototype.trim !== 'function') {
 //Polyfill for string.prototype.includes. Why the fuck. Just why the fuck.
 if (!String.prototype.includes) {
 	String.prototype.includes = function(search, start) {
-	  'use strict';
+		'use strict';
 
-	  if (search instanceof RegExp) {
-		throw TypeError('first argument must not be a RegExp');
-	  }
-	  if (start === undefined) { start = 0; }
-	  return this.indexOf(search, start) !== -1;
+		if (search instanceof RegExp) {
+			throw TypeError('first argument must not be a RegExp');
+		}
+	if (start === undefined) { start = 0; }
+	return this.indexOf(search, start) !== -1;
 	};
 }
 
@@ -307,7 +307,7 @@ function output(message, flag) {
 				if (!!$(messageHtml).children().attr('class')) {
 					messageClasses = messageClasses.concat($(messageHtml).children().attr('class').split(/\s+/));
 				}
-				var tempCount = 0;
+
 				for (var i = 0; i < messageClasses.length; i++) { //Every class
 					var thisClass = messageClasses[i];
 					$.each(opts.showMessagesFilters, function(key, val) { //Every filter
@@ -323,7 +323,6 @@ function output(message, flag) {
 						if (filteredOut) return false;
 					});
 					if (filteredOut) break;
-					tempCount++;
 				}
 			} else {
 				if (!opts.showMessagesFilters['Misc'].show) {
@@ -766,21 +765,21 @@ $(function() {
 		internalOutput('<span class="internal boldnshit">Loaded hide spam preference of: ' + savedConfig.shideSpam + '</span>', 'internal');
 	}
 	if (savedConfig.darkChat == "on") {
-		   $("head").append("<link>");
-		   var css = $("head").children(":last");
-		   css.attr({
-		     rel:  "stylesheet",
-		     type: "text/css",
-		     href: "./browserOutput-dark.css"
-		  });
+		$("head").append("<link>");
+		var css = $("head").children(":last");
+		css.attr({
+			rel:  "stylesheet",
+			type: "text/css",
+			href: "./browserOutput-dark.css"
+		});
 	} else {
-		   $("head").append("<link>");
-		   var css = $("head").children(":last");
-		   css.attr({
-		     rel:  "stylesheet",
-		     type: "text/css",
-		     href: "./browserOutput.css"
-		  });
+		$("head").append("<link>");
+		var css = $("head").children(":last");
+		css.attr({
+			rel:  "stylesheet",
+			type: "text/css",
+			href: "./browserOutput.css"
+		});
 	}
 	if(localStorage){
 		var backlog = localStorage.getItem('backlog')
@@ -1125,8 +1124,8 @@ $(function() {
 		var popupContent = '<div class="head">String Highlighting</div>' +
 			'<div class="highlightPopup" id="highlightPopup">' +
 				'<div>Choose up to '+opts.highlightLimit+' strings that will highlight the line when they appear in chat.<br>'+
-		    			'<input name="highlightRegex" id="highlightRegexEnable" type="checkbox">Enable Regex</input>'+
-		    		'<br><a href="" onclick="window.open(\'https://www.paradisestation.org/wiki/index.php/Guide_to_Regex\')">See here for details</a></div>' +
+					'<input name="highlightRegex" id="highlightRegexEnable" type="checkbox">Enable Regex</input>'+
+					'<br><a href="" onclick="window.open(\'https://www.paradisestation.org/wiki/index.php/Guide_to_Regex\')">See here for details</a></div>' +
 				'<form id="highlightTermForm">' +
 					termInputs +
 					'<div><input type="text" name="highlightColor" id="highlightColor" class="highlightColor" '+

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -1,6 +1,5 @@
 var/list/chatResources = list(
 	"goon/browserassets/js/jquery.min.js",
-	"goon/browserassets/js/jquery.mark.min.js",
 	"goon/browserassets/js/json2.min.js",
 	"goon/browserassets/js/twemoji.min.js",
 	"goon/browserassets/js/browserOutput.js",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes `jquery.mark.min.js` from the chat's resource list.
Reformats some files and removes a dead variable from the chat, stuff that'd not be worth a PR on its own.

## Why It's Good For The Game
Fixes #15994 and stops spamming the console on non-windows machines.

## Changelog
:cl:
fix: stop console spam due to missing chat resource
/:cl:

## Note
I didn't have a linux box available to reproduce this on, but it's such a simple change that should've been done regardless. It's tested to not break anything on my windows machine, and that's about it.