### PR TITLE
Bamboo drops wood

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -158,6 +158,20 @@
 	buildstacktype = /obj/item/stack/sheet/wood
 	item_chair = /obj/item/chair/wood
 
+/obj/structure/chair/sofa/bamboo
+	name = "bamboo sofa"
+	resistance_flags = FLAMMABLE
+	max_integrity = 70
+	buildstackamount = 2
+	buildstacktype = /obj/item/stack/sheet/wood
+
+/obj/structure/chair/stool/bamboo
+	name = "bamboo stool"
+	resistance_flags = FLAMMABLE
+	max_integrity = 70
+	buildstackamount = 2
+	buildstacktype = /obj/item/stack/sheet/wood
+
 /obj/structure/chair/wood/narsie_act()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #18105

```
/obj/structure/chair/sofa/bamboo
	name = "bamboo sofa"
	resistance_flags = FLAMMABLE
	max_integrity = 70
	buildstackamount = 2
	buildstacktype = /obj/item/stack/sheet/wood

/obj/structure/chair/stool/bamboo
	name = "bamboo stool"
	resistance_flags = FLAMMABLE
	max_integrity = 70
	buildstackamount = 2
	buildstacktype = /obj/item/stack/sheet/wood
```

## Why It's Good For The Game
People can not dupe metal with wood anymore, also bamboo should drop wood

## Images of changes
https://i.imgur.com/KRZ2YYw.gif

## Changelog
:cl:
fix: Bamboo stool/sofa no longer drops metal upon deconstruction, instead dropping equal amounts of wood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
