### PR TITLE
Stop slipping in closets

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -22,6 +22,8 @@
 
 #define isclothing(A) (istype(A, /obj/item/clothing))
 
+#define iscloset(A) (istype(A, /obj/structure/closet))
+
 #define is_pen(W) (istype(W, /obj/item/pen))
 
 GLOBAL_LIST_INIT(pointed_types, typecacheof(list(

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -22,8 +22,6 @@
 
 #define isclothing(A) (istype(A, /obj/item/clothing))
 
-#define iscloset(A) (istype(A, /obj/structure/closet))
-
 #define is_pen(W) (istype(W, /obj/item/pen))
 
 GLOBAL_LIST_INIT(pointed_types, typecacheof(list(

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -50,7 +50,7 @@
 /datum/component/slippery/proc/Slip(datum/source, mob/living/carbon/human/victim)
 	if(istype(victim) && !victim.flying)
 		var/atom/movable/owner = parent
-		if(iscloset(owner.loc))
+		if(!isturf(owner.loc))
 			return
 		if(prob(slip_chance) && victim.slip(description, knockdown, slip_tiles, walking_is_safe, slip_always, slip_verb))
 			owner.after_slip(victim)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -50,8 +50,7 @@
 /datum/component/slippery/proc/Slip(datum/source, mob/living/carbon/human/victim)
 	if(istype(victim) && !victim.flying)
 		var/atom/movable/owner = parent
-		if(owner && iscloset(owner.loc))
+		if(iscloset(owner.loc))
 			return
 		if(prob(slip_chance) && victim.slip(description, knockdown, slip_tiles, walking_is_safe, slip_always, slip_verb))
-			if(owner)
-				owner.after_slip(victim)
+			owner.after_slip(victim)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -48,6 +48,10 @@
 	Additionally calls the parent's `after_slip()` proc on the `victim`.
 */
 /datum/component/slippery/proc/Slip(datum/source, mob/living/carbon/human/victim)
-	if(istype(victim) && !victim.flying && prob(slip_chance) && victim.slip(description, knockdown, slip_tiles, walking_is_safe, slip_always, slip_verb))
+	if(istype(victim) && !victim.flying)
 		var/atom/movable/owner = parent
-		owner.after_slip(victim)
+		if(owner && iscloset(owner.loc))
+			return
+		if(prob(slip_chance) && victim.slip(description, knockdown, slip_tiles, walking_is_safe, slip_always, slip_verb))
+			if(owner)
+				owner.after_slip(victim)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #17155
So the problem was, when a Bluespace tomato and a player on an open box, and the box is closed, the following happens
* The tomato is put into the box
* The player is put into the box
  * The player is force moved into the box
  * The game checks to see if theres anything on the new turf (inside the box) for the player to slip on and finds the tomato
    * The player is force moved through the teleport
    * The game updates the player's view to where they've been teleported to
  * The game updates the player's view to the inside of the box
* Player is confused

Interupting a move to do a move before the original move has finished seems dangerous, but there wasn't any obvious way to stop this... so for now I just made it so you can't slip on things inside of closets.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: No longer slip on things inside a closet when the closet is closed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
