### PR TITLE
Reworks flap+windoor delivery areas, tidies delivery beacon directions

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -6799,15 +6799,6 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "azl" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/westleft{
-	name = "Janitoral Delivery";
-	req_access_txt = "26"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -7384,6 +7375,9 @@
 	dir = 8;
 	location = "Janitor"
 	},
+/obj/machinery/door/window/eastright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
 /turf/simulated/floor/plating,
 /area/janitor)
 "aAB" = (
@@ -10490,6 +10484,9 @@
 	dir = 4;
 	location = "Bar"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/machinery/door/window/westright,
 /turf/simulated/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "aHJ" = (
@@ -17812,6 +17809,8 @@
 	opacity = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door/window/westright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "aXL" = (
@@ -20001,6 +20000,9 @@
 	location = "Kitchen"
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/window/westright,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bcp" = (
@@ -20935,6 +20937,9 @@
 	opacity = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/machinery/door/window/southright,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bem" = (
@@ -28435,18 +28440,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"buG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/arrow{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "buH" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -29010,17 +29003,6 @@
 	},
 /area/atmos)
 "bvR" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "Atmospherics Deliveries";
-	req_access_txt = "24"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -29055,6 +29037,9 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door/window/eastright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bvT" = (
@@ -48742,13 +48727,6 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -49314,9 +49292,13 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
-	location = "Security"
+	location = "Security";
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/door/window/southleft,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "cnT" = (
@@ -56381,15 +56363,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engine_smes)
 "cDD" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/eastleft{
-	req_access_txt = "10"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -56726,9 +56699,13 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
-	location = "Engineering"
+	location = "Engineering";
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door/window/southright,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cEC" = (
@@ -60316,6 +60293,9 @@
 	dir = 8;
 	location = "Medbay"
 	},
+/obj/machinery/door/window/eastright,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/simulated/floor/plasteel,
 /area/medical/medbay2)
 "cMG" = (
@@ -77316,12 +77296,16 @@
 "dyP" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
-	location = "Robotics"
+	location = "Robotics";
+	dir = 1
 	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/window/southright,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "dyR" = (
@@ -89814,6 +89798,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/door/window/northleft,
 /turf/simulated/floor/plating,
 /area/toxins/misc_lab)
 "iiM" = (
@@ -96183,6 +96170,9 @@
 	dir = 8;
 	location = "Hydroponics"
 	},
+/obj/machinery/door/window/eastright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "wjm" = (
@@ -125353,7 +125343,7 @@ aOg
 btw
 brR
 btw
-buG
+buD
 bvR
 bxc
 byD

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3744,6 +3744,8 @@
 	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "aug" = (
@@ -6793,14 +6795,13 @@
 	opacity = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/door/window/westleft,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/simulated/floor/plasteel,
 /area/maintenance/fsmaint)
 "aEy" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/eastleft{
-	name = "Engineering Deliveries"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aEz" = (
@@ -23689,12 +23690,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "buw" = (
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Bridge Deliveries"
-	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "bridge blast";
 	name = "Bridge Blast Doors"
@@ -24040,6 +24036,9 @@
 	opacity = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/window/westleft,
 /turf/simulated/floor/plasteel,
 /area/maintenance/maintcentral)
 "bvo" = (
@@ -28235,6 +28234,9 @@
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/atmos/control)
 "bEL" = (
@@ -28841,7 +28843,6 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
-	dir = 4;
 	location = "Atmospherics"
 	},
 /obj/structure/disposalpipe/segment,
@@ -28850,6 +28851,11 @@
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
 	},
+/obj/machinery/door/window/northright{
+	name = "Atmospherics Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/atmos/control)
 "bGE" = (
@@ -33999,6 +34005,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
+/obj/machinery/door/window/southright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "bVy" = (
@@ -34048,10 +34057,6 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/door/window/eastleft{
-	name = "Kitchen Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -34065,6 +34070,11 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/plasticflaps{
 	opacity = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/window/eastleft{
+	name = "Kitchen Delivery"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -35226,6 +35236,9 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/window/westright,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -36190,13 +36203,6 @@
 "cbm" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	name = "Hydroponics Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
@@ -41392,11 +41398,9 @@
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "cqo" = (
-/obj/machinery/door/window/eastright,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
 /obj/machinery/light_switch{
 	name = "north bump";
 	pixel_y = 24
@@ -41620,16 +41624,6 @@
 /area/quartermaster/office)
 "cqZ" = (
 /obj/effect/decal/warning_stripes/blue,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/southright{
-	name = "Medical Deliveries"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -42501,6 +42495,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -43184,7 +43181,6 @@
 /area/hallway/primary/fore)
 "cvY" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -44912,13 +44908,13 @@
 "cBw" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
-	dir = 4;
 	location = "Medbay"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/door/window/northright,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cBx" = (
@@ -45320,6 +45316,7 @@
 	req_access_txt = "50";
 	name = "MuleBot Access"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cCD" = (
@@ -68385,12 +68382,15 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
-	dir = 8;
+	dir = 1;
 	location = "Hydroponics"
 	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
+/obj/machinery/door/window/southright,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "kJT" = (
@@ -72477,10 +72477,6 @@
 /obj/effect/turf_decal/loading_area,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/window/northright{
-	name = "Atmospherics Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -83607,6 +83603,9 @@
 	opacity = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/door/window/northright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard2)
 "svH" = (
@@ -86276,18 +86275,11 @@
 	})
 "tMV" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Bar Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "tNw" = (
 /obj/structure/table/wood,
@@ -86529,6 +86521,9 @@
 	id_tag = "Secure Gate";
 	name = "brig shutters"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/door/window/eastright,
 /turf/simulated/floor/plasteel,
 /area/maintenance/fore)
 "tUn" = (
@@ -93093,13 +93088,6 @@
 	},
 /area/medical/surgeryobs)
 "xyP" = (
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Security Delivery";
-	req_access_txt = "1"
-	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/security/main)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2977,19 +2977,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
-"akE" = (
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Security Delivery";
-	req_access_txt = "1"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
 "akF" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3860,6 +3847,9 @@
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/window/southright,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "amy" = (
@@ -22176,7 +22166,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "baM" = (
-/obj/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23568,10 +23557,6 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "bdL" = (
-/obj/machinery/door/window/southleft{
-	name = "Kitchen Delivery";
-	req_access_txt = "28"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -23584,9 +23569,6 @@
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
 	pixel_x = -5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -31924,11 +31906,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwe" = (
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Bridge Delivery";
-	req_access_txt = "19"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room)
@@ -34255,6 +34232,9 @@
 	opacity = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door/window/southleft,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room)
 "bBf" = (
@@ -40925,21 +40905,14 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
+/obj/machinery/door/window/eastright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
 /turf/simulated/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/medical/research)
 "bPk" = (
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Research Division Delivery";
-	req_access_txt = "47"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -44830,16 +44803,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bWX" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -45674,10 +45637,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bYF" = (
-/obj/machinery/door/window/westleft{
-	name = "Janitoral Delivery";
-	req_access_txt = "26"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -45795,10 +45754,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door/window/eastright,
+/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
 "bYR" = (
@@ -47359,6 +47321,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
+/obj/machinery/door/window/westleft,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/simulated/floor/plating,
 /area/medical/sleeper)
 "cbu" = (
@@ -48291,6 +48256,9 @@
 	id = "packageExternal"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/westright,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "ccZ" = (
@@ -62909,6 +62877,9 @@
 	opacity = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door/window/northleft,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cGV" = (
@@ -69764,6 +69735,9 @@
 	opacity = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/machinery/door/window/eastright,
 /turf/simulated/floor/plasteel,
 /area/maintenance/fsmaint)
 "cWv" = (
@@ -69852,13 +69826,8 @@
 /turf/simulated/floor/beach/sand,
 /area/hallway/secondary/exit)
 "cWG" = (
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Bar Delivery";
-	req_access_txt = "25"
-	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "cWH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -70301,6 +70270,9 @@
 	codes_txt = "delivery";
 	location = "Kitchen"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/machinery/door/window/northleft,
 /turf/simulated/floor/plasteel{
 	icon_state = "bot"
 	},
@@ -74278,6 +74250,9 @@
 	opacity = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/door/window/northleft,
 /turf/simulated/floor/plasteel{
 	icon_state = "bot"
 	},
@@ -74796,11 +74771,6 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "djt" = (
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Hydroponics Delivery";
-	req_access_txt = "35"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -74825,9 +74795,6 @@
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
 "djw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	name = "north bump";
 	pixel_y = 24
@@ -115592,7 +115559,7 @@ bSu
 cbY
 ceT
 bSu
-bQV
+chf
 chf
 chf
 chf
@@ -118354,7 +118321,7 @@ aih
 aih
 aqX
 aqW
-akE
+aqW
 amw
 avq
 aCh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR:
Tidies MULEbot delivery beacon dirs so they drop their cargo in the right spot.
Moves all MULEbot delivery windoors to under the plastic flaps, so that crawling people cannot easily break in through a directional window after crawling under a flap.
Assigns relevant departmental and cargo access, so that deliveries can be made by hand and department staff have access. This is done via access mapping helpers.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With crawling and the current setup for deliveries, you can crawl under the flaps and decon a directional window in less than 1 second. This makes break-ins stupidly trivial. With this change you now have to undertake a process (windoor deconstruction) that roughly the same length as breaking in took pre-crawling. (unscrewing and slicing flaps)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removed crawling vulnerabilities on MULEbot delivery points across all maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
