### PR TITLE
Changes Sleeping Carp's Keelhaul combo from stun to knockdown

### DIFF
--- a/code/modules/martial_arts/combos/sleeping_carp/keelhaul.dm
+++ b/code/modules/martial_arts/combos/sleeping_carp/keelhaul.dm
@@ -6,13 +6,15 @@
 /datum/martial_combo/sleeping_carp/keelhaul/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	user.do_attack_animation(target, ATTACK_EFFECT_KICK)
 	playsound(get_turf(target), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-	if(!target.IsWeakened() && !IS_HORIZONTAL(target) && !target.stat)
+	if(!IS_HORIZONTAL(target))
 		target.apply_damage(10, BRUTE, BODY_ZONE_HEAD)
-		target.Weaken(4 SECONDS)
+		target.KnockDown(4 SECONDS)
 		target.visible_message("<span class='warning'>[user] kicks [target] in the head, sending them face first into the floor!</span>",
 						"<span class='userdanger'>You are kicked in the head by [user], sending you crashing to the floor!</span>")
 	else
 		target.apply_damage(5, BRUTE, BODY_ZONE_HEAD)
+		target.drop_l_hand()
+		target.drop_r_hand()
 		target.visible_message("<span class='warning'>[user] kicks [target] in the head, leaving them reeling in pain!</span>",
 							"<span class='userdanger'>You are kicked in the head by [user], and you reel in pain!</span>")
 	target.apply_damage(40, STAMINA)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Keelhaul combo's stun has been changed to a knockdown, the duration is the same. When used on a horizontal target, items are knocked out of their hands instead. A redundant check has been simplified, as well. Part of the project by @hal9000PR. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Keelhaul is quite devastating in the hands of even a moderately robust user when other weapons do not cause instant stuns. It can be used to stun the opponent and remove their weapon reliably. This is possible even after the user is knocked down themselves, as carp is a martial art, and thus the user remains armed. A knockdown brings it up to par with the rest of the combat system, as counterplay is still possible after being hit with the combo.

Keelhaul was from the get-go meant to knock the target down, however this possibility did not exist at the time. Now that the possibility exists, and we are removing instant stuns, it is time to change it. 

## Changelog
:cl:
tweak: Sleeping Carp's Keelhaul combo knocks down, rather than stunning the opponent. Already knocked down enemies simply drop their weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
