### PR TITLE
Initialize hostile mobs

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -69,11 +69,11 @@
 		return 1
 	return ..()
 
-/mob/living/simple_animal/hostile/blob/blobspore/New(loc, obj/structure/blob/factory/linked_node)
+/mob/living/simple_animal/hostile/blob/blobspore/Initialize(mapload, obj/structure/blob/factory/linked_node)
+	. = ..()
 	if(istype(linked_node))
 		factory = linked_node
 		factory.spores += src
-	..()
 
 /mob/living/simple_animal/hostile/blob/blobspore/Life(seconds, times_fired)
 
@@ -200,8 +200,8 @@
 			adjustFireLoss(0.2)
 	..()
 
-/mob/living/simple_animal/hostile/blob/blobbernaut/New()
-	..()
+/mob/living/simple_animal/hostile/blob/blobbernaut/Initialize(mapload)
+	. = ..()
 	if(name == "blobbernaut")
 		name = text("blobbernaut ([rand(1, 1000)])")
 

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -114,8 +114,8 @@
 	to_chat(src, "3. Biological and sentient resources will be harvested at a later date, do not harm them.")
 	to_chat(src, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Swarmer)</span>")
 
-/mob/living/simple_animal/hostile/swarmer/New()
-	..()
+/mob/living/simple_animal/hostile/swarmer/Initialize(mapload)
+	. = ..()
 	add_language("Swarmer", 1)
 	verbs -= /mob/living/verb/pulled
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)

--- a/code/game/gamemodes/miniantags/guardian/types/healer.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/healer.dm
@@ -29,8 +29,9 @@
 	melee_damage_type = STAMINA
 	admin_spawned = TRUE
 
-/mob/living/simple_animal/hostile/guardian/healer/New()
-	..()
+/mob/living/simple_animal/hostile/guardian/healer/Destroy()
+	beacon = null
+	return ..()
 
 /mob/living/simple_animal/hostile/guardian/healer/Life(seconds, times_fired)
 	..()

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -76,7 +76,7 @@
 	real_name = "magical morph"
 	desc = "A revolting, pulsating pile of flesh. This one looks somewhat.. magical."
 
-/mob/living/simple_animal/hostile/morph/wizard/New()
+/mob/living/simple_animal/hostile/morph/wizard/Initialize(mapload)
 	. = ..()
 	AddSpell(new /obj/effect/proc_holder/spell/smoke)
 	AddSpell(new /obj/effect/proc_holder/spell/forcewall)

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -274,8 +274,8 @@
 	stop_automated_movement = TRUE
 	var/heal_power = 5
 
-/mob/living/simple_animal/hostile/lightgeist/New()
-	..()
+/mob/living/simple_animal/hostile/lightgeist/Initialize(mapload)
+	. = ..()
 	verbs -= /mob/living/verb/pulled
 	verbs -= /mob/verb/me_verb
 	var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -50,7 +50,7 @@
 		/datum/action/innate/minedrone/toggle_mode,
 		/datum/action/innate/minedrone/dump_ore,
 	))
-		var/datum/action/act = new action_path()
+		var/datum/action/act = new action_path
 		act.Grant(src)
 
 	SetCollectBehavior()

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -44,12 +44,13 @@
 /mob/living/simple_animal/hostile/mining_drone/Initialize(mapload)
 	. = ..()
 	stored_gun = new(src)
-	for(var/action_path in list(
+	var/static/list/action_paths = list(
 		/datum/action/innate/minedrone/toggle_light,
 		/datum/action/innate/minedrone/toggle_meson_vision,
 		/datum/action/innate/minedrone/toggle_mode,
 		/datum/action/innate/minedrone/dump_ore,
-	))
+	)
+	for(var/action_path in action_paths)
 		var/datum/action/act = new action_path
 		act.Grant(src)
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -40,22 +40,18 @@
 	var/mesons_active
 	var/obj/item/gun/energy/kinetic_accelerator/minebot/stored_gun
 
-	var/datum/action/innate/minedrone/toggle_light/toggle_light_action
-	var/datum/action/innate/minedrone/toggle_meson_vision/toggle_meson_vision_action
-	var/datum/action/innate/minedrone/toggle_mode/toggle_mode_action
-	var/datum/action/innate/minedrone/dump_ore/dump_ore_action
 
-/mob/living/simple_animal/hostile/mining_drone/New()
-	..()
+/mob/living/simple_animal/hostile/mining_drone/Initialize(mapload)
+	. = ..()
 	stored_gun = new(src)
-	toggle_light_action = new()
-	toggle_light_action.Grant(src)
-	toggle_meson_vision_action = new()
-	toggle_meson_vision_action.Grant(src)
-	toggle_mode_action = new()
-	toggle_mode_action.Grant(src)
-	dump_ore_action = new()
-	dump_ore_action.Grant(src)
+	for(var/action_path in list(
+		/datum/action/innate/minedrone/toggle_light,
+		/datum/action/innate/minedrone/toggle_meson_vision,
+		/datum/action/innate/minedrone/toggle_mode,
+		/datum/action/innate/minedrone/dump_ore,
+	))
+		var/datum/action/act = new action_path()
+		act.Grant(src)
 
 	SetCollectBehavior()
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -32,7 +32,7 @@
 	/// Message to send to the construct when they are created, containing information about their role.
 	var/playstyle_string = "<b>You are a generic construct! Your job is to not exist, and you should probably adminhelp this.</b>"
 
-/mob/living/simple_animal/hostile/construct/New()
+/mob/living/simple_animal/hostile/construct/Initialize(mapload)
 	. = ..()
 	if(!SSticker.mode)//work around for maps with runes and cultdat is not loaded all the way
 		name = "[construct_type] ([rand(1, 1000)])"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -32,9 +32,9 @@
 	gender = FEMALE
 	footstep_type = FOOTSTEP_MOB_SHOE
 
-/mob/living/simple_animal/hostile/retaliate/goat/New()
-	udder = new()
+/mob/living/simple_animal/hostile/retaliate/goat/Initialize(mapload)
 	. = ..()
+	udder = new()
 
 /mob/living/simple_animal/hostile/retaliate/goat/Destroy()
 	QDEL_NULL(udder)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -41,8 +41,8 @@
 	name = "Hudson"
 	desc = "Feared outlaw, this guy is one bad news bear." //I'm sorry...
 
-/mob/living/simple_animal/hostile/bear/Hudson/New()
-	..()
+/mob/living/simple_animal/hostile/bear/Hudson/Initialize(mapload)
+	. = ..()
 	var/unbearable_pun = pick("He's unbearably cute.", "It looks like he is a bearer of bad news.", "Sadly, he is bearly able to comprehend puns.")
 	desc = "That's Hudson. " +  unbearable_pun// I am not sorry for this.
 

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -60,7 +60,7 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/poison/bees/ComponentInitialize()
-	. = ..()
+	..()
 	AddComponent(/datum/component/swarming)
 
 /mob/living/simple_animal/hostile/poison/bees/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -59,10 +59,13 @@
 /mob/living/simple_animal/hostile/poison/bees/Process_Spacemove(movement_dir = 0)
 	return TRUE
 
-/mob/living/simple_animal/hostile/poison/bees/New()
-	..()
-	generate_bee_visuals()
+/mob/living/simple_animal/hostile/poison/bees/ComponentInitialize()
+	. = ..()
 	AddComponent(/datum/component/swarming)
+
+/mob/living/simple_animal/hostile/poison/bees/Initialize(mapload)
+	. = ..()
+	generate_bee_visuals()
 
 /mob/living/simple_animal/hostile/poison/bees/Destroy()
 	beegent = null
@@ -346,9 +349,9 @@
 	var/list/master_and_friends = list()
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
-/mob/living/simple_animal/hostile/poison/bees/syndi/New()
+/mob/living/simple_animal/hostile/poison/bees/syndi/Initialize(mapload)
+	. = ..()
 	beegent = GLOB.chemical_reagents_list["facid"] //Prepare to die
-	..()
 
 /mob/living/simple_animal/hostile/poison/bees/syndi/Destroy()
 	master_and_friends.Cut()

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -44,7 +44,7 @@
 	var/admincluwne = FALSE
 
 
-/mob/living/simple_animal/hostile/floor_cluwne/New()
+/mob/living/simple_animal/hostile/floor_cluwne/Initialize(mapload)
 	. = ..()
 	remove_from_all_data_huds()
 	var/obj/item/card/id/access_card = new (src)
@@ -59,8 +59,8 @@
 			return
 		Acquire_Victim()
 
-
 /mob/living/simple_animal/hostile/floor_cluwne/Destroy()
+	current_victim = null
 	return ..()
 
 

--- a/code/modules/mob/living/simple_animal/hostile/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hellhound.dm
@@ -37,7 +37,7 @@
 
 /mob/living/simple_animal/hostile/hellhound/Initialize(mapload)
 	. = ..()
-	var/datum/action/whisper_action = new /datum/action/innate/demon/whisper()
+	var/datum/action/innate/demon/whisper/whisper_action = new
 	whisper_action.Grant(src)
 	ADD_TRAIT(src, TRAIT_NOBREATH, SPECIES_TRAIT)
 

--- a/code/modules/mob/living/simple_animal/hostile/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hellhound.dm
@@ -33,12 +33,11 @@
 	var/life_regen_amount = -10 // negative, because negative = healing
 	var/smoke_lastuse = 0
 	var/smoke_freq = 300 // 30 seconds
-	var/datum/action/innate/demon/whisper/whisper_action
 	footstep_type = FOOTSTEP_MOB_CLAW
 
-/mob/living/simple_animal/hostile/hellhound/New()
+/mob/living/simple_animal/hostile/hellhound/Initialize(mapload)
 	. = ..()
-	whisper_action = new()
+	var/datum/action/whisper_action = new /datum/action/innate/demon/whisper()
 	whisper_action.Grant(src)
 	ADD_TRAIT(src, TRAIT_NOBREATH, SPECIES_TRAIT)
 
@@ -116,7 +115,7 @@
 	melee_damage_upper = 30
 	environment_smash = 2
 
-/mob/living/simple_animal/hostile/hellhound/greater/New()
+/mob/living/simple_animal/hostile/hellhound/greater/Initialize(mapload)
 	. = ..()
 	// Movement
 	AddSpell(new /obj/effect/proc_holder/spell/ethereal_jaunt/shift)

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -72,8 +72,8 @@
 	var/bot_amt = 10
 	var/spawn_delay = 600
 
-/mob/living/simple_animal/hostile/hivebot/tele/New()
-	..()
+/mob/living/simple_animal/hostile/hivebot/tele/Initialize(mapload)
+	. = ..()
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(5, 0, src.loc)
 	smoke.start()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -108,15 +108,19 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 /mob/living/simple_animal/hostile/mimic/copy
 	health = 100
 	maxHealth = 100
+	gold_core_spawnable = NO_SPAWN
 	var/mob/living/creator = null // the creator
 	var/destroy_objects = 0
 	var/knockdown_people = 0
 	var/image/googly_eyes = null
-	gold_core_spawnable = NO_SPAWN
 
-/mob/living/simple_animal/hostile/mimic/copy/New(loc, obj/copy, mob/living/creator, destroy_original = 0)
-	..(loc)
+/mob/living/simple_animal/hostile/mimic/copy/Initialize(mapload, obj/copy, mob/living/creator, destroy_original = 0)
+	. = ..()
 	CopyObject(copy, creator, destroy_original)
+
+/mob/living/simple_animal/hostile/mimic/copy/Destroy()
+	creator = null
+	return ..()
 
 /mob/living/simple_animal/hostile/mimic/copy/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -48,7 +48,8 @@
 	if(!stat)//Mushrooms slowly regenerate if conscious, for people who want to save them from being eaten
 		adjustBruteLoss(-2)
 
-/mob/living/simple_animal/hostile/mushroom/New()//Makes every shroom a little unique
+/mob/living/simple_animal/hostile/mushroom/Initialize(mapload)  //Makes every shroom a little unique
+	. = ..()
 	melee_damage_lower += rand(3, 5)
 	melee_damage_upper += rand(10,20)
 	maxHealth += rand(40,60)
@@ -60,7 +61,6 @@
 	cap_dead.color = cap_color
 	UpdateMushroomCap()
 	health = maxHealth
-	..()
 
 /mob/living/simple_animal/hostile/mushroom/CanAttack(atom/the_target) // Mushroom-specific version of CanAttack to handle stupid attack_same = 2 crap so we don't have to do it for literally every single simple_animal/hostile because this shit never gets spawned
 	if(!the_target || isturf(the_target) || istype(the_target, /atom/movable/lighting_object))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/kangaroo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/kangaroo.dm
@@ -25,7 +25,7 @@
 	var/attack_cycles_max = 3
 	footstep_type = FOOTSTEP_MOB_SHOE
 
-/mob/living/simple_animal/hostile/retaliate/kangaroo/New()
+/mob/living/simple_animal/hostile/retaliate/kangaroo/Initialize(mapload)
 	. = ..()
 	// Leap spell, player-only usage
 	AddSpell(new /obj/effect/proc_holder/spell/leap)

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -53,8 +53,8 @@
 
 // No movement while seen code.
 
-/mob/living/simple_animal/hostile/statue/New(loc, mob/living/creator)
-	..()
+/mob/living/simple_animal/hostile/statue/Initialize(mapload, mob/living/creator)
+	. = ..()
 	// Give spells
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(null))
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/blindness(null))
@@ -63,6 +63,10 @@
 	// Set creator
 	if(creator)
 		src.creator = creator
+
+/mob/living/simple_animal/hostile/statue/Destroy()
+	creator = null
+	return ..()
 
 /mob/living/simple_animal/hostile/statue/Move(turf/NewLoc)
 	if(can_be_seen(NewLoc))

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/brown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/brown.dm
@@ -30,5 +30,5 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/brown/Initialize(mapload)
 	. = ..()
-	var/datum/action/act = new /datum/action/innate/terrorspider/ventsmash()
+	var/datum/action/innate/terrorspider/ventsmash/act = new
 	act.Grant(src)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/brown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/brown.dm
@@ -27,9 +27,8 @@
 	freq_ventcrawl_combat = 600 // Ventcrawls very frequently, breaking open vents as it goes.
 	freq_ventcrawl_idle =  1800
 	web_type = null
-	var/datum/action/innate/terrorspider/ventsmash/ventsmash_action
 
-/mob/living/simple_animal/hostile/poison/terror_spider/brown/New()
-	..()
-	ventsmash_action = new()
-	ventsmash_action.Grant(src)
+/mob/living/simple_animal/hostile/poison/terror_spider/brown/Initialize(mapload)
+	. = ..()
+	var/datum/action/act = new /datum/action/innate/terrorspider/ventsmash()
+	act.Grant(src)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -32,9 +32,9 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/empress/Initialize(mapload)
 	. = ..()
-	var/datum/action/act_ling = new /datum/action/innate/terrorspider/queen/empress/empresslings()
+	var/datum/action/innate/terrorspider/queen/empress/empresslings/act_ling = new
 	act_ling.Grant(src)
-	var/datum/action/act_erase = new /datum/action/innate/terrorspider/queen/empress/empresserase()
+	var/datum/action/innate/terrorspider/queen/empress/empresserase/act_erase = new
 	act_erase.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/empress/spider_special_action()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -28,16 +28,14 @@
 	icon_state = "terror_empress"
 	icon_living = "terror_empress"
 	icon_dead = "terror_empress_dead"
-	var/datum/action/innate/terrorspider/queen/empress/empresslings/empresslings_action
-	var/datum/action/innate/terrorspider/queen/empress/empresserase/empresserase_action
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 
-/mob/living/simple_animal/hostile/poison/terror_spider/queen/empress/New()
-	..()
-	empresslings_action = new()
-	empresslings_action.Grant(src)
-	empresserase_action = new()
-	empresserase_action.Grant(src)
+/mob/living/simple_animal/hostile/poison/terror_spider/queen/empress/Initialize(mapload)
+	. = ..()
+	var/datum/action/act_ling = new /datum/action/innate/terrorspider/queen/empress/empresslings()
+	act_ling.Grant(src)
+	var/datum/action/act_erase = new /datum/action/innate/terrorspider/queen/empress/empresserase()
+	act_erase.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/empress/spider_special_action()
 	return

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
@@ -22,13 +22,12 @@
 	melee_damage_upper = 20
 	web_type = /obj/structure/spider/terrorweb/green
 	var/feedings_to_lay = 2
-	var/datum/action/innate/terrorspider/greeneggs/greeneggs_action
 
 
-/mob/living/simple_animal/hostile/poison/terror_spider/green/New()
-	..()
-	greeneggs_action = new()
-	greeneggs_action.Grant(src)
+/mob/living/simple_animal/hostile/poison/terror_spider/green/Initialize(mapload)
+	. = ..()
+	var/datum/action/act = new /datum/action/innate/terrorspider/greeneggs()
+	act.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/green/proc/DoLayGreenEggs()
 	var/obj/structure/spider/eggcluster/E = locate() in get_turf(src)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
@@ -26,7 +26,7 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/green/Initialize(mapload)
 	. = ..()
-	var/datum/action/act = new /datum/action/innate/terrorspider/greeneggs()
+	var/datum/action/innate/terrorspider/greeneggs/act = new
 	act.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/green/proc/DoLayGreenEggs()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -34,13 +34,14 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/mother/Initialize(mapload)
 	. = ..()
-	for(var/action_path in list(
+	var/static/list/action_paths = list(
 		/datum/action/innate/terrorspider/ventsmash,
 		/datum/action/innate/terrorspider/remoteview,
 		/datum/action/innate/terrorspider/mother/royaljelly,
 		/datum/action/innate/terrorspider/mother/gatherspiderlings,
 		/datum/action/innate/terrorspider/mother/incubateeggs,
-	))
+	)
+	for(var/action_path in action_paths)
 		var/datum/action/act = new action_path
 		act.Grant(src)
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -28,26 +28,21 @@
 	loudspeaker = TRUE
 	spider_opens_doors = 2
 	web_type = /obj/structure/spider/terrorweb/mother
-	var/datum/action/innate/terrorspider/ventsmash/ventsmash_action
-	var/datum/action/innate/terrorspider/remoteview/remoteview_action
-	var/datum/action/innate/terrorspider/mother/royaljelly/royaljelly_action
-	var/datum/action/innate/terrorspider/mother/gatherspiderlings/gatherspiderlings_action
-	var/datum/action/innate/terrorspider/mother/incubateeggs/incubateeggs_action
+
 	var/jelly_cost = 100
 
 
-/mob/living/simple_animal/hostile/poison/terror_spider/mother/New()
-	..()
-	ventsmash_action = new()
-	ventsmash_action.Grant(src)
-	remoteview_action = new()
-	remoteview_action.Grant(src)
-	royaljelly_action = new()
-	royaljelly_action.Grant(src)
-	gatherspiderlings_action = new()
-	gatherspiderlings_action.Grant(src)
-	incubateeggs_action = new()
-	incubateeggs_action.Grant(src)
+/mob/living/simple_animal/hostile/poison/terror_spider/mother/Initialize(mapload)
+	. = ..()
+	for(var/action_path in list(
+		/datum/action/innate/terrorspider/ventsmash,
+		/datum/action/innate/terrorspider/remoteview,
+		/datum/action/innate/terrorspider/mother/royaljelly,
+		/datum/action/innate/terrorspider/mother/gatherspiderlings,
+		/datum/action/innate/terrorspider/mother/incubateeggs,
+	))
+		var/datum/action/act = new action_path()
+		act.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/mother/death(gibbed)
 	DropSpiderlings()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -41,7 +41,7 @@
 		/datum/action/innate/terrorspider/mother/gatherspiderlings,
 		/datum/action/innate/terrorspider/mother/incubateeggs,
 	))
-		var/datum/action/act = new action_path()
+		var/datum/action/act = new action_path
 		act.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/mother/death(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -54,9 +54,9 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/Initialize(mapload)
 	. = ..()
-	var/datum/action/ventsmash_action = new /datum/action/innate/terrorspider/ventsmash/()
+	var/datum/action/innate/terrorspider/ventsmash/ventsmash_action = new
 	ventsmash_action.Grant(src)
-	var/datum/action/remoteview_action = new /datum/action/innate/terrorspider/remoteview()
+	var/datum/action/innate/terrorspider/remoteview/remoteview_action = new
 	remoteview_action.Grant(src)
 	grant_queen_subtype_abilities()
 	spider_myqueen = src

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -50,15 +50,13 @@
 	var/datum/action/innate/terrorspider/queen/queennest/queennest_action
 	var/datum/action/innate/terrorspider/queen/queensense/queensense_action
 	var/datum/action/innate/terrorspider/queen/queeneggs/queeneggs_action
-	var/datum/action/innate/terrorspider/ventsmash/ventsmash_action
-	var/datum/action/innate/terrorspider/remoteview/remoteview_action
 
 
-/mob/living/simple_animal/hostile/poison/terror_spider/queen/New()
-	..()
-	ventsmash_action = new()
+/mob/living/simple_animal/hostile/poison/terror_spider/queen/Initialize(mapload)
+	. = ..()
+	var/datum/action/ventsmash_action = new /datum/action/innate/terrorspider/ventsmash/()
 	ventsmash_action.Grant(src)
-	remoteview_action = new()
+	var/datum/action/remoteview_action = new /datum/action/innate/terrorspider/remoteview()
 	remoteview_action.Grant(src)
 	grant_queen_subtype_abilities()
 	spider_myqueen = src

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -269,11 +269,11 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	default_language = GLOB.all_languages["Spider Hivemind"]
 
 	if(web_type)
-		var/datum/action/web_act = new /datum/action/innate/terrorspider/web()
+		var/datum/action/innate/terrorspider/web/web_act = new
 		web_act.Grant(src)
 	if(regen_points_per_tick < regen_points_per_hp)
 		// Only grant the Wrap action button to spiders who need to use it to regenerate their health
-		var/datum/action/wrap_act = new /datum/action/innate/terrorspider/wrap()
+		var/datum/action/innate/terrorspider/wrap/wrap_act = new
 		wrap_act.Grant(src)
 	name += " ([rand(1, 1000)])"
 	real_name = name

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -149,9 +149,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	var/chasecycles = 0
 	var/spider_creation_time = 0
 
-	var/datum/action/innate/terrorspider/web/web_action
 	var/web_type = /obj/structure/spider/terrorweb
-	var/datum/action/innate/terrorspider/wrap/wrap_action
 
 	// Breathing - require some oxygen, and no toxins
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
@@ -262,8 +260,8 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 		if(killcount >= 1)
 			. += "<span class='warning'>[p_they(TRUE)] has blood dribbling from [p_their()] mouth.</span>"
 
-/mob/living/simple_animal/hostile/poison/terror_spider/New()
-	..()
+/mob/living/simple_animal/hostile/poison/terror_spider/Initialize(mapload)
+	. = ..()
 	GLOB.ts_spiderlist += src
 	add_language("Spider Hivemind")
 	if(spider_tier >= TS_TIER_2)
@@ -271,12 +269,12 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	default_language = GLOB.all_languages["Spider Hivemind"]
 
 	if(web_type)
-		web_action = new()
-		web_action.Grant(src)
+		var/datum/action/web_act = new /datum/action/innate/terrorspider/web()
+		web_act.Grant(src)
 	if(regen_points_per_tick < regen_points_per_hp)
 		// Only grant the Wrap action button to spiders who need to use it to regenerate their health
-		wrap_action = new()
-		wrap_action.Grant(src)
+		var/datum/action/wrap_act = new /datum/action/innate/terrorspider/wrap()
+		wrap_act.Grant(src)
 	name += " ([rand(1, 1000)])"
 	real_name = name
 	msg_terrorspiders("[src] has grown in [get_area(src)].")
@@ -316,6 +314,15 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	var/datum/atom_hud/U = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 	U.remove_hud_from(src)
 	handle_dying()
+
+	spider_mymother = null
+	spider_myqueen = null
+
+	entry_vent = null
+	exit_vent = null
+	nest_vent = null
+
+	cocoon_target = null
 	return ..()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/Life(seconds, times_fired)


### PR DESCRIPTION
## What Does This PR Do
`/mob/living/simple_animal/hostile` and its children are `/Initialize` now.
.. except for `/mob/living/simple_animal/hostile/spaceWorm` because.. reasons

Lightly tested; seems to work fine.
Action buttons definitely work, and GC is reasonably happy.

## Why It's Good For The Game
Good practice

## Changelog
N/A