### PR TITLE
Fix users being able to unintentionally emote while faking death

### DIFF
--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -482,7 +482,7 @@
 		return FALSE
 
 	if(check_mute(user.client?.ckey, MUTE_EMOTE))
-		to_chat(src, "<span class='warning'>You cannot send emotes (muted).</span>")
+		to_chat(user, "<span class='warning'>You cannot send emotes (muted).</span>")
 		return FALSE
 
 	if(status_check && !is_type_in_typecache(user, mob_type_ignore_stat_typecache))
@@ -496,7 +496,7 @@
 			if(stat)
 				to_chat(user, "<span class='warning'>You cannot [key] while [stat]!</span>")
 			return FALSE
-		if(HAS_TRAIT(src, TRAIT_FAKEDEATH))
+		if(HAS_TRAIT(user, TRAIT_FAKEDEATH))
 			// Don't let people blow their cover by mistake
 			return FALSE
 		if(hands_use_check && !user.can_use_hands() && (iscarbon(user)))
@@ -512,14 +512,14 @@
 	else
 		// deadchat handling
 		if(check_mute(user.client?.ckey, MUTE_DEADCHAT))
-			to_chat(src, "<span class='warning'>You cannot send deadchat emotes (muted).</span>")
+			to_chat(user, "<span class='warning'>You cannot send deadchat emotes (muted).</span>")
 			return FALSE
 		if(!(user.client?.prefs.toggles & PREFTOGGLE_CHAT_DEAD))
-			to_chat(src, "<span class='warning'>You have deadchat muted.</span>")
+			to_chat(user, "<span class='warning'>You have deadchat muted.</span>")
 			return FALSE
 		if(!check_rights(R_ADMIN, FALSE, user))
 			if(!GLOB.dsay_enabled)
-				to_chat(src, "<span class='warning'>Deadchat is globally muted</span>")
+				to_chat(user, "<span class='warning'>Deadchat is globally muted</span>")
 				return FALSE
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug introduced in #17544 that allowed people faking their death to emote, intentionally or not. Turns out we were checking the fake death trait of the emote datum by accident, whoops.

This PR also fixes some other similar mistakes around there as well, mostly with mute messages.

Shoutouts to @hal9000PR for the report
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When you're faking death, for (almost) all intents and purposes, you're supposed to be dead, and dead people can't emote. Plus, this might out someone playing dead.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: People faking death can no longer emote.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
