### PR TITLE
Mulebots can no longer ride wheelchairs

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -73,6 +73,9 @@
 	QDEL_NULL(cell)
 	return ..()
 
+/mob/living/simple_animal/bot/mulebot/can_buckle()
+	return FALSE //no ma'am, you cannot buckle mulebots to chairs
+
 /mob/living/simple_animal/bot/mulebot/proc/set_suffix(suffix)
 	src.suffix = suffix
 	if(paicard)


### PR DESCRIPTION
## What Does This PR Do
Prevents from Mulebots from being buckled to things.
Fixes #11325
## Why It's Good For The Game
Exploits are bad

## Changelog
:cl:
fix: Prevents from Mulebots from being buckled to things.
/:cl:

