### PR TITLE
Fixes a runtime on debris2.dmm

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/debris2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris2.dmm
@@ -183,9 +183,7 @@
 /turf/simulated/floor/plating/damaged,
 /area/space)
 "Z" = (
-/obj/machinery/computer/pandemic{
-	circuit = /obj/effect/decal/cleanable/shreds
-	},
+/obj/machinery/computer/pandemic,
 /turf/simulated/floor/plasteel/airless,
 /area/space)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Changes out the var-edited PANDEMIC machine on debris2.dmm for a normal one. This however means it now that explorers can get a PANDEMIC board, so a more complex solution may be in order.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->fixes #18098

## Changelog
Nothing player-facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
