### PR TITLE
Fixes simple mob crawling

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -164,7 +164,7 @@
 	health = clamp(health, 0, maxHealth)
 	med_hud_set_health()
 
-/mob/living/simple_animal/lay_down()
+/mob/living/simple_animal/on_lying_down(new_lying_angle)
 	..()
 	if(icon_resting && stat != DEAD)
 		icon_state = icon_resting
@@ -173,7 +173,7 @@
 			regenerate_icons()
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, LYING_DOWN_TRAIT) //simple mobs cannot crawl
 
-/mob/living/simple_animal/stand_up()
+/mob/living/simple_animal/on_standing_up()
 	..()
 	if(icon_resting && stat != DEAD)
 		icon_state = icon_living


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
if you rest, then buckle, then unbuckle as a simple animal, it wont look like you are still resting
fixes #18200
as a biproduct of this, bucking into a chair as a cat or similar, will display their stood up sprite.

## Why It's Good For The Game
bugs are bad

## Changelog
:cl:
fix: simple mobs sprite updates properly after unbuckling + resting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
