### PR TITLE
Restricts VV Godmode to +EVENT permissions

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -673,7 +673,7 @@
 		href_list["datumrefresh"] = href_list["give_spell"]
 
 	else if(href_list["godmode"])
-		if(!check_rights(R_REJUVINATE))	return
+		if(!check_rights(R_EVENT))	return
 
 		var/mob/M = locateUID(href_list["godmode"])
 		if(!istype(M))


### PR DESCRIPTION
## What Does This PR Do
Prevents Trial Admins or more specifically, those without +EVENT permissions from giving godmode to players. NOTE: trialmins still get rejuvenation rights as they need it to clean up griefing. 

## Why It's Good For The Game
Godmode is intended to be an event related admin tool and really doesn't have a purpose outside of adminbus or event related shenanigans.

## Changelog
:cl:
tweak: Restricts VV Godmode to +EVENT permissions
/:cl:

