### PR TITLE
`/obj/item/storage` no longer uses `/New`

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -472,8 +472,6 @@
 /obj/item/storage/box/syndie_kit/guardian
 	name = "holoparasite injector kit"
 
-/obj/item/storage/box/syndie_kit/guardian/New()
-	..()
+/obj/item/storage/box/syndie_kit/guardian/populate_contents()
 	new /obj/item/guardiancreator/tech/choose(src)
 	new /obj/item/paper/guardian(src)
-	return

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -607,8 +607,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	name = "Diskette Box"
 	icon_state = "disk_kit"
 
-/obj/item/storage/box/disks/New()
-	..()
+/obj/item/storage/box/disks/populate_contents()
 	new /obj/item/disk/data(src)
 	new /obj/item/disk/data(src)
 	new /obj/item/disk/data(src)

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -176,12 +176,6 @@
 /obj/item/storage/box/mechabeacons
 	name = "exosuit tracking beacons"
 
-/obj/item/storage/box/mechabeacons/New()
-	..()
-	new /obj/item/mecha_parts/mecha_tracking(src)
-	new /obj/item/mecha_parts/mecha_tracking(src)
-	new /obj/item/mecha_parts/mecha_tracking(src)
-	new /obj/item/mecha_parts/mecha_tracking(src)
-	new /obj/item/mecha_parts/mecha_tracking(src)
-	new /obj/item/mecha_parts/mecha_tracking(src)
-	new /obj/item/mecha_parts/mecha_tracking(src)
+/obj/item/storage/box/mechabeacons/populate_contents()
+	for(var/i in 1 to 7)
+		new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -6,30 +6,18 @@
 	desc = "Highly illegal drug. When you want to see the rainbow."
 	wrapper_color = COLOR_PINK
 
-/obj/item/storage/pill_bottle/happy/New()
-	..()
-	new /obj/item/reagent_containers/food/pill/happy( src )
-	new /obj/item/reagent_containers/food/pill/happy( src )
-	new /obj/item/reagent_containers/food/pill/happy( src )
-	new /obj/item/reagent_containers/food/pill/happy( src )
-	new /obj/item/reagent_containers/food/pill/happy( src )
-	new /obj/item/reagent_containers/food/pill/happy( src )
-	new /obj/item/reagent_containers/food/pill/happy( src )
+/obj/item/storage/pill_bottle/happy/populate_contents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/food/pill/happy(src)
 
 /obj/item/storage/pill_bottle/zoom
 	name = "Zoom pills"
 	desc = "Highly illegal drug. Trade brain for speed."
 	wrapper_color = COLOR_BLUE
 
-/obj/item/storage/pill_bottle/zoom/New()
-	..()
-	new /obj/item/reagent_containers/food/pill/zoom( src )
-	new /obj/item/reagent_containers/food/pill/zoom( src )
-	new /obj/item/reagent_containers/food/pill/zoom( src )
-	new /obj/item/reagent_containers/food/pill/zoom( src )
-	new /obj/item/reagent_containers/food/pill/zoom( src )
-	new /obj/item/reagent_containers/food/pill/zoom( src )
-	new /obj/item/reagent_containers/food/pill/zoom( src )
+/obj/item/storage/pill_bottle/zoom/populate_contents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/food/pill/zoom(src)
 
 /obj/item/reagent_containers/food/pill/random_drugs
 	name = "pill"

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -311,11 +311,9 @@
 /obj/item/storage/box/syndie_kit/teleporter
 	name = "syndicate teleporter kit"
 
-/obj/item/storage/box/syndie_kit/teleporter/New()
-	..()
+/obj/item/storage/box/syndie_kit/teleporter/populate_contents()
 	new /obj/item/teleporter(src)
 	new /obj/item/paper/teleporter(src)
-	return
 
 /obj/effect/temp_visual/teleport_abductor/syndi_teleporter
 	duration = 5

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -126,16 +126,22 @@
 	allow_wrap = FALSE
 	var/labelled = FALSE
 
-/obj/item/storage/pill_bottle/random_meds/New()
-	..()
+/obj/item/storage/pill_bottle/random_meds/Initialize(mapload)
+	. = ..()
+	pixel_x = rand(-10, 10)
+	pixel_y = rand(-10, 10)
+
+/obj/item/storage/pill_bottle/random_meds/populate_contents()
+	var/list/possible_meds_standard = GLOB.standard_medicines.Copy()
+	var/list/possible_meds_rare = GLOB.rare_medicines.Copy()
 	for(var/i in 1 to storage_slots)
-		var/list/possible_medicines = GLOB.standard_medicines.Copy()
-		if(prob(50))
-			possible_medicines += GLOB.rare_medicines.Copy()
-		var/datum/reagent/R = pick(possible_medicines)
+		var/is_rare = prob(33)
+		var/possible_meds = is_rare ? possible_meds_rare : possible_meds_standard
+
+		var/datum/reagent/R = pick(possible_meds)
 		var/obj/item/reagent_containers/food/pill/P = new(src)
 
-		if(GLOB.rare_medicines.Find(R))
+		if(is_rare)
 			P.reagents.add_reagent(R, 10)
 		else
 			P.reagents.add_reagent(R, rand(2, 5)*10)
@@ -145,8 +151,7 @@
 		else
 			P.name = "Unlabelled Pill"
 			P.desc = "Something about this pill entices you to try it, against your better judgement."
-	pixel_x = rand(-10, 10)
-	pixel_y = rand(-10, 10)
+
 
 /obj/item/storage/pill_bottle/random_meds/labelled
 	name = "variety pillbottle"
@@ -308,14 +313,21 @@
 	name = "tactical grenades"
 	desc = "A box with 6 tactical grenades."
 	icon_state = "flashbang"
-	var/list/grenadelist = list(/obj/item/grenade/chem_grenade/metalfoam, /obj/item/grenade/chem_grenade/incendiary,
-	/obj/item/grenade/chem_grenade/antiweed, /obj/item/grenade/chem_grenade/cleaner, /obj/item/grenade/chem_grenade/teargas,
-	/obj/item/grenade/chem_grenade/holywater, /obj/item/grenade/chem_grenade/meat,
-	/obj/item/grenade/chem_grenade/dirt, /obj/item/grenade/chem_grenade/lube, /obj/item/grenade/smokebomb,
-	/obj/item/grenade/chem_grenade/drugs, /obj/item/grenade/chem_grenade/ethanol) // holy list batman
 
-/obj/item/storage/box/grenades/New()
-	..()
+/obj/item/storage/box/grenades/populate_contents()
+	var/static/list/grenadelist = list(
+		/obj/item/grenade/chem_grenade/metalfoam,
+		/obj/item/grenade/chem_grenade/incendiary,
+		/obj/item/grenade/chem_grenade/antiweed,
+		/obj/item/grenade/chem_grenade/cleaner,
+		/obj/item/grenade/chem_grenade/teargas,
+		/obj/item/grenade/chem_grenade/holywater,
+		/obj/item/grenade/chem_grenade/meat,
+		/obj/item/grenade/chem_grenade/dirt,
+		/obj/item/grenade/chem_grenade/lube,
+		/obj/item/grenade/smokebomb,
+		/obj/item/grenade/chem_grenade/drugs,
+		/obj/item/grenade/chem_grenade/ethanol) // holy list batman
 	for(var/i in 1 to 6)
 		var/nade = pick(grenadelist)
 		new nade(src)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -924,8 +924,7 @@
 	name = "Box of Miniatures"
 	desc = "The nerd's best friends."
 	icon_state = "box"
-/obj/item/storage/box/characters/New()
-	..()
+/obj/item/storage/box/characters/populate_contents()
 	new /obj/item/toy/character/alien(src)
 	new /obj/item/toy/character/cleric(src)
 	new /obj/item/toy/character/warrior(src)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -6,8 +6,7 @@
 	can_hold = list(/obj/item/dice)
 	allow_wrap = FALSE
 
-/obj/item/storage/pill_bottle/dice/New()
-	..()
+/obj/item/storage/pill_bottle/dice/populate_contents()
 	var/special_die = pick("1","2","fudge","00","100")
 	if(special_die == "1")
 		new /obj/item/dice/d1(src)
@@ -385,8 +384,7 @@
 	desc = "ANOTHER ONE!? FUCK!"
 	icon_state = "box"
 
-/obj/item/storage/box/dice/New()
-	..()
+/obj/item/storage/box/dice/populate_contents()
 	new /obj/item/dice/d2(src)
 	new /obj/item/dice/d4(src)
 	new /obj/item/dice/d8(src)

--- a/code/game/objects/items/weapons/grenades/custom_grenades.dm
+++ b/code/game/objects/items/weapons/grenades/custom_grenades.dm
@@ -277,29 +277,23 @@
 /obj/item/storage/box/syndie_kit/remotegrenade
 	name = "remote grenade kit"
 
-/obj/item/storage/box/syndie_kit/remotegrenade/New()
-	..()
+/obj/item/storage/box/syndie_kit/remotegrenade/populate_contents()
 	new /obj/item/grenade/chem_grenade/explosion/remote(src)
 	new /obj/item/multitool(src) // used to adjust the chemgrenade's signaller
 	new /obj/item/assembly/signaler(src)
-	return
 
 /obj/item/storage/box/syndie_kit/remoteemp
 	name = "remote EMP kit"
 
-/obj/item/storage/box/syndie_kit/remoteemp/New()
-	..()
+/obj/item/storage/box/syndie_kit/remoteemp/populate_contents()
 	new /obj/item/grenade/chem_grenade/emp/remote(src)
 	new /obj/item/multitool(src) // used to adjust the chemgrenade's signaller
 	new /obj/item/assembly/signaler(src)
-	return
 
 /obj/item/storage/box/syndie_kit/remotelube
 	name = "remote lube kit"
 
-/obj/item/storage/box/syndie_kit/remotelube/New()
-	..()
+/obj/item/storage/box/syndie_kit/remotelube/populate_contents()
 	new /obj/item/grenade/chem_grenade/lube(src)
 	new /obj/item/multitool(src) // used to adjust the chemgrenade's signaller
 	new /obj/item/assembly/signaler(src)
-	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -97,8 +97,7 @@
 	wrapper_color = COLOR_PALE_BTL_GREEN
 
 // Why the hell is this in the closets folder?
-/obj/item/storage/pill_bottle/psychiatrist/New()
-	..()
+/obj/item/storage/pill_bottle/psychiatrist/populate_contents()
 	new /obj/item/reagent_containers/food/pill/haloperidol(src)
 	new /obj/item/reagent_containers/food/pill/haloperidol(src)
 	new /obj/item/reagent_containers/food/pill/haloperidol(src)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -219,8 +219,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	can_hold = list(/obj/item/inflatable)
 
-/obj/item/storage/briefcase/inflatable/New()
-	..()
+/obj/item/storage/briefcase/inflatable/populate_contents()
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)

--- a/code/modules/antagonists/traitor/contractor/datums/rep_purchases/fulton.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/rep_purchases/fulton.dm
@@ -12,7 +12,6 @@
 	name = "fulton extraction kit"
 	icon_state = "box_of_doom"
 
-/obj/item/storage/box/contractor/fulton_kit/New()
-	..()
+/obj/item/storage/box/contractor/fulton_kit/populate_contents()
 	new /obj/item/extraction_pack(src)
 	new /obj/item/fulton_core(src)

--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -34,8 +34,7 @@
 	)
 
 
-/obj/item/storage/box/syndie_kit/contractor/New()
-	..()
+/obj/item/storage/box/syndie_kit/contractor/populate_contents()
 	new /obj/item/paper/contractor_guide(src)
 	new /obj/item/contractor_uplink(src)
 	new /obj/item/storage/box/syndie_kit/contractor_loadout(src)
@@ -48,8 +47,7 @@
 	name = "contractor standard loadout box"
 	desc = "A standard issue box included in a contractor kit."
 
-/obj/item/storage/box/syndie_kit/contractor_loadout/New()
-	..()
+/obj/item/storage/box/syndie_kit/contractor_loadout/populate_contents()
 	new /obj/item/clothing/head/helmet/space/syndicate/contractor(src)
 	new /obj/item/clothing/suit/space/syndicate/contractor(src)
 	new /obj/item/melee/classic_baton/telescopic/contractor(src)

--- a/code/modules/arcade/mob_hunt/mob_cards.dm
+++ b/code/modules/arcade/mob_hunt/mob_cards.dm
@@ -38,7 +38,6 @@
 	desc = "Contains 6 random Nano-Mob Hunter Trading Cards. May contain a holographic card!"
 	can_hold = list(/obj/item/nanomob_card)
 
-/obj/item/storage/box/nanomob_booster_pack/New()
-	..()
+/obj/item/storage/box/nanomob_booster_pack/populate_contents()
 	for(var/i in 1 to 6)
 		new /obj/item/nanomob_card/booster(src)

--- a/code/modules/awaymissions/mission_code/ruins/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ruins/oldstation.dm
@@ -3,8 +3,7 @@
 	icon_state = "firstaid"
 	desc = "A first aid kit with the ability to heal common types of injuries."
 
-/obj/item/storage/firstaid/ancient/New()
-	..()
+/obj/item/storage/firstaid/ancient/populate_contents()
 	new /obj/item/stack/medical/bruise_pack(src)
 	new /obj/item/stack/medical/bruise_pack(src)
 	new /obj/item/stack/medical/bruise_pack(src)

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -265,8 +265,7 @@
 	max_combined_w_class = 9
 	storage_slots = 3
 
-/obj/item/storage/toolbox/fluff/lunchbox/New()
-	..()
+/obj/item/storage/toolbox/fluff/lunchbox/populate_contents()
 	new /obj/item/reagent_containers/food/snacks/sandwich(src)
 	new /obj/item/reagent_containers/food/snacks/chips(src)
 	new /obj/item/reagent_containers/food/drinks/cans/cola(src)

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -499,7 +499,6 @@
 	name = "plant data disks box"
 	icon_state = "disk_kit"
 
-/obj/item/storage/box/disks_plantgene/New()
-	..()
+/obj/item/storage/box/disks_plantgene/populate_contents()
 	for(var/i in 1 to 7)
 		new /obj/item/disk/plantgene(src)

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -13,8 +13,7 @@
 	max_combined_w_class = 40
 	can_hold = list(/obj/item/coin, /obj/item/stack/spacecash)
 
-/obj/item/storage/bag/money/vault/New()
-	..()
+/obj/item/storage/bag/money/vault/populate_contents()
 	new /obj/item/coin/silver(src)
 	new /obj/item/coin/silver(src)
 	new /obj/item/coin/silver(src)

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -188,8 +188,7 @@
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pdabox"
 
-/obj/item/storage/box/PDAs/New()
-	..()
+/obj/item/storage/box/PDAs/populate_contents()
 	new /obj/item/pda(src)
 	new /obj/item/pda(src)
 	new /obj/item/pda(src)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -93,7 +93,6 @@
 		/obj/item/ammo_casing/caseless/arrow
 		)
 
-/obj/item/storage/backpack/quiver/full/New()
-	..()
+/obj/item/storage/backpack/quiver/full/populate_contents()
 	for(var/i in 1 to storage_slots)
 		new /obj/item/ammo_casing/caseless/arrow(src)


### PR DESCRIPTION
## What Does This PR Do
Moves items from `/obj/item/storage` to use `populate_contents()` rather than `/New`

## Why It's Good For The Game
Good style.
Tested; works.

## Changelog
N/A