### PR TITLE
Fix a typo in tgui tutorial

### DIFF
--- a/tgui/docs/tutorial-and-examples.md
+++ b/tgui/docs/tutorial-and-examples.md
@@ -37,7 +37,7 @@ powerful interactions for embedded objects or remote access.
 Let's start with a very basic hello world.
 
 ```dm
-/obj/machinery/my_machine/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = default_state)
+/obj/machinery/my_machine/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
   ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
   if(!ui)
     ui = new(user, src, ui_key, "my_machine", name, 300, 300, master_ui, state)


### PR DESCRIPTION
## What Does This PR Do
Fixes typo

## Why It's Good For The Game
Presenting code that compiles is good for tutorials, especially if that doesn't detract from the main point they're trying to get across.