### PR TITLE
Makes the lavaland shuttle not spawn space when destroyed. Makes shuttles not take space/lava/chasms with them on transit

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -4182,6 +4182,10 @@
 	icon_state = "wood-broken"
 	},
 /area/mine/laborcamp)
+"rM" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "rS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18572,7 +18576,7 @@ ab
 tb
 NP
 Wo
-Cf
+rM
 Vu
 IZ
 xo

--- a/_maps/map_files/shuttles/emergency_clown.dmm
+++ b/_maps/map_files/shuttles/emergency_clown.dmm
@@ -109,7 +109,7 @@
 	},
 /area/shuttle/escape)
 "aB" = (
-/turf/simulated/floor/chasm,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aC" = (
 /obj/machinery/status_display{
@@ -118,7 +118,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/chasm,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aD" = (
 /obj/structure/bed,
@@ -141,7 +141,7 @@
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -28
 	},
-/turf/simulated/floor/chasm,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aH" = (
 /obj/item/storage/bible{
@@ -153,11 +153,7 @@
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aI" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "63"
-	},
-/turf/simulated/floor/noslip,
+/turf/simulated/wall/indestructible/fakedoor,
 /area/shuttle/escape)
 "aK" = (
 /obj/structure/closet/walllocker/emerglocker{
@@ -172,7 +168,7 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/turf/simulated/floor/chasm,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aP" = (
 /obj/docking_port/mobile/emergency{
@@ -250,7 +246,6 @@
 /obj/machinery/door/airlock/titanium{
 	aiControlDisabled = 1;
 	hackProof = 1;
-	id_tag = null;
 	name = "Shuttle Cargo Hatch"
 	},
 /turf/simulated/floor/plasteel{
@@ -268,7 +263,6 @@
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/plasteel{
@@ -379,6 +373,12 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
+"tH" = (
+/turf/simulated/wall/indestructible/opsglass,
+/area/shuttle/escape)
+"Dr" = (
+/turf/simulated/wall/indestructible/syndicate,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -387,11 +387,11 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
+Dr
+Dr
+Dr
+Dr
+Dr
 aP
 ab
 ac
@@ -413,11 +413,11 @@ aa
 aa
 aa
 aa
-ab
+Dr
 aB
 aG
 aB
-ab
+tH
 am
 aQ
 aR
@@ -439,11 +439,11 @@ aa
 aa
 ab
 ab
-ab
+Dr
 aC
 aH
 aB
-ab
+tH
 am
 am
 am
@@ -465,11 +465,11 @@ ab
 ac
 ab
 as
-ab
+Dr
 aB
 aB
 aL
-ab
+tH
 am
 aD
 aD
@@ -491,11 +491,11 @@ ab
 ak
 ao
 at
-ab
-ac
+Dr
+tH
 aI
-ac
-ac
+tH
+tH
 am
 ac
 ac

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -483,27 +483,31 @@
 
 	for(var/i in 1 to L0.len)
 		var/turf/T0 = L0[i]
-		if(!T0 || is_turf_blacklisted_for_transit(T0))
+		if(!T0)
 			continue
 		var/turf/T1 = L1[i]
 		if(!T1)
 			continue
 
-		T0.copyTurf(T1)
 		areaInstance.contents += T1
 
-		//copy over air
-		if(istype(T1, /turf/simulated))
-			var/turf/simulated/Ts1 = T1
-			Ts1.copy_air_with_tile(T0)
+		var/should_transit = !is_turf_blacklisted_for_transit(T0)
+		if(should_transit) // Only move over stuff if the transfer actually happened
+			T0.copyTurf(T1)
 
-		//move mobile to new location
-		for(var/atom/movable/AM in T0)
-			AM.onShuttleMove(T0, T1, rotation, last_caller)
+			//copy over air
+			if(istype(T1, /turf/simulated))
+				var/turf/simulated/Ts1 = T1
+				Ts1.copy_air_with_tile(T0)
 
-		if(rotation)
-			T1.shuttleRotate(rotation)
+			//move mobile to new location
+			for(var/atom/movable/AM in T0)
+				AM.onShuttleMove(T0, T1, rotation, last_caller)
 
+			if(rotation)
+				T1.shuttleRotate(rotation)
+
+		// Always do this stuff as it ensures that the destination turfs still behave properly with the rest of the shuttle transit
 		//atmos and lighting stuff
 		SSair.remove_from_active(T1)
 		T1.CalculateAdjacentTurfs()
@@ -511,7 +515,9 @@
 
 		T1.lighting_build_overlay()
 
-		T0.ChangeTurf(turf_type)
+		if(!should_transit)
+			continue // Don't want to actually change the skipped turf
+		T0.ChangeTurf(turf_type, keep_icon = FALSE)
 
 		SSair.remove_from_active(T0)
 		T0.CalculateAdjacentTurfs()
@@ -538,7 +544,7 @@
 	unlockPortDoors(S1)
 
 /obj/docking_port/mobile/proc/is_turf_blacklisted_for_transit(turf/T)
-	var/static/list/blacklisted_turf_types = typecacheof(list(/turf/space, /turf/simulated/floor/chasm, /turf/simulated/floor/plating/lava))
+	var/static/list/blacklisted_turf_types = typecacheof(list(/turf/space, /turf/simulated/floor/chasm, /turf/simulated/floor/plating/lava, /turf/simulated/floor/plating/asteroid))
 	return is_type_in_typecache(T, blacklisted_turf_types)
 
 
@@ -959,7 +965,7 @@
 		if(underlays.len)	//we have underlays, which implies some sort of transparency, so we want to a snapshot of the previous turf as an underlay
 			O = new()
 			O.underlays.Add(T)
-		T.ChangeTurf(type)
+		T.ChangeTurf(type, keep_icon = FALSE)
 		if(underlays.len)
 			T.underlays = O.underlays
 	if(T.icon_state != icon_state)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -483,7 +483,7 @@
 
 	for(var/i in 1 to L0.len)
 		var/turf/T0 = L0[i]
-		if(!T0)
+		if(!T0 || is_turf_blacklisted_for_transit(T0))
 			continue
 		var/turf/T1 = L1[i]
 		if(!T1)
@@ -497,7 +497,6 @@
 			var/turf/simulated/Ts1 = T1
 			Ts1.copy_air_with_tile(T0)
 
-		areaInstance.moving = TRUE
 		//move mobile to new location
 		for(var/atom/movable/AM in T0)
 			AM.onShuttleMove(T0, T1, rotation, last_caller)
@@ -537,6 +536,10 @@
 			W.update_audio()
 
 	unlockPortDoors(S1)
+
+/obj/docking_port/mobile/proc/is_turf_blacklisted_for_transit(turf/T)
+	var/static/list/blacklisted_turf_types = typecacheof(list(/turf/space, /turf/simulated/floor/chasm, /turf/simulated/floor/plating/lava))
+	return is_type_in_typecache(T, blacklisted_turf_types)
 
 
 /obj/docking_port/mobile/proc/findTransitDock()


### PR DESCRIPTION
## What Does This PR Do
As the title suggests. Shuttles now don't transfer any turfs that are space/chasms or lava. Anything on those turfs also gets ignored.
The lavaland shuttle now doesn't spawn space when it gets destroyed.
Fixes #15460
Fixes #18144

You can also reconstruct the shuttle at any point. Just remake the turfs that got exposed to space/lava and the shuttle will use those.

Changes the clown emergency shuttle to not have chasms. Since those won't be transferred with the shuttle. Now it has indestructible windows and walls :)

## Why It's Good For The Game
Space on lavaland is quite bad. Both immersion-wise and performance-wise. The open bug is an issue. But I'd say having space on lavaland is a bigger issue

![ezgif com-gif-maker](https://user-images.githubusercontent.com/15887760/177209798-ee2c36af-8860-4eb6-9e99-51ad8713648e.gif)

## Changelog
:cl:
fix: The lavaland shuttle now won't spawn space when it gets destroyed.
fix: Shuttles taking off now won't leave floors with wrong icons on lavaland
tweak: Shuttles now don't transport space/lava/planet or chasms with them. Anything on these turfs also doesn't get transported
/:cl: