### PR TITLE
Fix runtime in mass-hallucination event

### DIFF
--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -7,7 +7,7 @@
 		if(H.stat == DEAD)
 			continue
 		var/turf/T = get_turf(H)
-		if(!is_station_level(T.z))
+		if(!is_station_level(T?.z))
 			continue
 		var/armor = H.getarmor(type = RAD)
 		if(HAS_TRAIT(H, TRAIT_RADIMMUNE) || armor >= 75) // Leave radiation-immune species/rad armored players completely unaffected

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1131,6 +1131,7 @@
 			else
 				I = new organ(H) //Create the organ inside the player.
 				I.insert(H)
+	qdel(temp_holder)
 
 /**
  * Regrows a given external limb if it is missing. Does not add internal organs back in.


### PR DESCRIPTION
## What Does This PR Do
Fixes the following runtime:

```
[2022-06-26T08:12:05] Runtime in mass_hallucination.dm,10: Cannot read null.z
[2022-06-26T08:12:05]   proc name: start (/datum/event/mass_hallucination/start)
[2022-06-26T08:12:05]   src: /datum/event/mass_hallucinatio... (/datum/event/mass_hallucination)
[2022-06-26T08:12:05]   call stack:
[2022-06-26T08:12:05]   /datum/event/mass_hallucinatio... (/datum/event/mass_hallucination): start()
[2022-06-26T08:12:05]   /datum/event/mass_hallucinatio... (/datum/event/mass_hallucination): process()
[2022-06-26T08:12:05]   Events (/datum/controller/subsystem/events): fire(0)
[2022-06-26T08:12:05]   Events (/datum/controller/subsystem/events): ignite(0)
[2022-06-26T08:12:05]   Master (/datum/controller/master): RunQueue()
[2022-06-26T08:12:05]   Master (/datum/controller/master): Loop()
[2022-06-26T08:12:05]   Master (/datum/controller/master): StartProcessing(0)
```

The runtime stems from the fact that `GLOB.human_list` has mobs in nullspace in it.
The fix is twofold:
- Remove the only (hopefully) occurence of dummy humans being created in nullspace (via admin or cling rejuvenation among other things) and never delted
- Ignore nullspaced mobs in mass hallucination effects

## Why It's Good For The Game
Bugfix. 

## Changelog
:cl:
fix: Mass hallucination event is probably now working again.
/:cl:
