### PR TITLE
[GBP no update] Fix the display of the zone being operated on during the surgery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -119,7 +119,7 @@
 				if(S?.voluntary)
 					H.SetSleeping(0) // wake up people who are napping through the surgery
 					if(pain_mod < 0.95)
-						to_chat(H, "<span class='danger'>The surgery on your [parse_zone(target_zone)] is agonizingly painful, and wrecks you out of your shallow slumber!</span>")
+						to_chat(H, "<span class='danger'>The surgery on your [parse_zone(target_zone)] is agonizingly painful, and rips you out of your shallow slumber!</span>")
 					else
 						// Still wake people up, but they shouldn't be as alarmed.
 						to_chat(H, "<span class='warning'>The surgery being performed on your [parse_zone(target_zone)] wakes you up.</span>")

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -119,10 +119,10 @@
 				if(S?.voluntary)
 					H.SetSleeping(0) // wake up people who are napping through the surgery
 					if(pain_mod < 0.95)
-						to_chat(H, "<span class='danger'>The surgery on your [target_zone] is agonizingly painful, and wrecks you out of your shallow slumber!</span>")
+						to_chat(H, "<span class='danger'>The surgery on your [parse_zone(target_zone)] is agonizingly painful, and wrecks you out of your shallow slumber!</span>")
 					else
 						// Still wake people up, but they shouldn't be as alarmed.
-						to_chat(H, "<span class='warning'>The surgery being performed on your [target_zone] wakes you up.</span>")
+						to_chat(H, "<span class='warning'>The surgery being performed on your [parse_zone(target_zone)] wakes you up.</span>")
 				prob_chance *= pain_mod //operating on conscious people is hard.
 
 		if(prob(prob_chance) || isrobot(user))


### PR DESCRIPTION
## What Does This PR Do
fixes the way the body part being operated on is shown to the sleeping person
Oversight from #17661

## Why It's Good For The Game
Bugfix. This looks jank:
![image](https://user-images.githubusercontent.com/7831163/175795018-f5e64433-42e4-40da-92b8-9268bda73735.png)

## Images of changes
this looks better
![20220626-010546-dreamseeker](https://user-images.githubusercontent.com/7831163/175795196-145e3fea-fa80-479d-bb39-9537f75b05bc.png)



## Changelog
:cl:
fix: Fix the display of the zone being operated on during the surgery
/:cl:
