### PR TITLE
Using screwdrivers on posters pokes them, and tweaks the sounds for placing one down

### DIFF
--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -88,6 +88,9 @@
 	poster_item_icon_state = initial(selected.poster_item_icon_state)
 	ruined = initial(selected.ruined)
 
+/obj/structure/sign/poster/screwdriver_act(mob/user, obj/item/I)
+	return
+
 /obj/structure/sign/poster/wirecutter_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
@@ -161,7 +164,7 @@
 	flick("poster_being_set", D)
 	D.forceMove(temp_loc)
 	qdel(P)	//delete it now to cut down on sanity checks afterwards. Agouri's code supports rerolling it anyway
-	playsound(D.loc, 'sound/items/poster_being_created.ogg', 100, 1)
+	playsound(D.loc, 'sound/effects/rustle1.ogg', 100, 1)
 
 	if(do_after(user, PLACE_SPEED, target = src))
 		if(!D || QDELETED(D))
@@ -169,6 +172,7 @@
 
 		if(iswallturf(src) && user && user.loc == temp_loc)	//Let's check if everything is still there
 			to_chat(user, "<span class='notice'>You place the poster!</span>")
+			playsound(D.loc, 'sound/effects/pageturn3.ogg', 100, 1)
 			return
 
 	to_chat(user, "<span class='notice'>The poster falls down!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents posters from being unscrewed due to being sign subtypes, with wirecutters being the intended method. Tweaks the sounds for placing posters as it's a printing sound for some reasons?

## Why It's Good For The Game
Fixes #18029.

## Images of changes
https://user-images.githubusercontent.com/80771500/174899899-264b7328-3955-4391-8e27-b37c6df0c2c6.mp4


## Changelog
:cl:
tweak: Placing a poster doesn't make a printer sound
fix: Fixed unscrewing posters, making them invisible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
