### PR TITLE
Makes all Gamma ERT hardsuits have no slowdown

### DIFF
--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -97,6 +97,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gcommander"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/commander/gamma
+	slowdown = 0
 
 //Security
 /obj/item/clothing/head/helmet/space/hardsuit/ert/security
@@ -124,6 +125,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gsecurity"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/security/gamma
+	slowdown = 0
 
 //Engineer
 /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer
@@ -134,7 +136,6 @@
 	item_state = "helm-orange"
 	item_color = "ert_engineer"
 
-//Engineer
 /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer/gamma
 	name = "elite emergency response team engineer helmet"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -156,6 +157,7 @@
 	icon_state = "ert_gengineer"
 	armor = list(MELEE = 45, BULLET = 25, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 100, RAD = 100, FIRE = 80, ACID = 80)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer/gamma
+	slowdown = 0
 
 //Medical
 /obj/item/clothing/head/helmet/space/hardsuit/ert/medical
@@ -181,6 +183,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gmedical"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/medical/gamma
+	slowdown = 0
 
 //Janitor
 /obj/item/clothing/head/helmet/space/hardsuit/ert/janitor
@@ -206,6 +209,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gjanitor"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/janitor/gamma
+	slowdown = 0
 
 //Paranormal
 /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Makes all Gamma hardsuits slowdown to 0

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Consistency with Gamma Paranormal ERT (Inquisitor suit). Also Gamma ERT Hardsuits' only other buff is protecting against heat, they really should have something special going for them.

## Changelog
:cl:
tweak: Gamma ERT hardsuits now have no slowdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
