### PR TITLE
Fix runtime with borgs deathgasping

### DIFF
--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -112,6 +112,8 @@
 
 /datum/emote/living/deathgasp/play_sound_effect(mob/user, intentional, sound_path, sound_volume)
 	var/mob/living/carbon/human/H = user
+	if(!user)
+		return ..()
 	// special handling here: we don't want monkeys' gasps to sound through walls so you can actually walk past xenobio
 	playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(), ignore_walls = !isnull(user.mind))
 


### PR DESCRIPTION
## What Does This PR Do
Fixes the following runtime (presumably introduced by #18080):
```
[2022-06-27T05:33:38] Runtime in living_emote.dm,116: undefined proc or verb /mob/living/silicon/robot/get age pitch().
[2022-06-27T05:33:38] 
[2022-06-27T05:33:38]   proc name: play sound effect (/datum/emote/living/deathgasp/play_sound_effect)
[2022-06-27T05:33:38]   usr: Devin Hoffman (**CKEY**) (/mob/living/carbon/human)
[2022-06-27T05:33:38]   usr.loc: The floor (188,129,2) (/turf/simulated/floor/plasteel)
```

Did not test in game.

## Why It's Good For The Game
bugfix

## Changelog
N/A