### PR TITLE
Rebalances Krav Maga for Stamina Combat

### DIFF
--- a/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
+++ b/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
@@ -1,6 +1,6 @@
 /datum/martial_combo/krav_maga/leg_sweep
 	name = "Leg Sweep"
-	explaination_text = "Trips the victim, rendering them prone and unable to move for a short time."
+	explaination_text = "Trips the victim, rendering them prone for a short time."
 
 /datum/martial_combo/krav_maga/leg_sweep/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	if(target.stat || target.IsWeakened())

--- a/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
+++ b/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
@@ -16,7 +16,7 @@
 					  	"<span class='userdanger'>[user] leg sweeps you!</span>")
 	playsound(get_turf(user), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	target.apply_damage(5, BRUTE)
-	target.Weaken(4 SECONDS)
+	target.KnockDown(4 SECONDS)
 	add_attack_logs(user, target, "Melee attacked with martial-art [src] :  Leg Sweep", ATKLOG_ALL)
 	user.mind.martial_art.in_stance = FALSE
 	return MARTIAL_COMBO_DONE_CLEAR_COMBOS

--- a/code/modules/martial_arts/combos/krav_maga/lung_punch.dm
+++ b/code/modules/martial_arts/combos/krav_maga/lung_punch.dm
@@ -8,7 +8,7 @@
 				  	"<span class='userdanger'>[user] slams your chest! You can't breathe!</span>")
 	playsound(get_turf(user), 'sound/effects/hit_punch.ogg', 50, 1, -1)
 	target.AdjustLoseBreath(10 SECONDS)
-	target.adjustOxyLoss(10)
+	target.adjustStaminaLoss(30)
 	add_attack_logs(user, target, "Melee attacked with martial-art [src] :  Lung Punch", ATKLOG_ALL)
 	user.mind.martial_art.in_stance = FALSE
 	return MARTIAL_COMBO_DONE_CLEAR_COMBOS

--- a/code/modules/martial_arts/combos/krav_maga/lung_punch.dm
+++ b/code/modules/martial_arts/combos/krav_maga/lung_punch.dm
@@ -1,6 +1,6 @@
 /datum/martial_combo/krav_maga/lung_punch
 	name = "Lung Punch"
-	explaination_text = "Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time."
+	explaination_text = "Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time, and can be incapacitated with a few more punches."
 
 /datum/martial_combo/krav_maga/lung_punch/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	user.do_attack_animation(target, ATTACK_EFFECT_PUNCH)

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -94,7 +94,7 @@
 	add_attack_logs(A, D, "Melee attacked with [src]")
 	var/picked_hit_type = pick("punches", "kicks")
 	var/bonus_damage = 10
-	if(D.IsWeakened() || IS_HORIZONTAL(D))
+	if(IS_HORIZONTAL(D))
 		bonus_damage += 5
 		picked_hit_type = "stomps on"
 	D.apply_damage(bonus_damage, BRUTE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Leg Sweep: Now a 4 second knockdown instead of a hard stun.
Neck Chop: Unchanged.
Lung Punch: 30 stamina damage, 10 seconds loss of breath. (4 hits to stamina crit)
A redundant check for whether the target is weakened or horizontal was also simplified (weakened people are horizontal).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Leg Sweep: Currently an instant stunlock (you may be able to click the attacker once inbetween stuns if you have good ping, are able bodied, and have good reflexes) that ends with you dying quickly. Not good. Knockdown still allows the user to make use of krav maga's extra damage vs horizontal people, but the victim can actually try to do anything about it. 4 seconds might sound long, but it also prevents the user from knocking your weapons out of your hands constantly.
Neck Chop: This move is fine for antags using krav maga, but it was overshadowed before by...
Lung Punch: 20 oxyloss damage + 10 seconds of losebreath meant that the target would be in gasp town, mostly invalidating neck chop as this was also a good damage move. With 30 stamina damage, 4 hits can be used to stamina crit someone - the losebreath will cause about 50 oxy damage, which will then clear by itself.

## Changelog
:cl:
tweak: Krav maga leg sweep is now a knockdown. Lung punch now deals 30 stamina damage instead of 20 respiratory damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->