### PR TITLE
Removes the stun from flashes and gives them a cooldown

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -74,8 +74,8 @@
 
 /obj/item/flash/proc/try_use_flash(mob/user = null)
 	if(cooldown >= world.time)
-		to_chat(user, "<span class='warning'>Your [src] is recharging!</span>")
-		return
+		to_chat(user, "<span class='warning'>Your [src] is still too hot to use again!</span>")
+		return FALSE
 	cooldown = world.time + cooldown_duration
 	flash_recharge(user)
 
@@ -225,23 +225,14 @@
 	flash_cur_charges = min(flash_cur_charges+1, flash_max_charges)
 	return TRUE
 
-/obj/item/flash/cameraflash/attack(mob/living/M, mob/user)
-    if(flash_cur_charges > 0)
-        flash_cur_charges -= 1
-        to_chat(user, "[src] now has [flash_cur_charges] charge\s.")
-        ..()
-    else
-        to_chat(user, "<span class='warning'>\The [src] needs time to recharge!</span>")
-    return
-
-/obj/item/flash/cameraflash/attack_self(mob/living/carbon/user, flag = 0)
-    if(flash_cur_charges > 0)
-        flash_cur_charges -= 1
-        to_chat(user, "[src] now has [flash_cur_charges] charge\s.")
-        ..()
-    else
-        to_chat(user, "<span class='warning'>\The [src] needs time to recharge!</span>")
-    return
+/obj/item/flash/cameraflash/try_use_flash(mob/user = null)
+	if(!flash_cur_charges)
+		to_chat(user, "<span class='warning'>\The [src] needs time to recharge!</span>")
+		return FALSE
+	. = ..()
+	if(.)
+		flash_cur_charges--
+		to_chat(user, "[src] now has [flash_cur_charges] charge\s.")
 
 /obj/item/flash/memorizer
 	name = "memorizer"

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -19,7 +19,10 @@
 	var/battery_panel = 0 //whether the flash can be modified with a cell or not
 	var/overcharged = 0   //if overcharged the flash will set people on fire then immediately burn out (does so even if it doesn't blind them).
 	var/can_overcharge = TRUE //set this to FALSE if you don't want your flash to be overcharge capable
+	///This tracks the world.time until the flash can be used again
 	var/cooldown
+	///This is the duration of the cooldown
+	var/cooldown_duration = 5 SECONDS
 	var/use_sound = 'sound/weapons/flash.ogg'
 
 /obj/item/flash/proc/clown_check(mob/user)
@@ -71,9 +74,9 @@
 
 /obj/item/flash/proc/try_use_flash(mob/user = null)
 	if(cooldown >= world.time)
-		to_chat(user, "<span class='warning'>Your flash is recharging!</span>")
+		to_chat(user, "<span class='warning'>Your [src] is recharging!</span>")
 		return
-	cooldown = world.time + 5 SECONDS
+	cooldown = world.time + cooldown_duration
 	flash_recharge(user)
 
 	if(broken)
@@ -100,13 +103,13 @@
 				terrible_conversion_proc(M, user)
 				M.drop_l_hand()
 				M.drop_r_hand()
-				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
-				to_chat(user, "<span class='danger'>You blind [M] with the flash!</span>")
-				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
+				visible_message("<span class='disarm'>[user] blinds [M] with the [src]!</span>")
+				to_chat(user, "<span class='danger'>You blind [M] with the [src]!</span>")
+				to_chat(M, "<span class='userdanger'>[user] blinds you with the [src]!</span>")
 			else
-				visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
-				to_chat(user, "<span class='warning'>You fail to blind [M] with the flash!</span>")
-				to_chat(M, "<span class='danger'>[user] fails to blind you with the flash!</span>")
+				visible_message("<span class='disarm'>[user] fails to blind [M] with the [src]!</span>")
+				to_chat(user, "<span class='warning'>You fail to blind [M] with the [src]!</span>")
+				to_chat(M, "<span class='danger'>[user] fails to blind you with the [src]!</span>")
 			return
 
 	if(M.flash_eyes())
@@ -134,7 +137,7 @@
 /obj/item/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!try_use_flash(user))
 		return 0
-	user.visible_message("<span class='disarm'>[user]'s flash emits a blinding light!</span>", "<span class='danger'>Your flash emits a blinding light!</span>")
+	user.visible_message("<span class='disarm'>[user]'s [src] emits a blinding light!</span>", "<span class='danger'>Your [src] emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in oviewers(3, null))
 		flash_carbon(M, user, 6 SECONDS, 0)
 
@@ -249,34 +252,16 @@
 /obj/item/flash/armimplant
 	name = "photon projector"
 	desc = "A high-powered photon projector implant normally used for lighting purposes, but also doubles as a flashbulb weapon. Self-repair protocols fix the flashbulb if it ever burns out."
-	var/flashcd = 20
-	var/overheat = 0
+	cooldown_duration = 2 SECONDS
 	var/obj/item/organ/internal/cyberimp/arm/flash/I = null
+
+/obj/item/flash/armimplant/burn_out()
+	if(I && I.owner)
+		to_chat(I.owner, "<span class='warning'>Your [src] implant overheats and deactivates!</span>")
+		I.Retract()
 
 /obj/item/flash/armimplant/Destroy()
 	I = null
 	return ..()
-
-/obj/item/flash/armimplant/burn_out()
-	if(I && I.owner)
-		to_chat(I.owner, "<span class='warning'>Your photon projector implant overheats and deactivates!</span>")
-		I.Retract()
-	overheat = FALSE
-	addtimer(CALLBACK(src, .proc/cooldown), flashcd * 2)
-
-/obj/item/flash/armimplant/try_use_flash(mob/user = null)
-	if(overheat)
-		if(I && I.owner)
-			to_chat(I.owner, "<span class='warning'>Your photon projector is running too hot to be used again so quickly!</span>")
-		return FALSE
-	overheat = TRUE
-	addtimer(CALLBACK(src, .proc/cooldown), flashcd)
-	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
-	update_icon(1)
-	return TRUE
-
-/obj/item/flash/armimplant/proc/cooldown()
-	overheat = FALSE
-
 
 /obj/item/flash/synthetic //just a regular flash now

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -103,13 +103,13 @@
 				terrible_conversion_proc(M, user)
 				M.drop_l_hand()
 				M.drop_r_hand()
-				visible_message("<span class='disarm'>[user] blinds [M] with the [name]!</span>")
-				to_chat(user, "<span class='danger'>You blind [M] with the [name]!</span>")
-				to_chat(M, "<span class='userdanger'>[user] blinds you with the [name]!</span>")
+				visible_message("<span class='disarm'>[user] blinds [M] with [src]!</span>")
+				to_chat(user, "<span class='danger'>You blind [M] with [src]!</span>")
+				to_chat(M, "<span class='userdanger'>[user] blinds you with [src]!</span>")
 			else
-				visible_message("<span class='disarm'>[user] fails to blind [M] with the [name]!</span>")
-				to_chat(user, "<span class='warning'>You fail to blind [M] with the [name]!</span>")
-				to_chat(M, "<span class='danger'>[user] fails to blind you with the [name]!</span>")
+				visible_message("<span class='disarm'>[user] fails to blind [M] with [src]!</span>")
+				to_chat(user, "<span class='warning'>You fail to blind [M] with [src]!</span>")
+				to_chat(M, "<span class='danger'>[user] fails to blind you with [src]!</span>")
 			return
 
 	if(M.flash_eyes())
@@ -227,7 +227,7 @@
 
 /obj/item/flash/cameraflash/try_use_flash(mob/user = null)
 	if(!flash_cur_charges)
-		to_chat(user, "<span class='warning'>\The [name] needs time to recharge!</span>")
+		to_chat(user, "<span class='warning'>[src] needs time to recharge!</span>")
 		return FALSE
 	. = ..()
 	if(.)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -19,6 +19,7 @@
 	var/battery_panel = 0 //whether the flash can be modified with a cell or not
 	var/overcharged = 0   //if overcharged the flash will set people on fire then immediately burn out (does so even if it doesn't blind them).
 	var/can_overcharge = TRUE //set this to FALSE if you don't want your flash to be overcharge capable
+	var/cooldown
 	var/use_sound = 'sound/weapons/flash.ogg'
 
 /obj/item/flash/proc/clown_check(mob/user)
@@ -69,6 +70,10 @@
 
 
 /obj/item/flash/proc/try_use_flash(mob/user = null)
+	if(cooldown >= world.time)
+		to_chat(user, "<span class='warning'>Your flash is recharging!</span>")
+		return
+	cooldown = world.time + 5 SECONDS
 	flash_recharge(user)
 
 	if(broken)
@@ -93,7 +98,8 @@
 			if(M.flash_eyes(1, 1))
 				M.AdjustConfused(power)
 				terrible_conversion_proc(M, user)
-				M.Stun(2 SECONDS)
+				M.drop_l_hand()
+				M.drop_r_hand()
 				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
 				to_chat(user, "<span class='danger'>You blind [M] with the flash!</span>")
 				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
@@ -128,7 +134,7 @@
 /obj/item/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!try_use_flash(user))
 		return 0
-	user.visible_message("<span class='disarm'>[user]'s [src] emits a blinding light!</span>", "<span class='danger'>Your [src] emits a blinding light!</span>")
+	user.visible_message("<span class='disarm'>[user]'s flash emits a blinding light!</span>", "<span class='danger'>Your flash emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in oviewers(3, null))
 		flash_carbon(M, user, 6 SECONDS, 0)
 

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -74,7 +74,7 @@
 
 /obj/item/flash/proc/try_use_flash(mob/user = null)
 	if(cooldown >= world.time)
-		to_chat(user, "<span class='warning'>Your [src] is still too hot to use again!</span>")
+		to_chat(user, "<span class='warning'>Your [name] is still too hot to use again!</span>")
 		return FALSE
 	cooldown = world.time + cooldown_duration
 	flash_recharge(user)
@@ -103,13 +103,13 @@
 				terrible_conversion_proc(M, user)
 				M.drop_l_hand()
 				M.drop_r_hand()
-				visible_message("<span class='disarm'>[user] blinds [M] with the [src]!</span>")
-				to_chat(user, "<span class='danger'>You blind [M] with the [src]!</span>")
-				to_chat(M, "<span class='userdanger'>[user] blinds you with the [src]!</span>")
+				visible_message("<span class='disarm'>[user] blinds [M] with the [name]!</span>")
+				to_chat(user, "<span class='danger'>You blind [M] with the [name]!</span>")
+				to_chat(M, "<span class='userdanger'>[user] blinds you with the [name]!</span>")
 			else
-				visible_message("<span class='disarm'>[user] fails to blind [M] with the [src]!</span>")
-				to_chat(user, "<span class='warning'>You fail to blind [M] with the [src]!</span>")
-				to_chat(M, "<span class='danger'>[user] fails to blind you with the [src]!</span>")
+				visible_message("<span class='disarm'>[user] fails to blind [M] with the [name]!</span>")
+				to_chat(user, "<span class='warning'>You fail to blind [M] with the [name]!</span>")
+				to_chat(M, "<span class='danger'>[user] fails to blind you with the [name]!</span>")
 			return
 
 	if(M.flash_eyes())
@@ -137,7 +137,7 @@
 /obj/item/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!try_use_flash(user))
 		return 0
-	user.visible_message("<span class='disarm'>[user]'s [src] emits a blinding light!</span>", "<span class='danger'>Your [src] emits a blinding light!</span>")
+	user.visible_message("<span class='disarm'>[user]'s [name] emits a blinding light!</span>", "<span class='danger'>Your [name] emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in oviewers(3, null))
 		flash_carbon(M, user, 6 SECONDS, 0)
 
@@ -227,7 +227,7 @@
 
 /obj/item/flash/cameraflash/try_use_flash(mob/user = null)
 	if(!flash_cur_charges)
-		to_chat(user, "<span class='warning'>\The [src] needs time to recharge!</span>")
+		to_chat(user, "<span class='warning'>\The [name] needs time to recharge!</span>")
 		return FALSE
 	. = ..()
 	if(.)
@@ -248,7 +248,7 @@
 
 /obj/item/flash/armimplant/burn_out()
 	if(I && I.owner)
-		to_chat(I.owner, "<span class='warning'>Your [src] implant overheats and deactivates!</span>")
+		to_chat(I.owner, "<span class='warning'>Your [name] implant overheats and deactivates!</span>")
 		I.Retract()
 
 /obj/item/flash/armimplant/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The stun has been removed from the targeted flash, although it does still disarm the victim. Flashes have been given a cooldown of 5 seconds, except for the arm-mounted photon projector which already had a cooldown of 2 seconds, and this has been kept. Additionally, I have removed "your the" from the chat messages and a bit of duplicate code. Part of the stun removal project by @hal9000PR.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Instant stuns bad, we've been over this. The flash used to stun for 1 cycle, which was 0-2 seconds, presumably to remove items from your hands. This has since changed, and with it being guaranteed 2 seconds... it's a little silly. Additionally, flashes can be spammed until RNG decides to mercifully burn them out - with just a little luck, a roundstart item can be used to cause severe eye damage to everyone else on screen, friend or foe, spamming attack logs... and of course, it is ubiquitous enough that it is easy to stock up on them. This can happen accidentally too, when people (read: CMOs) panic a little. Removing this capability prevents such things from happening. 

## Changelog
:cl:
tweak: Flashes have been given a 5 second cooldown and no longer stun, but still disarm people. Photon projector implants still have a 2 second cooldown. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
