### PR TITLE
Fixes area-less ruin

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedtele.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedtele.dmm
@@ -57,9 +57,6 @@
 /obj/machinery/atmospherics/unary/tank/oxygen_agent_b,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/abandtele)
-"o" = (
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plating/airless)
 "p" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight,
@@ -121,17 +118,10 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/abandtele)
-"D" = (
-/turf/simulated/floor/plating/airless)
 "F" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/abandtele)
-"P" = (
-/obj/effect/spawner/window/reinforced{
-	useFull = 0
-	},
-/turf/simulated/floor/plating/airless)
 
 (1,1,1) = {"
 a
@@ -165,8 +155,8 @@ a
 a
 a
 c
-P
-o
+j
+F
 j
 c
 a
@@ -179,8 +169,8 @@ a
 a
 c
 c
-P
-D
+j
+h
 j
 c
 c


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a ruin that has turfs with no areas, introduced in https://github.com/ParadiseSS13/Paradise/pull/18047 by accident. This was causing runtimes at map init and weird shenanigans.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Images of changes
![image](https://user-images.githubusercontent.com/12197162/175547819-c2c15697-ec66-4b06-9b97-caa840095335.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
Backend fix no player facing changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
