### PR TITLE
Adds smoke bombs as maints loot

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -133,8 +133,8 @@
 				/obj/item/storage/bag/plasticbag = 20,
 				/obj/item/caution = 10,
 				////////////////CONTRABAND STUFF//////////////////
-				/obj/item/grenade/smokebomb = 7,
 				/obj/item/grenade/clown_grenade = 3,
+				/obj/item/grenade/smokebomb = 3,
 				/obj/item/seeds/ambrosia/cruciatus = 3,
 				/obj/item/gun/projectile/automatic/pistol = 1,
 				/obj/item/ammo_box/magazine/m10mm = 4,
@@ -159,7 +159,7 @@
 				/obj/item/storage/secure/briefcase/syndie = 2,
 				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 2,
 				/obj/item/storage/pill_bottle/fakedeath = 2,
-				"" = 57 // Reduce this number if you add things above. Make sure all the numbers in the list add to 100 EXACTLY
+				"" = 61 // Reduce this number if you add things above. Make sure all the numbers in the list add to 100 EXACTLY
 				)
 
 /obj/effect/spawner/lootdrop/maintenance/two

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -102,11 +102,10 @@
 				/obj/item/crowbar/red = 10,
 				/obj/item/restraints/handcuffs/toy = 5,
 				/obj/item/extinguisher = 90,
-				//obj/item/gun/projectile/revolver/russian = 1, //disabled until lootdrop is a proper world proc.
 				/obj/item/hand_labeler = 10,
 				/obj/item/paper/crumpled = 10,
 				/obj/item/pen = 10,
-				 /obj/item/cultivator = 10,
+				/obj/item/cultivator = 10,
 				/obj/item/reagent_containers/spray/pestspray = 10,
 				/obj/item/stock_parts/cell = 30,
 				/obj/item/storage/belt/utility = 20,
@@ -159,7 +158,7 @@
 				/obj/item/storage/secure/briefcase/syndie = 2,
 				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 2,
 				/obj/item/storage/pill_bottle/fakedeath = 2,
-				"" = 61 // Reduce this number if you add things above. Make sure all the numbers in the list add to 100 EXACTLY
+				"" = 60 // This should be a decently high number for chances where no loot will spawn
 				)
 
 /obj/effect/spawner/lootdrop/maintenance/two

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -89,7 +89,7 @@
 				/obj/item/stack/rods{amount = 50} = 10,
 				/obj/item/stack/sheet/cardboard = 20,
 				/obj/item/stack/sheet/metal{amount = 20} = 10,
-				/obj/item/stack/sheet/mineral/plasma{layer = 2.9} = 10,
+				/obj/item/stack/sheet/mineral/plasma = 10,
 				/obj/item/stack/sheet/rglass = 10,
 				/obj/item/book/manual/engineering_construction = 10,
 				/obj/item/book/manual/engineering_hacking = 10,
@@ -133,6 +133,7 @@
 				/obj/item/storage/bag/plasticbag = 20,
 				/obj/item/caution = 10,
 				////////////////CONTRABAND STUFF//////////////////
+				/obj/item/grenade/smokebomb = 7,
 				/obj/item/grenade/clown_grenade = 3,
 				/obj/item/seeds/ambrosia/cruciatus = 3,
 				/obj/item/gun/projectile/automatic/pistol = 1,
@@ -158,7 +159,7 @@
 				/obj/item/storage/secure/briefcase/syndie = 2,
 				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 2,
 				/obj/item/storage/pill_bottle/fakedeath = 2,
-				"" = 64 // Reduce this number if you add things above. Make sure all the numbers in the list add to 100 EXACTLY
+				"" = 57 // Reduce this number if you add things above. Make sure all the numbers in the list add to 100 EXACTLY
 				)
 
 /obj/effect/spawner/lootdrop/maintenance/two


### PR DESCRIPTION
## What Does This PR Do
Adds smoke bombs to the maints loot spawner with a weight of 3.

I also axed a weird layering thing in the loot spawner for plasma sheets.
## Why It's Good For The Game
This is a forum [suggestion ](https://www.paradisestation.org/forum/topic/22627-smoke-grenades/), probably a good idea to read it.

TG has smoke grenades as random maints loot, but with a key difference being that smoke bombs on Paradise cause you to drop whatever you're holding. For that reason, I decided to give smoke bombs a weight of 3 which is the same as a banana peel grenade.

## Changelog
:cl: Bmon
add: Smoke bombs added as maints loot
/:cl:

