### PR TITLE
 Makes plastic output vary based on inputs

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -99,7 +99,7 @@
 	result = null
 	required_reagents = list("oil" = 5, "sacid" = 2, "ash" = 3)
 	min_temp = T0C + 100
-	result_amount = 1
+	result_amount = 10
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
 	var/loc = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -102,9 +102,9 @@
 	result_amount = 1
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
-	var/obj/item/stack/sheet/plastic/P = new /obj/item/stack/sheet/plastic
-	P.amount = 10
-	P.forceMove(get_turf(holder.my_atom))
+	var/loc = get_turf(holder.my_atom)
+	for(var/i in 1 to created_volume)
+		new /obj/item/stack/sheet/plastic(loc)
 
 /datum/chemical_reaction/lube
 	name = "Space Lube"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
 Currently if you do the chemical reaction to create plastic, you always get 10 sheets no matter how much or how little goes into the reaction. 

 This makes it so that you get 10 sheets for 10 units of inputs. 


 This might be worth nerfing because getting 100 sheets is a **lot of plastic** in relation to how much things cost.
 (For reference, a plastic golem is 10 sheets, most other recipes that use it are about 1-3 sheets. There aren't many recipes.)
 I think 1 is too low, but maybe somewhere from 2-4 could be fair. Give me input on this. 

## Why It's Good For The Game
It's weird gameplay that the optimal way to spam plastic is to fill a 100u beaker, and then take 10u from it 10 times by spam-clicking it with a lighter.

## Images of changes

![image](https://user-images.githubusercontent.com/40812746/178748873-6c78817c-a5e3-484c-9de4-59005ac72bd0.png)


## Changelog
:cl:Froststahr
tweak: The reaction to create plastic now scales with the amount of Reagents put into the reaction (e.g, 30u produces 30 sheets.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
