### PR TITLE
Make monkey death/gasps not travel through walls

### DIFF
--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -149,7 +149,7 @@
 /datum/emote/living/carbon/human/gasp/play_sound_effect(mob/user, intentional, sound_path, sound_volume)
 	var/mob/living/carbon/human/H = user
 	// special handling here: we don't want monkeys' gasps to sound through walls so you can actually walk past xenobio
-	playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(), ignore_walls = !ismonkeybasic(H))
+	playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(), ignore_walls = !isnull(user.mind))
 
 /datum/emote/living/carbon/human/shake
 	key = "shake"

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -146,6 +146,11 @@
 	else
 		return pick(H.dna.species.male_dying_gasp_sounds)
 
+/datum/emote/living/carbon/human/gasp/play_sound_effect(mob/user, intentional, sound_path, sound_volume)
+	var/mob/living/carbon/human/H = user
+	// special handling here: we don't want monkeys' gasps to sound through walls so you can actually walk past xenobio
+	playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(), ignore_walls = !ismonkeybasic(H))
+
 /datum/emote/living/carbon/human/shake
 	key = "shake"
 	key_third_person = "shakes"

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -113,7 +113,7 @@
 /datum/emote/living/deathgasp/play_sound_effect(mob/user, intentional, sound_path, sound_volume)
 	var/mob/living/carbon/human/H = user
 	// special handling here: we don't want monkeys' gasps to sound through walls so you can actually walk past xenobio
-	playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(), ignore_walls = !ismonkeybasic(H))
+	playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(), ignore_walls = !isnull(user.mind))
 
 /datum/emote/living/drool
 	key = "drool"

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -110,6 +110,11 @@
 		var/mob/living/silicon/SI = user
 		return SI.death_sound
 
+/datum/emote/living/deathgasp/play_sound_effect(mob/user, intentional, sound_path, sound_volume)
+	var/mob/living/carbon/human/H = user
+	// special handling here: we don't want monkeys' gasps to sound through walls so you can actually walk past xenobio
+	playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(), ignore_walls = !ismonkeybasic(H))
+
 /datum/emote/living/drool
 	key = "drool"
 	key_third_person = "drools"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Quiets down gasps and deathgasps from mindless mobs by preventing them from traveling through walls.
The sound should still be audible if you're on the other side of a window from em, but you should now not have to hear them from xenobio maints.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Death and death-adjacent sounds often get drowned out when you're in maintenance around xenobiology. It becomes a bit obnoxious to hear seven monkeys gasping every few seconds when xenobio's on their game. It would be good to tone it down a little bit.

By extending it to mindless mobs as per @moxian's suggestion, this will benefit some other situations as well.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Mindless mobs gasps and deathgasps now no longer travel through walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->