### PR TITLE
Fixes a runtime in the Shuttle Manipulator

### DIFF
--- a/code/modules/shuttle/shuttle_manipulator.dm
+++ b/code/modules/shuttle/shuttle_manipulator.dm
@@ -105,6 +105,8 @@
 	data["shuttles"] = list()
 	for(var/i in SSshuttle.mobile)
 		var/obj/docking_port/mobile/M = i
+		if(!M)
+			continue
 		var/list/L = list()
 		L["name"] = M.name
 		L["id"] = M.id


### PR DESCRIPTION
## What Does This PR Do
When loading a new template for a shuttle, the mobile port list in SSshuttles has a null entry (likely due to the previous shuttle being deleted) and there were not checks in place to ensure that what we had wasn't actually null when creating a list of data from that port for the TGUI. This should fix it (I ran the game 3 times and had no runtime).

Not a player-facing change, so no changelog
