### PR TITLE
Disable BYOND macros and a few other things users shouldn't have access to.

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -41,7 +41,7 @@
 	var/list/topiclimiter
 
 	// comment out the line below when debugging locally to enable the options & messages menu
-	control_freak = 1
+	control_freak = CONTROL_FREAK_ALL
 
 	var/ssd_warning_acknowledged = FALSE
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -41,7 +41,7 @@
 	var/list/topiclimiter
 
 	// comment out the line below when debugging locally to enable the options & messages menu
-	//control_freak = 1
+	control_freak = 1
 
 	var/ssd_warning_acknowledged = FALSE
 
@@ -55,8 +55,6 @@
 	preload_rsc = 0 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
 
 	var/global/obj/screen/click_catcher/void
-
-	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_SKIN | CONTROL_FREAK_MACROS
 
 	var/ip_intel = "Disabled"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Disables BYOND macros by setting control_freak to 1.

This also disables custom user skins, something that shouldn't ever be touched anyways.

There is an exception for admins, admins (or anyone with access to the admin or debugger panel) have control_freak set to 0 and can still use macros among other things.

## Why It's Good For The Game
BYOND macros have been made obsolete by PR #18166. 

There are a number of things that can be done to exploit BYOND macros for a gameplay advantage, this is obviously not good. Disabling BYOND macros now that we have a key binding system in place which isn't abusable is the right thing to do.

## Changelog
:cl: Bmon
tweak: BYOND macros have been disabled. Use key bindings instead!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
