### PR TITLE
Holodeck claymores & eswords can only block holodeck items

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -425,7 +425,7 @@
 /obj/item/holo
 	damtype = STAMINA
 
-//ovveride block check, we don't want to block anything that's not a holo object
+//override block check, we don't want to block anything that's not a holo object
 /obj/item/holo/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby)
 	if(!istype(hitby, /obj/item/holo))
 		return FALSE

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -475,6 +475,11 @@
 	..()
 	item_color = "red"
 
+/obj/item/holo/esword/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(active)
+		return ..()
+	return 0
+
 /obj/item/holo/esword/New()
 	..()
 	item_color = pick("red","blue","green","purple")

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -425,6 +425,13 @@
 /obj/item/holo
 	damtype = STAMINA
 
+//ovveride block check, we don't want to block anything that's not a holo object
+/obj/item/holo/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby)
+	if(!istype(hitby, /obj/item/holo))
+		return FALSE
+	else
+		return ..()
+
 /obj/item/holo/claymore
 	name = "claymore"
 	desc = "What are you standing around staring at this for? Get to killing!"
@@ -437,12 +444,6 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
 
-//ovveride block check, we don't want to block anything that's not a holo object
-/obj/item/holo/claymore/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby)
-	if(!istype(hitby, /obj/item/holo))
-		return
-	else
-		..()
 
 /obj/item/holo/claymore/blue
 	icon_state = "claymoreblue"
@@ -473,12 +474,6 @@
 /obj/item/holo/esword/red/New()
 	..()
 	item_color = "red"
-
-/obj/item/holo/esword/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby)
-	if(!active || !istype(hitby, /obj/item/holo))
-		return
-	else
-		..()
 
 /obj/item/holo/esword/New()
 	..()

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -437,6 +437,13 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
 
+//ovveride block check, we don't want to block anything that's not a holo object
+/obj/item/holo/claymore/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby)
+	if(!istype(hitby, /obj/item/holo))
+		return
+	else
+		..()
+
 /obj/item/holo/claymore/blue
 	icon_state = "claymoreblue"
 	item_state = "claymoreblue"

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -474,10 +474,11 @@
 	..()
 	item_color = "red"
 
-/obj/item/holo/esword/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(active)
-		return ..()
-	return 0
+/obj/item/holo/esword/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby)
+	if(!active || !istype(hitby, /obj/item/holo))
+		return
+	else
+		..()
 
 /obj/item/holo/esword/New()
 	..()


### PR DESCRIPTION
## What Does This PR Do
Makes it so holodeck claymores & eswords can't block non-holodeck objects.
Fixes #9088
## Why It's Good For The Game
Holodeck items are VR/non-existent, they shouldn't have any actual "real-world" implications. 

## Changelog
:cl:
fix: Holodeck claymores can now only block holodeck items
/:cl:
