### PR TITLE
Fixes magic missile stun time, cult magic missile does knockdown

### DIFF
--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -157,7 +157,7 @@
 
 /obj/effect/proc_holder/spell/inflict_handler/magic_missile/lesser
 	amt_knockdown = 6 SECONDS
-	amt_stunned = 0
+	amt_weakened = 0
 
 /obj/effect/proc_holder/spell/smoke/disable
 	name = "Paralysing Smoke"

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -156,7 +156,7 @@
 	return T
 
 /obj/effect/proc_holder/spell/inflict_handler/magic_missile/lesser
-	amt_knockdown = 6
+	amt_knockdown = 6 SECONDS
 	amt_stunned = 0
 
 /obj/effect/proc_holder/spell/smoke/disable

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -146,6 +146,7 @@
 	invocation_type = "none"
 	holy_area_cancast = FALSE //Stops cult magic from working on holy ground eg: chapel
 	proj_lifespan = 10
+	proj_type = "/obj/effect/proc_holder/spell/inflict_handler/magic_missile/lesser"
 
 /obj/effect/proc_holder/spell/projectile/magic_missile/lesser/create_new_targeting()
 	var/datum/spell_targeting/targeted/T = new()
@@ -153,6 +154,11 @@
 	T.random_target = TRUE
 	T.max_targets = 6
 	return T
+
+/obj/effect/proc_holder/spell/inflict_handler/magic_missile/lesser
+	amt_knockdown = 6
+	amt_stunned = 0
+	sound = 'sound/magic/mm_hit.ogg'
 
 /obj/effect/proc_holder/spell/smoke/disable
 	name = "Paralysing Smoke"

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -158,7 +158,6 @@
 /obj/effect/proc_holder/spell/inflict_handler/magic_missile/lesser
 	amt_knockdown = 6
 	amt_stunned = 0
-	sound = 'sound/magic/mm_hit.ogg'
 
 /obj/effect/proc_holder/spell/smoke/disable
 	name = "Paralysing Smoke"

--- a/code/datums/spells/inflict_handler.dm
+++ b/code/datums/spells/inflict_handler.dm
@@ -5,6 +5,7 @@
 	var/amt_weakened = 0
 	var/amt_paralysis = 0
 	var/amt_stunned = 0
+	var/amt_knockdown = 0
 
 	//set to negatives for healing
 	var/amt_dam_fire = 0
@@ -49,12 +50,13 @@
 		target.adjustToxLoss(amt_dam_tox)
 		target.adjustOxyLoss(amt_dam_oxy)
 		//disabling
-		target.Weaken(amt_weakened)
-		target.Paralyse(amt_paralysis)
-		target.Stun(amt_stunned)
+		target.Weaken(amt_weakened SECONDS)
+		target.Paralyse(amt_paralysis SECONDS)
+		target.Stun(amt_stunned SECONDS)
+		target.KnockDown(amt_knockdown SECONDS)
 
-		target.AdjustEyeBlind(amt_eye_blind)
-		target.AdjustEyeBlurry(amt_eye_blurry)
+		target.AdjustEyeBlind(amt_eye_blind SECONDS)
+		target.AdjustEyeBlurry(amt_eye_blurry SECONDS)
 		//summoning
 		if(summon_type)
 			new summon_type(target.loc, target)

--- a/code/datums/spells/inflict_handler.dm
+++ b/code/datums/spells/inflict_handler.dm
@@ -50,13 +50,13 @@
 		target.adjustToxLoss(amt_dam_tox)
 		target.adjustOxyLoss(amt_dam_oxy)
 		//disabling
-		target.Weaken(amt_weakened SECONDS)
-		target.Paralyse(amt_paralysis SECONDS)
-		target.Stun(amt_stunned SECONDS)
-		target.KnockDown(amt_knockdown SECONDS)
+		target.Weaken(amt_weakened)
+		target.Paralyse(amt_paralysis)
+		target.Stun(amt_stunned)
+		target.KnockDown(amt_knockdown)
 
-		target.AdjustEyeBlind(amt_eye_blind SECONDS)
-		target.AdjustEyeBlurry(amt_eye_blurry SECONDS)
+		target.AdjustEyeBlind(amt_eye_blind)
+		target.AdjustEyeBlurry(amt_eye_blurry)
 		//summoning
 		if(summon_type)
 			new summon_type(target.loc, target)

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -32,7 +32,7 @@
 	return T
 
 /obj/effect/proc_holder/spell/inflict_handler/magic_missile
-	amt_weakened = 6
+	amt_weakened = 6 SECONDS
 	sound = 'sound/magic/mm_hit.ogg'
 
 
@@ -72,7 +72,7 @@
 	return T
 
 /obj/effect/proc_holder/spell/inflict_handler/honk_missile
-	amt_weakened = 3
+	amt_weakened = 6 SECONDS
 	sound = 'sound/items/bikehorn.ogg'
 
 /obj/effect/proc_holder/spell/noclothes

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -32,7 +32,7 @@
 	return T
 
 /obj/effect/proc_holder/spell/inflict_handler/magic_missile
-	amt_weakened = 3
+	amt_weakened = 6
 	sound = 'sound/magic/mm_hit.ogg'
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Magic missile now stuns for the proper amount of time, 6 seconds, rather than 0.3 seconds.

Cult magic missile now does knockdown for 6 seconds, rather than stuns.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixing the stun time being in old cycles rather than seconds is good.

Moving away from ranged stuns (although wizard can keep it) is good.


## Changelog
:cl:
fix: Fixed magic missile having incorrect stun time.
tweak: Cult magic missile does knockdown rather than stun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
