### PR TITLE
Mediborg - Run out of Medicine - Asks to be Refilled

### DIFF
--- a/code/modules/arcade/mob_hunt/battle_computer.dm
+++ b/code/modules/arcade/mob_hunt/battle_computer.dm
@@ -303,3 +303,6 @@
 		return
 	patient.mob_data.cur_health = patient.mob_data.max_health
 	to_chat(user, "<span class='notify'>[patient.mob_data.nickname ? patient.mob_data.nickname : patient.mob_data.mob_name] has been restored to full health!</span>")
+// 	patient.mob_data.save()
+	patient.save()
+	patient.update_health()

--- a/code/modules/arcade/mob_hunt/battle_computer.dm
+++ b/code/modules/arcade/mob_hunt/battle_computer.dm
@@ -303,6 +303,3 @@
 		return
 	patient.mob_data.cur_health = patient.mob_data.max_health
 	to_chat(user, "<span class='notify'>[patient.mob_data.nickname ? patient.mob_data.nickname : patient.mob_data.mob_name] has been restored to full health!</span>")
-// 	patient.mob_data.save()
-	patient.save()
-	patient.update_health()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -601,3 +601,16 @@
 
 /obj/machinery/bot_core/medbot/syndicate
 	req_one_access = list(ACCESS_SYNDICATE)
+
+// if the medibot has run out of medicine, ask for more
+/mob/living/simple_animal/bot/medbot/proc/check_medicine()
+	if(!medicine_list)
+		return
+	if(medicine_list.total_volume > 0)
+		return
+	if(!medicine_request_cooldown)
+		medicine_request_cooldown = 1
+		var/area/location = get_area(src)
+		speak("I'm out of medicine! I need more at [location]!", radio_channel)
+		spawn(200) //Twenty seconds
+			medicine_request_cooldown = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This updates the medibot to ask to be refilled when it runs out of medicine. This allows people to know when it has run out of medicine and is just sitting there doing nothing. The medibot will announce to the channel that it is a part of (medical) that it is in need of more medicine. It will check on it's own if it has run out of medicine and only broadcast this message when it needs to be refilled.

I added a cooldown to ensure that this does not cause any spam.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows medical to keep on top of the medibots and ensure they are all helping patients and not just sat there as they are out of medicine
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked the medibot to announce in the channel it is apart of (medical) when it has run out of medicine

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
