### PR TITLE
Toggles Nearest Neighbour By Default

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -2,13 +2,13 @@ macro "default"
 
 
 menu "menu"
-	elem
+	elem 
 		name = "&File"
-	elem
+	elem 
 		name = "&Quick screenshot\tF2"
 		command = ".screenshot auto"
 		category = "&File"
-	elem
+	elem 
 		name = "&Save screenshot as...\tShift+F2"
 		command = ".screenshot"
 		category = "&File"
@@ -16,16 +16,16 @@ menu "menu"
 		name = "&Reconnect"
 		command = ".reconnect"
 		category = "&File"
-	elem
+	elem 
 		name = ""
 		category = "&File"
-	elem
+	elem 
 		name = "&Quit"
 		command = ".quit"
 		category = "&File"
-	elem
+	elem 
 		name = "&Icons"
-	elem
+	elem 
 		name = "&Size"
 		category = "&Icons"
 	elem "stretch"
@@ -65,7 +65,7 @@ menu "menu"
 		category = "&Size"
 		can-check = true
 		group = "size"
-	elem
+	elem 
 		name = "&Scaling"
 		category = "&Icons"
 	elem "NN"
@@ -92,9 +92,9 @@ menu "menu"
 		command = ".winset \"menu.textmode.is-checked=true?mapwindow.map.text-mode=true:mapwindow.map.text-mode=false\""
 		category = "&Icons"
 		can-check = true
-	elem
+	elem 
 		name = "&Options"
-	elem
+	elem 
 		name = "&Open Volume Mixer"
 		command = "Open-Volume-Mixer"
 		category = "&Options"
@@ -105,13 +105,13 @@ menu "menu"
 		is-checked = true
 		saved-params = "is-checked"
 		command = ".winset \"menu.statusbar.is-checked=true?mapwindow.status_bar.is-visible=true:mapwindow.status_bar.is-visible=false\""
-	elem
+	elem 
 		name = "&Help"
-	elem
+	elem 
 		name = "&Admin help\tF1"
 		command = "adminhelp"
 		category = "&Help"
-	elem
+	elem 
 		name = "&Hotkeys"
 		command = "Hotkey-Help"
 		category = "&Help"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -2,13 +2,13 @@ macro "default"
 
 
 menu "menu"
-	elem 
+	elem
 		name = "&File"
-	elem 
+	elem
 		name = "&Quick screenshot\tF2"
 		command = ".screenshot auto"
 		category = "&File"
-	elem 
+	elem
 		name = "&Save screenshot as...\tShift+F2"
 		command = ".screenshot"
 		category = "&File"
@@ -16,16 +16,16 @@ menu "menu"
 		name = "&Reconnect"
 		command = ".reconnect"
 		category = "&File"
-	elem 
+	elem
 		name = ""
 		category = "&File"
-	elem 
+	elem
 		name = "&Quit"
 		command = ".quit"
 		category = "&File"
-	elem 
+	elem
 		name = "&Icons"
-	elem 
+	elem
 		name = "&Size"
 		category = "&Icons"
 	elem "stretch"
@@ -65,7 +65,7 @@ menu "menu"
 		category = "&Size"
 		can-check = true
 		group = "size"
-	elem 
+	elem
 		name = "&Scaling"
 		category = "&Icons"
 	elem "NN"
@@ -73,6 +73,7 @@ menu "menu"
 		command = ".winset \"mapwindow.map.zoom-mode=distort\""
 		category = "&Scaling"
 		can-check = true
+		is-checked = true
 		group = "scale"
 	elem "PS"
 		name = "&Point Sampling"
@@ -91,9 +92,9 @@ menu "menu"
 		command = ".winset \"menu.textmode.is-checked=true?mapwindow.map.text-mode=true:mapwindow.map.text-mode=false\""
 		category = "&Icons"
 		can-check = true
-	elem 
+	elem
 		name = "&Options"
-	elem 
+	elem
 		name = "&Open Volume Mixer"
 		command = "Open-Volume-Mixer"
 		category = "&Options"
@@ -104,13 +105,13 @@ menu "menu"
 		is-checked = true
 		saved-params = "is-checked"
 		command = ".winset \"menu.statusbar.is-checked=true?mapwindow.status_bar.is-visible=true:mapwindow.status_bar.is-visible=false\""
-	elem 
+	elem
 		name = "&Help"
-	elem 
+	elem
 		name = "&Admin help\tF1"
 		command = "adminhelp"
 		category = "&Help"
-	elem 
+	elem
 		name = "&Hotkeys"
 		command = "Hotkey-Help"
 		category = "&Help"
@@ -162,6 +163,7 @@ window "mapwindow"
 		text-color = none
 		is-default = true
 		saved-params = "icon-size"
+		zoom-mode = "distort"
 		style = ".center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .clown { color: #FF69Bf;} .tajaran {color: #803B56;} .skrell {color: #00CED1;} .solcom {color: #22228B;} .com_srus {color: #7c4848;} .zombie\t{color: #ff0000;} .soghun {color: #228B22;} .vox {color: #AA00AA;} .diona {color: #804000; font-weight: bold;} .trinary {color: #727272;} .kidan {color: #664205;} .slime {color: #0077AA;} .drask {color: #a3d4eb;} .vulpkanin {color: #B97A57;} .abductor {color: #800080; font-style: italic;} .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; }"
 		on-show = ".winset \"menu.statusbar.is-checked=true?mapwindow.status_bar.is-visible=true:mapwindow.status_bar.is-visible=false\""
 	elem "status_bar"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Toggles nearest neighbour or "distort" to be the default scaling option for Paradise as it was before byond version 511.

This is technically a very **_very_** light port of https://github.com/tgstation/tgstation/pull/23201 really only borrowing one line of code from this refractor but credit where credit is due.

## Why It's Good For The Game
Did you know that before byond version 511 nearest neighbour was the default scaling option for all byond games? byond 511 forced all byond games to use point sampling by default making everything look very blurry.

That means for the past 5 years we've been using the wrong scaling option on Paradise.

I noticed this around 2017 and even mhelped at the time asking why everything looked so blurry all of a sudden only to be met with a confused answer. It was only until later I realized you can make everything less blurry by selecting nearest neighbour as a scaling option. It was only until very recently I found out byond 511 is what caused everything to be blurry by forcing all byond games to use point sampling.


You might ask, why switch back to using nearest neighbour as the default scaling option?

Well, Space Station 13 primarily uses 32x32 sized sprites meaning that point sampling is sub-optimal for our smaller less detailed sprites. Yes, point sampling can work well with the bigger-sized sprites that are more commonly seen on other byond games but SS13's sprites weren't made with point sampling in mind and it shows with how blurry point sampling looks.

~~plus lummox jr didn't pr this change I am just reverting it!!!~~

Point sampling is of course still in the game and can be selected, it's just not the default anymore.

## Images of changes
I am not going to bother posting images since you can already toggle between the two scaling options. Just go in-game and select in the top left drop down
icons>scaling>nearest neighbour

## Changelog
:cl: Bmon, MrStonedOne
tweak: Nearest neighbour is now the default scaling option again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
