### PR TITLE
Fixes Flesh to Stone unbuckling people incorrectly

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -1,4 +1,4 @@
-/obj/structure/closet/statue
+/obj/structure/closet/statue //this type path is a crime, ponies what the fuck
 	name = "statue"
 	desc = "An incredibly lifelike marble carving"
 	icon = 'icons/obj/statue.dmi'
@@ -16,11 +16,10 @@
 	. = ..()
 	if(ishuman(L) || iscorgi(L))
 		if(L.buckled)
-			L.buckled = 0
-			L.anchored = 0
+			L.unbuckle_mob()
 		L.forceMove(src)
 		ADD_TRAIT(L, TRAIT_MUTE, STATUE_MUTE)
-		max_integrity = L.health + 100 //stoning damaged mobs will result in easier to shatter statues
+		max_integrity = max(L.health + 100, 100) //stoning damaged mobs will result in easier to shatter statues
 		intialTox = L.getToxLoss()
 		intialFire = L.getFireLoss()
 		intialBrute = L.getBruteLoss()


### PR DESCRIPTION
## What Does This PR Do
uses the proper procs to handle buckled stuff instead of setting a mobs `buckled` var to FALSE. I'm not even going to touch the rest of this file, its horrific and should absolutely just be a fucking structure instead of a closet subtype.
Fixes #18002

Additionally put in a `max()` check to ensure that max_integrity never goes below 0 (which would make the statue invincible)
## Why It's Good For The Game
Vehicles can no longer become glitched/nullspaced and prevent players from ever unbuckling from them.

## Changelog
:cl:
fix: Fixed flesh to stone and vehicles not getting along
/:cl:
