### PR TITLE
Shift+F3 debug menu

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -129,5 +129,8 @@
 // This should always be on top.
 #define HUD_PLANE_BUILDMODE 30
 
+// Nah, this should always be top
+#define HUD_PLANE_DEBUGVIEW 40
+
 ///Plane master controller keys
 #define PLANE_MASTERS_GAME "plane_masters_game"

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -126,10 +126,9 @@
 #define SPLASHSCREEN_LAYER 23
 #define SPLASHSCREEN_PLANE 23
 
-// This should always be on top.
 #define HUD_PLANE_BUILDMODE 30
 
-// Nah, this should always be top
+// This should always be on top. No exceptions.
 #define HUD_PLANE_DEBUGVIEW 40
 
 ///Plane master controller keys

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -191,8 +191,6 @@
 	stat(title, statclick.update(msg))
 
 /datum/controller/subsystem/proc/state_letter()
-	if(!can_fire)
-		return "O"
 	switch(state)
 		if(SS_RUNNING)
 			. = "R"

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -159,6 +159,9 @@
 		if(SS_SLEEPING)
 			state = SS_PAUSING
 
+// Gets extra details for the subsystem stat panes
+/datum/controller/subsystem/proc/get_stat_details()
+	return
 
 //used to initialize the subsystem AFTER the map has loaded
 /datum/controller/subsystem/Initialize(start_timeofday)
@@ -172,20 +175,24 @@
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug(null, "Initializing...", src)
 
-
+	var/ss_info = get_stat_details()
 
 	if(can_fire && !(SS_NO_FIRE & flags))
-		msg = "[round(cost, 1)]ms | [round(tick_usage, 1)]%([round(tick_overrun, 1)]%) | [round(ticks, 0.1)]\t[msg]"
+		msg = "[round(cost, 1)]ms | [round(tick_usage, 1)]%([round(tick_overrun, 1)]%) | [round(ticks, 0.1)]\t[ss_info]"
 	else
-		msg = "OFFLINE\t[msg]"
+		msg = "OFFLINE\t[ss_info]"
 
 	var/title = name
 	if(can_fire)
 		title = "[state_colour()]\[[state_letter()]][title]</font>"
+	else
+		title = "\[O][title]"
 
 	stat(title, statclick.update(msg))
 
 /datum/controller/subsystem/proc/state_letter()
+	if(!can_fire)
+		return "O"
 	switch(state)
 		if(SS_RUNNING)
 			. = "R"

--- a/code/controllers/subsystem/acid.dm
+++ b/code/controllers/subsystem/acid.dm
@@ -8,8 +8,8 @@ SUBSYSTEM_DEF(acid)
 	var/list/currentrun = list()
 	var/list/processing = list()
 
-/datum/controller/subsystem/acid/stat_entry()
-	..("P:[processing.len]")
+/datum/controller/subsystem/acid/get_stat_details()
+	return "P:[length(processing)]"
 
 /datum/controller/subsystem/acid/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -46,7 +46,8 @@ SUBSYSTEM_DEF(air)
 	var/list/currentrun = list()
 	var/currentpart = SSAIR_DEFERREDPIPENETS
 
-/datum/controller/subsystem/air/stat_entry(msg)
+/datum/controller/subsystem/air/get_stat_details()
+	var/list/msg = list()
 	msg += "C:{"
 	msg += "AT:[round(cost_turfs,1)]|"
 	msg += "EG:[round(cost_groups,1)]|"
@@ -64,7 +65,7 @@ SUBSYSTEM_DEF(air)
 	msg += "HP:[high_pressure_delta.len]|"
 	msg += "AS:[active_super_conductivity.len]|"
 	msg += "AT/MS:[round((cost ? active_turfs.len/cost : 0),0.1)]"
-	..(msg)
+	return msg.Join("")
 
 /datum/controller/subsystem/air/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/chat_pings.dm
+++ b/code/controllers/subsystem/chat_pings.dm
@@ -12,5 +12,5 @@ SUBSYSTEM_DEF(chat_pings)
 		if(MC_TICK_CHECK)
 			return
 
-/datum/controller/subsystem/chat_pings/stat_entry()
-	..("P: [length(chat_datums)]")
+/datum/controller/subsystem/chat_pings/get_stat_details()
+	return "P: [length(chat_datums)]"

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -24,8 +24,8 @@ SUBSYSTEM_DEF(dbcore)
 
 	offline_implications = "The server will no longer check for undeleted SQL Queries. No immediate action is needed."
 
-/datum/controller/subsystem/dbcore/stat_entry()
-	..("A: [length(active_queries)]")
+/datum/controller/subsystem/dbcore/get_stat_details()
+	return "A: [length(active_queries)]"
 
 // This is in Initialize() so that its actually seen in chat
 /datum/controller/subsystem/dbcore/Initialize()

--- a/code/controllers/subsystem/debugview.dm
+++ b/code/controllers/subsystem/debugview.dm
@@ -39,11 +39,7 @@ SUBSYSTEM_DEF(debugview)
 		C.debug_text_overlay.maptext = MAPTEXT(out_text)
 
 /datum/controller/subsystem/debugview/proc/start_processing(client/C)
-	C.debug_text_overlay = new /obj/screen/fullscreen
-	// DO NOT CHANGE THE BELOW VALUES
-	C.debug_text_overlay.plane = HUD_PLANE_DEBUGVIEW
-	C.debug_text_overlay.maptext_height = 480
-	C.debug_text_overlay.maptext_width = 480
+	C.debug_text_overlay = new /obj/screen/debugtextholder
 	C.screen |= C.debug_text_overlay
 	processing |= C
 
@@ -51,3 +47,11 @@ SUBSYSTEM_DEF(debugview)
 	C.screen -= C.debug_text_overlay
 	qdel(C.debug_text_overlay)
 	processing -= C
+
+/obj/screen/debugtextholder
+	icon = 'icons/mob/screen_full.dmi'
+	icon_state = "default"
+	screen_loc = "CENTER-7,CENTER-7"
+	plane = HUD_PLANE_DEBUGVIEW
+	maptext_height = 480 // If we ever change view size, increase this
+	maptext_width = 480

--- a/code/controllers/subsystem/debugview.dm
+++ b/code/controllers/subsystem/debugview.dm
@@ -44,9 +44,9 @@ SUBSYSTEM_DEF(debugview)
 	processing |= C
 
 /datum/controller/subsystem/debugview/proc/stop_processing(client/C)
+	processing -= C
 	C.screen -= C.debug_text_overlay
 	qdel(C.debug_text_overlay)
-	processing -= C
 
 /obj/screen/debugtextholder
 	icon = 'icons/mob/screen_full.dmi'

--- a/code/controllers/subsystem/fires.dm
+++ b/code/controllers/subsystem/fires.dm
@@ -8,8 +8,8 @@ SUBSYSTEM_DEF(fires)
 	var/list/currentrun = list()
 	var/list/processing = list()
 
-/datum/controller/subsystem/fires/stat_entry()
-	..("P:[processing.len]")
+/datum/controller/subsystem/fires/get_stat_details()
+	return "P:[length(processing)]"
 
 
 /datum/controller/subsystem/fires/get_metrics()

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -41,25 +41,26 @@ SUBSYSTEM_DEF(garbage)
 		pass_counts[i] = 0
 		fail_counts[i] = 0
 
-/datum/controller/subsystem/garbage/stat_entry(msg)
+/datum/controller/subsystem/garbage/get_stat_details()
+	var/list/msg = list()
 	var/list/counts = list()
 	for(var/list/L in queues)
 		counts += length(L)
-	msg += "Queue:[counts.Join(",")] | Del's:[delslasttick] | Soft:[gcedlasttick] |"
-	msg += "GR:"
+	msg += "Q:[counts.Join(",")] | D:[delslasttick] | S:[gcedlasttick] |"
+	msg += "GCR:"
 	if(!(delslasttick + gcedlasttick))
 		msg += "n/a|"
 	else
 		msg += "[round((gcedlasttick / (delslasttick + gcedlasttick)) * 100, 0.01)]% |"
 
-	msg += "Total Dels:[totaldels] | Soft:[totalgcs] |"
+	msg += "TD:[totaldels] | TS:[totalgcs] |"
 	if(!(totaldels + totalgcs))
 		msg += "n/a|"
 	else
-		msg += "TGR:[round((totalgcs / (totaldels + totalgcs)) * 100, 0.01)]% |"
-	msg += " Pass:[pass_counts.Join(",")]"
-	msg += " | Fail:[fail_counts.Join(",")]"
-	..(msg)
+		msg += "TGCR:[round((totalgcs / (totaldels + totalgcs)) * 100, 0.01)]% |"
+	msg += " P:[pass_counts.Join(",")]"
+	msg += " | F:[fail_counts.Join(",")]"
+	return msg.Join("")
 
 /datum/controller/subsystem/garbage/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(garbage)
 	var/list/counts = list()
 	for(var/list/L in queues)
 		counts += length(L)
-	msg += "Q:[counts.Join(",")] | D:[delslasttick] | S:[gcedlasttick] |"
+	msg += "Q:[counts.Join(", ")] | D:[delslasttick] | S:[gcedlasttick] |"
 	msg += "GCR:"
 	if(!(delslasttick + gcedlasttick))
 		msg += "n/a|"

--- a/code/controllers/subsystem/ghost_spawns.dm
+++ b/code/controllers/subsystem/ghost_spawns.dm
@@ -201,11 +201,12 @@ SUBSYSTEM_DEF(ghost_spawns)
 			if(!next_poll_to_finish || P2.time_left() < next_poll_to_finish.time_left())
 				next_poll_to_finish = P2
 
-/datum/controller/subsystem/ghost_spawns/stat_entry(msg)
+/datum/controller/subsystem/ghost_spawns/get_stat_details()
+	var/list/msg = list()
 	msg += "Active: [length(currently_polling)] | Total: [total_polls]"
 	if(next_poll_to_finish)
 		msg += " | Next: [DisplayTimeText(next_poll_to_finish.time_left())] ([length(next_poll_to_finish.signed_up)] candidates)"
-	..(msg)
+	return msg.Join("")
 
 // The datum that describes one instance of candidate polling
 /datum/candidate_poll

--- a/code/controllers/subsystem/http.dm
+++ b/code/controllers/subsystem/http.dm
@@ -20,8 +20,8 @@ SUBSYSTEM_DEF(http)
 	active_async_requests = list()
 	return ..()
 
-/datum/controller/subsystem/http/stat_entry()
-	..("P: [length(active_async_requests)] | T: [total_requests]")
+/datum/controller/subsystem/http/get_stat_details()
+	return "P: [length(active_async_requests)] | T: [total_requests]"
 
 /datum/controller/subsystem/http/fire(resumed)
 	for(var/r in active_async_requests)

--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -9,10 +9,8 @@ SUBSYSTEM_DEF(idlenpcpool)
 	var/list/currentrun = list()
 	var/static/list/idle_mobs_by_zlevel[][]
 
-/datum/controller/subsystem/idlenpcpool/stat_entry()
-	var/list/idlelist = GLOB.simple_animals[AI_IDLE]
-	var/list/zlist = GLOB.simple_animals[AI_Z_OFF]
-	..("IdleNPCS:[idlelist.len]|Z:[zlist.len]")
+/datum/controller/subsystem/idlenpcpool/get_stat_details()
+	return "IdleNPCS:[length(GLOB.simple_animals[AI_IDLE])]|Z:[length(GLOB.simple_animals[AI_Z_OFF])]"
 
 /datum/controller/subsystem/idlenpcpool/Initialize(start_timeofday)
 	idle_mobs_by_zlevel = new /list(world.maxz,0)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -8,8 +8,8 @@ SUBSYSTEM_DEF(lighting)
 	var/static/list/corners_queue = list() // List of lighting corners queued for update.
 	var/static/list/objects_queue = list() // List of lighting objects queued for update.
 
-/datum/controller/subsystem/lighting/stat_entry()
-	..("L:[length(sources_queue)]|C:[length(corners_queue)]|O:[length(objects_queue)]")
+/datum/controller/subsystem/lighting/get_stat_details()
+	return "L:[length(sources_queue)]|C:[length(corners_queue)]|O:[length(objects_queue)]"
 
 /datum/controller/subsystem/lighting/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -37,8 +37,8 @@ SUBSYSTEM_DEF(machines)
 			NewPN.add_cable(PC)
 			propagate_network(PC,PC.powernet)
 
-/datum/controller/subsystem/machines/stat_entry()
-	..("Machines: [processing.len]\nPowernets: [powernets.len]\tDeferred: [deferred_powernet_rebuilds.len]")
+/datum/controller/subsystem/machines/get_stat_details()
+	return "Machines: [processing.len] | Powernets: [powernets.len] | Deferred: [deferred_powernet_rebuilds.len]"
 
 /datum/controller/subsystem/machines/proc/process_defered_powernets(resumed = 0)
 	if(!resumed)

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -18,8 +18,8 @@ SUBSYSTEM_DEF(mobs)
 	cust["processing"] = length(GLOB.mob_living_list)
 	.["custom"] = cust
 
-/datum/controller/subsystem/mobs/stat_entry()
-	..("P:[GLOB.mob_living_list.len]")
+/datum/controller/subsystem/mobs/get_stat_details()
+	return "P:[length(GLOB.mob_living_list.len)]"
 
 /datum/controller/subsystem/mobs/Initialize(start_timeofday)
 	clients_by_zlevel = new /list(world.maxz,0)

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -7,9 +7,8 @@ SUBSYSTEM_DEF(npcpool)
 
     var/list/currentrun = list()
 
-/datum/controller/subsystem/npcpool/stat_entry()
-    var/list/activelist = GLOB.simple_animals[AI_ON]
-    ..("SimpleAnimals:[activelist.len]")
+/datum/controller/subsystem/npcpool/get_stat_details()
+    return "SimpleAnimals: [length(GLOB.simple_animals[AI_ON])]"
 
 /datum/controller/subsystem/npcpool/fire(resumed = FALSE)
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -23,8 +23,8 @@ SUBSYSTEM_DEF(overlays)
 	return ..()
 
 
-/datum/controller/subsystem/overlays/stat_entry()
-	..("Ov:[length(queue)]")
+/datum/controller/subsystem/overlays/get_stat_details()
+	return "Ov:[length(queue)]"
 
 /datum/controller/subsystem/overlays/Recover()
 	overlay_icon_state_caches = SSoverlays.overlay_icon_state_caches

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -11,8 +11,8 @@ SUBSYSTEM_DEF(processing)
 	var/list/currentrun = list()
 	offline_implications = "Objects using the default processor will no longer process. Shuttle call recommended."
 
-/datum/controller/subsystem/processing/stat_entry()
-	..("[stat_tag]:[processing.len]")
+/datum/controller/subsystem/processing/get_stat_details()
+	return "[stat_tag]:[length(processing)]"
 
 /datum/controller/subsystem/processing/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -13,8 +13,8 @@ SUBSYSTEM_DEF(profiler)
 	/// Time it took to send the stuff down FFI for redis (ms)
 	var/send_ffi_cost = 0
 
-/datum/controller/subsystem/profiler/stat_entry()
-	..("F:[round(fetch_cost, 1)]ms | W:[round(write_cost, 1)]ms | SE:[round(send_encode_cost, 1)]ms | SF:[round(send_ffi_cost, 1)]ms")
+/datum/controller/subsystem/profiler/get_stat_details()
+	return "F:[round(fetch_cost, 1)]ms | W:[round(write_cost, 1)]ms | SE:[round(send_encode_cost, 1)]ms | SF:[round(send_ffi_cost, 1)]ms"
 
 /datum/controller/subsystem/profiler/Initialize()
 	if(!GLOB.configuration.general.enable_auto_profiler)

--- a/code/controllers/subsystem/redis.dm
+++ b/code/controllers/subsystem/redis.dm
@@ -13,8 +13,8 @@ SUBSYSTEM_DEF(redis)
 	offline_implications = "The server will no longer be able to send or receive redis messages. Shuttle call recommended (Potential server crash inbound)."
 
 // SS meta procs
-/datum/controller/subsystem/redis/stat_entry()
-	..("S:[length(subbed_channels)] | Q:[length(queue)] | C:[connected ? "Y" : "N"]")
+/datum/controller/subsystem/redis/get_stat_details()
+	return "S:[length(subbed_channels)] | Q:[length(queue)] | C:[connected ? "Y" : "N"]"
 
 /datum/controller/subsystem/redis/Initialize()
 	// Connect to cappuccino

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -46,8 +46,8 @@ SUBSYSTEM_DEF(runechat)
 	head_offset = world.time
 	bucket_resolution = world.tick_lag
 
-/datum/controller/subsystem/runechat/stat_entry(msg)
-	..("ActMsgs:[bucket_count] SecQueue:[length(second_queue)]")
+/datum/controller/subsystem/runechat/get_stat_details()
+	return "ActMsgs:[bucket_count] SecQueue:[length(second_queue)]"
 
 /datum/controller/subsystem/runechat/fire(resumed = FALSE)
 	// Store local references to datum vars as it is faster to access them this way

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -65,8 +65,8 @@ SUBSYSTEM_DEF(shuttle)
 
 	return ..()
 
-/datum/controller/subsystem/shuttle/stat_entry(msg)
-	..("M:[mobile.len] S:[stationary.len] T:[transit.len]")
+/datum/controller/subsystem/shuttle/get_stat_details()
+	return "M:[length(mobile)] S:[length(stationary)] T:[length(transit)]"
 
 /datum/controller/subsystem/shuttle/proc/initial_load()
 	for(var/obj/docking_port/D in world)

--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -9,8 +9,8 @@ SUBSYSTEM_DEF(spacedrift)
 	var/list/currentrun = list()
 	var/list/processing = list()
 
-/datum/controller/subsystem/spacedrift/stat_entry()
-	..("P:[processing.len]")
+/datum/controller/subsystem/spacedrift/get_stat_details()
+	return "P:[length(processing)]"
 
 /datum/controller/subsystem/spacedrift/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -25,8 +25,8 @@ SUBSYSTEM_DEF(sun)
 	return ..()
 
 
-/datum/controller/subsystem/sun/stat_entry(msg)
-	..("P:[solars.len]")
+/datum/controller/subsystem/sun/get_stat_details()
+	return "P:[length(solars)]"
 
 /datum/controller/subsystem/sun/fire()
 	angle = (360 + angle + rate * 6) % 360	 // increase/decrease the angle to the sun, adjusted by the rate

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -24,8 +24,8 @@ SUBSYSTEM_DEF(tgui)
 /datum/controller/subsystem/tgui/Shutdown()
 	close_all_uis()
 
-/datum/controller/subsystem/tgui/stat_entry()
-	..("P:[processing_uis.len]")
+/datum/controller/subsystem/tgui/get_stat_details()
+	return "P:[length(processing_uis)]"
 
 /datum/controller/subsystem/tgui/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -12,8 +12,8 @@ SUBSYSTEM_DEF(throwing)
 	var/list/currentrun
 	var/list/processing = list()
 
-/datum/controller/subsystem/throwing/stat_entry()
-	..("P:[processing.len]")
+/datum/controller/subsystem/throwing/get_stat_details()
+	return "P:[length(processing)]"
 
 /datum/controller/subsystem/throwing/get_metrics()
 	. = ..()

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -62,8 +62,8 @@ SUBSYSTEM_DEF(tickets)
 			report += "[num], "
 		message_staff("<span class='[span_class]'>Tickets [report] have been open for over [TICKET_TIMEOUT / 600] minutes. Changing status to stale.</span>")
 
-/datum/controller/subsystem/tickets/stat_entry()
-	..("Tickets: [LAZYLEN(allTickets)]")
+/datum/controller/subsystem/tickets/get_stat_details()
+	return "Tickets: [LAZYLEN(allTickets)]"
 
 /datum/controller/subsystem/tickets/proc/checkStaleness()
 	var/stales = list()

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -58,8 +58,8 @@ SUBSYSTEM_DEF(timer)
 	head_offset = world.time
 	bucket_resolution = world.tick_lag
 
-/datum/controller/subsystem/timer/stat_entry(msg)
-	..("B:[bucket_count] P:[length(second_queue)] H:[length(hashes)] C:[length(clienttime_timers)] S:[length(timer_id_dict)] RST:[bucket_reset_count]")
+/datum/controller/subsystem/timer/get_stat_details()
+	return "B:[bucket_count] P:[length(second_queue)] H:[length(hashes)] C:[length(clienttime_timers)] S:[length(timer_id_dict)] RST:[bucket_reset_count]"
 
 /datum/controller/subsystem/timer/proc/dump_timer_buckets(full = TRUE)
 	var/list/to_log = list("Timer bucket reset. world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -167,6 +167,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/uid_log,
 	/client/proc/visualise_active_turfs,
 	/client/proc/reestablish_db_connection,
+	/client/proc/ss_breakdown,
 	#ifdef REFERENCE_TRACKING
 	/datum/proc/find_refs,
 	/datum/proc/qdel_then_find_references,
@@ -282,6 +283,7 @@ GLOBAL_LIST_INIT(admin_verbs_maintainer, list(
 			verbs += /client/proc/cmd_display_del_log_simple
 			verbs += /client/proc/toggledebuglogs
 			verbs += /client/proc/debug_variables /*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
+			verbs += /client/proc/ss_breakdown
 			spawn(1) // This setting exposes the profiler for people with R_VIEWRUNTIMES. They must still have it set in cfg/admin.txt
 				control_freak = 0
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -66,7 +66,7 @@
 	var/datum/tooltip/tooltips
 
 	// Overlay for showing debug info
-	var/obj/screen/fullscreen/debug_text_overlay
+	var/obj/screen/debugtextholder/debug_text_overlay
 
 	/// Persistent storage for the flavour text of examined atoms.
 	var/list/description_holders = list()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -65,6 +65,9 @@
 	//datum that controls the displaying and hiding of tooltips
 	var/datum/tooltip/tooltips
 
+	// Overlay for showing debug info
+	var/obj/screen/fullscreen/debug_text_overlay
+
 	/// Persistent storage for the flavour text of examined atoms.
 	var/list/description_holders = list()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -415,6 +415,7 @@
 
 /client/Destroy()
 	announce_leave() // Do not put this below
+	SSdebugview.stop_processing(src)
 	if(holder)
 		holder.owner = null
 		GLOB.admins -= src

--- a/code/modules/keybindings/bindings_admin.dm
+++ b/code/modules/keybindings/bindings_admin.dm
@@ -1,5 +1,14 @@
 /datum/admins/key_down(_key, client/user)
 	switch(_key)
+		if("F3")
+			if(user.keys_held["Shift"])
+				if(!check_rights(R_DEBUG|R_VIEWRUNTIMES))
+					return
+				if(user in SSdebugview.processing)
+					SSdebugview.stop_processing(user)
+				else
+					SSdebugview.start_processing(user)
+				return
 		if("F5")
 			user.get_admin_say()
 			return

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -58,11 +58,13 @@
 				adminhelp()
 			return
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
+			// AA 2022-06-23 - What the heck is the above comment here
 			ooc()
 			return
-		if("F3")
-			mob.say_wrapper()
-			return
+		if("F3") // Who the hell uses F3 to say
+			if(!keys_held["Shift"])
+				mob.say_wrapper()
+				return
 		if("F4")
 			mob.me_wrapper()
 			return

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -62,7 +62,7 @@
 			ooc()
 			return
 		if("F3") // Who the hell uses F3 to say
-			if(!keys_held["Shift"])
+			if(!keys_held["Shift"]) // Shift+F3 shows admin debug menu
 				mob.say_wrapper()
 				return
 		if("F4")

--- a/paradise.dme
+++ b/paradise.dme
@@ -233,6 +233,7 @@
 #include "code\controllers\subsystem\chat_pings.dm"
 #include "code\controllers\subsystem\cleanup.dm"
 #include "code\controllers\subsystem\dbcore.dm"
+#include "code\controllers\subsystem\debugview.dm"
 #include "code\controllers\subsystem\discord.dm"
 #include "code\controllers\subsystem\events.dm"
 #include "code\controllers\subsystem\fires.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds a debug menu that toggles when you press Shift+F3. I wish I could make it regular `F3` for reasons, but for some inane reason that key is bound to say.

This menu shows the stats for SSs which are likely to lag the game. We dont need the full list, and this is enough. It also doesn't lag the client (or the server) at all, whereas the existing MC tab straight up hardcrashes my client on prod most of the time, which is kind of an issue when you're the host

## Why It's Good For The Game
See above. The MC tab is bad, but we aren't moving to TG statpanes, because they're flawed in several ways.

## Images of changes
![image](https://user-images.githubusercontent.com/25063394/175522503-e9e76cac-a27b-4371-a4f7-283349aafced.png)

## Changelog
:cl: AffectedArc07
add: [Admin] You can now view a debug menu with SHIFT+F3
/:cl:

*miningggg awayyyyyyyyyyyyyyy*
