### PR TITLE
Antag-Banned Players No Longer Selected In 'Everyone Is a traitor'

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2868,11 +2868,11 @@
 				SSblackbox.record_feedback("tally", "admin_secrets_fun_used", 1, "Traitor All ([objective])")
 
 				for(var/mob/living/carbon/human/H in GLOB.player_list)
-					if(H.stat == 2 || !H.client || !H.mind)
+					if(H.stat == DEAD || !H.client || !H.mind)
 						continue
 					if(is_special_character(H))
 						continue
-					if(jobban_isbanned(H, ROLE_TRAITOR) || jobban_isbanned(H, "Syndicate"))
+					if(jobban_isbanned(H, ROLE_TRAITOR) || jobban_isbanned(H, ROLE_SYNDICATE))
 						continue
 					H.mind.add_antag_datum(/datum/antagonist/traitor)
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2868,9 +2868,12 @@
 				SSblackbox.record_feedback("tally", "admin_secrets_fun_used", 1, "Traitor All ([objective])")
 
 				for(var/mob/living/carbon/human/H in GLOB.player_list)
-					if(H.stat == 2 || !H.client || !H.mind) continue
-					if(is_special_character(H)) continue
-					//traitorize(H, objective, 0)
+					if(H.stat == 2 || !H.client || !H.mind)
+						continue
+					if(is_special_character(H))
+						continue
+					if(jobban_isbanned(H, ROLE_TRAITOR) || jobban_isbanned(H, "Syndicate"))
+						continue
 					H.mind.add_antag_datum(/datum/antagonist/traitor)
 
 				for(var/mob/living/silicon/A in GLOB.player_list)


### PR DESCRIPTION
## What Does This PR Do
Fixes #12906 . Antag-banned players can no longer be made an antag through 'Everyone is a traitor' secret.

## Why It's Good For The Game
Antag-banned players shouldn't be able to be an antagonist along with the concerns listed in the issue report.

## Changelog
No player-facing changes.
