### PR TITLE
Changes body collision to knockdown, adds a throw_range of 4 to carbon/human

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -138,7 +138,7 @@ SUBSYSTEM_DEF(throwing)
 		thrownthing.newtonian_move(init_dir)
 
 	if(target)
-		thrownthing.throw_impact(target, src)
+		thrownthing.throw_impact(target, src, speed)
 
 	if(callback)
 		callback.Invoke()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -583,6 +583,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		return
 
 	var/hurt = TRUE
+	var/damage = 10 + 1.5 * speed // speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4, highest speed is 14
 	/*if(istype(throwingdatum, /datum/thrownthing))
 		var/datum/thrownthing/D = throwingdatum
 		if(isrobot(D.thrower))
@@ -592,18 +593,18 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
 			visible_message("<span class='danger'>[src] slams into [hit_atom]!</span>", "<span class='userdanger'>You slam into [hit_atom]!</span>")
-			take_organ_damage(7.5 * speed) // speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
-			KnockDown(2 SECONDS)
+			take_organ_damage(damage)
+			KnockDown(3 SECONDS)
 			playsound(src, 'sound/weapons/punch1.ogg', 35, 1)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.flying)
 			return
 		if(hurt)
-			victim.take_organ_damage(7.5 * speed)// speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
-			take_organ_damage(7.5 * speed)
-			victim.KnockDown(2 SECONDS)
-			KnockDown(2 SECONDS)
+			victim.take_organ_damage(damage)
+			take_organ_damage(damage)
+			victim.KnockDown(3 SECONDS)
+			KnockDown(3 SECONDS)
 			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")
 		playsound(src, 'sound/weapons/punch1.ogg', 50, 1)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -594,6 +594,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 			visible_message("<span class='danger'>[src] slams into [hit_atom]!</span>", "<span class='userdanger'>You slam into [hit_atom]!</span>")
 			take_organ_damage(7.5*speed) // speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
 			KnockDown(2 SECONDS)
+			playsound(src, 'sound/weapons/punch1.ogg', 35, 1)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.flying)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -592,7 +592,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
 			visible_message("<span class='danger'>[src] slams into [hit_atom]!</span>", "<span class='userdanger'>You slam into [hit_atom]!</span>")
-			take_organ_damage(7.5*speed) // speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
+			take_organ_damage(7.5 * speed) // speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
 			KnockDown(2 SECONDS)
 			playsound(src, 'sound/weapons/punch1.ogg', 35, 1)
 	if(iscarbon(hit_atom) && hit_atom != src)
@@ -600,8 +600,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		if(victim.flying)
 			return
 		if(hurt)
-			victim.take_organ_damage(7.5*speed)// speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
-			take_organ_damage(7.5*speed)
+			victim.take_organ_damage(7.5 * speed)// speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
+			take_organ_damage(7.5 * speed)
 			victim.KnockDown(2 SECONDS)
 			KnockDown(2 SECONDS)
 			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -552,7 +552,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 //Throwing stuff
 
-/mob/living/carbon/throw_impact(atom/hit_atom, throwingdatum)
+/mob/living/carbon/throw_impact(atom/hit_atom, throwingdatum, speed = 1)
 	. = ..()
 	if(has_status_effect(STATUS_EFFECT_CHARGING))
 		var/hit_something = FALSE
@@ -591,17 +591,18 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 				hurt = FALSE*/
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Weaken(2 SECONDS)
-			take_organ_damage(10)
+			visible_message("<span class='danger'>[src] slams into [hit_atom]!</span>", "<span class='userdanger'>You slam into [hit_atom]!</span>")
+			take_organ_damage(7.5*speed) // speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
+			KnockDown(2 SECONDS)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.flying)
 			return
 		if(hurt)
-			victim.take_organ_damage(10)
-			take_organ_damage(10)
-			victim.Weaken(2 SECONDS)
-			Weaken(2 SECONDS)
+			victim.take_organ_damage(7.5*speed)// speed while thrower is standing still is 2, while walking with an aggressive grab is 2.4
+			take_organ_damage(7.5*speed)
+			victim.KnockDown(2 SECONDS)
+			KnockDown(2 SECONDS)
 			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")
 		playsound(src, 'sound/weapons/punch1.ogg', 50, 1)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -6,6 +6,7 @@
 	icon_state = "body_m_s"
 	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE|LONG_GLIDE
 	deathgasp_on_death = TRUE
+	throw_range = 4
 
 /mob/living/carbon/human/New(loc)
 	icon = null // This is now handled by overlays -- we just keep an icon for the sake of the map editor.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->All body collisions from being thrown now do 2 seconds of knockdown instead of stun, but brute damage is based on how fast you're thrown to compensate. A collision from when the thrower is standing still does 15 damage, if they are walking (with an aggressive grab so slowly) it does 18 damage (it was previously 10 damage). It does no stamina damage.


This PR also adds a throw_range of 4 to any carbon/humans, meaning people cant be thrown across your entire screen.

This also slightly changes up how gravitational anomalies work, since you cant get stunned by them but they are much more deadly with the brute damage increase.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Removes hard stun in favor of knockdown/stamina combat.

## Changelog
:cl:
tweak: Colliding into something when thrown will now make you knockdowned instead of stunned
add: Brute damage from a collision is now based on the thrown person's speed (a running/walking start before throwing someone will increase damage slightly)
tweak: you can now only throw humanoids 4 tiles instead of 7
soundadd: throwing someone into a wall will make a sound effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
