### PR TITLE
Stops space from being made on lavaland

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -214,7 +214,7 @@
 		return src
 
 	if(isspaceturf(path) && is_mining_level(z)) //if we are trying to make space on lavaland, we must scream and redirect
-		log_debug("Something just tried to turn [src] into space on lavaland, report it to a coder [ADMIN_COORDJMP(src)]")
+		log_debug("Something just tried to turn [src] into space on lavaland, report it to a coder. [ADMIN_COORDJMP(src)]")
 		path = /turf/simulated/floor/plating/lava
 
 	set_light(0)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -213,6 +213,10 @@
 	if(!GLOB.use_preloader && path == type) // Don't no-op if the map loader requires it to be reconstructed
 		return src
 
+	if(isspaceturf(path) && is_mining_level(z)) //if we are trying to make space on lavaland, we must scream and redirect
+		log_debug("Something just tried to turn [src] into space on lavaland, report it to a coder [ADMIN_COORDJMP(src)]")
+		path = /turf/simulated/floor/plating/lava
+
 	set_light(0)
 	var/old_opacity = opacity
 	var/old_dynamic_lighting = dynamic_lighting

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -215,7 +215,7 @@
 
 	if(isspaceturf(path) && is_mining_level(z)) //if we are trying to make space on lavaland, we must scream and redirect
 		log_debug("Something just tried to turn [src] into space on lavaland, report it to a coder. [ADMIN_COORDJMP(src)]")
-		path = /turf/simulated/floor/plating/lava
+		path = /turf/simulated/floor/plating/lava/smooth/lava_land_surface
 
 	set_light(0)
 	var/old_opacity = opacity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR catches any attemps at making space on lavaland, and repaths them to make lava instead.
It's not the ideal solution, as ideally this should be handled at the baseturf level, but there are issues with that approach that are currently making a fix difficult that way.

This works by catching any changeturf calls that change to space on the lavaland z level.
If then prints a debug message with a jumpto and coords so it can be investigated by admins and such to report to coders, then makes changeturf make it lava instead of space.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Space on lavaland is really bad since it's a planet (muh immersion), and has planetary atmos meaning space creates a big mess of ATs slowing the atmos SS down.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed being able to make space on lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
