### PR TITLE
Signaller bombs work when implanted again

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -145,6 +145,8 @@
 		if(!istype(I, /obj/item/organ))
 			IC = I
 			break
+	if(!IC && affected.hidden)
+		IC = affected.hidden
 	if(istype(tool,/obj/item/cautery))
 		to_chat(user, "<span class='notice'>You prepare to close the cavity wall.</span>")
 	else if(tool)
@@ -192,7 +194,7 @@
 				affected.cause_internal_bleeding()
 			user.drop_item()
 			affected.hidden = tool
-			tool.forceMove(affected)
+			tool.forceMove(target)
 			return 1
 	else
 		if(IC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cavity implanted objects are now put into the mob not the internal organ, so that they are not sat in nullspace where they do not interact with anything.
This means signaller triggered bombs will detonate even when implanted.

Despite these now being directly in the mob, they can be removed as normal by surgery since the internal organ still has a ref to them, the `hidden` var. They should also now (sometimes?) drop if you gib the mob.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cuban pete is back, and this time he _is_ the bomb.

This has been unintentionally broken for ages (since organs got refactored), and it's totally unintuitive when it does not work as you get no error or feedback. It just fails. This restores said functionality.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed cavity implanted signallers not getting signals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
