### PR TITLE
Removes the oil tank from robotics and sulfuric acid from circuit printers

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -65391,7 +65391,6 @@
 /area/toxins/lab)
 "cYr" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
@@ -83806,7 +83805,6 @@
 /area/hallway/secondary/exit)
 "dOD" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /obj/structure/window/reinforced/polarized,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -73872,7 +73872,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "nlQ" = (
-/obj/structure/reagent_dispensers/oil,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "nmh" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -36388,7 +36388,6 @@
 /area/medical/chemistry)
 "bGw" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -37256,7 +37255,7 @@
 	c_tag = "Research Robotics Lab";
 	network = list("Research","SS13")
 	},
-/obj/structure/reagent_dispensers/oil,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteredcorner"
@@ -39260,7 +39259,6 @@
 	pixel_x = 3;
 	pixel_y = 5
 	},
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
@@ -42655,7 +42653,8 @@
 /turf/simulated/floor/plasteel,
 /area/medical/genetics)
 "bSI" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bSJ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> This removes the oil tank from cyberiad, replacing it with a welding tank. The welding tank in mechbay was replaced by a table and an electrical toolbox. This also removes sulfuric acid beakers from circuit printers on Cyberiad, Delta, and Meta (I totally didn't forget about Meta).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Requested by @SteelSlayer , removes obsolete things.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->Before:
![unknown](https://user-images.githubusercontent.com/91113370/175133251-a0b2cbf4-d272-4416-b400-85a8ed4474c1.png)
After:
![unknown](https://user-images.githubusercontent.com/91113370/175133301-7355f8fd-9def-45bb-8fab-61bdb746489e.png)

## Changelog
:cl:
tweak: Oil tanks are replaced with welding fuel tanks
add: Adds an electrical toolbox to mech bay on box
del: Removes obsolete sulfuric acid beakers spawning on circuit printers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
