### PR TITLE
Rebalance Antagonist Targets

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -60,10 +60,11 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		if(is_invalid_target(possible_target))
 			continue
 
-		possible_targets += possible_target
+		possible_targets[possible_target.assigned_role] += list(possible_target)
 
 	if(possible_targets.len > 0)
-		target = pick(possible_targets)
+		var/target_role = pick(possible_targets)
+		target = pick(possible_targets[target_role])
 
 /**
   * Called when the objective's target goes to cryo.


### PR DESCRIPTION
## What Does This PR Do
* First you randomly choose a profession that you have a target on, and then a random target on that profession.
* In this way, all roles will become targets equally.

## Why It's Good For The Game
* Right now, the mechanics of getting a target are too primitive: we just take a random person on a station and write them down as a target.

* This creates strange situations where almost all antagonists try to kill engineers, miners, doctors and other personnel without affecting the most important roles in any way.

* The reason for this is that the other roles have more slots and are always filled, so the chance of getting a target on an engineer or someone in supply is {1 in 6.25} and the chance of getting a target on a department head is {1 in 100}, assuming a hundred people hit 'Ready' for convenience.

* It's strange that you are sent to kill such insignificant personnel.

## Changelog
:cl:
tweak: Limited roles are now more likely to be targeted by antagonists.
/:cl: