### PR TITLE
Syndicate chainsaws no longer give stun immunity on dead mobs GBP NO UPDATE

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -625,7 +625,8 @@
 		if(!isliving(target))
 			return
 		else
-			user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
+			if(target.stat != DEAD)
+				user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
 			if(..())
 				target.KnockDown(8 SECONDS)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Syndicate chainsaw checks if target is dead before giving the user stun immunity

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No, you can not drag a dead mob everywhere for permanent stun immunity

## Changelog
:cl:
fix: Fixed being able to hit dead mobs with syndicate chainsaw for stun immunity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
