### PR TITLE
Energy bolas no longer create energy snares if the target is already legcuffed.

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -200,6 +200,9 @@
 
 /obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom)
 	if(iscarbon(hit_atom))
+		var/mob/living/carbon/C = hit_atom
+		if(C.legcuffed)
+			return
 		var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy(get_turf(hit_atom))
 		B.Crossed(hit_atom, null)
 		qdel(src)


### PR DESCRIPTION
## What Does This PR Do
Energy bolas no longer create energy snares if the target is already legcuffed.

## Why It's Good For The Game
Fixes issue 18132

## Changelog
fix: Fixed energy bolas spawning energy snares on already legcuffed targets.
/:cl: