### PR TITLE
Reworks disarms into shoves, mostly from TG

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -619,6 +619,6 @@
 /atom/movable/proc/decompile_act(obj/item/matter_decompiler/C, mob/user) // For drones to decompile mobs and objs. See drone for an example.
 	return FALSE
 
-/// called when a mob gets shoved into an items turf
-/atom/movable/proc/shove_impact(mob/living/target)
+/// called when a mob gets shoved into an items turf. false means the mob will be shoved backwards normally, true means the mob will not be moved by the disarm proc.
+/atom/movable/proc/shove_impact(mob/living/target, mob/living/attacker)
 	return FALSE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -618,3 +618,7 @@
 
 /atom/movable/proc/decompile_act(obj/item/matter_decompiler/C, mob/user) // For drones to decompile mobs and objs. See drone for an example.
 	return FALSE
+
+/// called when a mob gets shoved into an items turf
+/atom/movable/proc/shove_impact(mob/living/target)
+	return FALSE

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -230,6 +230,11 @@
 	else
 		return ..()
 
+/obj/structure/table/shove_impact(mob/living/target)
+	target.forceMove(get_turf(src))
+	target.Weaken(4 SECONDS)
+	return FALSE
+
 
 /obj/structure/table/screwdriver_act(mob/user, obj/item/I)
 	if(flags & NODECONSTRUCT)
@@ -440,6 +445,11 @@
 			AM.throw_impact(L)
 	L.Weaken(10 SECONDS)
 	qdel(src)
+
+/obj/structure/table/glass/shove_impact(mob/living/target)
+	target.forceMove(get_turf(src))
+	table_shatter(target)
+	return TRUE
 
 /obj/structure/table/glass/deconstruct(disassembled = TRUE, wrench_disassembly = 0)
 	if(!(flags & NODECONSTRUCT))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -233,6 +233,8 @@
 /obj/structure/table/shove_impact(mob/living/target, mob/living/attacker)
 	if(locate(/obj/structure/table) in get_turf(target))
 		return FALSE
+	if(flipped)
+		return FALSE
 	var/pass_flags_cache = target.pass_flags
 	target.pass_flags |= PASSTABLE
 	if(target.Move(loc)) // moving onto a table smashes it, stunning them

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -237,7 +237,7 @@
 		return FALSE
 	var/pass_flags_cache = target.pass_flags
 	target.pass_flags |= PASSTABLE
-	if(target.Move(loc)) // moving onto a table smashes it, stunning them
+	if(target.Move(loc))
 		. = TRUE
 		target.Weaken(4 SECONDS)
 		add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -231,11 +231,12 @@
 		return ..()
 
 /obj/structure/table/shove_impact(mob/living/target, mob/living/attacker)
+	if(locate(/obj/structure/table) in get_turf(target))
+		return FALSE
 	add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
 	target.forceMove(get_turf(src))
 	target.Weaken(4 SECONDS)
 	return TRUE
-
 
 /obj/structure/table/screwdriver_act(mob/user, obj/item/I)
 	if(flags & NODECONSTRUCT)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -233,10 +233,15 @@
 /obj/structure/table/shove_impact(mob/living/target, mob/living/attacker)
 	if(locate(/obj/structure/table) in get_turf(target))
 		return FALSE
-	add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
-	target.forceMove(get_turf(src))
-	target.Weaken(4 SECONDS)
-	return TRUE
+	var/pass_flags_cache = target.pass_flags
+	target.pass_flags |= PASSTABLE
+	if(target.Move(loc)) // moving onto a table smashes it, stunning them
+		. = TRUE
+		target.Weaken(4 SECONDS)
+		add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
+	else
+		. = FALSE
+	target.pass_flags = pass_flags_cache
 
 /obj/structure/table/screwdriver_act(mob/user, obj/item/I)
 	if(flags & NODECONSTRUCT)
@@ -449,9 +454,14 @@
 	qdel(src)
 
 /obj/structure/table/glass/shove_impact(mob/living/target, mob/living/attacker)
-	add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
-	target.forceMove(get_turf(src)) // will break the table and then stun the person.
-	return TRUE
+	var/pass_flags_cache = target.pass_flags
+	target.pass_flags |= PASSTABLE
+	if(target.Move(loc)) // moving onto a table smashes it, stunning them
+		. = TRUE
+		add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
+	else
+		. = FALSE
+	target.pass_flags = pass_flags_cache
 
 /obj/structure/table/glass/deconstruct(disassembled = TRUE, wrench_disassembly = 0)
 	if(!(flags & NODECONSTRUCT))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -230,10 +230,11 @@
 	else
 		return ..()
 
-/obj/structure/table/shove_impact(mob/living/target)
+/obj/structure/table/shove_impact(mob/living/target, mob/living/attacker)
+	add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
 	target.forceMove(get_turf(src))
 	target.Weaken(4 SECONDS)
-	return FALSE
+	return TRUE
 
 
 /obj/structure/table/screwdriver_act(mob/user, obj/item/I)
@@ -446,9 +447,9 @@
 	L.Weaken(10 SECONDS)
 	qdel(src)
 
-/obj/structure/table/glass/shove_impact(mob/living/target)
-	target.forceMove(get_turf(src))
-	table_shatter(target)
+/obj/structure/table/glass/shove_impact(mob/living/target, mob/living/attacker)
+	add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
+	target.forceMove(get_turf(src)) // will break the table and then stun the person.
 	return TRUE
 
 /obj/structure/table/glass/deconstruct(disassembled = TRUE, wrench_disassembly = 0)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -512,8 +512,6 @@
 			target.forcesay(GLOB.hit_appends)
 		SEND_SIGNAL(target, COMSIG_PARENT_ATTACKBY)
 
-
-
 /datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(user == target)
 		return FALSE
@@ -531,6 +529,10 @@
 		return FALSE
 	if(attacker_style && attacker_style.disarm_act(user, target) == TRUE)
 		return TRUE
+	if(target.move_resist > user.pull_force)
+		return FALSE
+	if(!(target.status_flags & CANPUSH))
+		return FALSE
 
 	add_attack_logs(user, target, "Disarmed", ATKLOG_ALL)
 	user.do_attack_animation(target, ATTACK_EFFECT_DISARM)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -515,10 +515,6 @@
 /datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(user == target)
 		return FALSE
-	if(target.move_resist > user.pull_force)
-		return FALSE
-	if(!(target.status_flags & CANPUSH))
-		return FALSE
 	if(target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s disarm attempt!</span>")
 		return FALSE
@@ -542,7 +538,7 @@
 
 	var/blocked_by_item = FALSE
 	for(var/atom/movable/AM in shove_to)
-		if(AM.shove_impact(target))
+		if(AM.shove_impact(target, user))
 			blocked_by_item = TRUE
 
 	if(blocked_by_item)
@@ -550,6 +546,7 @@
 
 	var/moved = target.Move(shove_to, shove_dir)
 	if(!moved) //they got pushed into a dense object
+		add_attack_logs(user, target, "Disarmed into a dense object", ATKLOG_ALL)
 		if(!HAS_TRAIT(target, TRAIT_FLOORED))
 			target.KnockDown(3 SECONDS)
 			addtimer(CALLBACK(target, /mob/living.proc/SetKnockDown, 0), 3 SECONDS) // so you cannot chain stun someone

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -512,7 +512,15 @@
 			target.forcesay(GLOB.hit_appends)
 		SEND_SIGNAL(target, COMSIG_PARENT_ATTACKBY)
 
+
+
 /datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
+	if(user == target)
+		return FALSE
+	if(target.move_resist > user.pull_force)
+		return FALSE
+	if(!(target.status_flags & CANPUSH))
+		return FALSE
 	if(target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s disarm attempt!</span>")
 		return FALSE
@@ -523,59 +531,32 @@
 		return FALSE
 	if(attacker_style && attacker_style.disarm_act(user, target) == TRUE)
 		return TRUE
+
+	add_attack_logs(user, target, "Disarmed", ATKLOG_ALL)
+	user.do_attack_animation(target, ATTACK_EFFECT_DISARM)
+	var/shove_dir = get_dir(user.loc, target.loc)
+	var/turf/shove_to = get_step(target.loc, shove_dir)
+	playsound(shove_to, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+
+	var/blocked_by_item = FALSE
+	for(var/atom/movable/AM in shove_to)
+		if(AM.shove_impact(target))
+			blocked_by_item = TRUE
+
+	if(blocked_by_item)
+		return TRUE
+
+	var/moved = target.Move(shove_to, shove_dir)
+	if(!moved) //they got pushed into a dense object
+		if(!HAS_TRAIT(target, TRAIT_FLOORED))
+			target.KnockDown(3 SECONDS)
+			addtimer(CALLBACK(target, /mob/living.proc/SetKnockDown, 0), 3 SECONDS) // so you cannot chain stun someone
+		else if(!user.IsStunned())
+			target.Stun(0.5 SECONDS)
+	if(target.IsSlowed())
+		target.drop_item()
 	else
-		add_attack_logs(user, target, "Disarmed", ATKLOG_ALL)
-		user.do_attack_animation(target, ATTACK_EFFECT_DISARM)
-		if(target.w_uniform)
-			target.w_uniform.add_fingerprint(user)
-		var/obj/item/organ/external/affecting = target.get_organ(ran_zone(user.zone_selected))
-		var/randn = rand(1, 100)
-		if(randn <= 25)
-			target.apply_effect(4 SECONDS, WEAKEN, target.run_armor_check(affecting, MELEE))
-			playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			target.visible_message("<span class='danger'>[user] has pushed [target]!</span>")
-			add_attack_logs(user, target, "Pushed over", ATKLOG_ALL)
-			if(!iscarbon(user))
-				target.LAssailant = null
-			else
-				target.LAssailant = user
-			return
-
-		var/talked = 0	// BubbleWrap
-
-		if(randn <= 60)
-			//BubbleWrap: Disarming breaks a pull
-			if(target.pulling)
-				target.visible_message("<span class='danger'>[user] has broken [target]'s grip on [target.pulling]!</span>")
-				talked = 1
-				target.stop_pulling()
-
-			//BubbleWrap: Disarming also breaks a grab - this will also stop someone being choked, won't it?
-			if(istype(target.l_hand, /obj/item/grab))
-				var/obj/item/grab/lgrab = target.l_hand
-				if(lgrab.affecting)
-					target.visible_message("<span class='danger'>[user] has broken [target]'s grip on [lgrab.affecting]!</span>")
-					talked = 1
-				spawn(1)
-					qdel(lgrab)
-			if(istype(target.r_hand, /obj/item/grab))
-				var/obj/item/grab/rgrab = target.r_hand
-				if(rgrab.affecting)
-					target.visible_message("<span class='danger'>[user] has broken [target]'s grip on [rgrab.affecting]!</span>")
-					talked = 1
-				spawn(1)
-					qdel(rgrab)
-			//End BubbleWrap
-
-			if(!talked)	//BubbleWrap
-				if(target.drop_item())
-					target.visible_message("<span class='danger'>[user] has disarmed [target]!</span>")
-			playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			return
-
-
-	playsound(target.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-	target.visible_message("<span class='danger'>[user] attempted to disarm [target]!</span>")
+		target.Slowed(2.5 SECONDS, 1)
 
 /datum/species/proc/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style) //Handles any species-specific attackhand events.
 	if(!istype(M))

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -565,15 +565,10 @@
 				directional_blocked = TRUE
 				break
 
-	var/blocked_by_item = FALSE
 	if(!directional_blocked)
 		for(var/atom/movable/AM in shove_to)
 			if(AM.shove_impact(target, user)) // check for special interactions EG. tabling someone
-				blocked_by_item = TRUE
-				break // only hit one thing
-
-	if(blocked_by_item)
-		return TRUE
+				return TRUE
 
 	var/moved = target.Move(shove_to, shove_dir)
 	if(!moved) //they got pushed into a dense object

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -541,10 +541,20 @@
 	//Directional checks to make sure that we're not shoving through a windoor or something like that
 	var/directional_blocked = FALSE
 	var/target_turf = get_turf(target)
-	for(var/obj/obj_content in target_turf) // check the tile we are on for border
-		if(obj_content.flags & ON_BORDER && obj_content.dir & shove_dir && obj_content.density)
+	if(shove_dir in list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)) // if we are moving diagonially, we need to check if there are dense walls either side of us
+		var/turf/T = get_step(target.loc, turn(shove_dir, 45)) // check to the left for a dense turf
+		if(T.density)
 			directional_blocked = TRUE
-			break
+		else
+			T = get_step(target.loc, turn(shove_dir, -45)) // check to the right for a dense turf
+			if(T.density)
+				directional_blocked = TRUE
+
+	if(!directional_blocked)
+		for(var/obj/obj_content in target_turf) // check the tile we are on for border
+			if(obj_content.flags & ON_BORDER && obj_content.dir & shove_dir && obj_content.density)
+				directional_blocked = TRUE
+				break
 	if(!directional_blocked)
 		for(var/obj/obj_content in shove_to) // check tile we are moving to for borders
 			if(obj_content.flags & ON_BORDER && obj_content.dir & turn(shove_dir, 180) && obj_content.density)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -530,11 +530,13 @@
 	if(!(target.status_flags & CANPUSH))
 		return FALSE
 
-	add_attack_logs(user, target, "Disarmed", ATKLOG_ALL)
 	user.do_attack_animation(target, ATTACK_EFFECT_DISARM)
 	var/shove_dir = get_dir(user.loc, target.loc)
 	var/turf/shove_to = get_step(target.loc, shove_dir)
 	playsound(shove_to, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+
+	if(shove_to == user.loc)
+		return FALSE
 
 	var/blocked_by_item = FALSE
 	for(var/atom/movable/AM in shove_to)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -568,7 +568,7 @@
 	var/blocked_by_item = FALSE
 	if(!directional_blocked)
 		for(var/atom/movable/AM in shove_to)
-			if(AM.shove_impact(target, user))
+			if(AM.shove_impact(target, user)) // check for special interactions EG. tabling someone
 				blocked_by_item = TRUE
 				break // only hit one thing
 
@@ -578,8 +578,9 @@
 	var/moved = target.Move(shove_to, shove_dir)
 	if(!moved) //they got pushed into a dense object
 		add_attack_logs(user, target, "Disarmed into a dense object", ATKLOG_ALL)
-		target.visible_message("<span class='warning'>[target] gets slammed into the wall!</span>", \
-								"<span class='warning'>You get slammed into the wall!</span>")
+		target.visible_message("<span class='warning'>[user] slams [target] into an obstacle!</span>", \
+								"<span class='userdanger'>You get slammed into the obstacle by [user]!</span>", \
+								"You hear a loud thud.")
 		if(!HAS_TRAIT(target, TRAIT_FLOORED))
 			target.KnockDown(3 SECONDS)
 			addtimer(CALLBACK(target, /mob/living.proc/SetKnockDown, 0), 3 SECONDS) // so you cannot chain stun someone

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -378,6 +378,7 @@
 /mob/living/shove_impact(mob/living/target, mob/living/attacker)
 	if(!IS_HORIZONTAL(src))
 		add_attack_logs(attacker, target, "pushed into [src]", ATKLOG_ALL)
+		playsound(src, 'sound/weapons/punch1.ogg', 50, 1)
 		target.KnockDown(1 SECONDS) // knock them both down
 		KnockDown(1 SECONDS)
 		return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -376,10 +376,10 @@
 	return FALSE
 
 /mob/living/shove_impact(mob/living/target, mob/living/attacker)
-	if(!IS_HORIZONTAL(src))
-		add_attack_logs(attacker, target, "pushed into [src]", ATKLOG_ALL)
-		playsound(src, 'sound/weapons/punch1.ogg', 50, 1)
-		target.KnockDown(1 SECONDS) // knock them both down
-		KnockDown(1 SECONDS)
-		return TRUE
-	return FALSE
+	if(IS_HORIZONTAL(src))
+		return FALSE
+	add_attack_logs(attacker, target, "pushed into [src]", ATKLOG_ALL)
+	playsound(src, 'sound/weapons/punch1.ogg', 50, 1)
+	target.KnockDown(1 SECONDS) // knock them both down
+	KnockDown(1 SECONDS)
+	return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -375,8 +375,9 @@
 /mob/living/proc/cult_self_harm(damage)
 	return FALSE
 
-/mob/living/shove_impact(mob/living/target)
+/mob/living/shove_impact(mob/living/target, mob/living/attacker)
 	if(!IS_HORIZONTAL(src))
+		add_attack_logs(attacker, target, "pushed into [src]", ATKLOG_ALL)
 		target.KnockDown(1 SECONDS) // knock them both down
 		KnockDown(1 SECONDS)
 		return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -374,3 +374,10 @@
 
 /mob/living/proc/cult_self_harm(damage)
 	return FALSE
+
+/mob/living/shove_impact(mob/living/target)
+	if(!IS_HORIZONTAL(src))
+		target.KnockDown(1 SECONDS) // knock them both down
+		KnockDown(1 SECONDS)
+		return TRUE
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Disarming someone will shove them, if they cannot be pushed eg, they are a gargantua vampire or have a riot shield etc, the disarm attempt fails.
if you shove them into a dense object, it will knock them down, if you push them into a dense object while they are knocked down, they will be stunned for a very short, 0.5 second, duration
shoving them into another mob will knock both mobs down for 1 second
shoving them onto a table will hard stun for 4 seconds. perhaps too long?
if you dont shove them into anything, they will take a step back and be slowed very slightly for 2.5 seconds, if you disarm them while slowed, they will drop their item in their hand.

The ideas are from TG, the code however is mostly mostly my own. 

## Why It's Good For The Game
disarms are currently 100% RNG and incredibly annoying to fight, especially considering they do hard stuns currently. This PR changes that to be deterministic and environmental, it forces you to position yourself well or be punished.

I do need to test if shoving someone into a wall can hard stun, but I need another person to test that.

## Changelog
:cl:
tweak: reworked disarms to be shoves, shoving someone into a dense object knocks them down, shoving slows and knocks back a target, if you shove them while slowed they drop their item. If you shove them into a wall when they are knocked down they are briefly stunned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
