### PR TITLE
Gives the golden bike horn a cooldown

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -39,18 +39,23 @@
 	desc = "Golden? Clearly, its made with bananium! Honk!"
 	icon_state = "gold_horn"
 	item_state = "gold_horn"
+	var/cooldown = 0
 
-/obj/item/bikehorn/golden/attack()
-	flip_mobs()
+/obj/item/bikehorn/golden/attack(mob/M, mob/user)
+	flip_mobs(user)
 	return ..()
 
 /obj/item/bikehorn/golden/attack_self(mob/user)
-	flip_mobs()
+	flip_mobs(user)
 	..()
 
-/obj/item/bikehorn/golden/proc/flip_mobs(mob/living/carbon/M, mob/user)
+/obj/item/bikehorn/golden/proc/flip_mobs(mob/user)
+	if(cooldown >= world.time)
+		to_chat(user, "<span class='warning'>You can't make others flip yet!</span>")
+		return
+	cooldown = world.time + 30 SECONDS
 	var/turf/T = get_turf(src)
-	for(M in ohearers(7, T))
+	for(var/mob/living/carbon/M in ohearers(7, T))
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			if(!H.can_hear())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The golden bike horn's flipping ability has been given a 30 second cooldown. Additionally, the code has been refactored somewhat to be a little better.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes #18205
Being able to flip everyone on screen constantly is incredibly annoying, as the affected people have a slim chance to fall to the floor. This can interfere with command a lot when done by bridge hobos, and can even be abused in a chase (or a fight) to trip others, as the user is not affected themselves.

## Changelog
:cl:
tweak: Added a 30 second cooldown to the golden bike horn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
