### PR TITLE
Restores Music Note Toggle On Headphones

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -224,6 +224,9 @@
 /datum/action/item_action/toggle_mister
 	name = "Toggle Mister"
 
+/datum/action/item_action/toggle_note_effect
+	name = "Toggle Note Effect"
+
 /datum/action/item_action/toggle_helmet_light
 	name = "Toggle Helmet Light"
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -224,8 +224,8 @@
 /datum/action/item_action/toggle_mister
 	name = "Toggle Mister"
 
-/datum/action/item_action/toggle_note_effect
-	name = "Toggle Note Effect"
+/datum/action/item_action/toggle_music_notes
+	name = "Toggle Music Notes"
 
 /datum/action/item_action/toggle_helmet_light
 	name = "Toggle Helmet Light"

--- a/code/modules/instruments/objs/items/headphones.dm
+++ b/code/modules/instruments/objs/items/headphones.dm
@@ -3,7 +3,7 @@
 	desc = "Unce unce unce unce."
 	icon_state = "headphones0"
 	item_state = "headphones0"
-	actions_types = list(/datum/action/item_action/change_headphones_song, /datum/action/item_action/toggle_note_effect)
+	actions_types = list(/datum/action/item_action/change_headphones_song, /datum/action/item_action/toggle_music_notes)
 	var/datum/song/headphones/song
 	var/on = 0
 

--- a/code/modules/instruments/objs/items/headphones.dm
+++ b/code/modules/instruments/objs/items/headphones.dm
@@ -3,8 +3,9 @@
 	desc = "Unce unce unce unce."
 	icon_state = "headphones0"
 	item_state = "headphones0"
-	actions_types = list(/datum/action/item_action/change_headphones_song)
+	actions_types = list(/datum/action/item_action/change_headphones_song, /datum/action/item_action/toggle_note_effect)
 	var/datum/song/headphones/song
+	var/on = 0
 
 /obj/item/clothing/ears/headphones/Initialize(mapload)
 	. = ..()
@@ -19,8 +20,13 @@
 	QDEL_NULL(song)
 	return ..()
 
-/obj/item/clothing/ears/headphones/attack_self(mob/user)
-	ui_interact(user)
+/obj/item/clothing/ears/headphones/ui_action_click(mob/user, actiontype)
+	if(actiontype == /datum/action/item_action/change_headphones_song)
+		ui_interact(user)
+	else
+		on = !on
+		icon_state = item_state = "headphones[on]"
+		update_icon()
 
 /obj/item/clothing/ears/headphones/ui_data(mob/user)
 	return song.ui_data(user)

--- a/code/modules/instruments/objs/items/headphones.dm
+++ b/code/modules/instruments/objs/items/headphones.dm
@@ -5,7 +5,7 @@
 	item_state = "headphones0"
 	actions_types = list(/datum/action/item_action/change_headphones_song, /datum/action/item_action/toggle_music_notes)
 	var/datum/song/headphones/song
-	var/on = 0
+	var/on = FALSE
 
 /obj/item/clothing/ears/headphones/Initialize(mapload)
 	. = ..()
@@ -25,7 +25,8 @@
 		ui_interact(user)
 	else
 		on = !on
-		icon_state = item_state = "headphones[on]"
+		icon_state = "headphones[on]"
+		item_state = "headphones[on]"
 		update_icon()
 
 /obj/item/clothing/ears/headphones/ui_data(mob/user)


### PR DESCRIPTION
## What Does This PR Do
Restores the ability to toggle music notes on headphones without having to play a MIDI which was how the headphones used to behave before #13865

Playing a MIDI still turns the note effect on, you just now have the option to instead just push a button instead of doing that.
## Why It's Good For The Game
This was a [forum suggestion](https://www.paradisestation.org/forum/topic/22560-request-for-headphones-alterationreversion/), I don't really want this but a lot of other people do so be it.
## Changelog
:cl: Bmon
tweak: The ability to toggle the music notes on headphones has been restored
/:cl:
