### PR TITLE
Nerfs Deathnettle

### DIFF
--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -37,7 +37,7 @@
 	force = 15
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	throwforce = 5
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_NORMAL // Two nettle/deathnettle fit in a pneumatic cannon. They fit in plant bags.
 	throw_speed = 1
 	throw_range = 3
 	origin_tech = "combat=3"
@@ -104,7 +104,9 @@
 
 /obj/item/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
 	..()
-	if(isliving(M))
-		to_chat(M, "<span class='danger'>You flinch as you are struck by the Deathnettle!</span>")
-		add_attack_logs(user, M, "Hit with [src]")
-		M.AdjustEyeBlurry(force * 2) // Maximum duration 5 seconds.
+	if(!living(M))
+		return
+
+	to_chat(M, "<span class='danger'>You flinch as you are struck by the Deathnettle!</span>")
+	add_attack_logs(user, M, "Hit with [src]")
+	M.AdjustEyeBlurry(force * 2) // Maximum duration 5 seconds per hit.

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -25,7 +25,7 @@
 	yield = 2
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/stinging)
 	mutatelist = list()
-	reagents_add = list("facid" = 0.5, "sacid" = 0.5)
+	reagents_add = list("facid" = 0.25, "sacid" = 0.25)
 	rarity = 20
 
 /obj/item/grown/nettle //abstract type
@@ -37,7 +37,7 @@
 	force = 15
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	throwforce = 5
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	throw_range = 3
 	origin_tech = "combat=3"
@@ -81,20 +81,20 @@
 
 /obj/item/grown/nettle/basic/add_juice()
 	..()
-	force = round((5 + seed.potency / 5), 1)
+	force = round((5 + seed.potency / 10), 1) // Maximum damage 15.
 
 /obj/item/grown/nettle/death
 	seed = /obj/item/seeds/nettle/death
 	name = "deathnettle"
 	desc = "The <span class='danger'>glowing</span> nettle incites <span class='boldannounce'>rage</span> in you just from looking at it!"
 	icon_state = "deathnettle"
-	force = 30
-	throwforce = 15
+	force = 25
+	throwforce = 10
 	origin_tech = "combat=5"
 
 /obj/item/grown/nettle/death/add_juice()
 	..()
-	force = round((5 + seed.potency / 2.5), 1)
+	force = round((5 + seed.potency / 5), 1) // Maximum damage 25.
 
 /obj/item/grown/nettle/death/pickup(mob/living/carbon/user)
 	if(..())
@@ -105,13 +105,6 @@
 /obj/item/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
 	..()
 	if(isliving(M))
-		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of the Deathnettle!</span>")
+		to_chat(M, "<span class='danger'>You flinch as you are struck by the Deathnettle!</span>")
 		add_attack_logs(user, M, "Hit with [src]")
-
-		M.AdjustEyeBlurry((force / 7) STATUS_EFFECT_CONSTANT)
-		if(prob(20))
-			var/paralyze_time = (force * 10 / 3) SECONDS
-			var/stun_time = (force / 7.5) SECONDS
-			M.Paralyse(paralyze_time)
-			M.Weaken(stun_time)
-		M.drop_item()
+		M.AdjustEyeBlurry(force * 2) // Maximum duration 5 seconds.

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -107,6 +107,6 @@
 	if(!isliving(M))
 		return
 
-	to_chat(M, "<span class='danger'>You flinch as you are struck by the Deathnettle!</span>")
+	to_chat(M, "<span class='danger'>You flinch as you are struck by \the [src]!</span>")
 	add_attack_logs(user, M, "Hit with [src]")
 	M.AdjustEyeBlurry(force * 2) // Maximum duration 5 seconds per hit.

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -104,7 +104,7 @@
 
 /obj/item/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
 	..()
-	if(!living(M))
+	if(!isliving(M))
 		return
 
 	to_chat(M, "<span class='danger'>You flinch as you are struck by the Deathnettle!</span>")


### PR DESCRIPTION
## What Does This PR Do
Makes general changes to both Deathnettle and Nettle.

- Deathnettle's chemical productions have been lowered to 25% from 50% for both Sulphuric and Fluorosulphuric Acid, thus rendering acid smoke plants less of an instant kill (if still a war crime).

- Deathnettle no longer has a chance to paralyze (render you unconscious) upon hit.

- Deathnettle will no longer make those it hits drop their items.

- Deathnettle's damage has been generally lowered by a little more than half and now has a maximum damage of 25.

- Nettle's damage was similarly lowered to compensate, and now has a maximum damage of 15.

- Nettle, and therefore Deathnettle, are now normal sized items- less of them can fit in pneumatic cannons as a result.

- Deathnettle no longer weakens, and no longer has a chance to paralyse its target.

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/85680653/176281847-a2215085-f324-4d4c-a350-bfc9f3e994da.png)
100 Potency Deathnettle does about 40 burn damage minimum per melee hit.

100 Potency Deathnettle does about 60 damage when thrown and injects almost 20u of fluorosulphuric acid into the system of the target.

This kills people.

Ground up a singular 100 Potency Deathnettle can dispense about 50u of fluorosulphuric acid from a singular deathnettle.
I could grow four of these deathnettles per harvest at low yield every few minutes.

I am normal and can be trusted with plants.

## Changelog
:cl:
tweak: Nerfs Deathnettle and Nettle.
/:cl: