### PR TITLE
Cultists can now reliably find their cult dagger

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -276,12 +276,12 @@
 			return r_hand
 	return null
 
-//search for a path in inventory and storage items in that inventory (backpack, belt, etc) and return it. Not recursive, so doesnt search storage in storage
+//search for a path in inventory and storage items in that inventory (backpack, belt, etc) and return it.
 /mob/proc/find_item(path)
-	for(var/obj/item/I in contents)
-		if(istype(I, /obj/item/storage))
-			for(var/obj/item/SI in I.contents)
-				if(istype(SI, path))
-					return SI
-		else if(istype(I, path))
-			return I
+	var/list/L = get_contents()
+
+	for(var/obj/B in L)
+		if(B.type == path)
+			return B
+	return FALSE
+

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -283,5 +283,4 @@
 	for(var/obj/B in L)
 		if(B.type == path)
 			return B
-	return FALSE
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -283,4 +283,3 @@
 	for(var/obj/B in L)
 		if(B.type == path)
 			return B
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->This improves the find_item proc, which is literally only used by the cult dagger finding proc, allowing it to find the dagger anywhere on your person, including inside of boxes inside of boxes inside of boxes, etc.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->It was meant to retrieve the dagger from anywhere on your body, it should include a box inside your bag.

## Changelog
:cl:
fix: Cultists can now reliably find their cult dagger with their recall dagger spell, including a box inside your bag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
