### PR TITLE
Fixes Improper usages of Accessory Procs

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -678,6 +678,10 @@ BLIND     // can't see anything
 	return ..()
 
 /obj/item/clothing/under/proc/can_attach_accessory(obj/item/clothing/accessory/A)
+	if(istype(A))
+		. = TRUE
+	else
+		return FALSE
 	if(length(accessories) >= MAX_EQUIPABLE_ACCESSORIES) //this is neccesary to prevent chat spam when examining clothing
 		return FALSE
 	for(var/obj/item/clothing/accessory/AC in accessories)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -677,11 +677,13 @@ BLIND     // can't see anything
 	QDEL_LIST(accessories)
 	return ..()
 
+/*
+  * # can_attach_accessory
+  *
+  * Arguments:
+  * * A - The accessory object being checked. MUST BE TYPE /obj/item/clothing/accessory
+*/
 /obj/item/clothing/under/proc/can_attach_accessory(obj/item/clothing/accessory/A)
-	if(istype(A))
-		. = TRUE
-	else
-		return FALSE
 	if(length(accessories) >= MAX_EQUIPABLE_ACCESSORIES) //this is neccesary to prevent chat spam when examining clothing
 		return FALSE
 	for(var/obj/item/clothing/accessory/AC in accessories)
@@ -723,6 +725,8 @@ BLIND     // can't see anything
 	..()
 
 /obj/item/clothing/under/proc/attach_accessory(obj/item/clothing/accessory/A, mob/user, unequip = FALSE)
+	if(!istype(A))
+		return FALSE
 	if(can_attach_accessory(A))
 		if(unequip && !user.unEquip(A)) // Make absolutely sure this accessory is removed from hands
 			return FALSE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -725,8 +725,6 @@ BLIND     // can't see anything
 	..()
 
 /obj/item/clothing/under/proc/attach_accessory(obj/item/clothing/accessory/A, mob/user, unequip = FALSE)
-	if(!istype(A))
-		return FALSE
 	if(can_attach_accessory(A))
 		if(unequip && !user.unEquip(A)) // Make absolutely sure this accessory is removed from hands
 			return FALSE

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -785,12 +785,14 @@
 					return TRUE
 			return FALSE
 		if(slot_tie)
-			if(!H.w_uniform)
+			if(!istype(I, /obj/item/clothing/accessory))
+				return FALSE
+			var/obj/item/clothing/under/uniform = H.w_uniform
+			if(!uniform)
 				if(!disable_warning)
 					to_chat(H, "<span class='warning'>You need a jumpsuit before you can attach this [I.name].</span>")
 				return FALSE
-			var/obj/item/clothing/under/uniform = H.w_uniform
-			if(uniform.accessories.len && !uniform.can_attach_accessory(H))
+			if(length(uniform.accessories) && !uniform.can_attach_accessory(I))
 				if(!disable_warning)
 					to_chat(H, "<span class='warning'>You already have an accessory of this type attached to your [uniform].</span>")
 				return FALSE


### PR DESCRIPTION
## What Does This PR Do
Adds an istype to `attach_accessory` and fixes a usage of `can_attach_accessory` that was feeding a mob as the `/obj/clothing/accessory` parameter. Technically one of my fixes caused this runtime, but that's only because removing a safety check revealed other poor code.
