### PR TITLE
Gloves, shoes and suit storage are properly obscured on the player when wearing the appropriate gear

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1049,6 +1049,8 @@
 			obscured |= slot_w_uniform
 		if(wear_suit.flags_inv & HIDESHOES)
 			obscured |= slot_shoes
+		if(wear_suit.flags_inv & HIDESUITSTORAGE)
+			obscured |= slot_s_store
 
 	if(head)
 		if(head.flags_inv & HIDEMASK)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -638,6 +638,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 				gloves.screen_loc = ui_gloves		//...draw the item in the inventory screen
 			client.screen += gloves					//Either way, add the item to the HUD
 
+		if(slot_gloves in check_obscured_slots())
+			return
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
 
@@ -764,6 +766,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 				shoes.screen_loc = ui_shoes			//...draw the item in the inventory screen
 			client.screen += shoes					//Either way, add the item to the HUD
 
+		if(slot_shoes in check_obscured_slots())
+			return
 		var/mutable_appearance/standing
 		if(shoes.icon_override)
 			standing = mutable_appearance(shoes.icon_override, "[shoes.icon_state]", layer = -SHOES_LAYER)
@@ -799,6 +803,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			s_store.screen_loc = ui_sstore1
 			client.screen += s_store
 
+		if(slot_s_store in check_obscured_slots())
+			return
 		var/t_state = s_store.item_state
 		if(!t_state)
 			t_state = s_store.icon_state
@@ -901,6 +907,11 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		overlays_standing[SUIT_LAYER] = standing
 
 	apply_overlay(SUIT_LAYER)
+	
+	update_inv_gloves()
+	update_inv_shoes()
+	update_inv_s_store()
+
 	update_tail_layer()
 	update_wing_layer()
 	update_collar()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -632,13 +632,15 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(inv)
 			inv.update_icon()
 
+	var/hidden = (slot_gloves in check_obscured_slots())
+
 	if(gloves)
 		if(client && hud_used && hud_used.hud_shown)
 			if(hud_used.inventory_shown)			//if the inventory is open ...
 				gloves.screen_loc = ui_gloves		//...draw the item in the inventory screen
 			client.screen += gloves					//Either way, add the item to the HUD
 
-		if(slot_gloves in check_obscured_slots())
+		if(hidden)
 			return
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
@@ -657,7 +659,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			standing.overlays += bloodsies
 		overlays_standing[GLOVES_LAYER]	= standing
 	else
-		if(slot_gloves in check_obscured_slots())
+		if(hidden)
 			return
 		if(blood_DNA)
 			var/mutable_appearance/bloodsies = mutable_appearance(dna.species.blood_mask, "bloodyhands", layer = -GLOVES_LAYER)
@@ -762,13 +764,15 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(inv)
 			inv.update_icon()
 
+	var/hidden = (slot_shoes in check_obscured_slots())
+
 	if(shoes)
 		if(client && hud_used && hud_used.hud_shown)
 			if(hud_used.inventory_shown)			//if the inventory is open ...
 				shoes.screen_loc = ui_shoes			//...draw the item in the inventory screen
 			client.screen += shoes					//Either way, add the item to the HUD
 
-		if(slot_shoes in check_obscured_slots())
+		if(hidden)
 			return
 		var/mutable_appearance/standing
 		if(shoes.icon_override)
@@ -778,7 +782,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		else
 			standing = mutable_appearance('icons/mob/clothing/feet.dmi', "[shoes.icon_state]", layer = -SHOES_LAYER)
 
-
 		if(shoes.blood_DNA)
 			var/image/bloodsies = image("icon" = dna.species.blood_mask, "icon_state" = "shoeblood")
 			bloodsies.color = shoes.blood_color
@@ -787,7 +790,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		standing.color = shoes.color
 		overlays_standing[SHOES_LAYER] = standing
 	else
-		if(slot_shoes in check_obscured_slots())
+		if(hidden)
 			return
 		if(feet_blood_DNA)
 			var/mutable_appearance/bloodsies = mutable_appearance(dna.species.blood_mask, "shoeblood", layer = -SHOES_LAYER)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -657,6 +657,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			standing.overlays += bloodsies
 		overlays_standing[GLOVES_LAYER]	= standing
 	else
+		if(slot_gloves in check_obscured_slots())
+			return
 		if(blood_DNA)
 			var/mutable_appearance/bloodsies = mutable_appearance(dna.species.blood_mask, "bloodyhands", layer = -GLOVES_LAYER)
 			bloodsies.color = hand_blood_color
@@ -785,6 +787,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		standing.color = shoes.color
 		overlays_standing[SHOES_LAYER] = standing
 	else
+		if(slot_shoes in check_obscured_slots())
+			return
 		if(feet_blood_DNA)
 			var/mutable_appearance/bloodsies = mutable_appearance(dna.species.blood_mask, "shoeblood", layer = -SHOES_LAYER)
 			bloodsies.color = feet_blood_color


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds checks to not apply the gloves, shoes , suit storage or blood overlays if the human is wearing something that would obscure them. The `check_obscured_slots` also now checks for suit storage as well. Nothing actually makes use of it, but the flag is defined and could be used later down the line.

In most cases they're hidden by virtue of being covered by the other object's overlay, but this causes problems with anything that uses bulkier sprites (e.g. magboots). Examines do not show them, so it makes sense to make sure they aren't applied. This cuts down on overlays as well.

## Why It's Good For The Game
Fixes #18187. This also prevents edgecases where rather large sprites still show.

## Images of changes
![Suits](https://user-images.githubusercontent.com/80771500/177017178-9d1317be-eb2b-4688-a8a2-369328942f79.png)

## Changelog
:cl:
fix: Bulky gear does not show under other pieces of equipment to be obscuring them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
