### PR TITLE
fixes revenant being able to use machine verbs

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -463,6 +463,8 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(usr.default_can_use_topic(src) != STATUS_INTERACTIVE)
+		return
 	if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -491,6 +491,8 @@
 			return
 		go_out()//and release him from the eternal prison.
 	else
+		if(usr.default_can_use_topic(src) != STATUS_INTERACTIVE)
+			return
 		if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
 			return
 		add_attack_logs(usr, occupant, "Ejected from cryo cell at [COORD(src)]")


### PR DESCRIPTION
## What Does This PR Do
Adds some topic checks to cryotubes & sleepers in medbay to check that the person using the verb has the correct intractability status. Prevents revenants from ejecting people.
Fixes #3357

## Why It's Good For The Game
Exploits are bad, revenants are ghosts, they can't press ejection buttons!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Added new things
del: Removed old things
tweak: Tweaked a few things
fix: Fixed a few things
wip: Added a few works in progress
soundadd: Added a new sound thingy
sounddel: Removed an old sound thingy
imageadd: Added some icons and images
imagedel: Deleted some icons and images
spellcheck: Fixed a few typos
experiment: Added an experimental thingy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
