### PR TITLE
Fixes Antihol 2: Electric Boogaloo

### DIFF
--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -33,7 +33,7 @@ Bonus
 		if(A.stage >= 3)
 			M.AdjustSlur(-4 SECONDS)
 			M.AdjustDrunk(-8 SECONDS)
-			M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3, 0, 1)
+			M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3)
 		if(A.stage >= 4)
 			M.AdjustDrowsy(-4 SECONDS)
 			if(RD.has_reagent("lsd"))

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -697,7 +697,7 @@
 		// Switch between how we check the reagent type
 		if(strict)
 			if(R.type == reagent_type)
-				matches = FALSE
+				matches = TRUE
 		else
 			if(istype(R, reagent_type))
 				matches = TRUE

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -700,7 +700,7 @@
 				matches = FALSE
 		else
 			if(istype(R, reagent_type))
-				matches = FALSE
+				matches = TRUE
 		// We found a match, proceed to remove the reagent.	Keep looping, we might find other reagents of the same type.
 		if(matches)
 			// Have our other proc handle removement

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -856,7 +856,7 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	M.SetSlur(0)
 	M.AdjustDrunk(-4)
-	M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 8, 0, 1)
+	M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 8)
 	if(M.getToxLoss() <= 25)
 		update_flags |= M.adjustToxLoss(-2.0, FALSE)
 	return ..() | update_flags

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -855,7 +855,7 @@
 /datum/reagent/medicine/antihol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	M.SetSlur(0)
-	M.AdjustDrunk(-4)
+	M.AdjustDrunk(-8 SECONDS)
 	M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 8)
 	if(M.getToxLoss() <= 25)
 		update_flags |= M.adjustToxLoss(-2.0, FALSE)


### PR DESCRIPTION
## What Does This PR Do
Fixes #17922 
Antihol and Sensory Restoration that removes alcohol now actually does so properly. Two PRs in the past seem to have broken it (#13656 and possibly #2813). Not sure which, or if maybe both, are the culprit. Regardless, this PR addresses the issue at hand and makes it so the chemical and disease properly purge all variants of booze.

## Why It's Good For The Game
Antihol actually working instead of having a placebo effect is good. Less drunk and dying grey tide puking all over the medbay floors for ages.

## Changelog
:cl:
fix: Antihol now actually works.
fix: Sensory restoration now properly removes alcohol.
/:cl: