### PR TITLE
[GBP no update] Fixes Possible Firealarm spam

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -36,6 +36,8 @@ FIRE ALARM
 	var/report_fire_alarms = TRUE // Should triggered fire alarms also trigger an actual alarm?
 	var/show_alert_level = TRUE // Should fire alarms display the current alert level?
 
+	var/last_time_pulled //used to prevent pulling spam by same persons
+
 /obj/machinery/firealarm/no_alarm
 	report_fire_alarms = FALSE
 
@@ -227,6 +229,10 @@ FIRE ALARM
 	if(user.incapacitated())
 		return 1
 
+	if(fingerprintslast == user.ckey && world.time < last_time_pulled + 2 SECONDS) //no spamming >:C
+		to_chat(user, "<span class='warning'>It is still processing your earlier command.</span>")
+		return
+
 	toggle_alarm(user)
 
 
@@ -234,6 +240,7 @@ FIRE ALARM
 	var/area/A = get_area(src)
 	if(istype(A))
 		add_fingerprint(user)
+		last_time_pulled = world.time
 		if(A.fire)
 			reset()
 		else

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -230,7 +230,7 @@ FIRE ALARM
 		return 1
 
 	if(fingerprintslast == user.ckey && world.time < last_time_pulled + 2 SECONDS) //no spamming >:C
-		to_chat(user, "<span class='warning'>It is still processing your earlier command.</span>")
+		to_chat(user, "<span class='warning'>[src] is still processing your earlier command.</span>")
 		return
 
 	toggle_alarm(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
stops being able to trigger a fire alarm rapidly. You can spam click a fire alarm and as long as its active by the end of your spam, it will play an alarm sound for every click you made to it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
being able to spam the alarm is bad

## Changelog
:cl:
fix: Fixed being able to spam fire alarms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
