### PR TITLE
Adds icon size settings for 2.5x and 3.5x

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -41,9 +41,21 @@ menu "menu"
 		category = "&Size"
 		can-check = true
 		group = "size"
+	elem "icon112"
+		name = "&112x112 (3.5x)"
+		command = ".winset \"mapwindow.map.icon-size=112\""
+		category = "&Size"
+		can-check = true
+		group = "size"
 	elem "icon96"
 		name = "&96x96 (3x)"
 		command = ".winset \"mapwindow.map.icon-size=96\""
+		category = "&Size"
+		can-check = true
+		group = "size"
+	elem "icon80"
+		name = "&80x80 (2.5x)"
+		command = ".winset \"mapwindow.map.icon-size=80\""
 		category = "&Size"
 		can-check = true
 		group = "size"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds icon size settings for 80x80 (2.5x) and 112x112 (3.5x)

## Why It's Good For The Game

2.5x and 3.5x support 2560 x 1440 and 3840 x 2160 monitors.

2560 x 1440 is the second most common monitor resolution behind 1920 x 1080 according to the steam survey. Probably best to support it better.

Fixed icon sizes will always look better than stretch to fit.

## Images of changes
Taken on my 2560 x 1440 monitor. I don't have a 3840 x 2160 monitor so I can't test 3.5x but it should be an improvement.
![image](https://user-images.githubusercontent.com/92271472/178924686-f10f365e-7468-46df-9b6d-2ce352a6163f.png)

![image](https://user-images.githubusercontent.com/92271472/178925436-e1fb6d05-26a2-4ab4-947c-7e3dffe3c760.png)


## Changelog
:cl: Bmon 
add: 2.5x and 3.5x icon size settings added to better support QHD and UHD monitors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
