### PR TITLE
Fixes Order of Checks when Alt Clicking a chair

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -134,10 +134,10 @@
 	handle_rotation()
 
 /obj/structure/chair/AltClick(mob/user)
+	if(!Adjacent(user))
+		return
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!Adjacent(user))
 		return
 	rotate()
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #18256

changes check order when alt clicking a chair to rotate it. Previous it would display an error message if you were incapacitated anywhere you were as long as you were incapacitated. However, this should really only happen if you're close enough to the chair to actually rotate it.

## Changelog
:cl:
fix: Fixes feedback for failing to rotate chairs
/:cl: