### PR TITLE
Fix - Benches and bamboo banches aren't proper nouns

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -370,7 +370,7 @@
 	icon_state = "pewend_right"
 
 /obj/structure/chair/sofa/bench
-	name = "Bench"
+	name = "bench"
 	desc = "You sit in this. Either by will or force."
 	icon_state = "bench_middle_mapping"
 	base_icon_state = "bench_middle"
@@ -412,7 +412,7 @@
 	base_icon_state = "bench_right"
 
 /obj/structure/chair/sofa/bamboo
-	name = "Bamboo Bench"
+	name = "bamboo bench"
 	desc = "Not the most comfortable, but vegan!"
 	icon_state = "bamboo_sofamiddle"
 	color = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the names of benches and bamboo benches.

## Why It's Good For The Game
They're just benches.

## Images of changes
![Benches](https://user-images.githubusercontent.com/80771500/179330913-ac4c3f38-3c46-4d8e-8999-b59dee6ce549.PNG)

## Changelog
:cl:
fix: Benches and bamboo benches aren't refered to as proper nouns when examined.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
