### PR TITLE
Possibly fix runtime when sacrificing monkeys

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -395,7 +395,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				to_chat(M, "<span class='cultitalic'>You are now able to construct mirror shields inside the daemon forge.</span>")
 				SSticker.cultdat.mirror_shields_active = TRUE
 		else
-			if(ishuman(offering) && offering.mind.offstation_role && offering.mind.special_role != SPECIAL_ROLE_ERT) //If you try it on a ghost role, you get nothing
+			if(ishuman(offering) && offering.mind?.offstation_role && offering.mind.special_role != SPECIAL_ROLE_ERT) //If you try it on a ghost role, you get nothing
 				to_chat(M, "<span class='cultlarge'>\"This soul is of no use to either of us.\"</span>")
 				worthless = TRUE
 			else if(ishuman(offering) || isrobot(offering))


### PR DESCRIPTION
## What Does This PR Do
Possibly fixes the following runtime:
```
[2022-06-27T04:06:59] Runtime in runes.dm,398: Cannot read null.offstation_role
[2022-06-27T04:06:59]   proc name: do sacrifice (/obj/effect/rune/convert/proc/do_sacrifice)
[2022-06-27T04:06:59]   usr: Shade of Anton Fasani (**CKEY**) (/mob/living/simple_animal/shade/cult)
[2022-06-27T04:06:59]   usr.loc: The engraved floor (63,114,3) (/turf/simulated/floor/engine/cult)
```

I must disclose that i did not test the live version of the code to confirm that sacrificing monkeys *does* give the runtime, nor did it test the fix. However the implications of this single-character change should be somewhat easy to establish by code review alone.

## Why It's Good For The Game
Bugfix

## Changelog
too minor for the changelog