### PR TITLE
Punch stuns now knockdown instead of hard stunning.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -504,9 +504,9 @@
 		target.visible_message("<span class='danger'>[user] [pick(attack.attack_verb)]ed [target]!</span>")
 		target.apply_damage(damage, BRUTE, affecting, armor_block, sharp = attack.sharp) //moving this back here means Armalis are going to knock you down  70% of the time, but they're pure adminbus anyway.
 		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-			target.visible_message("<span class='danger'>[user] has weakened [target]!</span>", \
-							"<span class='userdanger'>[user] has weakened [target]!</span>")
-			target.apply_effect(8 SECONDS, WEAKEN, armor_block)
+			target.visible_message("<span class='danger'>[user] has knocked down [target]!</span>", \
+							"<span class='userdanger'>[user] has knocked down [target]!</span>")
+			target.KnockDown(4 SECONDS)
 			target.forcesay(GLOB.hit_appends)
 		else if(IS_HORIZONTAL(target))
 			target.forcesay(GLOB.hit_appends)


### PR DESCRIPTION

## What Does This PR Do

Replaces the stun from punches to a knockdown effect for 4 seconds.
Now with clean master.

## Why It's Good For The Game

Part of a project to remove hardstuns.
RNG stuns are bad.



## Changelog
:cl:
tweak: Punches now knock you down instead of stunning you.
/:cl:

