### PR TITLE
Operative nuke spawns in the right place

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -108,7 +108,7 @@
 
 	var/obj/machinery/nuclearbomb/syndicate/the_bomb
 	if(nuke_spawn && length(synd_spawn))
-		the_bomb = new /obj/machinery/nuclearbomb/syndicate(nuke_spawn.loc)
+		the_bomb = new /obj/machinery/nuclearbomb/syndicate(get_turf(nuke_spawn))
 		the_bomb.r_code = nuke_code
 
 	for(var/datum/mind/synd_mind in syndicates)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -108,7 +108,7 @@
 
 	var/obj/machinery/nuclearbomb/syndicate/the_bomb
 	if(nuke_spawn && length(synd_spawn))
-		the_bomb = new /obj/machinery/nuclearbomb/syndicate(get_turf(nuke_spawn))
+		the_bomb = new /obj/machinery/nuclearbomb/syndicate(nuke_spawn)
 		the_bomb.r_code = nuke_code
 
 	for(var/datum/mind/synd_mind in syndicates)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -99,7 +99,7 @@
 		qdel(S)
 		continue
 
-	var/obj/effect/landmark/nuke_spawn = get_turf(locate(/obj/effect/landmark/spawner/nuclear_bomb))
+	var/obj/effect/landmark/nuke_spawn = locate(/obj/effect/landmark/spawner/nuclear_bomb)
 
 	var/nuke_code = rand(10000, 99999)
 	var/leader_selected = 0
@@ -108,7 +108,7 @@
 
 	var/obj/machinery/nuclearbomb/syndicate/the_bomb
 	if(nuke_spawn && length(synd_spawn))
-		the_bomb = new /obj/machinery/nuclearbomb/syndicate(nuke_spawn)
+		the_bomb = new /obj/machinery/nuclearbomb/syndicate(get_turf(nuke_spawn))
 		the_bomb.r_code = nuke_code
 
 	for(var/datum/mind/synd_mind in syndicates)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Small tweak to how the nuke is spawned so it doesn't wind up in the wrong area.

## Why It's Good For The Game
Fixes #18198

## Images of changes
![Nuke](https://user-images.githubusercontent.com/80771500/177051695-f501676e-2d04-473b-ac94-c2ac75fe88e4.PNG)

## Changelog
:cl:
fix: Operative nuke spawns near the thursters in the shuttle properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
