### PR TITLE
Fix unstable mutagen not causing mutations in mobs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -179,9 +179,7 @@
 	taste_description = "slime"
 
 /datum/reagent/mutagen/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)
-	if(!..())
-		return
-	if(!M.dna || HAS_TRAIT(M, TRAIT_BADDNA) || HAS_TRAIT(M, TRAIT_GENELESS))
+	if(!M || !M.dna || HAS_TRAIT(M, TRAIT_BADDNA) || HAS_TRAIT(M, TRAIT_GENELESS))
 		return //No robots, AIs, aliens, Ians or other mobs should be affected by this.
 	if((method==REAGENT_TOUCH && prob(33)) || method==REAGENT_INGEST)
 		randmutb(M)
@@ -1175,9 +1173,7 @@
 	taste_description = "slime"
 
 /datum/reagent/glowing_slurry/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume) //same as mutagen
-	if(!..())
-		return
-	if(!M.dna)
+	if(!M || !M.dna)
 		return //No robots, AIs, aliens, Ians or other mobs should be affected by this.
 	if((method==REAGENT_TOUCH && prob(50)) || method==REAGENT_INGEST)
 		randmutb(M)


### PR DESCRIPTION
## What Does This PR Do
Makes unstable mutagen once again cause mutation to people drinking it.

This got broken in #17911 which removed the `return TRUE` part of the base `reaction_mob` proc. Said return value was undocumented and seemingly unused at a time. Turns out it is used in exactly two places, and even then only as a means to guard against null mob being passed in.
This PR changes both those occurences from checking the `..()` return value to checking the truthiness of the mob directly.

## Why It's Good For The Game
Bugfix

## Images of changes
![20220621-033800-dreamseeker](https://user-images.githubusercontent.com/7831163/174711157-ff7e4ba7-4d81-4620-b866-070e137636b1.png)

## Changelog
:cl:
fix: Fixed unstable mutagen not causing mutations in mobs
/:cl: