### PR TITLE
Fix age based emote audio

### DIFF
--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -249,6 +249,7 @@
 /**
  * Play the sound effect in an emote.
  * If you want to change the way the playsound call works, override this.
+ * Note! If you want age_based to work, you need to force vary to TRUE.
  * * user - The user of the emote.
  * * intentional - Whether or not the emote was triggered intentionally.
  * * sound_path - Filesystem path to the audio clip to play.
@@ -257,7 +258,8 @@
 /datum/emote/proc/play_sound_effect(mob/user, intentional, sound_path, sound_volume)
 	if(age_based && ishuman(user))
 		var/mob/living/carbon/human/H = user
-		playsound(user.loc, sound_path, sound_volume, vary, frequency = H.get_age_pitch())
+		// Vary needs to be true as otherwise frequency changes get ignored deep within playsound_local :(
+		playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch())
 	else
 		playsound(user.loc, sound_path, sound_volume, vary)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes age-based emotes not always changing their pitch based on age.
Fixes #18051
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Age-based audio adds a lot of character flavor, and was accidentally broken in the refactor.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Some emotes that had age-based audio will now actually be adjusted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
