### PR TITLE
Fixes Maintenance Areas/Doors on DeltaStation

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -4935,7 +4935,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/security/customs)
+/area/maintenance/fore)
 "avg" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -6087,7 +6087,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/maintenance/disposal)
+/area/maintenance/fore2)
 "axy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8604,7 +8604,7 @@
 	req_access_txt = "26"
 	},
 /turf/simulated/floor/plating,
-/area/janitor)
+/area/maintenance/fore)
 "aDt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12324,18 +12324,12 @@
 	icon_state = "barber"
 	},
 /area/civilian/barber)
-"aLF" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "46"
-	},
-/turf/simulated/floor/plating,
-/area/clownoffice)
 "aLG" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "46"
 	},
 /turf/simulated/floor/plating,
-/area/mimeoffice)
+/area/maintenance/starboard)
 "aLH" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -44622,11 +44616,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -45321,11 +45310,6 @@
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/button/windowtint{
 	dir = 4;
@@ -45944,7 +45928,6 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -78406,7 +78389,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/medical/research)
+/area/maintenance/apmaint)
 "dBj" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -82284,7 +82267,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
-/area/chapel/office)
+/area/maintenance/apmaint)
 "dKZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84533,7 +84516,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/aft)
 "dQu" = (
 /obj/item/bonegel{
 	pixel_x = 6;
@@ -89892,6 +89875,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
+"iwk" = (
+/obj/effect/spawner/random_spawners/wall_rusted_always,
+/turf/simulated/wall/rust,
+/area/medical/surgery)
 "iwQ" = (
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -90199,7 +90186,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/lawoffice)
+/area/maintenance/starboard2)
 "jav" = (
 /obj/machinery/door/airlock{
 	name = "Magistrate's Office";
@@ -96425,7 +96412,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/maintenance/fore)
 "wZe" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -147727,7 +147714,7 @@ aFt
 aFt
 cSX
 dDE
-cXI
+iwk
 dlz
 dlz
 dcF
@@ -148495,7 +148482,7 @@ cLo
 cMM
 aHQ
 cQf
-aLF
+aLG
 boG
 dDy
 dlz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Fixes some mild mapping errors regarding maintenance doors and their areas (places like mime, clown, law office... places I may have built...) where they wouldn't have their doors open to all access modes during events like radiation storms. Also removed some stray wiring left behind in the law office.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Doors that should open/unlock during radiation storms and the like should open. As these are my errors, should probably not be GBP related.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. --> No visual changes

## Changelog
:cl:
fix: Certain maintenance airlocks on DeltaStation now open when maintenance all access is granted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
