### PR TITLE
Fixes Spirit Realm text not showing large and bold.

### DIFF
--- a/code/game/gamemodes/cult/cult_actions.dm
+++ b/code/game/gamemodes/cult/cult_actions.dm
@@ -81,7 +81,7 @@
 		if(iscultist(M))
 			to_chat(M, living_message)
 		else if((M in GLOB.dead_mob_list) && !isnewplayer(M))
-			to_chat(M, "<span class='cultspeech'>[title] ([ghost_follow_link(user, ghost=M)]): [message]</span>")
+			to_chat(M, "<span class='cultlarge'>[title] ([ghost_follow_link(user, ghost=M)]): [message]</span>")
 
 
 //Objectives


### PR DESCRIPTION
## What Does This PR Do
Makes cult text appear bold and large to the spirit realm user again.

## Why It's Good For The Game
Currently not working correctly. This makes it work correctly. What more do you want?

## Images of changes
![image](https://user-images.githubusercontent.com/85680653/176314752-f2667d5a-a9b9-48d8-82c8-92fafdf0e53d.png)

## Changelog
fix: Fixes spirit realm text
/:cl:
