### PR TITLE
Fix: Placing roller bed acts the same as expanding it in inventory

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -136,7 +136,7 @@
 	if(isturf(target))
 		var/turf/T = target
 		if(!T.density)
-			var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(T)
+			var/obj/structure/bed/roller/R = new extended(T)
 			R.add_fingerprint(user)
 			qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #18248
Placing a roller bed on the ground now works the same as expanding it in inventory - it creates the structure as defined in it's class, rather than always creating a basic roller bed.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Game acts like you'd expect it to.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Placing a holo roller bed directly onto the ground no longer turns it into a normal roller bed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
