### PR TITLE
Makes Collosus death bolt dust dead people

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -262,6 +262,10 @@ Difficulty: Very Hard
 	. = ..()
 	if(isturf(target) || isobj(target))
 		target.ex_act(2)
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.stat == DEAD)
+			L.dust()
 
 /obj/item/gps/internal/colossus
 	icon_state = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Causes Collosus deathbolts to dust corpses they hit.

## Why It's Good For The Game
Prevents cheesing of collosus fight via pulling of corpses on pullable chairs.

## Changelog
:cl:
tweak: Collosus death bolts now dust dead mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
