### PR TITLE
Moves ED209 / security bots to stamina batons

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -7,11 +7,11 @@
 	icon_state = "ed2090"
 	density = 1
 	anchored = 0
-	health = 100
-	maxHealth = 100
+	health = 150
+	maxHealth = 150
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	obj_damage = 60
-	environment_smash = 2 //Walls can't stop THE LAW
+	environment_smash = ENVIRONMENT_SMASH_WALLS //Walls can't stop THE LAW //someone fix this please this is funny
 	mob_size = MOB_SIZE_LARGE
 
 	radio_channel = "Security"

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -11,7 +11,7 @@
 	maxHealth = 150
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	obj_damage = 60
-	environment_smash = ENVIRONMENT_SMASH_WALLS //Walls can't stop THE LAW //someone fix this please this is funny
+	environment_smash = ENVIRONMENT_SMASH_WALLS //Walls can't stop THE LAW
 	mob_size = MOB_SIZE_LARGE
 
 	radio_channel = "Security"
@@ -580,16 +580,13 @@
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
 	addtimer(CALLBACK(C, .proc/KnockDown, 10 SECONDS), 2.5 SECONDS)
-	addtimer(CALLBACK(src, .proc/reset_baton_cooldown), BATON_COOLDOWN)
+	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
 	C.visible_message("<span class='danger'>[src] has stunned [C]!</span>",\
 							"<span class='userdanger'>[src] has stunned you!</span>")
-
-/mob/living/simple_animal/bot/ed209/proc/reset_baton_cooldown()
-	baton_delayed = FALSE
 
 /mob/living/simple_animal/bot/ed209/proc/cuff(mob/living/carbon/C)
 	mode = BOT_ARREST

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -1,3 +1,5 @@
+#define BATON_COOLDOWN 3.5 SECONDS
+
 /mob/living/simple_animal/bot/ed209
 	name = "\improper ED-209 Security Robot"
 	desc = "A security robot.  He looks less than thrilled."
@@ -42,6 +44,7 @@
 	var/arrest_type = 0 //If true, don't handcuff
 	var/projectile = /obj/item/projectile/beam/disabler //Holder for projectile type
 	var/shoot_sound = 'sound/weapons/taser.ogg'
+	var/baton_delayed = FALSE
 
 
 /mob/living/simple_animal/bot/ed209/New(loc, created_name, created_lasercolor)
@@ -260,7 +263,7 @@
 				back_to_idle()
 
 			if(target)		// make sure target exists
-				if(Adjacent(target) && isturf(target.loc)) // if right next to perp
+				if(Adjacent(target) && isturf(target.loc) && !baton_delayed) // if right next to perp
 					stun_attack(target)
 					if(!lasercolor)
 						mode = BOT_PREP_ARREST
@@ -286,7 +289,7 @@
 		if(BOT_PREP_ARREST)		// preparing to arrest target
 
 			// see if he got away. If he's no no longer adjacent or inside a closet or about to get up, we hunt again.
-			if(!Adjacent(target) || !isturf(target.loc) || target.AmountWeakened() < 4 SECONDS)
+			if(!Adjacent(target) || !isturf(target.loc) || world.time - target.stam_regen_start_time < 4 SECONDS && target.getStaminaLoss() <= 100)
 				back_to_hunt()
 				return
 
@@ -313,7 +316,7 @@
 				back_to_idle()
 				return
 
-			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.AmountWeakened() < 4 SECONDS)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
+			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && world.time - target.stam_regen_start_time < 4 SECONDS && target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
 				back_to_hunt()
 				return
 			else
@@ -547,7 +550,7 @@
 		return
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
-		if(!C.IsStunned() || arrest_type)
+		if(!C.IsStunned() || arrest_type && !baton_delayed)
 			stun_attack(A)
 		else if(C.canBeHandcuffed() && !C.handcuffed)
 			cuff(A)
@@ -574,13 +577,19 @@
 		icon_state = "[lasercolor]ed209[on]"
 	var/threat = C.assess_threat(src)
 	C.SetStuttering(10 SECONDS)
-	C.Weaken(10 SECONDS)
-	add_attack_logs(src, C, "stunned")
+	C.adjustStaminaLoss(60)
+	baton_delayed = TRUE
+	addtimer(CALLBACK(C, .proc/KnockDown, 10 SECONDS), 2.5 SECONDS)
+	addtimer(CALLBACK(src, .proc/reset_baton_cooldown), BATON_COOLDOWN)
+	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
 	C.visible_message("<span class='danger'>[src] has stunned [C]!</span>",\
 							"<span class='userdanger'>[src] has stunned you!</span>")
+
+/mob/living/simple_animal/bot/ed209/proc/reset_baton_cooldown()
+	baton_delayed = FALSE
 
 /mob/living/simple_animal/bot/ed209/proc/cuff(mob/living/carbon/C)
 	mode = BOT_ARREST
@@ -595,3 +604,5 @@
 			C.handcuffed = new /obj/item/restraints/handcuffs/cable/zipties/used(C)
 			C.update_handcuffed()
 			back_to_idle()
+
+#undef BATON_COOLDOWN

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -273,7 +273,7 @@
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
 	addtimer(CALLBACK(C, .proc/KnockDown, 10 SECONDS), 2.5 SECONDS)
-	addtimer(CALLBACK(src, .proc/reset_baton_cooldown), BATON_COOLDOWN)
+	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
@@ -437,8 +437,6 @@
 		return 1
 	return 0
 
-/mob/living/simple_animal/bot/secbot/proc/reset_baton_cooldown()
-	baton_delayed = FALSE
 
 /mob/living/simple_animal/bot/secbot/explode()
 	walk_to(src,0)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -7,8 +7,8 @@
 	icon_state = "secbot0"
 	density = 0
 	anchored = 0
-	health = 25
-	maxHealth = 25
+	health = 60
+	maxHealth = 60
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	pass_flags = PASSMOB
 
@@ -79,7 +79,8 @@
 
 /mob/living/simple_animal/bot/secbot/armsky
 	name = "Sergeant-at-Armsky"
-	health = 45
+	health = 100
+	maxHealth = 100
 	idcheck = 1
 	arrest_type = 1
 	weaponscheck = 1
@@ -215,6 +216,9 @@
 			if(!Proj.nodamage && Proj.damage < src.health)
 				retaliate(Proj.firer)
 	..()
+
+/mob/living/simple_animal/bot/secbot/projectile_hit_check(obj/item/projectile/P)
+	return FALSE
 
 
 /mob/living/simple_animal/bot/secbot/UnarmedAttack(atom/A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Security bots / ED209's now deal 60 stamina and later cause crawling like batons in the baton TM.
They have a cooldown of 3.5 seconds between batons.
Now check stamina vs weaken.

Sec bots no longer have lasers / bullets fly over them.

Hp of secbots boosted from 25 -> 60, armsky 45 > 100, ed209 100 > 150 to compensate for stamina batons.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If batons no longer instantly stun, sec bots should not either. Behaving the same way as current stunbatons makes sense.

## Changelog
:cl:
tweak: Secbots / ed209 batons deal 60 stamina and force crawling after 2.5 seconds, and have a 3.5 second cooldown between stuns.
tweak: Secbots / ed209's have greatly increased health.
tweak: Secbots no longer have projectiles fly over them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
