### PR TITLE
[GBP no update] Undo suits obscuring other items by removing their overlays

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1049,8 +1049,6 @@
 			obscured |= slot_w_uniform
 		if(wear_suit.flags_inv & HIDESHOES)
 			obscured |= slot_shoes
-		if(wear_suit.flags_inv & HIDESUITSTORAGE)
-			obscured |= slot_s_store
 
 	if(head)
 		if(head.flags_inv & HIDEMASK)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -632,16 +632,12 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(inv)
 			inv.update_icon()
 
-	var/hidden = (slot_gloves in check_obscured_slots())
-
 	if(gloves)
 		if(client && hud_used && hud_used.hud_shown)
 			if(hud_used.inventory_shown)			//if the inventory is open ...
 				gloves.screen_loc = ui_gloves		//...draw the item in the inventory screen
 			client.screen += gloves					//Either way, add the item to the HUD
 
-		if(hidden)
-			return
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
 
@@ -659,8 +655,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			standing.overlays += bloodsies
 		overlays_standing[GLOVES_LAYER]	= standing
 	else
-		if(hidden)
-			return
 		if(blood_DNA)
 			var/mutable_appearance/bloodsies = mutable_appearance(dna.species.blood_mask, "bloodyhands", layer = -GLOVES_LAYER)
 			bloodsies.color = hand_blood_color
@@ -764,16 +758,12 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(inv)
 			inv.update_icon()
 
-	var/hidden = (slot_shoes in check_obscured_slots())
-
 	if(shoes)
 		if(client && hud_used && hud_used.hud_shown)
 			if(hud_used.inventory_shown)			//if the inventory is open ...
 				shoes.screen_loc = ui_shoes			//...draw the item in the inventory screen
 			client.screen += shoes					//Either way, add the item to the HUD
 
-		if(hidden)
-			return
 		var/mutable_appearance/standing
 		if(shoes.icon_override)
 			standing = mutable_appearance(shoes.icon_override, "[shoes.icon_state]", layer = -SHOES_LAYER)
@@ -790,8 +780,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		standing.color = shoes.color
 		overlays_standing[SHOES_LAYER] = standing
 	else
-		if(hidden)
-			return
 		if(feet_blood_DNA)
 			var/mutable_appearance/bloodsies = mutable_appearance(dna.species.blood_mask, "shoeblood", layer = -SHOES_LAYER)
 			bloodsies.color = feet_blood_color
@@ -810,8 +798,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			s_store.screen_loc = ui_sstore1
 			client.screen += s_store
 
-		if(slot_s_store in check_obscured_slots())
-			return
 		var/t_state = s_store.item_state
 		if(!t_state)
 			t_state = s_store.icon_state
@@ -914,11 +900,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		overlays_standing[SUIT_LAYER] = standing
 
 	apply_overlay(SUIT_LAYER)
-	
-	update_inv_gloves()
-	update_inv_shoes()
-	update_inv_s_store()
-
 	update_tail_layer()
 	update_wing_layer()
 	update_collar()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Undoes #18190. It was a triangle of 3 conflicting behaviors, and reworking sprites would be the more troublesome of the bunch.

## Why It's Good For The Game
That caused more problems than anything else.

## Changelog
:cl:
fix: Equipped suits that don't have their own shoes and gloves show other equipped items again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
