### PR TITLE
Nerfs stuns on being shocked

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -307,7 +307,7 @@ GLOBAL_LIST_EMPTY(airlock_overlays)
 	if(shockCooldown > world.time)
 		return FALSE	//Already shocked someone recently?
 	if(..())
-		shockCooldown = world.time + 10
+		shockCooldown = world.time + 2 SECONDS
 		return TRUE
 	else
 		return FALSE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -19,7 +19,7 @@
 	var/grille_type
 	var/broken_type = /obj/structure/grille/broken
 	var/shockcooldown = 0
-	var/my_shockcooldown = 1 SECONDS
+	var/my_shockcooldown = 2 SECONDS
 
 /obj/structure/grille/detailed_examine()
 	return "A powered and knotted wire underneath this will cause the grille to shock anyone not wearing insulated gloves.<br>\

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -164,18 +164,18 @@
 	//Stun
 	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
 	if(should_stun)
-		Stun(4 SECONDS)
+		Stun(1 SECONDS)
 	//Jitter and other fluff.
 	AdjustJitter(2000 SECONDS)
 	AdjustStuttering(4 SECONDS)
-	addtimer(CALLBACK(src, .proc/secondary_shock, should_stun), 2 SECONDS)
+	addtimer(CALLBACK(src, .proc/secondary_shock, should_stun), 1 SECONDS)
 	return shock_damage
 
-///Called slightly after electrocute act to reduce jittering and apply a secondary stun.
+///Called slightly after electrocute act to reduce jittering and apply a secondary knockdown.
 /mob/living/carbon/proc/secondary_shock(should_stun)
 	AdjustJitter(-2000 SECONDS, bound_lower = 20 SECONDS) //Still jittery, but vastly less
 	if(should_stun)
-		Weaken(6 SECONDS)
+		KnockDown(6 SECONDS)
 
 /mob/living/carbon/swap_hand()
 	var/obj/item/item_in_hand = get_active_hand()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The 10 seconds combined (4s standing up 6s laying down) stun on being shocked has been replaced with 1 second of stun and 6 seconds of knockdown.

Grilles and airlocks now have a 2 second cooldown (up from 1). This means you can crawl through a shocked airlock right after it has zapped you - though this isn't a good trespass strategy because getting shocked hurts, and the resulting damage and knockdown will still heavily mess you up in a chase. This also means you can't be easily repeatedly pushed into a door and stunlocked.

Part of @hal9000PR stun removal project.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Getting shocked is a common occurence, but it applies an enormous stun. This can be used and abused, I am sure anyone who has played security enough knows the pain of an antag with insuls cutting wires on every damn maint airlock and stopping all chases completely dead - and any antag that has been round-ended by an AI also should understand it (hi wizards). This nerfs strategies that overly rely on door shocks, though door shocking remains strong, as the conditions it causes are still significant.

Aside from balance, this also makes mundane shocks, like a greytider shocking a vendor, much less frustrating.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_3CkIzlzaU6](https://user-images.githubusercontent.com/107632879/179211101-9e0ea465-d969-4dac-882f-62bbe0370001.gif)
After some messing around, I think this looks and feels modern and nice.

## Changelog
:cl:
tweak: Getting shocked now stuns for 1 second and knocks down for 6 seconds, instead of stunning for 4 seconds and then stunning again for 6 seconds. The shock cooldown on grilles and airlocks is now 2 seconds, up from 1.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
