### PR TITLE
Removes holdover text from Mindshields.

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -31,7 +31,7 @@
 /obj/item/implant/mindshield/removed(mob/target, silent = 0)
 	if(..())
 		if(target.stat != DEAD && !silent)
-			to_chat(target, "<span class='boldnotice'>You feel a sense of liberation as Nanotrasen's grip on your mind fades away.</span>")
+			to_chat(target, "<span class='boldnotice'>Your mind softens. You feel susceptible to the effects of brainwashing once more.</span>")
 		return 1
 	return 0
 

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -25,15 +25,15 @@
 			to_chat(target, "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		else
 			to_chat(target, "<span class='notice'>Your mind feels hardened - more resistant to brainwashing.</span>")
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/item/implant/mindshield/removed(mob/target, silent = 0)
 	if(..())
 		if(target.stat != DEAD && !silent)
 			to_chat(target, "<span class='boldnotice'>Your mind softens. You feel susceptible to the effects of brainwashing once more.</span>")
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 
 /obj/item/implanter/mindshield


### PR DESCRIPTION
## What Does This PR Do
Changes the text on mindshields from `You feel a sense of liberation as Nanotrasen's grip on your mind fades away.` to `Your mind softens. You feel susceptible to the effects of brainwashing once more.`

## Why It's Good For The Game
For some reason with this people were thinking that Mindshields function as loyalty implant-lite, when that's not their intended function nor use whatsoever. This fixes that. If it's wanted that I change the text line that cultists receive when being implanted with one as well I'll do so, but will need suggestions for it, as it does seem to also be holdover text from the loyalty implant era.

Also if Tweak if the wrong CL field, lemme know. I was going to use spellcheck but it feels less grammar-y and more tweak-y.

## Changelog
:cl:
tweak: Changed the flavor text one receives when having their mindshield implant removed.
/:cl:

