### PR TITLE
Fixes a runtime when mindslave implanted people are gibbed or otherwise deleted

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_traitor.dm
+++ b/code/game/objects/items/weapons/implants/implant_traitor.dm
@@ -3,6 +3,8 @@
 	desc = "Divide and Conquer"
 	origin_tech = "programming=5;biotech=5;syndicate=8"
 	activated = FALSE
+	/// The UID of the mindslave's `mind`. Stored to solve GC race conditions and ensure we can remove their mindslave status even when they're deleted or gibbed.
+	var/mindslave_UID
 
 /obj/item/implant/traitor/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
@@ -45,11 +47,11 @@
 
 	// Create a new mindslave datum for the target with the user as their master.
 	mindslave_target.mind.add_antag_datum(new /datum/antagonist/mindslave(user.mind))
+	mindslave_UID = mindslave_target.mind.UID()
 	log_admin("[key_name_admin(user)] has mind-slaved [key_name_admin(mindslave_target)].")
 	return TRUE
 
 /obj/item/implant/traitor/removed(mob/target)
-	if(..())
-		target.mind.remove_antag_datum(/datum/antagonist/mindslave)
-		return TRUE
-	return FALSE
+	. = ..()
+	var/datum/mind/M = locateUID(mindslave_UID)
+	M.remove_antag_datum(/datum/antagonist/mindslave)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The issue here is that if the mindslave is gibbed/deleted, when `/obj/item/implant/traitor/removed(mob/target)` is reached and it's time to remove the mindslave datum, the `target` exists but it's mind does not, because it's already been transferred to a ghost.

So we simply store the mindslave's mind UID to later remove the mindslave status, no matter where that mind may be.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #12393
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes a runtime when mindslave implanted people are gibbed or otherwise deleted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
