### PR TITLE
Removes the ability to EMP Handheld Defibs

### DIFF
--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -24,18 +24,6 @@
 		if(user)
 			to_chat(user, "<span class='warning'>You restore the safeties on [src]</span>")
 
-/obj/item/handheld_defibrillator/emp_act(severity)
-	if(emagged)
-		emagged = FALSE
-		desc = "Used to restart stopped hearts."
-		visible_message("<span class='notice'>[src] beeps: Safety protocols enabled!</span>")
-		playsound(get_turf(src), 'sound/machines/defib_saftyon.ogg', 50, 0)
-	else
-		emagged = TRUE
-		desc += " The screen only shows the word KILL flashing over and over."
-		visible_message("<span class='notice'>[src] beeps: Safety protocols disabled!</span>")
-		playsound(get_turf(src), 'sound/machines/defib_saftyoff.ogg', 50, 0)
-
 /obj/item/handheld_defibrillator/attack(mob/living/carbon/human/H, mob/user)
 	if(!istype(H))
 		return ..()


### PR DESCRIPTION
## What Does This PR Do
To preface: I was given the go-ahead by Doc to post this PR for possible testing after PMing them about it. I'm also aware of the new changes in how stuff works, and going by their response this is still OK to do as things largely haven't changed on a whole. Let me know if that isn't the case.

Now that that is out of the way. This PR removes the ability to use an EMP(of any kind) to emag a handheld defib and unlock its function to sleep targets with a chance of giving them heart attacks. Nothing more, nothing less. Emag functionality has been retained.

## Why It's Good For The Game
For a long while now ever since they were added Handheld Defibs have been incredibly problematic when EMP'd. Somewhat often, crew will EMP them for 'self-defense' which leads to a whole host of valid hunting issues. And if it's not crew EMPing them it's a medical or scientist antagonist EMPing them. Which, is fine to a degree. However. Just by mixing iron and uranium with a bit of material to print these/opening a locker round start antagonists are able to get one of the best, infinitely charging, melee weapons in the game.

This is quite terrible from a balance perspective. While I do agree that some options should be available for antagonists to more easily acquire weaponry and support utility items, I do not believe this should be one of them. These things go through shielded hardsuits and all forms of blocking with no way to counter them. You simply get zapped and fall asleep to a black screen that leads to death. You're unable to counter it in any way or call for help; this is fine with the combat defib nuclear operatives get. They're nuclear operatives. But when every single other antag has access to them to use them it becomes problematic.

This solves the issue by removing the ability to EMP up yourself a backpack full(or even just one or two) of the strongest weapons in the game. Syndicate Agents that wish to utilize these will have to buy an emag in order to use them. Vampires or Changelings that want to do the same will now have to work with an Agent in order to acquire them.

## Changelog
:cl:
tweak: You are now no longer able to EMP a handheld defib to unlock its stunning/lethal mode. Now emag/cryptographic sequencer only.
/:cl:
