### PR TITLE
Removes ability from simple mobs to help invoke runes

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -161,6 +161,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 					continue
 				if(L.stat)
 					continue
+				if(isanimal(L))
+					continue
 				invokers |= L
 
 		if(length(invokers) >= req_cultists) // If there's enough invokers
@@ -360,11 +362,12 @@ structure_check() searches for nearby cultist structures required for the invoca
 			H.uncuff()
 			H.Silence(6 SECONDS) //Prevent "HALP MAINT CULT" before you realise you're converted
 
-			var/obj/item/melee/cultblade/dagger/D = new(get_turf(src))
-			if(H.equip_to_slot_if_possible(D, slot_in_backpack, FALSE, TRUE))
-				to_chat(H, "<span class='cultlarge'>You have a dagger in your backpack. Use it to do [SSticker.cultdat.entity_title1]'s bidding. </span>")
-			else
-				to_chat(H, "<span class='cultlarge'>There is a dagger on the floor. Use it to do [SSticker.cultdat.entity_title1]'s bidding.</span>")
+			if(!isanimal(convertee))
+				var/obj/item/melee/cultblade/dagger/D = new(get_turf(src))
+				if(H.equip_to_slot_if_possible(D, slot_in_backpack, FALSE, TRUE))
+					to_chat(H, "<span class='cultlarge'>You have a dagger in your backpack. Use it to do [SSticker.cultdat.entity_title1]'s bidding. </span>")
+				else
+					to_chat(H, "<span class='cultlarge'>There is a dagger on the floor. Use it to do [SSticker.cultdat.entity_title1]'s bidding.</span>")
 
 /obj/effect/rune/convert/proc/do_sacrifice(mob/living/offering, list/invokers)
 	var/mob/living/user = invokers[1] //the first invoker is always the user

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -161,7 +161,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 					continue
 				if(L.stat)
 					continue
-				if(isanimal(L))
+				if(isanimal(L) && !isconstruct(L)) //simple animals that arent constructs cannot help invoke
 					continue
 				invokers |= L
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes ability from simple mobs to help invoke runes.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Simple mobs like mice, slimes, or lizards should not be able to help invoke runes or count towards ascension.

These changes are untested, due to cult gamemode playercount requirement... Merge with caution.

## Changelog
:cl:
fix: Fixed simple mobs being able to contribute to invoking cult runes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
