### PR TITLE
Code cleanup for antag datum adding/removing procs + fixes a runtime

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -76,12 +76,7 @@
 
 /datum/mind/Destroy()
 	SSticker.minds -= src
-	if(islist(antag_datums))
-		for(var/i in antag_datums)
-			var/datum/antagonist/antag_datum = i
-			if(antag_datum.delete_on_mind_deletion)
-				qdel(i)
-		antag_datums = null
+	QDEL_LIST(antag_datums)
 	current = null
 	return ..()
 
@@ -1483,8 +1478,6 @@
  * * datum/team/team - the antag team that the src mind should join, if any
  */
 /datum/mind/proc/add_antag_datum(datum_type_or_instance, datum/team/team = null)
-	if(!datum_type_or_instance)
-		return
 	var/datum/antagonist/A
 	if(!ispath(datum_type_or_instance))
 		A = datum_type_or_instance
@@ -1512,18 +1505,15 @@
  * * datum_type - an antag datum typepath
  */
 /datum/mind/proc/remove_antag_datum(datum_type)
-	if(!datum_type)
-		return
 	var/datum/antagonist/A = has_antag_datum(datum_type)
+	LAZYREMOVE(antag_datums, A)
 	qdel(A)
 
 /**
  * Removes all antag datums from the src mind.
  */
 /datum/mind/proc/remove_all_antag_datums() //For the Lazy amongst us.
-	for(var/a in antag_datums)
-		var/datum/antagonist/A = a
-		qdel(A)
+	QDEL_LIST(antag_datums)
 
 /**
  * Returns an antag datum instance if the src mind has the specified `datum_type`. Returns `null` otherwise.
@@ -1533,10 +1523,7 @@
  * * check_subtypes - TRUE if this proc will consider subtypes of `datum_type` as valid. FALSE if only the exact same type should be considered.
  */
 /datum/mind/proc/has_antag_datum(datum_type, check_subtypes = TRUE)
-	if(!datum_type)
-		return
-	for(var/a in antag_datums)
-		var/datum/antagonist/A = a
+	for(var/datum/antagonist/A as anything in antag_datums)
 		if(check_subtypes && istype(A, datum_type))
 			return A
 		else if(A.type == datum_type)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -13,8 +13,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/silent = FALSE
 	/// List of other antag datum types that this type can't coexist with.
 	var/list/antag_datum_blacklist
-	/// Should this datum be deleted when the owner's mind is deleted.
-	var/delete_on_mind_deletion = TRUE
 	/// Used to determine if the player jobbanned from this role. Things like `SPECIAL_ROLE_TRAITOR` should go here to determine the role.
 	var/job_rank
 	/// Should we replace the role-banned player with a ghost?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fairly sure the issue below is due to me adding the `remove_all_antag_datums()` call when someone leaves the round via cryo. That proc deletes all antag datums but doesn't remove it from the mind's `antag_datums` list. Likewise, `remove_antag_datum()` didn't remove the deleted datum from that list either, so I fixed that too.

Additionally, I removed the
```dm
if(!datum_type_or_instance)
    return
```
and similar checks from the add/remove antag datum procs. If someone is silly enough to call these without passing an antag datum type, it should runtime. Also removed the `delete_on_mind_deletion` var, because I don't see a situation where we would ever set this false.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #18046

I'm like 99% sure this is the cause of that bug, but if it turns out that it still exists after this fix, then that issue can be re-opened.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
