### PR TITLE
Fixes Area Shenanigans on Labour Camp, Derelict 5, and CharlieStation

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
@@ -5,9 +5,6 @@
 "b" = (
 /turf/simulated/mineral,
 /area/ruin/unpowered)
-"c" = (
-/turf/simulated/mineral,
-/area/space/nearstation)
 "d" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/unpowered)
@@ -65,9 +62,6 @@
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
-"r" = (
-/turf/simulated/floor/plating/asteroid/airless,
-/area/space/nearstation)
 
 (1,1,1) = {"
 a
@@ -853,8 +847,8 @@ b
 d
 d
 d
-r
-r
+d
+d
 a
 a
 a
@@ -895,8 +889,8 @@ b
 d
 d
 d
-r
-r
+d
+d
 d
 d
 d
@@ -937,7 +931,7 @@ b
 d
 d
 d
-r
+d
 d
 d
 d
@@ -979,7 +973,7 @@ b
 d
 d
 d
-r
+d
 d
 d
 d
@@ -1021,7 +1015,7 @@ b
 d
 d
 d
-r
+d
 d
 d
 d
@@ -1063,7 +1057,7 @@ d
 d
 d
 d
-r
+d
 d
 d
 d
@@ -1105,7 +1099,7 @@ b
 d
 d
 d
-r
+d
 d
 d
 d
@@ -1123,7 +1117,7 @@ b
 a
 a
 a
-c
+b
 a
 a
 a
@@ -1147,7 +1141,7 @@ b
 d
 d
 d
-r
+d
 d
 d
 d
@@ -1189,7 +1183,7 @@ b
 b
 b
 b
-r
+d
 d
 d
 d
@@ -1229,9 +1223,9 @@ b
 b
 b
 b
-c
-c
-c
+b
+b
+b
 d
 d
 d
@@ -1271,9 +1265,9 @@ b
 b
 b
 b
-c
-c
-c
+b
+b
+b
 d
 d
 d

--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -26,10 +26,6 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/space/nearstation)
-"ag" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
 "ah" = (
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/ancientstation/hivebot)
@@ -5682,7 +5678,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5730,7 +5726,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa

--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -21,11 +21,11 @@
 /area/ruin/space/ancientstation/hivebot)
 "ae" = (
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "af" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/template_noop)
+/area/space/nearstation)
 "ag" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -191,7 +191,7 @@
 "aH" = (
 /obj/item/solar_assembly,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "aI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -473,7 +473,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "bu" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -694,7 +694,7 @@
 "cc" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "cd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -751,7 +751,7 @@
 "ck" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "cl" = (
 /obj/structure/transit_tube/station/reverse,
 /obj/effect/decal/cleanable/dirt,
@@ -885,14 +885,14 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "cD" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -922,7 +922,7 @@
 	},
 /obj/machinery/power/solar,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "cI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pickaxe,
@@ -1042,7 +1042,7 @@
 "cX" = (
 /obj/structure/transit_tube,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "cY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -1062,7 +1062,7 @@
 /obj/item/solar_assembly,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -1098,11 +1098,11 @@
 	icon_state = "E-W-Pass"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "df" = (
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "dg" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -1140,7 +1140,7 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "dl" = (
 /obj/item/stack/cable_coil,
 /turf/template_noop,
@@ -1156,7 +1156,7 @@
 	icon_state = "N-S"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space/nearstation)
 "do" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1172,7 +1172,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "dq" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -1762,7 +1762,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "eL" = (
 /obj/machinery/light{
 	dir = 4
@@ -2935,7 +2935,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "hg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2988,7 +2988,7 @@
 	amount = 2
 	},
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "hm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3062,7 +3062,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "ht" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3241,7 +3241,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "hK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -3644,7 +3644,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "iC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3754,7 +3754,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating,
-/area/template_noop)
+/area/space/nearstation)
 "iP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3763,7 +3763,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating,
-/area/template_noop)
+/area/space/nearstation)
 "iQ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -4051,7 +4051,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "jx" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -4370,7 +4370,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/airless,
-/area/template_noop)
+/area/space/nearstation)
 "km" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4457,7 +4457,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating,
-/area/template_noop)
+/area/space/nearstation)
 "kw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -4670,7 +4670,7 @@
 "kZ" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating,
-/area/template_noop)
+/area/space/nearstation)
 "la" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5095,6 +5095,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/ancientstation/thetacorridor)
+"uQ" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
 "AY" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
@@ -5136,11 +5140,11 @@ aa
 aa
 aV
 aV
-ag
+uQ
 aV
 aV
 aa
-ag
+uQ
 aV
 aV
 aa
@@ -5153,7 +5157,7 @@ aa
 aa
 aa
 in
-ag
+uQ
 in
 in
 in
@@ -5163,7 +5167,7 @@ kk
 ku
 kC
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5192,14 +5196,14 @@ be
 be
 ei
 aV
-ag
-ag
-ag
+uQ
+uQ
+uQ
 ae
-ag
-ag
-ag
-ag
+uQ
+uQ
+uQ
+uQ
 io
 lr
 lr
@@ -5243,7 +5247,7 @@ eA
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5276,7 +5280,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aV
 aV
 bf
@@ -5291,7 +5295,7 @@ bf
 aW
 aV
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5325,7 +5329,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aV
 bo
 be
@@ -5344,14 +5348,14 @@ aa
 aa
 aa
 aa
-ag
+uQ
 lr
 in
 in
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5389,19 +5393,19 @@ fs
 be
 aV
 gV
-ag
-ag
-ag
-ag
+uQ
+uQ
+uQ
+uQ
 lr
 lr
 in
 in
 aa
-ag
+uQ
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5438,7 +5442,7 @@ bz
 bf
 aW
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5447,7 +5451,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5486,7 +5490,7 @@ be
 gB
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5495,7 +5499,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5516,7 +5520,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 ab
 aa
 bf
@@ -5525,15 +5529,15 @@ bY
 be
 bf
 aV
-ag
+uQ
 aV
 eB
 aV
 fu
 go
 aV
-ag
-ag
+uQ
+uQ
 ae
 aa
 aa
@@ -5543,7 +5547,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5562,7 +5566,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5572,8 +5576,8 @@ bz
 bW
 bz
 bf
-ag
-ag
+uQ
+uQ
 aa
 aV
 aV
@@ -5581,17 +5585,17 @@ fv
 aV
 aV
 aa
-ag
+uQ
 ae
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5612,7 +5616,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5624,9 +5628,9 @@ aW
 aa
 aa
 aa
-ag
+uQ
 fv
-ag
+uQ
 aa
 aa
 af
@@ -5634,11 +5638,11 @@ cc
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5659,16 +5663,21 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
-ag
+uQ
 aa
 aa
 cX
 aa
 aa
-ag
+uQ
+aa
+aa
+aa
+aa
+uQ
 aa
 aa
 aa
@@ -5677,12 +5686,7 @@ ag
 aa
 aa
 aa
-aa
-ag
-aa
-aa
-aa
-ag
+uQ
 aa
 aa
 aa
@@ -5706,8 +5710,8 @@ aa
 aa
 aa
 aa
-ag
-ag
+uQ
+uQ
 aa
 aa
 aa
@@ -5716,7 +5720,12 @@ aa
 de
 aa
 aa
-ag
+uQ
+aa
+aa
+aa
+aa
+uQ
 aa
 aa
 aa
@@ -5725,19 +5734,14 @@ ag
 aa
 aa
 aa
-aa
-ag
-aa
-aa
-aa
-ag
+uQ
 aa
 aa
 aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5755,8 +5759,8 @@ aa
 aa
 aa
 aa
-ag
-ag
+uQ
+uQ
 aa
 aa
 aa
@@ -5775,7 +5779,7 @@ aa
 cC
 ae
 ae
-ag
+uQ
 ae
 ae
 cH
@@ -5784,7 +5788,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5803,7 +5807,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5811,7 +5815,7 @@ aa
 aa
 cX
 aa
-ag
+uQ
 ck
 ck
 hf
@@ -5827,11 +5831,11 @@ kZ
 iO
 kZ
 iP
-ag
+uQ
 aa
 aa
 aa
-ag
+uQ
 aa
 aH
 ab
@@ -5851,7 +5855,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5871,7 +5875,7 @@ aa
 ae
 cC
 ae
-ag
+uQ
 ae
 ae
 ae
@@ -5899,7 +5903,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5907,7 +5911,7 @@ aa
 aa
 cX
 aa
-ag
+uQ
 ck
 ck
 eK
@@ -5927,7 +5931,7 @@ df
 aa
 aa
 aa
-ag
+uQ
 ab
 ab
 kH
@@ -5947,7 +5951,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -5967,14 +5971,14 @@ aa
 ae
 ae
 ae
-ag
+uQ
 ae
 ae
 ae
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 ab
@@ -5995,7 +5999,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6003,7 +6007,7 @@ aa
 aa
 cX
 aa
-ag
+uQ
 eK
 hf
 ck
@@ -6019,7 +6023,7 @@ ck
 hf
 hf
 kl
-ag
+uQ
 aa
 aa
 aa
@@ -6043,7 +6047,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6063,7 +6067,7 @@ aa
 ae
 cD
 ae
-ag
+uQ
 ae
 cD
 cD
@@ -6071,9 +6075,9 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6091,7 +6095,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6100,7 +6104,7 @@ aa
 cX
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6110,16 +6114,16 @@ eC
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6139,7 +6143,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6148,7 +6152,7 @@ aa
 cX
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6158,16 +6162,16 @@ eC
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6187,7 +6191,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6210,12 +6214,12 @@ cU
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6235,7 +6239,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6258,12 +6262,12 @@ cU
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6283,7 +6287,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6311,7 +6315,7 @@ cU
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6331,7 +6335,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6359,7 +6363,7 @@ cU
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6379,7 +6383,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6407,7 +6411,7 @@ cU
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6427,7 +6431,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -6455,7 +6459,7 @@ cU
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7290,7 +7294,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7319,7 +7323,7 @@ az
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7338,7 +7342,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7367,7 +7371,7 @@ az
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7385,7 +7389,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7415,7 +7419,7 @@ az
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7435,7 +7439,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7463,7 +7467,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7511,7 +7515,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7559,7 +7563,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7592,9 +7596,9 @@ aa
 aa
 aa
 aa
-ag
+uQ
 bt
-ag
+uQ
 aa
 aa
 aa
@@ -7607,7 +7611,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7640,9 +7644,9 @@ aa
 dn
 aa
 aa
-ag
+uQ
 bt
-ag
+uQ
 aa
 aa
 aa
@@ -7655,7 +7659,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 ab
@@ -7688,9 +7692,9 @@ ab
 ab
 aa
 aa
-ag
+uQ
 bt
-ag
+uQ
 aa
 aa
 aa
@@ -7703,7 +7707,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 ab
@@ -7721,7 +7725,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7736,9 +7740,9 @@ ab
 ab
 ab
 aa
-ag
+uQ
 bt
-ag
+uQ
 aa
 aa
 aa
@@ -7751,7 +7755,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7771,7 +7775,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7799,7 +7803,7 @@ bu
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7847,7 +7851,7 @@ bu
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7866,7 +7870,7 @@ aa
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7895,7 +7899,7 @@ bu
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7912,8 +7916,8 @@ aa
 aa
 aa
 aa
-ag
-ag
+uQ
+uQ
 aa
 aa
 aa
@@ -7943,7 +7947,7 @@ bu
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -7991,7 +7995,7 @@ bu
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa
@@ -8039,7 +8043,7 @@ bu
 aa
 aa
 aa
-ag
+uQ
 aa
 aa
 aa

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -871,7 +871,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
-/area/mine/laborcamp)
+/area/mine/laborcamp/security)
 "ca" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -4221,7 +4221,7 @@
 	dir = 4;
 	icon_state = "darkredcorners"
 	},
-/area/mine/laborcamp)
+/area/mine/laborcamp/security)
 "sP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4427,7 +4427,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp)
+/area/mine/laborcamp/security)
 "xM" = (
 /obj/structure/ore_box,
 /obj/machinery/light/small{
@@ -4831,7 +4831,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp)
+/area/mine/laborcamp/security)
 "LO" = (
 /obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4882,7 +4882,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/mine/laborcamp)
+/area/mine/laborcamp/security)
 "Nj" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
@@ -4945,6 +4945,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"PX" = (
+/turf/simulated/wall,
+/area/mine/laborcamp/security)
 "QE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -10088,9 +10091,9 @@ ao
 aq
 aJ
 aq
-aq
+PX
 Ni
-aq
+PX
 aj
 aD
 aj
@@ -10347,7 +10350,7 @@ hQ
 aq
 bZ
 sO
-ap
+cG
 aj
 aj
 aj

--- a/code/modules/awaymissions/mission_code/ruins/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ruins/oldstation.dm
@@ -325,7 +325,7 @@
 
 /area/ruin/space/ancientstation/betanorth
 	name = "Beta Station North Corridor"
-	icon_state = "blue"
+	icon_state = "purple"
 
 /area/ruin/space/ancientstation/solar
 	name = "Station Solar Array"
@@ -342,7 +342,7 @@
 
 /area/ruin/space/ancientstation/hydroponics
 	name = "Charlie Station Hydroponics"
-	icon_state = "garden"
+	icon_state = "hydro"
 
 /area/ruin/space/ancientstation/kitchen
 	name = "Charlie Station Kitchen"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> Fixes area issues on Labour Camp (see below), Derelict 5 Ruin (again, see below), and even more including invisible areas (for mapping) on CharlieStation/AncientStation/OldStation ruin. For the invisible areas, I redirected their icon states from non-existing to pre-existing ("garden" to "hydro" for the garden area, and "blue" to "purple" for BetaNorth)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> 

1. Visible areas are good for mapping
2. Near Space should be used for items that are not proper areas, but also not blank space
3. Near Space shouldn't be placed for tiles that are in proper areas otherwise
4. Labour camp security office had weird shenanigans occurring

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

A sample of what was done with Charlie/Ancient/Old:
![image](https://user-images.githubusercontent.com/16112919/174183037-e540d265-5595-4d53-b48a-649d8122e195.png)

Old Derelict 5

![image](https://user-images.githubusercontent.com/16112919/174184655-d78c8084-8e15-4407-8efb-ea9980c73a7b.png)

New Derelict:

![image](https://user-images.githubusercontent.com/16112919/174185048-c564710c-9844-4aff-a7d8-087748d989b6.png)

Old Labour

![image](https://user-images.githubusercontent.com/16112919/174185116-7f29b7e5-5316-4d82-98c1-1a02b66d13f3.png)

New Labour

![image](https://user-images.githubusercontent.com/16112919/174183697-786a96c7-5106-49f3-a5b8-ce06eb3ecdea.png)


## Changelog
:cl:
tweak: Labour Camp Security Office should function more like every other room now
tweak: Area fixes to CharlieStation space ruin (no player side changes)
tweak: Area fixes to Derelict 5 space ruin (no player side changes)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
