### PR TITLE
Adds in a missed QDEL so a query doesn't go undeleted in Karma_holder.dm

### DIFF
--- a/code/modules/karma/karma_holder.dm
+++ b/code/modules/karma/karma_holder.dm
@@ -147,6 +147,8 @@
 		qdel(insert_query)
 		return
 
+	qdel(insert_query)
+
 	// Update for this round
 	purchased_packages -= package.database_id
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #18099
Adds `qdel(insert_query)` after 
```dm
if(!insert_query.warn_execute())
	to_chat(user, "<span class='warning'>Failed to refund [package.friendly_name]. Please contact the server host.</span>")
	qdel(insert_query)
	return
```

reason being, if the query doesn't fail, it fails to get deleted. This fixes it.
## Why It's Good For The Game
Undeleted queries, while not a terrible issue, should be cleaned up.

CL removed due to no player-facing changes


