### PR TITLE
fixes some issues with whetstones

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -1,6 +1,8 @@
 /obj/item/melee/energy
 	var/active = 0
 	var/force_on = 30 //force when active
+	var/force_off = 0 //Used to properly reset the force
+	var/throwforce_off = 0
 	var/throwforce_on = 20
 	var/faction_bonus_force = 0 //Bonus force dealt against certain factions
 	var/list/nemesis_factions //Any mob with a faction that exists in this list will take bonus damage/effects
@@ -18,6 +20,11 @@
 	light_power = 2
 	var/brightness_on = 2
 	var/colormap = list(red=LIGHT_COLOR_RED, blue=LIGHT_COLOR_LIGHTBLUE, green=LIGHT_COLOR_GREEN, purple=LIGHT_COLOR_PURPLE, rainbow=LIGHT_COLOR_WHITE)
+
+/obj/item/melee/energy/Initialize(mapload)
+	. = ..()
+	force_off = initial(force) //We want to check this only when initializing, not when swapping, so sharpening works.
+	throwforce_off = initial(force)
 
 /obj/item/melee/energy/attack(mob/living/target, mob/living/carbon/human/user)
 	var/nemesis_faction = FALSE
@@ -59,8 +66,8 @@
 		playsound(user, 'sound/weapons/saberon.ogg', 35, 1) //changed it from 50% volume to 35% because deafness
 		to_chat(user, "<span class='notice'>[src] is now active.</span>")
 	else
-		force = initial(force)
-		throwforce = initial(throwforce)
+		force = force_off
+		throwforce = throwforce_off
 		hitsound = initial(hitsound)
 		throw_speed = initial(throw_speed)
 		if(attack_verb_on.len)
@@ -318,8 +325,8 @@
 		playsound(user, 'sound/magic/fellowship_armory.ogg', 35, TRUE, frequency = 90000 - (active * 30000))
 		to_chat(user, "<span class='notice'>You open [src]. It will now cleave enemies in a wide arc and deal additional damage to fauna.</span>")
 	else
-		force = initial(force)
-		throwforce = initial(throwforce)
+		force = force_off
+		throwforce = throwforce_off
 		hitsound = initial(hitsound)
 		throw_speed = initial(throw_speed)
 		if(attack_verb_on.len)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -1,9 +1,9 @@
 /obj/item/melee/energy
 	var/active = 0
 	var/force_on = 30 //force when active
-	var/force_off = 0 //Used to properly reset the force
-	var/throwforce_off = 0
 	var/throwforce_on = 20
+	var/force_off //Used to properly reset the force
+	var/throwforce_off
 	var/faction_bonus_force = 0 //Bonus force dealt against certain factions
 	var/list/nemesis_factions //Any mob with a faction that exists in this list will take bonus damage/effects
 	stealthy_audio = TRUE //Most of these are antag weps so we dont want them to be /too/ overt.
@@ -24,7 +24,7 @@
 /obj/item/melee/energy/Initialize(mapload)
 	. = ..()
 	force_off = initial(force) //We want to check this only when initializing, not when swapping, so sharpening works.
-	throwforce_off = initial(force)
+	throwforce_off = initial(throwforce)
 
 /obj/item/melee/energy/attack(mob/living/target, mob/living/carbon/human/user)
 	var/nemesis_faction = FALSE

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -33,7 +33,7 @@
 
 	if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/E = I
-		if(E.force_on >= max || E.force_on > initial(E.force_on) || (E.force > initial(E.force)))
+		if(E.force_on > initial(E.force_on) || (E.force > initial(E.force)))
 			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
 			return
 		E.throwforce_on = clamp(E.throwforce_on + increment, 0, max)

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -25,28 +25,22 @@
 		return
 	if(istype(I, /obj/item/twohanded))//some twohanded items should still be sharpenable, but handle force differently. therefore i need this stuff
 		var/obj/item/twohanded/TH = I
-		if(TH.force_wielded >= max)
+		if(TH.force_wielded >= max || TH.force_wielded > initial(TH.force_wielded))
 			to_chat(user, "<span class='warning'>[TH] is much too powerful to sharpen further!</span>")
 			return
 		if(TH.wielded)
 			to_chat(user, "<span class='warning'>[TH] must be unwielded before it can be sharpened!</span>")
-			return
-		if(TH.force_wielded > initial(TH.force_wielded))
-			to_chat(user, "<span class='warning'>[TH] has already been refined before. It cannot be sharpened further!</span>")
 			return
 		TH.force_wielded = clamp(TH.force_wielded + increment, 0, max)//wieldforce is increased since normal force wont stay
 		TH.force_unwielded = clamp(TH.force_unwielded + increment, 0, max)
 
 	if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/E = I
-		if(E.force_on >= max)
+		if(E.force_on >= max || E.force_on > initial(E.force_on))
 			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
 			return
 		if(E.active)
 			to_chat(user, "<span class='warning'>[E] must be reset to default before it can be sharpened!</span>") //You can't sharpen an esword, but a cleaving saw can be!
-			return
-		if(E.force_on > initial(E.force_on))
-			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
 			return
 		if(E.force > initial(E.force))//Either have to istype a 3rd time or do an if twice, think if twice is better
 			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -35,6 +35,27 @@
 			to_chat(user, "<span class='warning'>[TH] has already been refined before. It cannot be sharpened further!</span>")
 			return
 		TH.force_wielded = clamp(TH.force_wielded + increment, 0, max)//wieldforce is increased since normal force wont stay
+		TH.force_unwielded = clamp(TH.force_unwielded + increment, 0, max)
+
+	if(istype(I, /obj/item/melee/energy))
+		var/obj/item/melee/energy/E = I
+		if(E.force_on >= max)
+			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
+			return
+		if(E.active)
+			to_chat(user, "<span class='warning'>[E] must be reset to default before it can be sharpened!</span>") //You can't sharpen an esword, but a cleaving saw can be!
+			return
+		if(E.force_on > initial(E.force_on))
+			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
+			return
+		if(E.force > initial(E.force))//Either have to istype a 3rd time or do an if twice, think if twice is better
+			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
+			return
+		E.throwforce_on = clamp(E.throwforce_on + increment, 0, max)
+		E.throwforce_off = clamp(E.throwforce_off + increment, 0, max)
+		E.force_on = clamp(E.force_on + increment, 0, max)
+		E.force_off = clamp(E.force_off + increment, 0, max)
+
 	if(I.force > initial(I.force))
 		to_chat(user, "<span class='warning'>[I] has already been refined before. It cannot be sharpened further!</span>")
 		return

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -28,9 +28,6 @@
 		if(TH.force_wielded >= max || TH.force_wielded > initial(TH.force_wielded))
 			to_chat(user, "<span class='warning'>[TH] is much too powerful to sharpen further!</span>")
 			return
-		if(TH.wielded)
-			to_chat(user, "<span class='warning'>[TH] must be unwielded before it can be sharpened!</span>")
-			return
 		TH.force_wielded = clamp(TH.force_wielded + increment, 0, max)//wieldforce is increased since normal force wont stay
 		TH.force_unwielded = clamp(TH.force_unwielded + increment, 0, max)
 
@@ -38,9 +35,6 @@
 		var/obj/item/melee/energy/E = I
 		if(E.force_on >= max || E.force_on > initial(E.force_on) || (E.force > initial(E.force)))
 			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
-			return
-		if(E.active)
-			to_chat(user, "<span class='warning'>[E] must be reset to default before it can be sharpened!</span>") //You can't sharpen an esword, but a cleaving saw can be!
 			return
 		E.throwforce_on = clamp(E.throwforce_on + increment, 0, max)
 		E.throwforce_off = clamp(E.throwforce_off + increment, 0, max)

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -36,14 +36,11 @@
 
 	if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/E = I
-		if(E.force_on >= max || E.force_on > initial(E.force_on))
+		if(E.force_on >= max || E.force_on > initial(E.force_on) || (E.force > initial(E.force)))
 			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
 			return
 		if(E.active)
 			to_chat(user, "<span class='warning'>[E] must be reset to default before it can be sharpened!</span>") //You can't sharpen an esword, but a cleaving saw can be!
-			return
-		if(E.force > initial(E.force))//Either have to istype a 3rd time or do an if twice, think if twice is better
-			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
 			return
 		E.throwforce_on = clamp(E.throwforce_on + increment, 0, max)
 		E.throwforce_off = clamp(E.throwforce_off + increment, 0, max)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Fixes twohanded weapons loosing their unwielded sharpness when being wielded and unwielded. 

Fixes all energy weapons (only cleaving saw can be sharpened (normally) however not sharpening right at aall, losing all bonuses on transforming, but allowing you to sharpen it multiple times, leading to a cultist being able to make a cleaving saw called "The darkened darkened darkened darkened darkened darkened darkened darkened darkened cleaving saw.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Whetstones working properly is good.

Endlessly long item names that block out a chat window is bad.

## Changelog
:cl:
fix: Fix whetstone interactions with 2 handed weapons and cleaving saws.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
