### PR TITLE
Meteor shield sats can now shoot meaty ores

### DIFF
--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -39,6 +39,7 @@
 	var/endy = 0
 	var/endx = 0
 	var/startside = pick(GLOB.cardinal)
+	GLOB.meteor_list += src
 
 	switch(startside)
 		if(NORTH)
@@ -100,3 +101,7 @@
 
 /obj/effect/space_dust/ex_act(severity)
 	qdel(src)
+
+/obj/effect/space_dust/Destroy()
+	GLOB.meteor_list -= src
+	return ..()

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -162,13 +162,15 @@
 /obj/machinery/satellite/meteor_shield/process()
 	if(!active)
 		return
-	for(var/obj/effect/meteor/M in GLOB.meteor_list)
+	for(var/obj/effect/M in GLOB.meteor_list)
 		if(M.z != z)
 			continue
 		if(get_dist(M, src) > kill_range)
 			continue
 		if(!emagged && space_los(M))
 			Beam(get_turf(M), icon_state = "sat_beam", time = 5, maxdistance = kill_range)
+			if(istype(M, /obj/effect/space_dust/meaty))
+				new /obj/item/reagent_containers/food/snacks/meatsteak(M.loc)
 			qdel(M)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -170,7 +170,7 @@
 		if(!emagged && space_los(M))
 			Beam(get_turf(M), icon_state = "sat_beam", time = 5, maxdistance = kill_range)
 			if(istype(M, /obj/effect/space_dust/meaty))
-				new /obj/item/reagent_containers/food/snacks/meatsteak(M.loc)
+				new /obj/item/reagent_containers/food/snacks/meatsteak(get_turf(M))
 			qdel(M)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Space dust (meaty ores being the most common / important of these) are added to the GLOB.meteor_list, and alows meteor sats to shoot them down.

Meaty ores themselfs are fried into steak.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Meteor shield sats not working on meaty ores, which are quite destructive, kinda makes them sad. Allowing meaty ores and space dust to be shot down by meteor sats should be nice, and turning them to steak rather then just deleting the cows is funny.

## Changelog
:cl:
tweak: Meteor shield sats can now shoot down space dust, and meaty ores.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
