### PR TITLE
Fix cutting meat to be consistent with itself and cutting other food items

### DIFF
--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -18,8 +18,8 @@
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		user.visible_message( \
-			"<span class ='notice'>[user] cuts the [src] with the [W]!</span>", \
-			"<span class ='notice'>You cut the [src] with your [W]!</span>" \
+			"<span class ='notice'>[user] cuts [src] with [W]!</span>", \
+			"<span class ='notice'>You cut [src] with [W]!</span>" \
 			)
 		qdel(src)
 	else
@@ -74,8 +74,8 @@
 /obj/item/reagent_containers/food/snacks/rawcutlet/attackby(obj/item/W, mob/user, params)
 	if(istype(W,/obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
 		user.visible_message( \
-			"<span class ='notice'>[user] cuts the raw cutlet with the [W]!</span>", \
-			"<span class ='notice'>You cut the raw cutlet with your [W]!</span>" \
+			"<span class ='notice'>[user] cuts the raw cutlet with [W]!</span>", \
+			"<span class ='notice'>You cut the raw cutlet with [W]!</span>" \
 			)
 		new /obj/item/reagent_containers/food/snacks/raw_bacon(loc)
 		qdel(src)

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -17,7 +17,10 @@
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-		to_chat(user, "You cut the meat in thin strips.")
+		user.visible_message( \
+			"<span class ='notice'>[user] cuts the [src] with the [W]!</span>", \
+			"<span class ='notice'>You cut the [src] with your [W]!</span>" \
+			)
 		qdel(src)
 	else
 		..()

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -69,7 +69,7 @@
 	list_reagents = list("protein" = 1)
 
 /obj/item/reagent_containers/food/snacks/rawcutlet/attackby(obj/item/W, mob/user, params)
-	if(istype(W,/obj/item/kitchen/knife))
+	if(istype(W,/obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
 		user.visible_message( \
 			"[user] cuts the raw cutlet with the knife!", \
 			"<span class ='notice'>You cut the raw cutlet with your knife!</span>" \

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -71,8 +71,8 @@
 /obj/item/reagent_containers/food/snacks/rawcutlet/attackby(obj/item/W, mob/user, params)
 	if(istype(W,/obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
 		user.visible_message( \
-			"[user] cuts the raw cutlet with the knife!", \
-			"<span class ='notice'>You cut the raw cutlet with your knife!</span>" \
+			"<span class ='notice'>[user] cuts the raw cutlet with the [W]!</span>", \
+			"<span class ='notice'>You cut the raw cutlet with your [W]!</span>" \
 			)
 		new /obj/item/reagent_containers/food/snacks/raw_bacon(loc)
 		qdel(src)

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -72,7 +72,7 @@
 	list_reagents = list("protein" = 1)
 
 /obj/item/reagent_containers/food/snacks/rawcutlet/attackby(obj/item/W, mob/user, params)
-	if(istype(W,/obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
+	if(istype(W, /obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
 		user.visible_message( \
 			"<span class ='notice'>[user] cuts the raw cutlet with [W]!</span>", \
 			"<span class ='notice'>You cut the raw cutlet with [W]!</span>" \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so you can cut cutlets into bacon with the scalple as well as with a kitchen knife, bringing it into consistency with both cutting of meat as well as cutting of all food sliceables.
Fixes messages sent to chat to be consistent with the way messages are handled elsewhere.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency in how food can be cut is good. Consistency in messages is good. Consistency is (mostly) always good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Player can now use scalple to cut cutlets into bacon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
