### PR TITLE
Prevent fishtank from being fished in more than once at the same time

### DIFF
--- a/code/modules/fish/fishtank.dm
+++ b/code/modules/fish/fishtank.dm
@@ -344,9 +344,9 @@
 		var/count = length(fish_types[key])
 		fish_types_input += list("[initial(fish_type.fish_name)][count > 1 ? " (x[count])" : ""]" = fish_types[key])
 	var/caught_fish = input("Select a fish to catch.", "Fishing") as null|anything in fish_types_input		//Select a fish from the tank
+	current_fisher = null
 	if(fish_count <= 0)
 		to_chat(user, "There are no fish in [src] to catch!")
-		current_fisher = null
 		return
 	else if(caught_fish)
 		var/list/fishes_of_type = fish_types_input[caught_fish]
@@ -366,7 +366,6 @@
 				fish_bag.handle_item_insertion(I)
 		user.visible_message("[user.name] scoops \a [fish_name] from [src].", "You scoop \a [fish_name] out of [src].")
 		kill_fish(fish_to_scoop)						//Kill the caught fish from the tank
-		current_fisher = null
 
 /obj/machinery/fishtank/proc/spill_water()
 	var/turf/simulated/T = get_turf(src)

--- a/code/modules/fish/fishtank.dm
+++ b/code/modules/fish/fishtank.dm
@@ -30,6 +30,8 @@
 	var/leaking = FALSE			// 0 if not leaking, 1 if minor leak, 2 if major leak (not leaking by default)
 	var/shard_count = 0			// Number of glass shards to salvage when broken (1 less than the number of sheets to build the tank)
 
+	var/mob/current_fisher = null // Only one person can fish in the tank at a time
+
 /obj/machinery/fishtank/bowl
 	name = "fish bowl"
 	desc = "A small bowl capable of housing a single fish, commonly found on desks. This one has a tiny treasure chest in it!"
@@ -326,6 +328,13 @@
 	if(fish_count <= 0)									//Can't catch non-existant fish!
 		to_chat(user, "There are no fish in [src] to catch!")
 		return
+	if(current_fisher)
+		if(current_fisher == user)
+			to_chat(user, "You are already fishing in [src]!")
+		else
+			to_chat(user, "[current_fisher.name] is already trying to fish in [src].")
+		return
+	current_fisher = user
 	var/list/fish_types = list()
 	var/list/fish_types_input = list()
 	for(var/datum/fish/F in fish_list) // Group up the fish first
@@ -337,6 +346,7 @@
 	var/caught_fish = input("Select a fish to catch.", "Fishing") as null|anything in fish_types_input		//Select a fish from the tank
 	if(fish_count <= 0)
 		to_chat(user, "There are no fish in [src] to catch!")
+		current_fisher = null
 		return
 	else if(caught_fish)
 		var/list/fishes_of_type = fish_types_input[caught_fish]
@@ -356,6 +366,7 @@
 				fish_bag.handle_item_insertion(I)
 		user.visible_message("[user.name] scoops \a [fish_name] from [src].", "You scoop \a [fish_name] out of [src].")
 		kill_fish(fish_to_scoop)						//Kill the caught fish from the tank
+		current_fisher = null
 
 /obj/machinery/fishtank/proc/spill_water()
 	var/turf/simulated/T = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #17196
Anytime someone fishes out a fish, the fishtank locks itself to being fished by anyone else (or even the same person), until the original person finishes getting a fish out (or failing).
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes a dupe bug.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Stop duplication of fish in fish tank by preventing fishing multiple times at once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
