### PR TITLE
Library Fixes

### DIFF
--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -167,7 +167,7 @@
 		user << browse("<body bgcolor='[book_bgcolor]'>[dat]<br>" + "[pages[current_page]]", "window=book[UID()]")
 
 /obj/item/book/Topic(href, href_list)
-	if(..())
+	if(..() || isobserver(usr))
 		return
 	if(href_list["next_page"])
 		if(current_page > length(pages)) //should never be false, but just in-case

--- a/code/modules/library/library_computer.dm
+++ b/code/modules/library/library_computer.dm
@@ -444,7 +444,7 @@
 					user_data.search_rating["max"] = clamp(text2num(answer), user_data.search_rating["min"], 10)
 					populate_booklist()
 				if("edit_search_ratingmin")
-					if(!text2num(answer))
+					if(!text2num(answer) && text2num(answer) != 0)
 						return
 					user_data.search_rating["min"] = clamp(text2num(answer), 0, user_data.search_rating["max"])
 					populate_booklist()
@@ -463,8 +463,8 @@
 				if("setpagenumber")
 					if(!text2num(answer))
 						return
-					archive_page_num = clamp(text2num(answer), 1, getmaxpages())
 					populate_booklist()
+					archive_page_num = clamp(text2num(answer), 1, getmaxpages())
 				else
 					return FALSE
 		else


### PR DESCRIPTION
## What Does This PR Do
Fixes #18413 
also fixed issue with who can turn pages in books

## Changelog
:cl:
fix: library computer min rating search can be set to 0 now without clearing seach
fix: Observers can no longer turn book pages
/:cl:
