### PR TITLE
Adds more verbose logging when a signal type is overriden

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -188,7 +188,8 @@
 	var/list/sig_types = islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)
 	for(var/sig_type in sig_types)
 		if(!override && procs[target][sig_type])
-			stack_trace("[sig_type] overridden. Use override = TRUE to suppress this warning")
+			stack_trace("RegisterSignal overrode a signal without having 'override = TRUE' set.\n \
+						src: [src], signal type: [sig_type], target: [target], proc: [proctype].")
 
 		procs[target][sig_type] = proctype
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The current logging for this is just awful. all it says is `[sig_type] overridden.`. This should provide a bit more information to debug these sort of runtimes.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
