### PR TITLE
Fixes Issue with Wizarditis Teleportation

### DIFF
--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -48,7 +48,7 @@ STI KALY - blind
 			if(prob(0.5))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("the tidal wave of raw power building inside","that this location gives you a +2 to INT and +1 to WIS","an urge to teleport")].</span>")
 				spawn_wizard_clothes(50)
-			if(prob(0.5))
+			if(prob(0.01))
 				teleport()
 	return
 

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -100,7 +100,7 @@ STI KALY - blind
 	for(var/turf/T in get_area_turfs(chosen_area.type))
 		if(!is_teleport_allowed(T.z) || T.z != affected_mob.z)
 			break
-		if(T.name == "space")
+		if(isspaceturf(T))
 			continue
 		if(!T.density)
 			var/clear = TRUE
@@ -117,4 +117,3 @@ STI KALY - blind
 	affected_mob.say("SCYAR NILA [uppertext(chosen_area.name)]!")
 	affected_mob.forceMove(pick(teleport_turfs))
 
-	return

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -98,10 +98,8 @@ STI KALY - blind
 
 	var/list/teleport_turfs = list()
 	for(var/turf/T in get_area_turfs(chosen_area.type))
-		if(!is_teleport_allowed(T.z))
+		if(!is_teleport_allowed(T.z) || T.z != affected_mob.z)
 			break
-		if(T.z != affected_mob.z)
-			continue
 		if(T.name == "space")
 			continue
 		if(!T.density)
@@ -117,6 +115,6 @@ STI KALY - blind
 		return
 
 	affected_mob.say("SCYAR NILA [uppertext(chosen_area.name)]!")
-	affected_mob.loc = pick(teleport_turfs)
+	affected_mob.forceMove(pick(teleport_turfs))
 
 	return

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -28,16 +28,16 @@ STI KALY - blind
 
 	switch(stage)
 		if(2)
-			if(prob(1) && prob(50))
+			if(prob(0.5))
 				affected_mob.say(pick("You shall not pass!", "Expeliarmus!", "By Merlins beard!", "Feel the power of the Dark Side!"))
-			if(prob(1) && prob(50))
+			if(prob(0.5))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("that you don't have enough mana", "that the winds of magic are gone", "an urge to summon familiar")].</span>")
 
 
 		if(3)
-			if(prob(1) && prob(50))
+			if(prob(0.5))
 				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!", "STI KALY!", "TARCOL MINTI ZHERI!"))
-			if(prob(1) && prob(50))
+			if(prob(0.5))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("the magic bubbling in your veins","that this location gives you a +1 to INT","an urge to summon familiar")].</span>")
 
 		if(4)
@@ -45,10 +45,10 @@ STI KALY - blind
 			if(prob(1))
 				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!","STI KALY!","EI NATH!"))
 				return
-			if(prob(1) && prob(50))
+			if(prob(0.5))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("the tidal wave of raw power building inside","that this location gives you a +2 to INT and +1 to WIS","an urge to teleport")].</span>")
 				spawn_wizard_clothes(50)
-			if(prob(1) && prob(1))
+			if(prob(0.5))
 				teleport()
 	return
 
@@ -87,6 +87,9 @@ STI KALY - blind
 
 
 /datum/disease/wizarditis/proc/teleport()
+	if(!is_teleport_allowed(affected_mob.z))
+		return
+
 	var/list/possible_areas = get_areas_in_range(80, affected_mob)
 	for(var/area/space/S in possible_areas)
 		possible_areas -= S
@@ -98,8 +101,6 @@ STI KALY - blind
 
 	var/list/teleport_turfs = list()
 	for(var/turf/T in get_area_turfs(chosen_area.type))
-		if(!is_teleport_allowed(T.z) || T.z != affected_mob.z)
-			break
 		if(isspaceturf(T))
 			continue
 		if(!T.density)

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -28,16 +28,16 @@ STI KALY - blind
 
 	switch(stage)
 		if(2)
-			if(prob(1)&&prob(50))
+			if(prob(1) && prob(50))
 				affected_mob.say(pick("You shall not pass!", "Expeliarmus!", "By Merlins beard!", "Feel the power of the Dark Side!"))
-			if(prob(1)&&prob(50))
+			if(prob(1) && prob(50))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("that you don't have enough mana", "that the winds of magic are gone", "an urge to summon familiar")].</span>")
 
 
 		if(3)
-			if(prob(1)&&prob(50))
+			if(prob(1) && prob(50))
 				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!", "STI KALY!", "TARCOL MINTI ZHERI!"))
-			if(prob(1)&&prob(50))
+			if(prob(1) && prob(50))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("the magic bubbling in your veins","that this location gives you a +1 to INT","an urge to summon familiar")].</span>")
 
 		if(4)
@@ -45,10 +45,10 @@ STI KALY - blind
 			if(prob(1))
 				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!","STI KALY!","EI NATH!"))
 				return
-			if(prob(1)&&prob(50))
+			if(prob(1) && prob(50))
 				to_chat(affected_mob, "<span class='danger'>You feel [pick("the tidal wave of raw power building inside","that this location gives you a +2 to INT and +1 to WIS","an urge to teleport")].</span>")
 				spawn_wizard_clothes(50)
-			if(prob(1)&&prob(1))
+			if(prob(1) && prob(1))
 				teleport()
 	return
 
@@ -87,32 +87,36 @@ STI KALY - blind
 
 
 /datum/disease/wizarditis/proc/teleport()
-	var/list/theareas = get_areas_in_range(80, affected_mob)
-	for(var/area/space/S in theareas)
-		theareas -= S
+	var/list/possible_areas = get_areas_in_range(80, affected_mob)
+	for(var/area/space/S in possible_areas)
+		possible_areas -= S
 
-	if(!theareas||!theareas.len)
+	if(!length(possible_areas))
 		return
 
-	var/area/thearea = pick(theareas)
+	var/area/chosen_area = pick(possible_areas)
 
-	var/list/L = list()
-	for(var/turf/T in get_area_turfs(thearea.type))
-		if(T.z != affected_mob.z) continue
-		if(T.name == "space") continue
+	var/list/teleport_turfs = list()
+	for(var/turf/T in get_area_turfs(chosen_area.type))
+		if(!is_teleport_allowed(T.z))
+			break
+		if(T.z != affected_mob.z)
+			continue
+		if(T.name == "space")
+			continue
 		if(!T.density)
-			var/clear = 1
+			var/clear = TRUE
 			for(var/obj/O in T)
 				if(O.density)
-					clear = 0
+					clear = FALSE
 					break
 			if(clear)
-				L+=T
+				teleport_turfs += T
 
-	if(!L)
+	if(!length(teleport_turfs))
 		return
 
-	affected_mob.say("SCYAR NILA [uppertext(thearea.name)]!")
-	affected_mob.loc = pick(L)
+	affected_mob.say("SCYAR NILA [uppertext(chosen_area.name)]!")
+	affected_mob.loc = pick(teleport_turfs)
 
 	return


### PR DESCRIPTION
## What Does This PR Do
Places a z-level check for wizarditis teleportation and cleans up that section of the code.
Fixes #14242

## Why It's Good For The Game
Edge case, but you shouldn't be able to use wizarditis to teleport to say somewhere like..... the syndicate elite shuttle (which I was able to do)

## Changelog
:cl:
fix: Wizarditis no longer teleports infected players on CC z-level
/:cl:
