### PR TITLE
Allows Library Computer & Bookbinder to be wrenchable again

### DIFF
--- a/code/modules/library/library_computer.dm
+++ b/code/modules/library/library_computer.dm
@@ -97,6 +97,10 @@
 			user_data.patron_account = null
 			to_chat(user, "<span class='notice'>[src]'s screen flashes: 'WARNING! Patron without associated account number Selected'</span>")
 		return
+
+	if(default_unfasten_wrench(user, O, time = 60))
+		return
+
 	return ..()
 
 /obj/machinery/computer/library/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = TRUE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)

--- a/code/modules/library/library_equipment.dm
+++ b/code/modules/library/library_equipment.dm
@@ -166,10 +166,6 @@
 /obj/machinery/bookbinder/attack_ghost(mob/user)
 	ui_interact(user)
 
-/obj/machinery/bookbinder/wrench_act(mob/living/user, obj/item/I)
-	. = ..()
-	if(default_unfasten_wrench(user, I))
-		power_change()
 
 /obj/machinery/bookbinder/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/paper))
@@ -178,8 +174,10 @@
 		select_paper_stack(I)
 	if(istype(I, /obj/item/book))
 		select_book(I)
-	else
-		return ..()
+	if(default_unfasten_wrench(user, I, time = 60))
+		return
+
+	return ..()
 
 /obj/machinery/bookbinder/proc/select_paper(obj/item/paper/P)
 	selected_content.title = P.name


### PR DESCRIPTION
## What Does This PR Do
Allows Library Computer & Bookbinder to be wrenchable again. Here's to me praying that I wouldn't break thing with my overhaul, currently only up to one bug now.
Fixes #18323
## Changelog
:cl:
fix: Library Computer & Bookbinder are now wrenchable again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
