### PR TITLE
[GBP no update] Fix a runtime in dna vault Initialize

### DIFF
--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -188,8 +188,6 @@ GLOBAL_LIST_INIT(non_simple_animals, typecacheof(list(/mob/living/carbon/human/m
 			dna_max = G.human_count
 			break
 
-	..()
-
 /obj/machinery/dna_vault/update_icon()
 	..()
 	if(stat & NOPOWER)


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime happening due to double-initialization of dna vault

## Why It's Good For The Game
bugfix

## Images of changes

## Changelog
