### PR TITLE
Adds a blue overlay to scrying orb users. Spirit realm and scrying orb users now have a special description instead of being catatonic

### DIFF
--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -222,6 +222,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define CHANGELING_DRAIN "drain"
 #define TRAIT_HULK "hulk"
 #define STASIS_MUTE "stasis"
+#define SCRYING "scrying" // for ghosts that may return to their body (spirit rune, scrying orb, etc)
 #define SCRYING_ORB "scrying-orb"
 #define CULT_EYES "cult_eyes"
 #define DOGGO_SPACESUIT "doggo_spacesuit"

--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -222,7 +222,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define CHANGELING_DRAIN "drain"
 #define TRAIT_HULK "hulk"
 #define STASIS_MUTE "stasis"
-#define SCRYING "scrying" // for ghosts that may return to their body (spirit rune, scrying orb, etc)
+#define SCRYING "scrying" // for mobs that have ghosted, but their ghosts are allowed to return to their body outside of aghosting (spirit rune, scrying orb, etc)
 #define SCRYING_ORB "scrying-orb"
 #define CULT_EYES "cult_eyes"
 #define DOGGO_SPACESUIT "doggo_spacesuit"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -947,6 +947,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		new_human.dust()
 
 /obj/effect/rune/manifest/proc/ghostify(mob/living/user, turf/T)
+	ADD_TRAIT(user, SCRYING, CULT_TRAIT)
 	user.add_atom_colour(RUNE_COLOR_DARKRED, ADMIN_COLOUR_PRIORITY)
 	user.visible_message("<span class='warning'>[user] freezes statue-still, glowing an unearthly red.</span>",
 					"<span class='cult'>You see what lies beyond. All is revealed. In this form you find that your voice booms above all others.</span>")
@@ -977,6 +978,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		CM.Remove(ghost)
 		V.Remove(ghost)
 		//GM.Remove(ghost)
+	REMOVE_TRAIT(user, SCRYING, CULT_TRAIT)
 	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, RUNE_COLOR_DARKRED)
 	user = null
 	rune_in_use = FALSE

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -213,6 +213,7 @@
 	force = 15
 	hitsound = 'sound/items/welder2.ogg'
 	var/mob/current_owner
+	var/mob/dead/observer/ghost // owners ghost when active
 
 /obj/item/scrying/Initialize(mapload)
 	. = ..()
@@ -245,9 +246,25 @@
 		current_owner.update_icons()
 
 /obj/item/scrying/attack_self(mob/user as mob)
-	to_chat(user, "<span class='notice'> You can see...everything!</span>")
-	visible_message("<span class='danger'>[user] stares into [src], [user.p_their()] eyes glazing over.</span>")
-	user.ghostize(1)
+	if(!in_use)
+		in_use = TRUE
+		ADD_TRAIT(user, SCRYING, SCRYING_ORB)
+		user.add_atom_colour(COLOR_BLUE, ADMIN_COLOUR_PRIORITY) // stolen spirit rune code
+		user.visible_message("<span class='notice'>[user] stares into [src], [user.p_their()] eyes glazing over.</span>",
+						"<span class='danger'> You stare into [src], you can see the entire universe!</span>")
+		ghost = user.ghostize(TRUE)
+		ghost.name = "Magic Spirit of [ghost.name]"
+		ghost.color = COLOR_BLUE
+		while(!QDELETED(user))
+			if(user.key || QDELETED(src))
+				user.visible_message("<span class='notice'>[user] blinks, returning to the world around [user.p_them()].</span>",
+									"<span class='danger'>You look away from [src].</span>")
+				break
+			sleep(5)
+		user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, COLOR_BLUE)
+		REMOVE_TRAIT(user, SCRYING, SCRYING_ORB)
+		user = null
+		in_use = FALSE
 
 /////////////////////Multiverse Blade////////////////////
 GLOBAL_LIST_EMPTY(multiverse)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -246,30 +246,32 @@
 		current_owner.update_icons()
 
 /obj/item/scrying/attack_self(mob/user as mob)
-	if(!in_use)
-		in_use = TRUE
-		ADD_TRAIT(user, SCRYING, SCRYING_ORB)
-		user.add_atom_colour(COLOR_BLUE, ADMIN_COLOUR_PRIORITY) // stolen spirit rune code
-		user.visible_message("<span class='notice'>[user] stares into [src], [user.p_their()] eyes glazing over.</span>",
-						"<span class='danger'> You stare into [src], you can see the entire universe!</span>")
-		ghost = user.ghostize(TRUE)
-		ghost.name = "Magic Spirit of [ghost.name]"
-		ghost.color = COLOR_BLUE
-		while(!QDELETED(user))
-			if(user.key || QDELETED(src))
-				user.visible_message("<span class='notice'>[user] blinks, returning to the world around [user.p_them()].</span>",
-									"<span class='danger'>You look away from [src].</span>")
-				break
-			if(user.get_active_hand() != src)
-				user.grab_ghost()
-				user.visible_message("<span class='notice'>[user]'s focus is forced away from [src].</span>",
-									"<span class='userdanger'>Your vision is ripped away from [src].</span>")
-				break
-			sleep(5)
-		user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, COLOR_BLUE)
-		REMOVE_TRAIT(user, SCRYING, SCRYING_ORB)
-		user = null
-		in_use = FALSE
+	if(in_use)
+		return
+	in_use = TRUE
+	ADD_TRAIT(user, SCRYING, SCRYING_ORB)
+	user.add_atom_colour(COLOR_BLUE, ADMIN_COLOUR_PRIORITY) // stolen spirit rune code
+	user.visible_message("<span class='notice'>[user] stares into [src], [user.p_their()] eyes glazing over.</span>",
+					"<span class='danger'> You stare into [src], you can see the entire universe!</span>")
+	ghost = user.ghostize(TRUE)
+	ghost.name = "Magic Spirit of [ghost.name]"
+	ghost.color = COLOR_BLUE
+	while(!QDELETED(user))
+		if(user.key || QDELETED(src))
+			user.visible_message("<span class='notice'>[user] blinks, returning to the world around [user.p_them()].</span>",
+								"<span class='danger'>You look away from [src].</span>")
+			break
+		if(user.get_active_hand() != src)
+			user.grab_ghost()
+			user.visible_message("<span class='notice'>[user]'s focus is forced away from [src].</span>",
+								"<span class='userdanger'>Your vision is ripped away from [src].</span>")
+			break
+		sleep(5)
+	if(QDELETED(user))
+		return
+	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, COLOR_BLUE)
+	REMOVE_TRAIT(user, SCRYING, SCRYING_ORB)
+	in_use = FALSE
 
 /////////////////////Multiverse Blade////////////////////
 GLOBAL_LIST_EMPTY(multiverse)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -260,6 +260,10 @@
 				user.visible_message("<span class='notice'>[user] blinks, returning to the world around [user.p_them()].</span>",
 									"<span class='danger'>You look away from [src].</span>")
 				break
+			if(user.get_active_hand() != src)
+				user.visible_message("<span class='notice'>[user]'s focus is forced away from [src].</span>",
+									"<span class='danger'>Your vision is ripped away from [src].</span>")
+				break
 			sleep(5)
 		user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, COLOR_BLUE)
 		REMOVE_TRAIT(user, SCRYING, SCRYING_ORB)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -267,11 +267,11 @@
 								"<span class='userdanger'>Your vision is ripped away from [src].</span>")
 			break
 		sleep(5)
+	in_use = FALSE
 	if(QDELETED(user))
 		return
 	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, COLOR_BLUE)
 	REMOVE_TRAIT(user, SCRYING, SCRYING_ORB)
-	in_use = FALSE
 
 /////////////////////Multiverse Blade////////////////////
 GLOBAL_LIST_EMPTY(multiverse)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -261,8 +261,9 @@
 									"<span class='danger'>You look away from [src].</span>")
 				break
 			if(user.get_active_hand() != src)
+				user.grab_ghost()
 				user.visible_message("<span class='notice'>[user]'s focus is forced away from [src].</span>",
-									"<span class='danger'>Your vision is ripped away from [src].</span>")
+									"<span class='userdanger'>Your vision is ripped away from [src].</span>")
 				break
 			sleep(5)
 		user.remove_atom_colour(ADMIN_COLOUR_PRIORITY, COLOR_BLUE)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -95,8 +95,14 @@
 					if(blood_DNA)
 						msg += "<span class='warning'>[p_they(TRUE)] [p_have()] [hand_blood_color != "#030303" ? "blood-stained":"oil-stained"] hands!</span>\n"
 				if("eyes")
-					if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
-						msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glowing an unnatural red!</span>\n"
+					if(HAS_TRAIT(src, SCRYING))
+						if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
+							msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glowing an unnatural red and are glazed over!</span>\n"
+						else
+							msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glazed over.</span>\n"
+					else
+						if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
+							msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glowing an unnatural red!</span>\n"
 			continue
 
 	//handcuffed?
@@ -269,10 +275,11 @@
 
 		if(get_int_organ(/obj/item/organ/internal/brain))
 			if(dna.species.show_ssd)
-				if(!key)
-					msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] totally catatonic. The stresses of life in deep-space must have been too much for [p_them()]. Any recovery is unlikely.</span>\n"
-				else if(!client)
-					msg += "[p_they(TRUE)] [p_have()] suddenly fallen asleep, suffering from Space Sleep Disorder. [p_they(TRUE)] may wake up soon.\n"
+				if(!HAS_TRAIT(src, SCRYING))
+					if(!key)
+						msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] totally catatonic. The stresses of life in deep-space must have been too much for [p_them()]. Any recovery is unlikely.</span>\n"
+					else if(!client)
+						msg += "[p_they(TRUE)] [p_have()] suddenly fallen asleep, suffering from Space Sleep Disorder. [p_they(TRUE)] may wake up soon.\n"
 
 	if(decaylevel == 1)
 		msg += "[p_they(TRUE)] [p_are()] starting to smell.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -97,7 +97,7 @@
 				if("eyes")
 					if(HAS_TRAIT(src, SCRYING))
 						if(iscultist(src) && HAS_TRAIT(src, CULT_EYES))
-							msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glowing an unnatural red and are glazed over!</span>\n"
+							msg += "<span class='boldwarning'>[p_their(TRUE)] glowing red eyes are glazed over!</span>\n"
 						else
 							msg += "<span class='boldwarning'>[p_their(TRUE)] eyes are glazed over.</span>\n"
 					else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->A blue overlay is applied to scrying orb users, similar to spirit realm, and their ghost is called a magic spirit to distinguish it from normal ghosts. Spirit realm users and scrying orb users now have a special description if their eyes are visible, this does not affect adminghosting.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->It better demonstrates whats going on in the game and stops any confusion of admins thinking a wizard or something similar has ghosted from their body.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/91113370/178802174-8718a637-240e-41a1-b4da-9d797470fbfa.png)
Scrying orb
![image](https://user-images.githubusercontent.com/91113370/178802189-85ac9616-baf8-4a51-8ab8-c8501ecefee1.png)
Cultist's body while in the spirit realm
![image](https://user-images.githubusercontent.com/91113370/178802276-a814afac-cb99-4738-a481-d9859886db46.png)

## Changelog
:cl:
tweak: Scrying orb users will be better displayed as such, making them blue and their eyes glazed over, instead of appearing catatonic.
tweak: Spirit realm users will make their eyes glaze over, instead of appearing catatonic.
tweak: Removing the Scrying orb from someone's hand will return them to their body
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
