### PR TITLE
Adds the EMT labcoat to the paramedic wardrobe, removes extra two caps

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -148,5 +148,7 @@
 	new /obj/item/clothing/head/soft/blue(src)
 	new /obj/item/clothing/suit/storage/paramedic(src)
 	new /obj/item/clothing/suit/storage/paramedic(src)
+	new /obj/item/clothing/suit/storage/labcoat/emt(src)
+	new /obj/item/clothing/suit/storage/labcoat/emt(src)
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -144,8 +144,6 @@
 	new /obj/item/clothing/gloves/color/latex(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/head/soft/blue(src)
-	new /obj/item/clothing/head/soft/blue(src)
 	new /obj/item/clothing/suit/storage/paramedic(src)
 	new /obj/item/clothing/suit/storage/paramedic(src)
 	new /obj/item/clothing/suit/storage/labcoat/emt(src)


### PR DESCRIPTION
## What Does This PR Do
Adds the "EMT labcoat" item to the paramedic's wardrobe. Previously, you could only access it via the loadout option, so I labelled this as a "tweak".

## Why It's Good For The Game
It's inconsistent that some non-unique items only show up in the preferences loadout, but not in the game. I added it to the paramedic wardrobe instead of the medical clothing vendor as this is a job-specific item.

## Images of changes
![image](https://user-images.githubusercontent.com/33333517/177729251-59514858-0264-49ea-9765-471176264340.png)

## Changelog
:cl:
tweak: EMT labcoat is now accessible not only from the loadout, but the paramedic wardrobe as well.
del: Removed two superfluous blue caps from the paramedic wardrobe.
/:cl:
