### PR TITLE
Adds a greytide themed wizard loadout with His Grace

### DIFF
--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -57,7 +57,7 @@ STI KALY - blind
 /datum/disease/wizarditis/proc/spawn_wizard_clothes(chance = 0)
 	if(istype(affected_mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = affected_mob
-		if(prob(chance))
+		if(prob(chance) && !isplasmaman(H))
 			if(!istype(H.head, /obj/item/clothing/head/wizard))
 				if(!H.unEquip(H.head))
 					qdel(H.head)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -650,7 +650,11 @@
 	for(var/path in spells_path)
 		var/obj/effect/proc_holder/spell/S = new path()
 		LearnSpell(user, book, S)
+	OnBuy(user, book)
 	return TRUE
+
+/datum/spellbook_entry/loadout/proc/OnBuy(mob/living/carbon/human/user, obj/item/spellbook/book)
+	return
 
 /obj/item/spellbook
 	name = "spell book"

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -76,11 +76,11 @@
 	desc = "A set of legendary artifacts used by a bald, grey wizard, now passed on to you. <br> \
 		Open His Grace's latch once you are ready to kill by using It in your hand. Keep It fed or you will be Its next meal.<br> \
 		You might want to raid the Armory or loot a Security Officer to get ranged weapons like a disabler, His Grace's Hunger has little patience.<br><br> \
-		</i>Provides His Grace, an Ancient Jumpsuit, an Assistant ID, a Gas Mask and Shoes, Insulated Gloves, a full Toolbelt, Ethereal Jaunt, Teleport, Knock and No Clothes.<i>"
+		</i>Provides His Grace, an Ancient Jumpsuit, an Assistant ID, a Gas Mask and Shoes, Insulated Gloves, a full Toolbelt, Ethereal Jaunt, Force Wall, Knock and No Clothes.<i>"
 	log_name = "GT"
 	items_path = list(/obj/item/his_grace, /obj/item/clothing/under/color/grey/glorf, /obj/item/clothing/mask/gas, /obj/item/clothing/shoes/black, \
 		 /obj/item/clothing/gloves/color/yellow, /obj/item/storage/belt/utility/full/multitool)
-	spells_path = list(/obj/effect/proc_holder/spell/ethereal_jaunt, /obj/effect/proc_holder/spell/area_teleport/teleport, \
+	spells_path = list(/obj/effect/proc_holder/spell/ethereal_jaunt, /obj/effect/proc_holder/spell/forcewall, \
 		/obj/effect/proc_holder/spell/aoe_turf/knock, /obj/effect/proc_holder/spell/noclothes)
 	category = "Unique"
 	destroy_spellbook = TRUE

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -78,25 +78,22 @@
 		You might want to raid the Armory or loot a Security Officer to get ranged weapons like a disabler, His Grace's Hunger has little patience.<br><br> \
 		</i>Provides His Grace, an Ancient Jumpsuit, an Assistant ID, a Gas Mask and Shoes, Insulated Gloves, a full Toolbelt, Ethereal Jaunt, Teleport, Knock and No Clothes.<i>"
 	log_name = "GT"
-	items_path = list(/obj/item/his_grace, /obj/item/clothing/gloves/color/yellow, /obj/item/storage/belt/utility/full/multitool)
+	items_path = list(/obj/item/his_grace, /obj/item/clothing/under/color/grey/glorf, /obj/item/clothing/mask/gas, /obj/item/clothing/shoes/black, \
+		 /obj/item/clothing/gloves/color/yellow, /obj/item/storage/belt/utility/full/multitool)
 	spells_path = list(/obj/effect/proc_holder/spell/ethereal_jaunt, /obj/effect/proc_holder/spell/area_teleport/teleport, \
 		/obj/effect/proc_holder/spell/aoe_turf/knock, /obj/effect/proc_holder/spell/noclothes)
 	category = "Unique"
 	destroy_spellbook = TRUE
 
 /datum/spellbook_entry/loadout/greytide/OnBuy(mob/living/carbon/human/user, obj/item/spellbook/book)
-	if(!user) //Clothing is annoying to unequip/equip. Instant greytider time.
+	if(!user)
 		return
-	to_chat(user, "<span class='notice'>Your clothes fall to the floor as a brand new outfit magically snaps on your body out of nowhere!</span>")
-	user.unEquip(user.w_uniform)
-	user.unEquip(user.wear_mask)
-	user.unEquip(user.shoes)
-	user.unEquip(user.wear_suit)
-	user.unEquip(user.head)
+	if(isplasmaman(user))
+		to_chat(user, "<span class='notice'>A spectral hand appears from your spellbook and pulls a brand new plasmaman suit with helmet from the void, then drops it on the floor.</span>")
+		new /obj/item/clothing/head/helmet/space/plasmaman/assistant(get_turf(user))
+		new /obj/item/clothing/under/plasmaman/assistant(get_turf(user))
 	user.unEquip(user.wear_id)
-	user.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey/glorf, slot_w_uniform)
-	user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas, slot_wear_mask)
-	user.equip_to_slot_or_del(new /obj/item/clothing/shoes/black, slot_shoes)
+	user.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey/glorf, slot_w_uniform) //Just in case they're naked
 	var/obj/item/card/id/wizid = new /obj/item/card/id(src)
 	user.equip_to_slot_or_del(wizid, slot_wear_id)
 	wizid.registered_name = user.real_name

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -86,25 +86,26 @@
 	destroy_spellbook = TRUE
 
 /datum/spellbook_entry/loadout/greytide/OnBuy(mob/living/carbon/human/user, obj/item/spellbook/book)
-	if(user) //Clothing is annoying to unequip/equip. Instant greytider time.
-		to_chat(user, "<span class='notice'>Your clothes fall to the floor as a brand new outfit magically snaps on your body out of nowhere!</span>")
-		user.unEquip(user.w_uniform)
-		user.unEquip(user.wear_mask)
-		user.unEquip(user.shoes)
-		user.unEquip(user.wear_suit)
-		user.unEquip(user.head)
-		user.unEquip(user.wear_id)
-		user.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey/glorf, slot_w_uniform)
-		user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas, slot_wear_mask)
-		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/black, slot_shoes)
-		var/obj/item/card/id/wizid = new /obj/item/card/id(src)
-		user.equip_to_slot_or_del(wizid, slot_wear_id)
-		wizid.registered_name = user.real_name
-		wizid.access = list(ACCESS_MAINT_TUNNELS)
-		wizid.assignment = "Assistant"
-		wizid.rank = "Assistant"
-		wizid.photo = get_id_photo(user, "Assistant")
-		wizid.registered_name = user.real_name
-		wizid.SetOwnerInfo(user)
-		wizid.UpdateName()
-		wizid.RebuildHTML()
+	if(!user) //Clothing is annoying to unequip/equip. Instant greytider time.
+		return
+	to_chat(user, "<span class='notice'>Your clothes fall to the floor as a brand new outfit magically snaps on your body out of nowhere!</span>")
+	user.unEquip(user.w_uniform)
+	user.unEquip(user.wear_mask)
+	user.unEquip(user.shoes)
+	user.unEquip(user.wear_suit)
+	user.unEquip(user.head)
+	user.unEquip(user.wear_id)
+	user.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey/glorf, slot_w_uniform)
+	user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas, slot_wear_mask)
+	user.equip_to_slot_or_del(new /obj/item/clothing/shoes/black, slot_shoes)
+	var/obj/item/card/id/wizid = new /obj/item/card/id(src)
+	user.equip_to_slot_or_del(wizid, slot_wear_id)
+	wizid.registered_name = user.real_name
+	wizid.access = list(ACCESS_MAINT_TUNNELS)
+	wizid.assignment = "Assistant"
+	wizid.rank = "Assistant"
+	wizid.photo = get_id_photo(user, "Assistant")
+	wizid.registered_name = user.real_name
+	wizid.SetOwnerInfo(user)
+	wizid.UpdateName()
+	wizid.RebuildHTML()

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -46,7 +46,7 @@
 	category = "Unique"
 	destroy_spellbook = TRUE
 
-/datum/spellbook_entry/loadout/mimewiz/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
+/datum/spellbook_entry/loadout/mimewiz/OnBuy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	if(user.mind)
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/mime/speak(null))
 		user.mind.miming = TRUE
@@ -54,7 +54,7 @@
 
 /datum/spellbook_entry/loadout/gunreaper
 	name = "Gunslinging Reaper"
-	desc = "Cloned over and over, the souls aboard this station yearn for a deserved rest.<br> \
+	desc = "Cloned over and over, the souls aboard this station yearn for a deserved rest. <br> \
 		Bring them to the afterlife, one trigger pull at a time. <br> \
 		You will likely need to scavenge additional ammo or weapons aboard the station. <br><br>\
 		</i>Provides a .357 Revolver, 4 speedloaders of ammo, Ethereal Jaunt, Blink, Summon Item, No Clothes, and Bind Soul, with a unique outfit.<i>"
@@ -71,3 +71,40 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(H), slot_gloves)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/syndicate(H), slot_w_uniform)
+
+/datum/spellbook_entry/loadout/greytide
+	name = "Tyde the Grey"
+	desc = "A set of legendary artifacts used by a bald, grey wizard, now passed on to you. <br> \
+		Open His Grace's latch once you are ready to kill by using It in your hand. Keep It fed or you will be Its next meal.<br> \
+		You might want to raid the Armory or loot a Security Officer to get ranged weapons like a disabler, His Grace's Hunger has little patience.<br><br> \
+		</i>Provides His Grace, an Ancient Jumpsuit, an Assistant ID, a Gas Mask and Shoes, Insulated Gloves, a full Toolbelt, Ethereal Jaunt, Teleport, Knock and No Clothes.<i>"
+	log_name = "GT"
+	items_path = list(/obj/item/his_grace, /obj/item/clothing/gloves/color/yellow, /obj/item/storage/belt/utility/full/multitool)
+	spells_path = list(/obj/effect/proc_holder/spell/ethereal_jaunt, /obj/effect/proc_holder/spell/area_teleport/teleport, \
+		/obj/effect/proc_holder/spell/aoe_turf/knock, /obj/effect/proc_holder/spell/noclothes)
+	category = "Unique"
+	destroy_spellbook = TRUE
+
+/datum/spellbook_entry/loadout/greytide/OnBuy(mob/living/carbon/human/user, obj/item/spellbook/book)
+	if(user) //Clothing is annoying to unequip/equip. Instant greytider time.
+		to_chat(user, "<span class='notice'>Your clothes fall to the floor as a brand new outfit magically snaps on your body out of nowhere!</span>")
+		user.unEquip(user.w_uniform)
+		user.unEquip(user.wear_mask)
+		user.unEquip(user.shoes)
+		user.unEquip(user.wear_suit)
+		user.unEquip(user.head)
+		user.unEquip(user.wear_id)
+		user.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey/glorf, slot_w_uniform)
+		user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas, slot_wear_mask)
+		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/black, slot_shoes)
+		var/obj/item/card/id/wizid = new /obj/item/card/id(src)
+		user.equip_to_slot_or_del(wizid, slot_wear_id)
+		wizid.registered_name = user.real_name
+		wizid.access = list(ACCESS_MAINT_TUNNELS)
+		wizid.assignment = "Assistant"
+		wizid.rank = "Assistant"
+		wizid.photo = get_id_photo(user, "Assistant")
+		wizid.registered_name = user.real_name
+		wizid.SetOwnerInfo(user)
+		wizid.UpdateName()
+		wizid.RebuildHTML()

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -89,7 +89,7 @@
 	if(!user)
 		return
 	if(isplasmaman(user))
-		to_chat(user, "<span class='notice'>A spectral hand appears from your spellbook and pulls a brand new plasmaman suit with helmet from the void, then drops it on the floor.</span>")
+		to_chat(user, "<span class='notice'>A spectral hand appears from your spellbook and pulls a brand new plasmaman envirosuit, complete with helmet, from the void, then drops it on the floor.</span>")
 		new /obj/item/clothing/head/helmet/space/plasmaman/assistant(get_turf(user))
 		new /obj/item/clothing/under/plasmaman/assistant(get_turf(user))
 	user.unEquip(user.wear_id)

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -50,7 +50,6 @@
 	if(user.mind)
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/mime/speak(null))
 		user.mind.miming = TRUE
-	..()
 
 /datum/spellbook_entry/loadout/gunreaper
 	name = "Gunslinging Reaper"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -879,6 +879,7 @@
 	name = "magical box"
 	desc = "It's just an ordinary magical box."
 	icon_state = "box_wizard"
+	w_class = WEIGHT_CLASS_GIGANTIC
 
 #undef NODESIGN
 #undef NANOTRASEN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds a new wizard loadout, 'Tyde the Grey', providing His Grace, an Ancient Jumpsuit, an Assistant ID, a Gas Mask and Shoes, Insulated Gloves, a full Toolbelt, Ethereal Jaunt, Force Wall, Knock and No Clothes.
The ID is properly set to look like a real ID with the wizard's name, info, photo, and 'Assistant' job on it.

Plasmamen get an assistant envirosuit and helmet aswell.

Increase the size of magical loadout boxes to prevent carrying them in your backpack (and hide His Grace or any other bulky loadout item)

Wizarditis no longer removes helmet off of plasmamen. (Envirosuits are already left alone)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
His Grace is a magical item that lets you go on a rampage. Wizards are magical users going on a rampage. It seems the two together would be a good fit. However, His Grace would be way too strong if the wizard could get any spells they want alongside it, locking it a specific loadout prevents it from being completely unfair. 

The wizard does not get any aggressive spells, His Grace already providing plenty to work with.

The clothing, ID, and tools provided to the wizard, aside from being thematic, can let the wizard do a little bit of stealthy equipment gathering before  the rampage starts, since you do not need to open His Grace's latch immediately since its rework. Of course, this is assuming nobody questions the green toolbox you're carrying around...

As wizarditis can be accessed by hacking the magivend, I've fixed it to prevent it from permakilling infected plasmamen. The disease itself is fine to get as an easter egg for the ~~code diving~~ knowledgeable wizard, it's mostly gimmicky, with the only significant gameplay effect being an extremely rare random teleport on occasion. It's not particularly hard to cure either, it's manly dwarf from the bar.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![greytide2](https://user-images.githubusercontent.com/22121511/175809224-b7b56abb-8d3b-4762-bfd1-3ec5552eae3a.png)
![greytide3](https://user-images.githubusercontent.com/22121511/175809239-861595e8-9725-4b6b-8f38-c2c679610559.png)

## Changelog

:cl:
add: Added 'Tyde the Grey' wizard loadout, containing His Grace, a greytider outfit, Jaunt, Force Wall, and Knock.
tweak: Wizarditis no longer removes plasmamen helmets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
