### PR TITLE
Changes ranged guardian damage from 25 damage to 20. Also slightly adjusts damage transfer

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/guardian
 	name = "crystal spray"
 	icon_state = "guardian"
-	damage = 25
+	damage = 20
 	damage_type = BRUTE
 	armour_penetration = 100
 

--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -9,7 +9,7 @@
 	friendly = "quietly assesses"
 	melee_damage_lower = 10
 	melee_damage_upper = 10
-	damage_transfer = 0.9
+	damage_transfer = 1
 	can_strip = TRUE
 	projectiletype = /obj/item/projectile/guardian
 	ranged_cooldown_time = 5 //fast!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Lowers damage from 25 to 20 damage.
5 hits to crit, 10 to deep crit, vs 4 and 8 respectivly.

Damage transfer goes from 0.9 to 1. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Perhaps being able to do damage faster than any other guardian was a bit much, even with 100% damage transfer. It still is faster at killing, but now it is much more comparable to wt550, then a stechkin. 
Since it also attacks from range, and is fast as hell, I removed the 10% damage reduction from the body.
Yes it still it ignores armor with it's attacks. No this PR doesn't change this.

## Changelog
:cl:
tweak: Ranged guardians have 100% damage transfer vs 90%, as well as it's projectiles doing 20 damage vs 25.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
