### PR TITLE
Meathook now uses KnockDown instead of just Weaken 

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -24,6 +24,7 @@
 
 #define STUN		"stun"
 #define WEAKEN		"weaken"
+#define KNOCKDOWN	"knockdown"
 #define PARALYZE	"paralize"
 #define IRRADIATE	"irradiate"
 #define STUTTER		"stutter"

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -380,7 +380,8 @@
 	armour_penetration = 100
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
-	weaken = 6 SECONDS
+	weaken = 2 SECONDS
+	knockdown = 6 SECONDS
 
 /obj/item/projectile/hook/fire(setAngle)
 	if(firer)

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -380,7 +380,7 @@
 	armour_penetration = 100
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
-	weaken = 2 SECONDS
+	weaken = 1 SECONDS
 	knockdown = 6 SECONDS
 
 /obj/item/projectile/hook/fire(setAngle)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -83,6 +83,8 @@
 			Stun(effect * blocked)
 		if(WEAKEN)
 			Weaken(effect * blocked)
+		if(KNOCKDOWN)
+			KnockDown(effect * blocked)
 		if(PARALYZE)
 			Paralyse(effect * blocked)
 		if(IRRADIATE)
@@ -101,13 +103,15 @@
 	updatehealth("apply effect")
 	return TRUE
 
-/mob/living/proc/apply_effects(stun = 0, weaken = 0, paralyze = 0, irradiate = 0, slur = 0, stutter = 0, eyeblur = 0, drowsy = 0, blocked = 0, stamina = 0, jitter = 0)
+/mob/living/proc/apply_effects(stun = 0, weaken = 0, knockdown = 0, paralyze = 0, irradiate = 0, slur = 0, stutter = 0, eyeblur = 0, drowsy = 0, blocked = 0, stamina = 0, jitter = 0)
 	if(blocked >= 100)
 		return FALSE
 	if(stun)
 		apply_effect(stun, STUN, blocked)
 	if(weaken)
 		apply_effect(weaken, WEAKEN, blocked)
+	if(knockdown)
+		apply_effect(knockdown, KNOCKDOWN, blocked)
 	if(paralyze)
 		apply_effect(paralyze, PARALYZE, blocked)
 	if(irradiate)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -45,6 +45,7 @@
 	//Effects
 	var/stun = 0
 	var/weaken = 0
+	var/knockdown = 0
 	var/paralyze = 0
 	var/irradiate = 0
 	var/stutter = 0
@@ -176,7 +177,7 @@
 
 	if(!log_override && firer && !alwayslog)
 		add_attack_logs(firer, L, "Shot with a [type][additional_log_text]")
-	return L.apply_effects(stun, weaken, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
+	return L.apply_effects(stun, weaken, knockdown, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
 
 /obj/item/projectile/proc/get_splatter_blockage(turf/step_over, atom/target, splatter_dir, target_loca) //Check whether the place we want to splatter blood is blocked (i.e. by windows).
 	var/turf/step_cardinal = !(splatter_dir in list(NORTH, SOUTH, EAST, WEST)) ? get_step(target_loca, get_cardinal_dir(target_loca, step_over)) : null


### PR DESCRIPTION
## What Does This PR Do
The meat hook originally did 6 seconds of weaken, this PR makes it so the meat hook now does 1 seconds of weaken and 6 seconds of knockdown. In order to make this work, I also added KnockDown support for projectiles.

## Why It's Good For The Game
The meat hook is a very powerful weapon, it is pretty much inescapable and game over if you get hit with it in its current state considering it hard stuns you for 6 seconds (user can also stack meathook yoinks also). This PR aims to maintain the oomph of the weapon by still making it stun a target for 1 seconds (and drop whatever they're holding) but give the target a chance to fight back.

A skilled player can still pair the meathook with another stun weapon to great effectiveness but this PR ensures that it's not a guaranteed win if you get a single hit off. This will help balance a quite powerful lavaland weapon.

## Changelog
:cl:
tweak: Meathook now does 6 seconds knockdown and 1 seconds of weaken
/:cl:

