### PR TITLE
Grants VIEW variables to +VIEWRUNTIMES

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -83,7 +83,7 @@
 
 	var/static/cookieoffset = rand(1, 9999) //to force cookies to reset after the round.
 
-	if(!is_admin(usr))
+	if(!check_rights(R_ADMIN|R_VIEWRUNTIMES))
 		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
 		return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -281,6 +281,7 @@ GLOBAL_LIST_INIT(admin_verbs_maintainer, list(
 			verbs += /client/proc/cmd_display_del_log
 			verbs += /client/proc/cmd_display_del_log_simple
 			verbs += /client/proc/toggledebuglogs
+			verbs += /client/proc/debug_variables /*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 			spawn(1) // This setting exposes the profiler for people with R_VIEWRUNTIMES. They must still have it set in cfg/admin.txt
 				control_freak = 0
 


### PR DESCRIPTION
## What Does This PR Do
Allows people with `+VIEWRUNTIMES` to view variables on objects. **They cannot edit variables. I repeat, they CANNOT edit variables. Put your pitchforks down.**

## Why It's Good For The Game
Given we give these people runtimes already, as well as kibana logs and everything else, we may as well give them VV with no edit rights, since they should be able to debug stuff with their TMs a lot easier without having to nag admins.

## Changelog
:cl: AffectedArc07
tweak: The +VIEWRUNTIMES right now grants read-only VV menu access.
/:cl:
