### PR TITLE
Fixes MetaStation not having a magistrate stamp

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -86139,6 +86139,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/item/stamp/magistrate,
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "tHA" = (


### PR DESCRIPTION
## What Does This PR Do
Adds a magistrate stamp to the magistrate office. 

Fixes #18217.

## Why It's Good For The Game
Every other map has a magistrate stamp, MetaStation did not have one.

## Images of changes
Here it is!

![image](https://user-images.githubusercontent.com/33333517/177415545-f49c3097-16cc-4d27-8d40-a8c6718fce90.png)


## Changelog
:cl:
fix: Fixed MetaStation not having a magistrate stamp. 
/:cl:
