### PR TITLE
Reworks CNS Implant + Emagged Upgraded Cybernetic Heart

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -241,7 +241,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/eyes/cybernetic/xray,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/arm/combat/centcom
 	)
@@ -725,7 +725,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/hardened,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
 		/obj/item/organ/internal/cyberimp/arm/flash,
 		/obj/item/organ/internal/eyes/cybernetic/shield
 	)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1621,9 +1621,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/cyber_implants/antistun
 	name = "Hardened CNS Rebooter Implant"
-	desc = "This implant will help you get back up on your feet faster after being stunned. It is immune to EMP attacks. Comes with an autosurgeon."
+	desc = "This implant will help you get back up on your feet faster after being fatigued. It is immune to EMP attacks. Comes with an autosurgeon."
 	reference = "CIAS"
-	item = /obj/item/autosurgeon/organ/syndicate/anti_stun
+	item = /obj/item/autosurgeon/organ/syndicate/anti_stam
 	cost = 12
 
 /datum/uplink_item/cyber_implants/reviver

--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -94,7 +94,7 @@
 	)
 	cybernetic_implants = list(
 		/obj/item/organ/internal/eyes/cybernetic/xray/hardened,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/arm/combat/centcom
 	)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -58,7 +58,7 @@
 /obj/item/projectile/beam/disabler/on_hit(atom/target, blocked, hit_zone)
 	. = ..()
 	if(isliving(target))
-		SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK, 20)
+		SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK, 15)
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -55,11 +55,6 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_CYAN
 
-/obj/item/projectile/beam/disabler/on_hit(atom/target, blocked, hit_zone)
-	. = ..()
-	if(isliving(target))
-		SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK, 15)
-
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -55,6 +55,11 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_CYAN
 
+/obj/item/projectile/beam/disabler/on_hit(atom/target, blocked, hit_zone)
+	. = ..()
+	if(isliving(target))
+		SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK, 20)
+
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -445,13 +445,13 @@
 
 /datum/design/cyberimp_antistun
 	name = "CNS Rebooter implant"
-	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned. Incompatible with the Neural Jumpstarter."
+	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when fatigued. Incompatible with the Neural Jumpstarter."
 	id = "ci-antistun"
 	req_tech = list("materials" = 6, "programming" = 5, "biotech" = 6)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
 	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 500, MAT_GOLD = 1000)
-	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
+	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stam
 	category = list("Medical")
 
 /datum/design/cyberimp_antisleep

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -110,7 +110,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
 		/obj/item/organ/internal/cyberimp/arm/flash
 	)
 
@@ -198,7 +198,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
 		/obj/item/organ/internal/cyberimp/arm/telebaton,
 		/obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	)
@@ -282,7 +282,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
 		/obj/item/organ/internal/eyes/cybernetic/shield,
 		/obj/item/organ/internal/cyberimp/arm/toolset
 	)
@@ -389,7 +389,7 @@
 		/obj/item/organ/internal/cyberimp/arm/medibeam,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	)
 
 	implants = list(/obj/item/implant/mindshield,
@@ -456,7 +456,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	)
 
 	implants = list(/obj/item/implant/mindshield,
@@ -528,7 +528,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
 		/obj/item/organ/internal/cyberimp/arm/advmop,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	)
 
 	implants = list(/obj/item/implant/mindshield,

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -129,14 +129,6 @@
 	var/last_stamina_damage = 0
 	var/max_stamina_increment = 40
 
-/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
-	name = "Hardened CNS Rebooter implant"
-	emp_proof = TRUE
-
-/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened/Initialize(mapload)
-	. = ..()
-	desc += "This implant will automatically give you back control over your central nervous system, reducing downtime when fatigued. Incompatible with the Neural Jumpstarter. The implant has been hardened. It is invulnerable to EMPs."
-
 /obj/item/organ/internal/cyberimp/brain/anti_stam/on_life()
 	..()
 	if(crit_fail)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -29,10 +29,10 @@
 /obj/item/organ/internal/cyberimp/brain/emp_act(severity)
 	if(!owner || emp_proof)
 		return
-	var/stun_amount = (5 + (severity-1 ? 0 : 5)) STATUS_EFFECT_CONSTANT
-	owner.Stun(stun_amount)
+	var/weaken_time = (5 + (severity-1 ? 0 : 5)) STATUS_EFFECT_CONSTANT
+	owner.Weaken(weaken_time)
 	to_chat(owner, "<span class='warning'>Your body seizes up!</span>")
-	return stun_amount
+	return weaken_time
 
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop
@@ -120,42 +120,42 @@
 		ui_action_click()
 	return ..()
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun
+/obj/item/organ/internal/cyberimp/brain/anti_stam
 	name = "CNS Rebooter implant"
-	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned. Incompatible with the Neural Jumpstarter."
+	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when fatigued. Incompatible with the Neural Jumpstarter."
 	implant_color = "#FFFF00"
 	slot = "brain_antistun"
 	origin_tech = "materials=5;programming=4;biotech=5"
-	var/stun_max_amount = 4 SECONDS
-
-/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+	var/last_stamina_damage = 0
+	var/max_stamina_increment = 40
+/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	name = "Hardened CNS Rebooter implant"
 	emp_proof = TRUE
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened/Initialize(mapload)
+/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened/Initialize(mapload)
 	. = ..()
 	desc += " The implant has been hardened. It is invulnerable to EMPs."
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun/on_life()
+/obj/item/organ/internal/cyberimp/brain/anti_stam/on_life()
 	..()
 	if(crit_fail)
 		return
-	if(owner.AmountStun() > stun_max_amount)
-		owner.SetStunned(stun_max_amount)
-	if(owner.AmountWeakened() > stun_max_amount)
-		owner.SetWeakened(stun_max_amount)
+	if(last_stamina_damage + max_stamina_increment < owner.getStaminaLoss())
+		owner.setStaminaLoss(last_stamina_damage + max_stamina_increment)
+	last_stamina_damage = owner.getStaminaLoss()
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun/emp_act(severity)
+
+/obj/item/organ/internal/cyberimp/brain/anti_stam/emp_act(severity)
 	..()
 	if(crit_fail || emp_proof)
 		return
 	crit_fail = TRUE
 	addtimer(CALLBACK(src, .proc/reboot), 90 / severity)
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun/proc/reboot()
+/obj/item/organ/internal/cyberimp/brain/anti_stam/proc/reboot()
 	crit_fail = FALSE
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	name = "Hardened CNS Rebooter implant"
 	desc = "A military-grade version of the standard implant, for NT's more elite forces."
 	origin_tech = "materials=6;programming=5;biotech=5"
@@ -443,7 +443,7 @@
 	var/list/boxed = list(
 		/obj/item/autosurgeon/organ/syndicate/thermal_eyes,
 		/obj/item/autosurgeon/organ/syndicate/xray_eyes,
-		/obj/item/autosurgeon/organ/syndicate/anti_stun,
+		/obj/item/autosurgeon/organ/syndicate/anti_stam,
 		/obj/item/autosurgeon/organ/syndicate/reviver)
 	var/amount = 5
 

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -29,7 +29,7 @@
 /obj/item/organ/internal/cyberimp/brain/emp_act(severity)
 	if(!owner || emp_proof)
 		return
-	var/weaken_time = (5 + (severity-1 ? 0 : 5)) STATUS_EFFECT_CONSTANT
+	var/weaken_time = (5 + (severity - 1 ? 0 : 5)) STATUS_EFFECT_CONSTANT
 	owner.Weaken(weaken_time)
 	to_chat(owner, "<span class='warning'>Your body seizes up!</span>")
 	return weaken_time

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -128,6 +128,7 @@
 	origin_tech = "materials=5;programming=4;biotech=5"
 	var/last_stamina_damage = 0
 	var/max_stamina_increment = 40
+
 /obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	name = "Hardened CNS Rebooter implant"
 	emp_proof = TRUE

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -134,7 +134,7 @@
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/hardened/Initialize(mapload)
 	. = ..()
-	desc += " The implant has been hardened. It is invulnerable to EMPs."
+	desc += "This implant will automatically give you back control over your central nervous system, reducing downtime when fatigued. Incompatible with the Neural Jumpstarter. The implant has been hardened. It is invulnerable to EMPs."
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/on_life()
 	..()

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -94,8 +94,8 @@
 /obj/item/autosurgeon/organ/syndicate/xray_eyes
 	starting_organ = /obj/item/organ/internal/eyes/cybernetic/xray/hardened
 
-/obj/item/autosurgeon/organ/syndicate/anti_stun
-	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+/obj/item/autosurgeon/organ/syndicate/anti_stam
+	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 
 /obj/item/autosurgeon/organ/syndicate/reviver
 	starting_organ = /obj/item/organ/internal/cyberimp/chest/reviver/hardened

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -215,7 +215,6 @@
 
 	if(!(status & ORGAN_DEAD))
 		var/boost = emagged ? 2 : 1
-		playsound(owner,'sound/effects/singlebeat.ogg',40,1)
 		owner.AdjustParalysis(-2 SECONDS * boost)
 		owner.AdjustStunned(-2 SECONDS * boost)
 		owner.AdjustWeakened(-2 SECONDS * boost)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -215,13 +215,12 @@
 
 	if(!(status & ORGAN_DEAD))
 		var/boost = emagged ? 2 : 1
-		owner.AdjustDrowsy(-8 SECONDS * boost)
+		playsound(owner,'sound/effects/singlebeat.ogg',40,1)
 		owner.AdjustParalysis(-2 SECONDS * boost)
 		owner.AdjustStunned(-2 SECONDS * boost)
 		owner.AdjustWeakened(-2 SECONDS * boost)
 		owner.AdjustKnockDown(-2 SECONDS * boost)
-		owner.SetSleeping(0)
-		owner.adjustStaminaLoss(-1 * boost)
+		owner.adjustStaminaLoss(-10 * boost)
 
 
 /obj/item/organ/internal/heart/cybernetic/upgraded/proc/message_to_owner(mob/M, message)


### PR DESCRIPTION
## What Does This PR Do

- Changes all instances of anti_stun to anti_stam in the code in relation to the CNS implant. 

- Reworks the CNS implant to protect against large bursts of stamina damage. 

- Reworks the emagged upgraded cybernetic heart to cause the user to regenerate stamina passively. 

- Removes emagged upgraded cybernetic heart's ability to negate drowsiness and sleeping. 

- CNS will now cause a 'weaken' instead of a 'stun' to give a better visual effect of the weakness if the user is subject to an EMP. Duration has not been changed.

## Why It's Good For The Game
With the move towards stamina based combat, CNS and Emagged Heart have been left behind, not really fitting in the current direction combat is moving. As a result, this PR reworks both to fit this new direction.

## Changelog
:cl:
tweak: Reworked CNS Implant and Emagged Upgraded Cybernetic Heart to fit within new direction of stamina combat.
/:cl: