### PR TITLE
Examine Energy Weapon Charge

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -20,6 +20,11 @@
 	/// Do you want the gun to fit into a turret, defaults to true, used for if a energy gun is too strong to be in a turret, or does not make sense to be in one.
 	var/can_fit_in_turrets = TRUE
 
+/obj/item/gun/energy/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It is [(cell.charge / cell.maxcharge) * 100]% charged.</span>"
+
+
 /obj/item/gun/energy/detailed_examine()
 	return "This is an energy weapon. Most energy weapons can fire through windows harmlessly. To recharge this weapon, use a weapon recharger."
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds a blurb when examining energy weapons that tells you its current charge.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The fabled golden bolt used to have this information which is very useful to tell if you have enough charge for a difficult encounter as a sec officer or if you are unprepared. This info was lost with the switch to disablers which dont display this info apart from their graphics which dont have alot of clarity.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/16618648/173196192-b9c1b8de-10da-42ef-8235-27704cf73f38.png)

## Changelog
:cl:
add: When examining energy weapons you can now see their charge level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
