### PR TITLE
Makes the c-20r take two bursts to stamina crit you

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -121,12 +121,13 @@
  	..()
 
 /obj/item/projectile/bullet/midbullet
-	damage = 20
-	stamina = 65 //two rounds from the c20r knocks people down
+	damage = 25
+	stamina = 40 //two bursts from the c20r knock people down
+	armour_penetration = 10
 
 /obj/item/projectile/bullet/midbullet_r
 	damage = 5
-	stamina = 75 //Still two rounds to knock people down
+	stamina = 75 //Two rounds to knock people down
 
 /obj/item/projectile/bullet/midbullet2
 	damage = 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The stamina damage of midbullet, the projectile used by nukie c-20r SMG as well as syndicate turrets, has been reduced from 65 to 40. This means that two bursts are now needed to down a crew member without bulletproof armor. The brute damage has been increased by 5 to compensate, mostly for the turrets. 10 armor piercing has been added to ensure that officers wearing basic gear are still downed by two bursts - though it will take full four shots connecting.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Part of the project to remove instant stuns from the game, as outlined by @hal9000PR. The c-20r is currently a much disliked weapon due to how it effectively is a ranged instant stun - or stamcrit in this case. This makes it so that you do not get instantly downed, leading to some opportunity to fight or run, though your odds are still bad - as they should be, against a nukie.

## Changelog
:cl:
tweak: Changed the damage of c-20r SMG to stamina crit in two bursts. Adjusted damage and armor penetration slightly to compensate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
