### PR TITLE
Nerfs xenobio xenomorph mobs HP

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -31,10 +31,15 @@
 	minbodytemp = 0
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN
 	death_sound = 'sound/voice/hiss6.ogg'
 	deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw..."
 	footstep_type = FOOTSTEP_MOB_CLAW
+
+/mob/living/simple_animal/hostile/alien/xenobio
+	maxHealth = 60
+	health = 60
+	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/alien/drone
 	name = "alien drone"
@@ -45,6 +50,11 @@
 	melee_damage_upper = 15
 	var/plant_cooldown = 30
 	var/plants_off = 0
+
+/mob/living/simple_animal/hostile/alien/drone/xenobio
+	maxHealth = 60
+	health = 60
+	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/alien/drone/handle_automated_action()
 	if(!..()) //AIStatus is off
@@ -71,6 +81,11 @@
 	projectilesound = 'sound/weapons/pierce.ogg'
 
 
+/mob/living/simple_animal/hostile/alien/sentinel/xenobio
+	health = 75
+	maxHealth = 75
+	gold_core_spawnable = HOSTILE_SPAWN
+
 /mob/living/simple_animal/hostile/alien/queen
 	name = "alien queen"
 	icon_state = "alienq_running"
@@ -92,6 +107,11 @@
 	var/plants_off = 0
 	var/egg_cooldown = 30
 	var/plant_cooldown = 30
+
+/mob/living/simple_animal/hostile/alien/queen/xenobio
+	health = 100
+	maxHealth = 100
+	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/alien/queen/handle_automated_action()
 	if(!..())
@@ -134,7 +154,6 @@
 	health = 400
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat= 10, /obj/item/stack/sheet/animalhide/xeno = 2)
 	mob_size = MOB_SIZE_LARGE
-	gold_core_spawnable = NO_SPAWN
 
 /obj/item/projectile/neurotox
 	name = "neurotoxin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Approximately halfs Xenobio alien hunters HP (125 -> 60)
Xenobio drone has the same health decrease.
Xenobio sentinel down half (150 -> 75)
Xenobio queen down to 100 (250 -> 100) 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Xenobio is an interesting department, to say the least. They can create a bunch of normally hostile mobs, and make them friendly to the crew. The HP of these mobs vary, as well as their health and speed. However, out of all the xenobio mobs, one type stands out a lot, having a bunch of HP, a bunch of health, and often a ranged attack that hits super hard.

The biggest example, and the one I am toning back, is aliens, especially the alien queen and sentinal, which have ranged attacks that hit for 30 brute.

While there are other mobs that have the same health as the xenobio aliens, or damage, no mob has both, with a ranged option.

This tones down the health of these mobs, making it easier for crew or terrors to kill, when xenobio is spaming sentieent ones out, without nerfing their damage, or the base mobtype.

### Why lower the queen to 100 rather than 125?
Because if I lower the queen to 125 hp, it is basically the same as lowering the alien sentinels HP by 25. It is a nerf, and nerfs the queen, but would basically leave the second strongest, the sentinel as is. 100 hp with a range option is a much better limit, then 125.

For those curious, have a shitty graph / chart of all xenobio possible hostile spawns, with health and damage. (frankly the graph sucks, could not make it work)

![image](https://user-images.githubusercontent.com/52090703/173246540-71978da8-bcba-4a94-91c2-ea9d933ed8db.png)


## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Xenobio Xenomorphs now spawn with greatly reduced HP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
