### PR TITLE
expanded plastic crafting

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -519,6 +519,14 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("wet floor sign", /obj/item/caution, 2), \
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/empty), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
+	new /datum/stack_recipe("first-aid kit", /obj/item/storage/firstaid/regular, 4), \
+	new /datum/stack_recipe("brute trauma treatment kit", /obj/item/storage/firstaid/brute, 4), \
+	new /datum/stack_recipe("fire first-aid kit", /obj/item/storage/firstaid/fire, 4), \
+	new /datum/stack_recipe("toxin first aid kit", /obj/item/storage/firstaid/toxin, 4), \
+	new /datum/stack_recipe("oxygen deprivation first aid kit", /obj/item/storage/firstaid/o2, 4), \
+	new /datum/stack_recipe("advanced first-aid kit", /obj/item/storage/firstaid/adv, 4), \
+	new /datum/stack_recipe("pill bottle", /obj/item/storage/pill_bottle), \
+	new /datum/stack_recipe("IV bag", /obj/item/reagent_containers/iv_bag, 2), \
 	new /datum/stack_recipe("plastic crate", /obj/structure/closet/crate/plastic, 10, one_per_turf = 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic ashtray", /obj/item/ashtray/plastic, 2, one_per_turf = 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic fork", /obj/item/kitchen/utensil/pfork, 1, on_floor = 1), \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Allows to craft different type of empty first-aid kit boxes, empty IV drip and empty pill bottle from plastic polymer sheets. 

- 4 plastic sheets: first-aid kit (and standard variants)
- 1 plastic sheets: pill bottle
- 2 plastic sheets: IV bag

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently, there is no ability to craft or print first-aid kit boxes and IV drip. They are spawned in at the beginning of a shift or supplied from a cargo shuttle. pill bottle may be printed in an autolathe. In the spirit of making those items craftable, I've created this PR. Plastic sheet currently isn't very useful and have just a few crafting recipes and it feels right that those items are craftable from plastic sheets. They are the kind of item that only cargo can get but it's not useful enough to bother them for it.

IV bag spawn in medbay and pill bottle are spawn in sci chem and chemist. in case they are lost or stolen, this gave more option on how to get more.

This allows chemist and scichem to create meds packaged in a nice kit instead of stashing the drugs into a box and will improve rp by a tiny bit. Similar to how chef can craft paper bag from paper and fill them with food and use them as a lunch bag. it's neat!

## Changelog
:cl:
add: Added the abilities to craft first-aid kits boxes, empty IV drip, and empty pill bottle from plastic polymer sheets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
