### PR TITLE
Fixes surgery cancellation bug/exploit.

### DIFF
--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -50,6 +50,7 @@
 	user.visible_message("<span class='notice'> [user] has cut [target]'s [affected.encased] open with \the [tool].</span>",		\
 	"<span class='notice'> You have cut [target]'s [affected.encased] open with \the [tool].</span>")
 	affected.open = 2.5
+	affected.fracture()
 	return 1
 
 /datum/surgery_step/open_encased/saw/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Sawing through the chest or head now breaks the affected bone. 

If the surgery is finished normally (as per wiki with bone setters and bone gel) the fracture is fixed at the end of the surgery. If the surgeon uses the bug/exploit of cancelling the surgery early the bone stays broken.

This fixes the bug/exploit where you can do all the needed surgery steps to get to the organs in the chest or the head and then skip the part of the surgery where you actually close up and fix the bones you sawed through.

## Why It's Good For The Game
Removes an exploit/bug.
Makes surgery work the way it is described on the wiki.

## Notes

Calling the .fracture() proc may be too dramatic, with sound and all (though I consider it quite fitting, opening the ribcage is not a gentle process). I could change the proc so it is silent in case of a surgery.

But I wanted to make a minimal viable fix first to judge the response to this PR.

## Changelog
:cl: uc_guy
fix: Sawing somebodys chest/head open causes a fracture that needs to be fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
