### PR TITLE
Makes help intent shakes remove a small amount of stamina damage

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -231,6 +231,7 @@
 				AdjustStunned(-6 SECONDS)
 				AdjustWeakened(-6 SECONDS)
 				AdjustKnockDown(-6 SECONDS)
+				adjustStaminaLoss(-10)
 				resting = FALSE
 				stand_up() // help them up if possible
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Help intent shaking someone who is horizontal will now remove 10 stamina damage. This means that three shakes will get someone up if they just have fallen. 
This was requested of me by @hal9000PR as part of the stamina combat project.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Being able to help someone up after they've been incapacitated is something that used to be possible in stun combat, and it was lost in the transition. Stamina crit is currently a full stop to whatever you're doing, and not being able to shake people up is counter-intuitive - in fact, people constantly try to do it anyway, I caught myself doing that too, recently.

## Changelog
:cl:
tweak: You can now shake someone up from stamina crit after a few shakes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
