### PR TITLE
Fix several runtimes with remote welderbombing

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -294,7 +294,7 @@
 			add_attack_logs(user, t, what_done, custom_level)
 		return
 
-	var/user_str = key_name_log(user) + COORD(user)
+	var/user_str = key_name_log(user) + (istype(user) ? COORD(user) : "")
 	var/target_str
 	var/target_info
 	if(isatom(target))

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -73,8 +73,11 @@
 /proc/key_name_admin(whom)
 	if(whom)
 		var/datum/whom_datum = whom //As long as it's not null, will be close enough/has the proc UID() that is all that's needed
-		var/message = "[key_name(whom, 1)]([ADMIN_QUE(whom_datum,"?")])[isAntag(whom) ? "<font color='red'>(A)</font>" : ""][isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom)])"
-		return message
+		if(istype(whom_datum))  // strings and numbers are not datums, but sometimes they do get here...
+			var/message = "[key_name(whom, 1)]([ADMIN_QUE(whom_datum,"?")])[isAntag(whom) ? "<font color='red'>(A)</font>" : ""][isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom)])"
+			return message
+		else
+			return "INVALID/[whom]"
 
 /proc/key_name_mentor(whom)
 	// Same as key_name_admin, but does not include (?) or (A) for antags.

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -194,7 +194,7 @@
 	if(normal && a_right && a_left)
 		if(a_right != D)
 			a_right.pulsed(0)
-		if(a_left != D)
+		if(a_left && a_left != D)  // the right pools might have sent us boom, so `a_left` can be null here
 			a_left.pulsed(0)
 	if(master)
 		master.receive_signal()

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -26,16 +26,17 @@
 	var/turf/location = get_turf(loc)
 	if(location)
 		location.hotspot_expose(1000,1000)
+	sparks.start()
 	if(istype(loc, /obj/item/assembly_holder))
-		if(istype(loc.loc, /obj/structure/reagent_dispensers/fueltank))
-			var/obj/structure/reagent_dispensers/fueltank/tank = loc.loc
+		var/locloc = loc.loc
+		if(istype(locloc, /obj/structure/reagent_dispensers/fueltank))
+			var/obj/structure/reagent_dispensers/fueltank/tank = locloc
 			if(tank)
-				tank.boom(TRUE)
-		if(istype(loc.loc, /obj/item/reagent_containers/glass/beaker))
-			var/obj/item/reagent_containers/glass/beaker/beakerbomb = loc.loc
+				tank.boom(TRUE)  // this qdel's `src`
+		else if(istype(locloc, /obj/item/reagent_containers/glass/beaker))
+			var/obj/item/reagent_containers/glass/beaker/beakerbomb = locloc
 			if(beakerbomb)
 				beakerbomb.heat_beaker()
-	sparks.start()
 	return TRUE
 
 


### PR DESCRIPTION
## What Does This PR Do
Fixes these two runtimes that can be observed on live:

```dm
[2022-06-29T01:08:42] Runtime in mobs.dm,297: Cannot read "Moxian/(Carl Wile)".x
[2022-06-29T01:08:42]   proc name: add attack logs (/proc/add_attack_logs)
[2022-06-29T01:08:42]   usr: Carl Wile (moxian) (/mob/living/carbon/human)
[2022-06-29T01:08:42]   usr.loc: The floor (68,147,2) (/turf/simulated/floor/plasteel)
[2022-06-29T01:08:42]   src: null
[2022-06-29T01:08:42]   call stack:
[2022-06-29T01:08:42]   add attack logs("Moxian/(Carl Wile)", the fuel tank (/obj/structure/reagent_dispensers/fueltank), "rigged fuel tank exploded", 3)
[2022-06-29T01:08:42]   the fuel tank (/obj/structure/reagent_dispensers/fueltank): do boom(1, 0)
[2022-06-29T01:08:42]   the fuel tank (/obj/structure/reagent_dispensers/fueltank): boom(1, 0)
[2022-06-29T01:08:42]   the igniter (/obj/item/assembly/igniter): activate()
[2022-06-29T01:08:42]   the igniter (/obj/item/assembly/igniter): pulsed(0)
[2022-06-29T01:08:42]   the igniter-remote signaling d... (/obj/item/assembly_holder): process activation(the remote signaling device (/obj/item/assembly/signaler), 1, 0)
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): pulse(1)
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): receive signal(/datum/signal (/datum/signal), 1, 1457)
[2022-06-29T01:08:42]   /datum/radio_frequency (/datum/radio_frequency): send to filter(the remote signaling device (/obj/item/assembly/signaler), /datum/signal (/datum/signal), "radio_telecoms", null, null)
[2022-06-29T01:08:42]   /datum/radio_frequency (/datum/radio_frequency): post signal(the remote signaling device (/obj/item/assembly/signaler), /datum/signal (/datum/signal), null, null)
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): signal()
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): Topic("src=\[0x200335a]_601;send=1", /list (/list))
```
```dm
[2022-06-29T01:08:42] Runtime in igniter.dm,34: Cannot read null.loc
[2022-06-29T01:08:42]   proc name: activate (/obj/item/assembly/igniter/activate)
[2022-06-29T01:08:42]   usr: Carl Wile (moxian) (/mob/living/carbon/human)
[2022-06-29T01:08:42]   usr.loc: The floor (68,147,2) (/turf/simulated/floor/plasteel)
[2022-06-29T01:08:42]   src: the igniter (/obj/item/assembly/igniter)
[2022-06-29T01:08:42]   src.loc: null
[2022-06-29T01:08:42]   call stack:
[2022-06-29T01:08:42]   the igniter (/obj/item/assembly/igniter): activate()
[2022-06-29T01:08:42]   the igniter (/obj/item/assembly/igniter): pulsed(0)
[2022-06-29T01:08:42]   the igniter-remote signaling d... (/obj/item/assembly_holder): process activation(the remote signaling device (/obj/item/assembly/signaler), 1, 0)
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): pulse(1)
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): receive signal(/datum/signal (/datum/signal), 1, 1457)
[2022-06-29T01:08:42]   /datum/radio_frequency (/datum/radio_frequency): send to filter(the remote signaling device (/obj/item/assembly/signaler), /datum/signal (/datum/signal), "radio_telecoms", null, null)
[2022-06-29T01:08:42]   /datum/radio_frequency (/datum/radio_frequency): post signal(the remote signaling device (/obj/item/assembly/signaler), /datum/signal (/datum/signal), null, null)
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): signal()
[2022-06-29T01:08:42]   the remote signaling device (/obj/item/assembly/signaler): Topic("src=\[0x200335a]_601;send=1", /list (/list))
```

and a few more that got uncovered after fixing the ones above (sadly don't have them at hand, as i've lost the logs whoops).

These all are due to the fact that attack logs really like references to mobs, whereas the welder tanks stores a *string* of who rigged it (since mobs/clients/minds can reasonably go poof in time between rigging and activation)

## Why It's Good For The Game
bugfix

## Images of changes
![image](https://user-images.githubusercontent.com/7831163/176352561-0cf21581-2a31-465a-aa91-1be53f9d6509.png)

(the second `ATTACK` log line mentions the rigger, not the signaller; the `INVALID` there is sorta intentional)

## Changelog
N/A