### PR TITLE
Abductor surgery now does not leave people with broken torsos.

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -62,10 +62,12 @@
 	..()
 
 /datum/surgery_step/internal/gland_insert/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] inserts [tool] into [target].", "<span class ='notice'>You insert [tool] into [target].</span>")
 	user.drop_item()
 	var/obj/item/organ/internal/heart/gland/gland = tool
 	gland.insert(target, 2)
+	affected.mend_fracture() // Look, any sufficiently advanced technology is indistinguishable from magic.
 	return TRUE
 
 /datum/surgery_step/internal/gland_insert/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it so bones are automagically fixed when the gland is inserted during Experimental Dissection surgery.

At first I considered just adding the regular bone fixing steps to the surgery, but coding chat convinced me otherwise, since abductors tend to leave their patients chests open far too often as it is.

## Why It's Good For The Game
Makes it less likely that abductors will release the subjects to the station with broken torsos, causing organ damage in the process.


## Changelog
:cl: uc_guy
fix: Abductor surgery no longer leaves people with broken torsos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
