### PR TITLE
Removes compact sniper rifle (the uplink one don't panic)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -509,16 +509,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 25
 	gamemodes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/dangerous/sniper_compact //For when you really really hate that one guy.
-	name = "Compact Sniper Rifle"
-	desc = "A compact, unscoped version of the operative sniper rifle. Packs a powerful punch, but ammo is limited."
-	reference = "CSR"
-	item = /obj/item/gun/projectile/automatic/sniper_rifle/compact
-	cost = 16
-	surplus = 0
-	cant_discount = TRUE
-	excludefrom = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/dangerous/crossbow
 	name = "Energy Crossbow"
 	desc = "A miniature energy crossbow that is small enough both to fit into a pocket and to slip into a backpack unnoticed by observers. Fires bolts tipped with toxin, a poisonous substance that is the product of a living organism. Stuns enemies for a short period of time. Recharges automatically."

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -41,24 +41,6 @@
 	else
 		icon_state = "sniper"
 
-/obj/item/gun/projectile/automatic/sniper_rifle/compact //holds very little ammo, lacks zooming, and bullets are primarily damage dealers, but the gun lacks the downsides of the full size rifle
-	name = "compact sniper rifle"
-	desc = "A compact, unscoped version of the standard issue syndicate sniper rifle. Still capable of sending people crying."
-	icon_state = "snipercompact"
-	recoil = 0
-	weapon_weight = WEAPON_LIGHT
-	fire_delay = 0
-	mag_type = /obj/item/ammo_box/magazine/sniper_rounds/compact
-	can_unsuppress = FALSE
-	can_suppress = FALSE
-	zoomable = FALSE
-
-/obj/item/gun/projectile/automatic/sniper_rifle/compact/update_icon()
-	if(magazine)
-		icon_state = "snipercompact-mag"
-	else
-		icon_state = "snipercompact"
-
 //Normal Boolets
 /obj/item/ammo_box/magazine/sniper_rounds
 	name = "sniper rounds (.50)"
@@ -187,22 +169,6 @@
 	forcedodge = 1
 	dismemberment = 0
 	weaken = 0
-
-//compact ammo
-/obj/item/ammo_box/magazine/sniper_rounds/compact
-	name = "sniper rounds (compact)"
-	desc = "An extremely powerful round capable of inflicting massive damage on a target."
-	ammo_type = /obj/item/ammo_casing/compact
-	max_ammo = 4
-
-/obj/item/ammo_casing/compact
-	desc = "A .50 caliber compact round casing."
-	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper //Same as the base sniper bullet, but can't be reloaded with any fancy sniper ammo in the mag, which only holds 4
-	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
-	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
-	icon_state = ".50"
-
 
 //toy magazine
 /obj/item/ammo_box/magazine/toy/sniper_rounds


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The compact sniper rifle available in the uplink is gone from the game. Its special magazine is gone too. Penetrator and nukie sniper rifles are untouched. Part of the stun removal project overseen by @hal9000PR 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This gun has a ten second stun on it. Despite this, it is also completely awful, has no niche, and functions solely as noob bait. For just SIXTEEN telecrystals, you can buy a four-shot weapon without any way of getting extra ammo, that does not even put its victim in crit in one shot, but stuns for ten seconds. So, a very bad, glorified lethal taser. Balancing this weapon is also hard, because it uses the same cartridge as the nukie and penetrator snipers - both perfectly fine weapons on their own. Making a special snowflake ammo type without the stun, just for the compact, would also make it a worse .357 revolver. Removing the stun from all .50 ammunition would be an unnecessary nukie nerf - their sniper rifle is probably an acceptable source of instant stuns, considering what it has to compete with and how it works.

This gun has no use or identity, and no one will miss it.

## Changelog
:cl:
del: Removed the compact sniper rifle. Penetrator and nukie sniper rifles are unchanged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
