### PR TITLE
A few antag datum related fixes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -434,6 +434,8 @@
 			occupant.ghostize(FALSE) // Players despawned too early may not re-enter the game
 		else
 			occupant.ghostize(TRUE)
+
+	occupant.mind.remove_all_antag_datums()
 	QDEL_NULL(occupant)
 	name = initial(name)
 

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -27,7 +27,8 @@
 	if(owner.som)
 		owner.som.serv -= owner
 		owner.som.leave_serv_hud(owner)
-	master = null
+	// Remove the reference but turn this into a string so it can still be used in /datum/antagonist/mindslave/farewell().
+	master = "[master.current.real_name]"
 	return ..()
 
 /datum/antagonist/mindslave/on_gain()
@@ -67,7 +68,7 @@
 
 /datum/antagonist/mindslave/farewell()
 	if(owner && owner.current)
-		to_chat(owner.current, "<span class='biggerdanger'>You are no longer a mindslave of [master.current]!</span>")
+		to_chat(owner.current, "<span class='biggerdanger'>You are no longer a mindslave of [master]!</span>")
 
 /datum/antagonist/mindslave/add_antag_hud(mob/living/antag_mob)
 	. = ..()

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -49,12 +49,17 @@
 	M.RemoveSpell(/obj/effect/proc_holder/spell/vampire/thrall_commune)
 
 /datum/antagonist/vampire/Destroy(force, ...)
-	SSticker.mode.vampires -= owner
 	owner.current.create_log(CONVERSION_LOG, "De-vampired")
 	draining = null
 	QDEL_NULL(subclass)
 	QDEL_LIST(powers)
 	return ..()
+
+/datum/antagonist/vampire/add_owner_to_gamemode()
+	SSticker.mode.vampires += owner
+
+/datum/antagonist/vampire/remove_owner_from_gamemode()
+	SSticker.mode.vampires -= owner
 
 /datum/antagonist/vampire/proc/adjust_nullification(base, extra)
 	// First hit should give full nullification, while subsequent hits increase the value slower
@@ -218,11 +223,6 @@
 			else if(istype(p, /datum/vampire_passive))
 				var/datum/vampire_passive/power = p
 				to_chat(owner.current, "<span class='boldnotice'>[power.gain_desc]</span>")
-
-
-/datum/antagonist/vampire/on_gain()
-	SSticker.mode.vampires += owner
-	..()
 
 /datum/antagonist/vampire/proc/check_sun()
 	var/ax = owner.current.x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
* Fixes #17958 by removing all antag datums when a player leaves the round via cryo
* Gives `/datum/antagonist/vampire` an `add_owner_to_gamemode()` and `remove_owner_to_gamemode()` which I somehow missed when doing #17830
* Fixes a runtime with `/datum/antagonist/mindslave/farewell()` where `[master.current]` would runtime due to `master` being nulled out in `Destroy()` first
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Vampire thralls will now lose their thrall status when leaving the round via cryo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
