### PR TITLE
Nerfs beanbags & rubber pellet shots

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -82,6 +82,15 @@
 	damage = 3
 	stamina = 12.5
 	icon_state = "bullet-r"
+	armour_penetration = -10
+
+/obj/item/projectile/bullet/pellet/rubber/on_hit(atom/target, blocked = 0)
+    . = ..()
+    if(!ishuman(target))
+        return
+    var/mob/living/carbon/human/H = target
+    if(H.getStaminaLoss() >= 60)
+        H.KnockDown(8 SECONDS)
 
 /obj/item/projectile/bullet/pellet/weak
 	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -10,7 +10,7 @@
 /obj/item/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	name = "beanbag slug"
 	damage = 5
-	stamina = 80
+	stamina = 40
 
 /obj/item/projectile/bullet/weakbullet/booze
 
@@ -80,7 +80,7 @@
 /obj/item/projectile/bullet/pellet/rubber
 	name = "rubber pellet"
 	damage = 3
-	stamina = 25
+	stamina = 12.5
 	icon_state = "bullet-r"
 
 /obj/item/projectile/bullet/pellet/weak


### PR DESCRIPTION
## What Does This PR Do
Makes it so beanbags now take 3 hits to down you.
Rubber shots will knock you down in one hit at close range, allowing the user to crawl but two hits will stam crit them, and the negative armour penetration has been changed from -30 to -10.

## Why It's Good For The Game
We don't want people going down instantly from these.

## Changelog
:cl: CornMyCob
tweak: Beanbag shots & rubber shotgun rounds have been nerfed to require multiple/more hits to down.
/:cl:
