### PR TITLE
Nerfs telekinesis

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -104,7 +104,7 @@
 /obj/item/tk_grab/afterattack(atom/target , mob/living/user, proximity, params)//TODO: go over this
 	if(!target || !user)
 		return
-	if(last_throw+3 > world.time)
+	if(last_throw + 3 SECONDS > world.time)
 		return
 	if(!host || host != user)
 		qdel(src)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -4,7 +4,7 @@
 	This needs more thinking out, but I might as well.
 */
 #define TK_MAXRANGE 15
-#define TK_COOLDOWN (1.5 SECONDS)
+#define TK_COOLDOWN 1.5 SECONDS
 /*
 	Telekinetic attack:
 

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -4,7 +4,7 @@
 	This needs more thinking out, but I might as well.
 */
 #define TK_MAXRANGE 15
-
+#define TK_COOLDOWN (1.5 SECONDS)
 /*
 	Telekinetic attack:
 
@@ -101,10 +101,10 @@
 	afterattack(target, user)
 	return TRUE
 
-/obj/item/tk_grab/afterattack(atom/target , mob/living/user, proximity, params)//TODO: go over this
+/obj/item/tk_grab/afterattack(atom/target , mob/living/user, proximity, params)
 	if(!target || !user)
 		return
-	if(last_throw + 3 SECONDS > world.time)
+	if(last_throw + TK_COOLDOWN > world.time)
 		return
 	if(!host || host != user)
 		qdel(src)
@@ -197,3 +197,5 @@
 	overlays.Cut()
 	if(focus && focus.icon && focus.icon_state)
 		overlays += icon(focus.icon,focus.icon_state)
+
+#undef TK_COOLDOWN


### PR DESCRIPTION
## What Does This PR Do
Nerfs the cooldown of the TK genetic ability from .3 seconds to 1.5 seconds (the I fixed my branch edition) 

## Why It's Good For The Game
TK already does a lot; it lets you use items from range such as a flash and allows you to interact with some objects from a distance. However, TK is mostly used for its power in combat as you can very quickly destroy structures/kill mobs due to its extremely low cooldown. Its cooldown is being raised to 1.5 seconds from .3 seconds so that it still has the ability to move items for purpose of utility, but it's less powerful for combat related shenanigans.

## Images of changes


https://user-images.githubusercontent.com/96800819/176977420-91eb2a61-e44d-4da5-98ef-7e550cc47ebd.mp4


## Changelog
:cl:
tweak: Nerfs the use time of TK from .3 seconds to 1.5 seconds
/:cl:
