### PR TITLE
Buffs the regenration gene from genetics.

### DIFF
--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -26,8 +26,12 @@
 	block = GLOB.regenerateblock
 
 /datum/mutation/regenerate/on_life(mob/living/carbon/human/H)
-	H.adjustBruteLoss(-0.1, FALSE)
-	H.adjustFireLoss(-0.1)
+	if(!H.ignore_gene_stability && H.gene_stability < GENETIC_DAMAGE_STAGE_1)
+		H.adjustBruteLoss(-0.25, FALSE)
+		H.adjustFireLoss(-0.25)
+		return
+	H.adjustBruteLoss(-1, FALSE)
+	H.adjustFireLoss(-1)
 
 /datum/mutation/increaserun
 	name = "Super Speed"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Buffs the value of the regeneration gene from genetics, from **0.1** brute and burn being healed each cycle (2 seconds), to 1.

However, if you are past stage 1 of gene instability, without having the ignore gene instability flag, heal is lowered to 0.25, to reduce being able to ignore the stage 1 side effect.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The regeneration gene at the moment is practically useless. 0.1 brute and burn each cycle. It would take 200 seconds to heal off a crowbar, or 400 seconds to heal off a laser blast. Almost any other heal method will easily surpass this, not to mention healing viruses, ever common saline, or diona. This brings regeneration to something more reasonable, actually healing off damage at a mostly decent rate, while being lowered when genes are unstable.


## Changelog
:cl:
tweak: The regeneration gene now heals 1 brute / burn per cycle, instead of 0.1. If genes are unstable, will only heal 0.25 instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
