### PR TITLE
Removes unneeded SSticker checks

### DIFF
--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -10,13 +10,13 @@
 #define TARGET_INVALID_BLACKLISTED	9
 
 //gamemode istype helpers
-#define GAMEMODE_IS_BLOB		(SSticker && istype(SSticker.mode, /datum/game_mode/blob))
-#define GAMEMODE_IS_CULT		(SSticker && istype(SSticker.mode, /datum/game_mode/cult))
-#define GAMEMODE_IS_HEIST		(SSticker && istype(SSticker.mode, /datum/game_mode/heist))
-#define GAMEMODE_IS_NUCLEAR		(SSticker && istype(SSticker.mode, /datum/game_mode/nuclear))
-#define GAMEMODE_IS_REVOLUTION	(SSticker && istype(SSticker.mode, /datum/game_mode/revolution))
-#define GAMEMODE_IS_WIZARD		(SSticker && istype(SSticker.mode, /datum/game_mode/wizard))
-#define GAMEMODE_IS_RAGIN_MAGES (SSticker && istype(SSticker.mode, /datum/game_mode/wizard/raginmages))
+#define GAMEMODE_IS_BLOB		(istype(SSticker.mode, /datum/game_mode/blob))
+#define GAMEMODE_IS_CULT		(istype(SSticker.mode, /datum/game_mode/cult))
+#define GAMEMODE_IS_HEIST		(istype(SSticker.mode, /datum/game_mode/heist))
+#define GAMEMODE_IS_NUCLEAR		(istype(SSticker.mode, /datum/game_mode/nuclear))
+#define GAMEMODE_IS_REVOLUTION	(istype(SSticker.mode, /datum/game_mode/revolution))
+#define GAMEMODE_IS_WIZARD		(istype(SSticker.mode, /datum/game_mode/wizard))
+#define GAMEMODE_IS_RAGIN_MAGES (istype(SSticker.mode, /datum/game_mode/wizard/raginmages))
 
 //special roles
 // Distinct from the ROLE_X defines because some antags have multiple special roles but only one ban type

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -163,7 +163,7 @@ GLOBAL_PROTECT(log_end)
 // A logging proc that only outputs after setup is done, to
 // help devs test initialization stuff that happens a lot
 /proc/log_after_setup(message)
-	if(SSticker && SSticker.current_state > GAME_STATE_SETTING_UP)
+	if(SSticker.current_state > GAME_STATE_SETTING_UP)
 		to_chat(world, "<span class='danger'>[message]</span>")
 		log_world(message)
 

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -269,10 +269,9 @@ SUBSYSTEM_DEF(jobs)
 	SetupOccupations()
 
 	//Holder for Triumvirate is stored in the ticker, this just processes it
-	if(SSticker)
-		for(var/datum/job/ai/A in occupations)
-			if(SSticker.triai)
-				A.spawn_positions = 3
+	for(var/datum/job/ai/A in occupations)
+		if(SSticker.triai)
+			A.spawn_positions = 3
 
 	//Get the players who are ready
 	for(var/mob/new_player/player in GLOB.player_list)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -169,7 +169,7 @@ SUBSYSTEM_DEF(vote)
 			if("gamemode")
 				if(GLOB.master_mode != .)
 					world.save_mode(.)
-					if(SSticker && SSticker.mode)
+					if(SSticker.mode)
 						restart = 1
 					else
 						GLOB.master_mode = .
@@ -221,17 +221,17 @@ SUBSYSTEM_DEF(vote)
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")
 			if("gamemode")
-				if(SSticker.current_state >= 2)
+				if(SSticker.current_state >= GAME_STATE_SETTING_UP)
 					return 0
 				choices.Add(GLOB.configuration.gamemode.votable_modes)
 			if("crew transfer")
 				if(check_rights(R_ADMIN|R_MOD))
-					if(SSticker.current_state <= 2)
+					if(SSticker.current_state <= GAME_STATE_SETTING_UP)
 						return 0
 					question = "End the shift?"
 					choices.Add("Initiate Crew Transfer", "Continue The Round")
 				else
-					if(SSticker.current_state <= 2)
+					if(SSticker.current_state <= GAME_STATE_SETTING_UP)
 						return 0
 					question = "End the shift?"
 					choices.Add("Initiate Crew Transfer", "Continue The Round")

--- a/code/datums/cache/air_alarm.dm
+++ b/code/datums/cache/air_alarm.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(air_alarm_repository, /datum/repository/air_alarm, new())
 	if(!refresh && cache_entry.timestamp + AIR_ALARM_DATA_CACHE_DURATION > world.time)
 		return cache_entry.data
 
-	if(SSticker && SSticker.current_state < GAME_STATE_PLAYING && istype(passed_alarm)) // Generating the list for the first time as the game hasn't started - no need to run through the machines list everything every time
+	if(SSticker.current_state < GAME_STATE_PLAYING && istype(passed_alarm)) // Generating the list for the first time as the game hasn't started - no need to run through the machines list everything every time
 		alarms = cache_entry.data // Don't deleate the list
 		if(is_station_contact(passed_alarm.z) && passed_alarm.remote_control) // Still need sanity checks
 			alarms[++alarms.len] = passed_alarm.get_console_data()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -437,7 +437,7 @@
 		//         ^ whoever left this comment is literally a grammar nazi. stalin better. in russia grammar correct you.
 
 /datum/mind/proc/edit_memory()
-	if(!SSticker || !SSticker.mode)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("Not before round-start!", "Alert")
 		return
 
@@ -1778,10 +1778,7 @@
 		mind.key = key
 	else
 		mind = new /datum/mind(key)
-		if(SSticker)
-			SSticker.minds += mind
-		else
-			error("mind_initialize(): No ticker ready yet! Please inform Carn")
+		SSticker.minds += mind
 	if(!mind.name)
 		mind.name = real_name
 	mind.current = src

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -12,9 +12,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			var/datum/uplink_item/I = new path
 			if(!I.item)
 				continue
-			if(I.gamemodes.len && SSticker && !(SSticker.mode.type in I.gamemodes))
+			if(I.gamemodes.len && !(SSticker.mode.type in I.gamemodes))
 				continue
-			if(I.excludefrom.len && SSticker && (SSticker.mode.type in I.excludefrom))
+			if(I.excludefrom.len && (SSticker.mode.type in I.excludefrom))
 				continue
 			if(I.last)
 				last += I

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -249,7 +249,6 @@
 /mob/living/carbon/human/proc/sec_hud_set_security_status()
 	var/image/holder = hud_list[WANTED_HUD]
 	var/perpname = get_visible_name(TRUE) //gets the name of the perp, works if they have an id or if their face is uncovered
-	if(!SSticker) return //wait till the game starts or the monkeys runtime....
 	if(perpname)
 		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.security)
 		if(R)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -390,7 +390,7 @@
 	new /obj/structure/blob/core(get_turf(N), null, blob_core.point_rate, TRUE)
 	qdel(N)
 
-	if(SSticker.mode.name == "blob")
+	if(GAMEMODE_IS_BLOB)
 		var/datum/game_mode/blob/BL = SSticker.mode
 		BL.blobwincount += initial(BL.blobwincount)
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -390,7 +390,7 @@
 	new /obj/structure/blob/core(get_turf(N), null, blob_core.point_rate, TRUE)
 	qdel(N)
 
-	if(SSticker && SSticker.mode.name == "blob")
+	if(SSticker.mode.name == "blob")
 		var/datum/game_mode/blob/BL = SSticker.mode
 		BL.blobwincount += initial(BL.blobwincount)
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 	var/ascend_percent
 
 /proc/iscultist(mob/living/M)
-	return istype(M) && M.mind && SSticker && SSticker.mode && (M.mind in SSticker.mode.cult)
+	return istype(M) && M.mind && SSticker.mode && (M.mind in SSticker.mode.cult)
 
 /proc/is_convertable_to_cult(datum/mind/mind)
 	if(!mind)

--- a/code/game/gamemodes/cult/cult_actions.dm
+++ b/code/game/gamemodes/cult/cult_actions.dm
@@ -104,7 +104,7 @@
 /datum/action/innate/cult/check_progress/Activate()
 	if(!IsAvailable())
 		return
-	if(SSticker && SSticker.mode)
+	if(SSticker.mode)
 		SSticker.mode.cult_objs.study(usr, TRUE)
 	else
 		to_chat(usr, "<span class='cultitalic'>You fail to study the Veil. (This should never happen, adminhelp and/or yell at a coder)</span>")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -94,7 +94,7 @@
 
 // I wonder what this could do guessing by the name
 /datum/game_mode/proc/set_mode_in_db()
-	if(SSticker?.mode && SSdbcore.IsConnected())
+	if(SSticker.mode && SSdbcore.IsConnected())
 		var/datum/db_query/query_round_game_mode = SSdbcore.NewQuery("UPDATE round SET game_mode=:gm WHERE id=:rid", list(
 			"gm" = SSticker.mode.name,
 			"rid" = GLOB.round_id

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -4,7 +4,7 @@
 	var/list/datum/mind/syndicates = list()
 
 /proc/issyndicate(mob/living/M as mob)
-	return istype(M) && M.mind && SSticker && SSticker.mode && (M.mind in SSticker.mode.syndicates)
+	return istype(M) && M.mind && SSticker.mode && (M.mind in SSticker.mode.syndicates)
 
 /datum/game_mode/nuclear
 	name = "nuclear emergency"

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -469,7 +469,7 @@ GLOBAL_VAR(bomb_set)
 	SSticker.station_explosion_cinematic(off_station,null)
 	if(SSticker.mode)
 		SSticker.mode.explosion_in_progress = FALSE
-		if(SSticker.mode.name == "nuclear emergency")
+		if(GAMEMODE_IS_NUCLEAR)
 			SSticker.mode:nukes_left --
 		else if(off_station == 1)
 			to_chat(world, "<b>A nuclear device was set off, but the explosion was out of reach of the station!</b>")

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -461,7 +461,7 @@ GLOBAL_VAR(bomb_set)
 	else
 		off_station = 2
 
-	if(SSticker.mode && SSticker.mode.name == "nuclear emergency")
+	if(SSticker.mode && GAMEMODE_IS_NUCLEAR)
 		var/obj/docking_port/mobile/syndie_shuttle = SSshuttle.getShuttle("syndicate")
 		if(syndie_shuttle)
 			SSticker.mode:syndies_didnt_escape = is_station_level(syndie_shuttle.z)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -446,7 +446,7 @@ GLOBAL_VAR(bomb_set)
 	if(!lighthack)
 		icon_state = "nuclearbomb3"
 	playsound(src,'sound/machines/alarm.ogg',100,0,5)
-	if(SSticker && SSticker.mode)
+	if(SSticker.mode)
 		SSticker.mode.explosion_in_progress = TRUE
 	sleep(100)
 
@@ -461,30 +461,29 @@ GLOBAL_VAR(bomb_set)
 	else
 		off_station = 2
 
-	if(SSticker)
-		if(SSticker.mode && SSticker.mode.name == "nuclear emergency")
-			var/obj/docking_port/mobile/syndie_shuttle = SSshuttle.getShuttle("syndicate")
-			if(syndie_shuttle)
-				SSticker.mode:syndies_didnt_escape = is_station_level(syndie_shuttle.z)
-			SSticker.mode:nuke_off_station = off_station
-		SSticker.station_explosion_cinematic(off_station,null)
-		if(SSticker.mode)
-			SSticker.mode.explosion_in_progress = FALSE
-			if(SSticker.mode.name == "nuclear emergency")
-				SSticker.mode:nukes_left --
-			else if(off_station == 1)
-				to_chat(world, "<b>A nuclear device was set off, but the explosion was out of reach of the station!</b>")
-			else if(off_station == 2)
-				to_chat(world, "<b>A nuclear device was set off, but the device was not on the station!</b>")
-			else
-				to_chat(world, "<b>The station was destroyed by the nuclear blast!</b>")
+	if(SSticker.mode && SSticker.mode.name == "nuclear emergency")
+		var/obj/docking_port/mobile/syndie_shuttle = SSshuttle.getShuttle("syndicate")
+		if(syndie_shuttle)
+			SSticker.mode:syndies_didnt_escape = is_station_level(syndie_shuttle.z)
+		SSticker.mode:nuke_off_station = off_station
+	SSticker.station_explosion_cinematic(off_station,null)
+	if(SSticker.mode)
+		SSticker.mode.explosion_in_progress = FALSE
+		if(SSticker.mode.name == "nuclear emergency")
+			SSticker.mode:nukes_left --
+		else if(off_station == 1)
+			to_chat(world, "<b>A nuclear device was set off, but the explosion was out of reach of the station!</b>")
+		else if(off_station == 2)
+			to_chat(world, "<b>A nuclear device was set off, but the device was not on the station!</b>")
+		else
+			to_chat(world, "<b>The station was destroyed by the nuclear blast!</b>")
 
-			SSticker.mode.station_was_nuked = (off_station < 2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
-															//kinda shit but I couldn't  get permission to do what I wanted to do.
+		SSticker.mode.station_was_nuked = (off_station < 2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
+														//kinda shit but I couldn't  get permission to do what I wanted to do.
 
-			if(!SSticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
-				SSticker.reboot_helper("Station destroyed by Nuclear Device.", "nuke - unhandled ending")
-				return
+		if(!SSticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
+			SSticker.reboot_helper("Station destroyed by Nuclear Device.", "nuke - unhandled ending")
+			return
 	return
 
 /obj/machinery/nuclearbomb/proc/reset_lighthack_callback()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -536,21 +536,20 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 
 /datum/objective/absorb/proc/gen_amount_goal(lowbound = 4, highbound = 6)
 	target_amount = rand (lowbound,highbound)
-	if(SSticker)
-		var/n_p = 1 //autowin
-		if(SSticker.current_state == GAME_STATE_SETTING_UP)
-			for(var/mob/new_player/P in GLOB.player_list)
-				if(P.client && P.ready && P.mind != owner)
-					if(P.client.prefs && (P.client.prefs.active_character.species == "Machine")) // Special check for species that can't be absorbed. No better solution.
-						continue
-					n_p++
-		else if(SSticker.current_state == GAME_STATE_PLAYING)
-			for(var/mob/living/carbon/human/P in GLOB.player_list)
-				if(HAS_TRAIT(P, TRAIT_GENELESS))
+	var/n_p = 1 //autowin
+	if(SSticker.current_state == GAME_STATE_SETTING_UP)
+		for(var/mob/new_player/P in GLOB.player_list)
+			if(P.client && P.ready && P.mind != owner)
+				if(P.client.prefs && (P.client.prefs.active_character.species == "Machine")) // Special check for species that can't be absorbed. No better solution.
 					continue
-				if(P.client && !(P.mind in SSticker.mode.changelings) && P.mind!=owner)
-					n_p++
-		target_amount = min(target_amount, n_p)
+				n_p++
+	else if(SSticker.current_state == GAME_STATE_PLAYING)
+		for(var/mob/living/carbon/human/P in GLOB.player_list)
+			if(HAS_TRAIT(P, TRAIT_GENELESS))
+				continue
+			if(P.client && !(P.mind in SSticker.mode.changelings) && P.mind!=owner)
+				n_p++
+	target_amount = min(target_amount, n_p)
 
 	explanation_text = "Acquire [target_amount] compatible genomes. The 'Extract DNA Sting' can be used to stealthily get genomes without killing somebody."
 	return target_amount

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -278,4 +278,4 @@ Made a proc so this is not repeated 14 (or more) times.*/
 		return 1
 
 /proc/iswizard(mob/living/M as mob)
-	return istype(M) && M.mind && SSticker && SSticker.mode && ((M.mind in SSticker.mode.wizards) || (M.mind in SSticker.mode.apprentices))
+	return istype(M) && M.mind && SSticker.mode && ((M.mind in SSticker.mode.wizards) || (M.mind in SSticker.mode.apprentices))

--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -82,5 +82,4 @@
 
 	user.AddSpell(new /obj/effect/proc_holder/spell/chaplain_bless(null))
 
-	if(SSticker)
-		SSticker.Bible_deity_name = B.deity_name
+	SSticker.Bible_deity_name = B.deity_name

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -426,7 +426,7 @@
 		to_chat(user, "<span class='warning'>The emergency shuttle may not be called while returning to Central Command.</span>")
 		return
 
-	if(SSticker.mode.name == "blob")
+	if(GAMEMODE_IS_BLOB)
 		to_chat(user, "<span class='warning'>Under directive 7-10, [station_name()] is quarantined until further notice.</span>")
 		return
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -58,10 +58,6 @@
 	add_fingerprint(usr)
 
 	var/dat
-
-	if(!( SSticker ))
-		return
-
 	dat += "<hr/><br/><b>[storage_name]</b><br/>"
 	dat += "<i>Welcome, [user.real_name].</i><br/><br/><hr/>"
 	dat += "<a href='?src=[UID()];log=1'>View storage log</a>.<br>"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -73,8 +73,7 @@
 			else
 				do_animate("deny")
 		return
-	if(!SSticker)
-		return
+
 	var/mob/living/M = AM
 	if(!M.restrained() && M.mob_size > MOB_SIZE_TINY && (!(isrobot(M) && M.stat)))
 		bumpopen(M)

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -12,12 +12,10 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 /obj/effect/particle_effect/New()
 	..()
-	if(SSticker)
-		GLOB.cameranet.updateVisibility(src)
+	GLOB.cameranet.updateVisibility(src)
 
 /obj/effect/particle_effect/Destroy()
-	if(SSticker)
-		GLOB.cameranet.updateVisibility(src)
+	GLOB.cameranet.updateVisibility(src)
 	return ..()
 
 /datum/effect_system

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -51,7 +51,7 @@
 		if((HAS_TRAIT(user, TRAIT_CLUMSY) || user.getBrainLoss() >= 60) && prob(50))	//too dumb to use flashlight properly
 			return ..()	//just hit them in the head
 
-		if(!(istype(user, /mob/living/carbon/human) || SSticker) && SSticker.mode.name != "monkey")	//don't have dexterity
+		if(!istype(user, /mob/living/carbon/human))	//don't have dexterity
 			to_chat(user, "<span class='notice'>You don't have the dexterity to do this!</span>")
 			return
 

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -75,7 +75,7 @@
 	else
 		M.LAssailant = user
 
-	if(!(ishuman(user) || SSticker) && SSticker.mode.name != "monkey")
+	if(!ishuman(user))
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 	if(!user.mind?.isholy)
@@ -170,11 +170,10 @@
 					T.dir = carpet_dir*/
 
 	SSblackbox.record_feedback("text", "religion_book", 1, "[choice]", 1)
-
-	if(SSticker)
-		SSticker.Bible_name = name
-		SSticker.Bible_icon_state = icon_state
-		SSticker.Bible_item_state = item_state
+	
+	SSticker.Bible_name = name
+	SSticker.Bible_icon_state = icon_state
+	SSticker.Bible_item_state = item_state
 
 /obj/item/storage/bible/proc/radial_check(mob/user)
 	if(!user?.mind.isholy || !ishuman(user))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -10,15 +10,14 @@
 /obj/structure/New()
 	..()
 	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
-		if(SSticker && SSticker.current_state == GAME_STATE_PLAYING)
+		if(SSticker.current_state == GAME_STATE_PLAYING)
 			QUEUE_SMOOTH(src)
 			QUEUE_SMOOTH_NEIGHBORS(src)
 		if(smoothing_flags & SMOOTH_CORNERS)
 			icon_state = ""
 	if(climbable)
 		verbs += /obj/structure/proc/climb_on
-	if(SSticker)
-		GLOB.cameranet.updateVisibility(src)
+	GLOB.cameranet.updateVisibility(src)
 
 /obj/structure/Initialize(mapload)
 	if(!armor)
@@ -26,8 +25,7 @@
 	return ..()
 
 /obj/structure/Destroy()
-	if(SSticker)
-		GLOB.cameranet.updateVisibility(src)
+	GLOB.cameranet.updateVisibility(src)
 	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 		var/turf/T = get_turf(src)
 		spawn(0)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -178,7 +178,7 @@ falloff_distance - Distance at which falloff begins. Sound is at peak volume (in
 	SEND_SOUND(src, S)
 
 /client/proc/playtitlemusic()
-	if(!SSticker || !SSticker.login_music || GLOB.configuration.general.disable_lobby_music)
+	if(!SSticker.login_music || GLOB.configuration.general.disable_lobby_music)
 		return
 	if(prefs.sound & SOUND_LOBBY)
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = 85 * prefs.get_channel_volume(CHANNEL_LOBBYMUSIC), channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -504,8 +504,7 @@
 	return 2
 
 /turf/proc/visibilityChanged()
-	if(SSticker)
-		GLOB.cameranet.updateVisibility(src)
+	GLOB.cameranet.updateVisibility(src)
 
 /turf/attackby(obj/item/I, mob/user, params)
 	if(can_lay_cable())
@@ -551,7 +550,7 @@
 	LAZYADD(blueprint_data, I)
 
 /turf/proc/add_blueprints_preround(atom/movable/AM)
-	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
+	if(SSticker.current_state != GAME_STATE_PLAYING)
 		add_blueprints(AM)
 
 /turf/proc/empty(turf_type = /turf/space)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -59,7 +59,7 @@
 		to_chat(src, "You're already dead!")
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(src, "You can't commit suicide before the game starts!")
 		return
 
@@ -112,7 +112,7 @@
 		to_chat(src, "You're already dead!")
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(src, "You can't commit suicide before the game starts!")
 		return
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -209,7 +209,7 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	if(GLOB.configuration.general.server_tag_line)
 		s += "<br>[GLOB.configuration.general.server_tag_line]"
 
-	if(SSticker && ROUND_TIME > 0)
+	if(ROUND_TIME > 0)
 		s += "<br>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)], [capitalize(get_security_level())]"
 	else
 		s += "<br><b>STARTING</b>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -503,10 +503,6 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	if(!check_rights(R_SERVER))
 		return
 
-	if(!SSticker)
-		alert("Unable to start the game as it is not set up.")
-		return
-
 	if(GLOB.configuration.general.start_now_confirmation)
 		if(alert(usr, "This is a live server. Are you sure you want to start now?", "Start game", "Yes", "No") != "Yes")
 			return
@@ -587,7 +583,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	if(!check_rights(R_SERVER))
 		return
 
-	if(!SSticker || SSticker.current_state != GAME_STATE_PREGAME)
+	if(SSticker.current_state != GAME_STATE_PREGAME)
 		SSticker.delay_end = !SSticker.delay_end
 		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
 		message_admins("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].", 1)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -347,7 +347,7 @@
 /datum/admins/proc/check_antagonists()
 	if(!check_rights(R_ADMIN))
 		return
-	if(SSticker && SSticker.current_state >= GAME_STATE_PLAYING)
+	if(SSticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[SSticker.mode.name]</B><BR>"
 		dat += "Round Duration: <B>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)]:[add_zero(num2text(ROUND_TIME / 10 % 60), 2)]</B><BR>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -982,7 +982,7 @@
 	else if(href_list["c_mode"])
 		if(!check_rights(R_ADMIN))	return
 
-		if(SSticker && SSticker.mode)
+		if(SSticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
 		var/dat = {"<b>What mode do you wish to play?</b><hr>"}
 		for(var/mode in GLOB.configuration.gamemode.gamemodes)
@@ -995,7 +995,7 @@
 	else if(href_list["f_secret"])
 		if(!check_rights(R_ADMIN))	return
 
-		if(SSticker && SSticker.mode)
+		if(SSticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
 		if(GLOB.master_mode != "secret")
 			return alert(usr, "The game mode has to be secret!", null, null, null, null)
@@ -1009,7 +1009,7 @@
 	else if(href_list["c_mode2"])
 		if(!check_rights(R_ADMIN|R_SERVER))	return
 
-		if(SSticker && SSticker.mode)
+		if(SSticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
 		GLOB.master_mode = href_list["c_mode2"]
 		log_admin("[key_name(usr)] set the mode as [GLOB.master_mode].")
@@ -1022,7 +1022,7 @@
 	else if(href_list["f_secret2"])
 		if(!check_rights(R_ADMIN|R_SERVER))	return
 
-		if(SSticker && SSticker.mode)
+		if(SSticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
 		if(GLOB.master_mode != "secret")
 			return alert(usr, "The game mode has to be secret!", null, null, null, null)
@@ -2556,7 +2556,7 @@
 	else if(href_list["traitor"])
 		if(!check_rights(R_ADMIN|R_MOD))	return
 
-		if(!SSticker || !SSticker.mode)
+		if(SSticker.current_state < GAME_STATE_PLAYING)
 			alert("The game hasn't started yet!")
 			return
 
@@ -2699,7 +2699,7 @@
 	else if(href_list["kick_all_from_lobby"])
 		if(!check_rights(R_ADMIN))
 			return
-		if(SSticker && SSticker.current_state == GAME_STATE_PLAYING)
+		if(SSticker.current_state == GAME_STATE_PLAYING)
 			var/afkonly = text2num(href_list["afkonly"])
 			if(alert("Are you sure you want to kick all [afkonly ? "AFK" : ""] clients from the lobby?","Confirmation","Yes","Cancel") != "Yes")
 				return
@@ -2778,7 +2778,7 @@
 				usr.client.triple_ai()
 				SSblackbox.record_feedback("tally", "admin_secrets_fun_used", 1, "Triple AI")
 			if("gravity")
-				if(!(SSticker && SSticker.mode))
+				if(SSticker.mode)
 					to_chat(usr, "<span class='warning'>Please wait until the game starts! Not sure how it will work otherwise.</span>")
 					return
 				GLOB.gravity_is_on = !GLOB.gravity_is_on
@@ -2822,7 +2822,7 @@
 				SSblackbox.record_feedback("tally", "admin_secrets_fun_used", 1, "Power All SMESs")
 				log_and_message_admins("<span class='notice'>[key_name(usr)] made all SMESs powered</span>", 1)
 			if("prisonwarp")
-				if(!SSticker)
+				if(SSticker.current_state < GAME_STATE_PLAYING)
 					alert("The game hasn't started yet!", null, null, null, null, null)
 					return
 				SSblackbox.record_feedback("tally", "admin_secrets_fun_used", 1, "Prison Warp")
@@ -2861,7 +2861,7 @@
 						H.loc = pick(GLOB.prisonsecuritywarp)
 					GLOB.prisonwarped += H
 			if("traitor_all")
-				if(!SSticker)
+				if(SSticker.current_state < GAME_STATE_PLAYING)
 					alert("The game hasn't started yet!")
 					return
 				var/objective = sanitize(copytext(input("Enter an objective"),1,MAX_MESSAGE_LEN))
@@ -3133,7 +3133,7 @@
 			if("showailaws")
 				output_ai_laws()
 			if("showgm")
-				if(!SSticker)
+				if(SSticker.current_state < GAME_STATE_PLAYING)
 					alert("The game hasn't started yet!")
 				else if(SSticker.mode)
 					alert("The game mode is [SSticker.mode.name]")

--- a/code/modules/admin/verbs/cinematic.dm
+++ b/code/modules/admin/verbs/cinematic.dm
@@ -3,8 +3,6 @@
 	set category = "Debug"
 	set desc = "Shows a cinematic."	// Intended for testing but I thought it might be nice for events on the rare occasion Feel free to comment it out if it's not wanted.
 	set hidden = 1
-	if(!SSticker)
-		return
 
 	if(!check_rights(R_MAINTAINER))
 		return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -278,7 +278,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!check_rights(R_SPAWN))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("Wait until the game starts")
 		return
 	if(istype(M, /mob/living/carbon/human))
@@ -296,7 +296,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!check_rights(R_SPAWN))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("Wait until the game starts")
 		return
 
@@ -356,7 +356,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!check_rights(R_SPAWN))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_STARTUP)
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))
@@ -376,7 +376,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!check_rights(R_SPAWN))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))
@@ -396,7 +396,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!check_rights(R_SPAWN))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))
@@ -449,7 +449,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!check_rights(R_EVENT))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("Wait until the game starts")
 		return
 	if(istype(M, /mob/living/carbon/human))
@@ -839,7 +839,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!check_rights(R_SPAWN))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))

--- a/code/modules/admin/verbs/gimmick_team.dm
+++ b/code/modules/admin/verbs/gimmick_team.dm
@@ -7,7 +7,7 @@
 	set desc = "Spawns a group of players in the specified outfit."
 	if(!check_rights(R_EVENT))
 		return
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("The game hasn't started yet!")
 		return
 	if(alert("Do you want to spawn a Gimmick Team at YOUR CURRENT LOCATION?",,"Yes","No")=="No")

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -10,7 +10,7 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 	if(!check_rights(R_ADMIN))
 		to_chat(src, "Only administrators may use this command.")
 		return
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("The game hasn't started yet!")
 		return
 	if(alert("Do you want to send in the Syndicate Infiltration Team?",,"Yes","No")=="No")

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -1,5 +1,5 @@
 /client/proc/only_one()
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("The game hasn't started yet!")
 		return
 
@@ -64,7 +64,7 @@
 			SEND_SOUND(M, music)
 
 /client/proc/only_me()
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("The game hasn't started yet!")
 		return
 

--- a/code/modules/admin/verbs/onlyoneteam.dm
+++ b/code/modules/admin/verbs/onlyoneteam.dm
@@ -1,5 +1,5 @@
 /client/proc/only_one_team()
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("The game hasn't started yet!")
 		return
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -22,7 +22,7 @@
 	var/prayer_type = "PRAYER"
 	var/deity
 	if(usr.job == "Chaplain")
-		if(SSticker && SSticker.Bible_deity_name)
+		if(SSticker.Bible_deity_name)
 			deity = SSticker.Bible_deity_name
 		cross = image('icons/obj/storage.dmi',"kingyellow")
 		font_color = "blue"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -882,9 +882,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set category = "Admin"
 	set name = "Toggle Deny Shuttle"
 
-	if(!SSticker)
-		return
-
 	if(!check_rights(R_ADMIN))
 		return
 
@@ -919,7 +916,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_SERVER|R_EVENT))
 		return
 
-	if(SSticker && SSticker.mode)
+	if(SSticker.mode)
 		to_chat(usr, "Nope you can't do this, the game's already started. This only works before rounds!")
 		return
 
@@ -1108,9 +1105,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!input)
 		return
 
-	if(!SSticker)
-		return
-
 	SSticker.selected_tip = input
 
 	// If we've already tipped, then send it straight away.
@@ -1130,7 +1124,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	holder.modify_goals()
 
 /datum/admins/proc/modify_goals()
-	if(!SSticker || !SSticker.mode)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(usr, "<span class='warning'>This verb can only be used if the round has started.</span>")
 		return
 

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 	if(!src.holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		alert("The game hasn't started yet!")
 		return
 	if(GLOB.sent_syndicate_strike_team == 1)

--- a/code/modules/admin/verbs/tripAI.dm
+++ b/code/modules/admin/verbs/tripAI.dm
@@ -6,17 +6,11 @@
 		to_chat(usr, "This option is currently only usable during pregame. This may change at a later date.")
 		return
 
-	if(SSjobs)
-		var/datum/job/job = SSjobs.GetJob("AI")
-		if(!job)
-			to_chat(usr, "Unable to locate the AI job")
-			return
-		if(SSticker.triai)
-			SSticker.triai = 0
-			to_chat(usr, "Only one AI will be spawned at round start.")
-			message_admins("<span class='notice'>[key_name_admin(usr)] has toggled off triple AIs at round start.</span>", 1)
-		else
-			SSticker.triai = 1
-			to_chat(usr, "There will be an AI Triumvirate at round start.")
-			message_admins("<span class='notice'>[key_name_admin(usr)] has toggled on triple AIs at round start.</span>", 1)
+	var/datum/job/job = SSjobs.GetJob("AI")
+	if(!job)
+		to_chat(usr, "Unable to locate the AI job")
+		return
+	SSticker.triai = !SSticker.triai
+	to_chat(usr, "There will be [SSticker.triai ? "an AI Triumvirate" : "only one AI"] at round start.")
+	message_admins("<span class='notice'>[key_name_admin(usr)] has toggled [SSticker.triai ? "on" : "off"] triple AIs at round start.</span>", 1)
 	return

--- a/code/modules/admin/verbs/tripAI.dm
+++ b/code/modules/admin/verbs/tripAI.dm
@@ -6,7 +6,7 @@
 		to_chat(usr, "This option is currently only usable during pregame. This may change at a later date.")
 		return
 
-	if(SSjobs && SSticker)
+	if(SSjobs)
 		var/datum/job/job = SSjobs.GetJob("AI")
 		if(!job)
 			to_chat(usr, "Unable to locate the AI job")

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -34,7 +34,7 @@
 			var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
 			new_xeno.amount_grown += (0.75 * new_xeno.max_grown)	//event spawned larva start off almost ready to evolve.
 			new_xeno.key = C.key
-			if(SSticker && SSticker.mode)
+			if(SSticker.mode)
 				SSticker.mode.xenos += new_xeno.mind
 
 			spawncount--

--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -85,7 +85,7 @@ GLOBAL_LIST_EMPTY(karma_spenders)
 	if(!GLOB.configuration.general.enable_karma)
 		to_chat(src, "<span class='warning'>Karma is disabled.</span>")
 		return FALSE
-	if(!SSticker || !GLOB.player_list.len || (SSticker.current_state == GAME_STATE_PREGAME))
+	if(!GLOB.player_list.len || (SSticker.current_state < GAME_STATE_PLAYING))
 		to_chat(src, "<span class='warning'>You can't award karma until the game has started.</span>")
 		return FALSE
 	if(ckey in GLOB.karma_spenders)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -95,7 +95,7 @@
 					// Not-very-datumized antags follow
 					// Associative list of antag name => whether this mind is this antag
 					var/list/other_antags = list()
-					if(SSticker && SSticker.mode)
+					if(SSticker.mode)
 						other_antags += list(
 							"Blob" = (mind.special_role == SPECIAL_ROLE_BLOB),
 							"Cultist" = (mind in SSticker.mode.cult),

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -93,7 +93,7 @@
 		spawn(6)
 			var/mob/living/carbon/alien/larva/new_xeno = new(owner.drop_location())
 			new_xeno.key = C.key
-			if(SSticker && SSticker.mode)
+			if(SSticker.mode)
 				SSticker.mode.xenos += new_xeno.mind
 			new_xeno.mind.name = new_xeno.name
 			new_xeno.mind.assigned_role = SPECIAL_ROLE_XENOMORPH

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -95,7 +95,7 @@
 		//Handle species-specific deaths.
 		dna.species.handle_death(gibbed, src)
 
-	if(SSticker && SSticker.mode)
+	if(SSticker.mode)
 		SSblackbox.ReportDeath(src)
 
 /mob/living/carbon/human/update_revive(updating)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -89,7 +89,7 @@
 				if((M.client?.prefs.toggles2 & PREFTOGGLE_2_DEATHMESSAGE) && (isobserver(M) || M.stat == DEAD))
 					to_chat(M, "<span class='deadsay'><b>[mind.name]</b> has died at <b>[area_name]</b>. (<a href='?src=[M.UID()];jump=\ref[T]'>JMP</a>)</span>")
 
-	if(SSticker && SSticker.mode)
+	if(SSticker.mode)
 		SSticker.mode.check_win()
 
 	// u no we dead

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -796,8 +796,6 @@
 	return name
 
 /mob/living/update_gravity(has_gravity)
-	if(!SSticker)
-		return
 	if(has_gravity)
 		clear_alert("weightless")
 	else

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -295,7 +295,7 @@
 	return G
 
 /mob/living/attack_slime(mob/living/simple_animal/slime/M)
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(M, "You cannot attack people before the game has started.")
 		return
 

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/ai/attack_alien(mob/living/carbon/alien/humanoid/M)
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(M, "You cannot attack people before the game has started.")
 		return
 	..()

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -101,7 +101,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new())
 
 /datum/cameranet/proc/updateVisibility(atom/A, opacity_check = 1)
 
-	if(!SSticker || (opacity_check && !A.opacity))
+	if(opacity_check && !A.opacity)
 		return
 	majorChunkChange(A, 2)
 

--- a/code/modules/mob/living/silicon/login.dm
+++ b/code/modules/mob/living/silicon/login.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/Login()
 	SetSleeping(0)
-	if(mind && SSticker && SSticker.mode)
+	if(mind && SSticker.mode)
 		SSticker.mode.remove_revolutionary(mind, 1)
 		SSticker.mode.remove_cultist(mind, 1)
 		SSticker.mode.remove_wizard(mind)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -93,7 +93,7 @@
 		to_chat(usr, "<span class='warning'>You are banned from playing drones, and cannot spawn as one.</span>")
 		return
 
-	if(!SSticker || SSticker.current_state < GAME_STATE_PLAYING)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(src, "<span class='warning'>You can't join as a drone before the game starts!</span>")
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -766,7 +766,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		to_chat(usr, "<span class='warning'>Respawning is disabled.</span>")
 		return
 
-	if(stat != DEAD || !SSticker)
+	if(stat != DEAD)
 		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
 		return
 
@@ -1014,8 +1014,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	statpanel("Status") // Switch to the Status panel again, for the sake of the lazy Stat procs
 
 	if(client?.statpanel == "Status")
-		if(SSticker)
-			show_stat_station_time()
+		show_stat_station_time()
 		stat(null, "Players Connected: [length(GLOB.clients)]")
 
 // this function displays the station time in the status panel
@@ -1141,7 +1140,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		to_chat(usr, "<span class='warning'>You are banned from playing as sentient animals.</span>")
 		return
 
-	if(!SSticker || SSticker.current_state < 3)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(src, "<span class='warning'>You can't respawn as an NPC before the game starts!</span>")
 		return
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -51,7 +51,7 @@
 		real_name = "Random Character Slot"
 	var/output = "<center><p><a href='byond://?src=[UID()];show_preferences=1'>Setup Character</A><br /><i>[real_name]</i></p>"
 
-	if(!SSticker || SSticker.current_state <= GAME_STATE_PREGAME)
+	if(SSticker.current_state <= GAME_STATE_PREGAME)
 		if(!ready)	output += "<p><a href='byond://?src=[UID()];ready=1'>Declare Ready</A></p>"
 		else	output += "<p><b>You are ready</b> (<a href='byond://?src=[UID()];ready=2'>Cancel</A>)</p>"
 	else
@@ -64,7 +64,7 @@
 		else	output += "<p><a href='byond://?src=[UID()];skip_antag=2'>Global Antag Candidacy</A>"
 		output += "<br /><small>You are <b>[client.skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
 
-	if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
+	if(SSticker.current_state == GAME_STATE_STARTUP)
 		output += "<p>Observe (Please wait...)</p>"
 	else
 		output += "<p><a href='byond://?src=[UID()];observe=1'>Observe</A></p>"
@@ -86,7 +86,7 @@
 	..()
 
 	statpanel("Lobby")
-	if(client.statpanel=="Lobby" && SSticker)
+	if(client.statpanel=="Lobby")
 		if(SSticker.hide_mode)
 			stat("Game Mode:", "Secret")
 		else
@@ -169,7 +169,7 @@
 		if(client.version_blocked)
 			client.show_update_notice()
 			return FALSE
-		if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
+		if(SSticker.current_state == GAME_STATE_STARTUP)
 			to_chat(usr, "<span class='warning'>You must wait for the server to finish starting before you can join!</span>")
 			return FALSE
 
@@ -213,7 +213,7 @@
 		if(client.version_blocked)
 			client.show_update_notice()
 			return FALSE
-		if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
+		if(SSticker.current_state != GAME_STATE_PLAYING)
 			to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 			return
 		if(client.prefs.active_character.species in GLOB.whitelisted_species)
@@ -302,7 +302,7 @@
 /mob/new_player/proc/AttemptLateSpawn(rank)
 	if(src != usr)
 		return 0
-	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
+	if(SSticker.current_state != GAME_STATE_PLAYING)
 		to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 		return 0
 	if(!GLOB.enter_allowed)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -231,7 +231,7 @@
 	terminal.master = src
 
 /obj/machinery/power/smes/Destroy()
-	if(SSticker && SSticker.current_state == GAME_STATE_PLAYING)
+	if(SSticker.current_state == GAME_STATE_PLAYING)
 		var/area/area = get_area(src)
 		if(area)
 			message_admins("SMES deleted at (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>[area.name]</a>)")

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -21,12 +21,8 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 	if(!check_rights(R_EVENT))
 		return
 
-	if(!SSticker)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
 		to_chat(usr, "<span class='warning'>The game hasn't started yet!</span>")
-		return
-
-	if(SSticker.current_state == GAME_STATE_PREGAME)
-		to_chat(usr, "<span class='warning'>The round hasn't started yet!</span>")
 		return
 
 	if(GLOB.send_emergency_team)

--- a/code/modules/world_topic/status.dm
+++ b/code/modules/world_topic/status.dm
@@ -35,7 +35,7 @@
 	
 	// Add more info if we are authed
 	if(key_valid)
-		if(SSticker && SSticker.mode)
+		if(SSticker.mode)
 			status_info["real_mode"] = SSticker.mode.name
 			status_info["security_level"] = get_security_level()
 			status_info["ticker_state"] = SSticker.current_state


### PR DESCRIPTION
## What Does This PR Do
Snips out some SSticker checks (as per #18159), and additionally smacks some magic numbers that were used in `current_state` to their proper defines.
<sub>Also reduces the Carn index by one.</sub>

I used the regex expression `!?SSticker(?!\.)( |[&|]{2}|\s|\))` to find all the SSticker checks.

I also briefly poked at one or two things in a local server, and there wasn't egregious monstrosities from the nether realms lurking about.

## Why It's Good For The Game
Woo! Refactor!
Closes #18159 