### PR TITLE
Makes it so the baseturf on lavaland is lava, not space. Fixing breaches into space on lavaland

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -103,7 +103,7 @@
 				if(TURF_WET_PERMAFROST) // Permafrost
 					M.slip("the frosted floor", 10 SECONDS, tilesSlipped = 1, walkSafely = 0, slipAny = 1)
 
-/turf/simulated/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
+/turf/simulated/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE, copy_existing_baseturf = TRUE)
 	. = ..()
 	QUEUE_SMOOTH_NEIGHBORS(src)
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 /turf/simulated/floor/proc/make_plating()
 	return ChangeTurf(/turf/simulated/floor/plating)
 
-/turf/simulated/floor/ChangeTurf(turf/simulated/floor/T, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
+/turf/simulated/floor/ChangeTurf(turf/simulated/floor/T, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE, copy_existing_baseturf = TRUE)
 	if(!istype(src, /turf/simulated/floor))
 		return ..() //fucking turfs switch the fucking src of the fucking running procs
 	if(!ispath(T, /turf/simulated/floor))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -207,7 +207,7 @@
 	return ChangeTurf(path, defer_change, keep_icon, ignore_air)
 
 //Creates a new turf
-/turf/proc/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
+/turf/proc/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE, copy_existing_baseturf = TRUE)
 	if(!path)
 		return
 	if(!GLOB.use_preloader && path == type) // Don't no-op if the map loader requires it to be reconstructed
@@ -228,7 +228,8 @@
 	changing_turf = TRUE
 	qdel(src)	//Just get the side effects and call Destroy
 	var/turf/W = new path(src)
-	W.baseturf = old_baseturf
+	if(copy_existing_baseturf)
+		W.baseturf = old_baseturf
 
 	if(!defer_change)
 		W.AfterChange(ignore_air)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -319,7 +319,7 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 	var/turf/T = locate(x, y, z)
 	if(T)
 		if(ispath(path, /turf))
-			T.ChangeTurf(path, defer_change = TRUE, keep_icon = FALSE)
+			T.ChangeTurf(path, defer_change = TRUE, keep_icon = FALSE, copy_existing_baseturf = FALSE)
 			instance = T
 		else if(ispath(path, /area))
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -137,7 +137,7 @@
 		if(prob(50))
 			ChangeTurf(baseturf)
 
-/turf/simulated/floor/vines/ChangeTurf(turf/simulated/floor/T, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
+/turf/simulated/floor/vines/ChangeTurf(turf/simulated/floor/T, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE, copy_existing_baseturf = TRUE)
 	. = ..()
 	//Do this *after* the turf has changed as qdel in spacevines will call changeturf again if it hasn't
 	for(var/obj/structure/spacevine/SV in src)


### PR DESCRIPTION
## What Does This PR Do
Makes it so the maploader doesn't copy the baseturf from the existing space when it loads the map. Thus keeping the intended base turf.
Fixes #17829
Alternative to #18140

This does not fix the shuttle leaving space when it gets exploded. That can be "fixed" using a lavaland baseturf helper. However, that will also make it so that if the shuttle gets destroyed, that sending it back will send the lava back.
The same applies now the other way around. Nuking the shuttle at the station side will send over space to lavaland. I'll make a separate PR to fix this issue.

## Why It's Good For The Game
Breaching into space on a planet is bad. Both immersive wise and processing power wise due to the atmos leak.

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/177029869-8f4d47b9-58a1-481a-a524-260466bd5e65.png)
In the beach bum place. The lattice stuff is odd. But not part of this PR to fix

![image](https://user-images.githubusercontent.com/15887760/177029877-a64b6d9a-5302-4843-b79c-eb076775ef65.png)
The outpost. I forgot if this was affected by the bug or not.

## Changelog
:cl:
fix: Lavaland explosions near ruins now don't breach to space
/:cl: