### PR TITLE
Removes the Invisible Second Resource Meter from Changelings ("Genetic Damage")

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -27,10 +27,6 @@
 	var/req_human = FALSE
 	/// What `stat` value the changeling needs to have to use this power. Will be CONSCIOUS, UNCONSCIOUS or DEAD.
 	var/req_stat = CONSCIOUS
-	/// The amount of genetic damage caused by using this power. Is not related to the mob's `cloneloss`.
-	var/genetic_damage = 0
-	/// The max `genetic_damage` the changeling is allowed to have before they cannot use this power anymore.
-	var/max_genetic_damage = 100
 	/// If this power is active or not. Used for toggleable abilities.
 	var/active = FALSE
 	/// If this power can be used while the changeling has the `TRAIT_FAKE_DEATH` trait.
@@ -72,7 +68,6 @@
 
 /datum/action/changeling/proc/take_chemical_cost()
 	cling.chem_charges -= chemical_cost
-	cling.genetic_damage += genetic_damage
 
 /datum/action/changeling/proc/can_sting(mob/user, mob/target)
 	SHOULD_CALL_PARENT(TRUE)
@@ -90,9 +85,6 @@
 		return FALSE
 	if(HAS_TRAIT(user, TRAIT_FAKEDEATH) && !bypass_fake_death)
 		to_chat(user, "<span class='warning'>We are incapacitated.</span>")
-		return FALSE
-	if(cling.genetic_damage > max_genetic_damage)
-		to_chat(user, "<span class='warning'>Our genomes are still reassembling. We need time to recover first.</span>")
 		return FALSE
 	return TRUE
 

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -5,7 +5,6 @@
 	chemical_cost = 0
 	power_type = CHANGELING_INNATE_POWER
 	req_human = TRUE
-	max_genetic_damage = 100
 
 /datum/action/changeling/absorbDNA/can_sting(mob/living/carbon/user)
 	if(!..())

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -6,7 +6,6 @@
 	power_type = CHANGELING_INNATE_POWER
 	req_dna = 1
 	req_stat = DEAD
-	max_genetic_damage = 100
 
 //Fake our own death and fully heal. You will appear to be dead but regenerate fully after a short delay.
 /datum/action/changeling/fakedeath/sting_action(mob/living/user)

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -3,9 +3,7 @@
 	desc = "We change into a human. Costs 5 chemicals."
 	button_icon_state = "human_form"
 	chemical_cost = 5
-	genetic_damage = 3
 	req_dna = 1
-	max_genetic_damage = 3
 
 //Transform into a human.
 /datum/action/changeling/humanform/sting_action(mob/living/carbon/human/user)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -5,7 +5,6 @@
 	button_icon_state = "lesser_form"
 	chemical_cost = 5
 	dna_cost = 1
-	genetic_damage = 3
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -6,7 +6,6 @@
 	chemical_cost = 0
 	power_type = CHANGELING_INNATE_POWER
 	req_human = TRUE
-	max_genetic_damage = 100
 
 /datum/action/changeling/linglink/can_sting(mob/living/carbon/user)
 	if(!..())

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -12,7 +12,6 @@
 	desc = "Go tell a coder if you see this"
 	helptext = "Yell at coderbus"
 	chemical_cost = 1000
-	genetic_damage = 1000
 	power_type = CHANGELING_UNOBTAINABLE_POWER
 	var/silent = FALSE
 	var/weapon_type
@@ -47,7 +46,6 @@
 	desc = "Go tell a coder if you see this"
 	helptext = "Yell at coderbus"
 	chemical_cost = 1000
-	genetic_damage = 1000
 	power_type = CHANGELING_UNOBTAINABLE_POWER
 	var/helmet_type = /obj/item
 	var/suit_type = /obj/item
@@ -62,7 +60,7 @@
 
 	var/mob/living/carbon/human/H = user
 	if(istype(H.wear_suit, suit_type) || istype(H.head, helmet_type))
-		H.visible_message("<span class='warning'>[H] casts off [H.p_their()] [suit_name_simple]!</span>", "<span class='warning'>We cast off our [suit_name_simple][genetic_damage > 0 ? ", temporarily weakening our genomes." : "."]</span>", "<span class='warning'>You hear the organic matter ripping and tearing!</span>")
+		H.visible_message("<span class='warning'>[H] casts off [H.p_their()] [suit_name_simple]!</span>", "<span class='warning'>We cast off our [suit_name_simple].</span>", "<span class='warning'>You hear the organic matter ripping and tearing!</span>")
 		qdel(H.wear_suit)
 		qdel(H.head)
 		H.update_inv_wear_suit()
@@ -74,7 +72,6 @@
 			H.add_splatter_floor()
 			playsound(H.loc, 'sound/effects/splat.ogg', 50, 1) //So real sounds
 
-		cling.genetic_damage += genetic_damage //Casting off a space suit leaves you weak for a few seconds.
 		cling.chem_recharge_slowdown -= recharge_slowdown
 		return FALSE
 	..(H, target)
@@ -108,9 +105,7 @@
 	button_icon_state = "armblade"
 	chemical_cost = 25
 	dna_cost = 2
-	genetic_damage = 10
 	req_human = TRUE
-	max_genetic_damage = 20
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
 	power_type = CHANGELING_PURCHASABLE_POWER
@@ -176,9 +171,7 @@
 	button_icon_state = "tentacle"
 	chemical_cost = 10
 	dna_cost = 2
-	genetic_damage = 5
 	req_human = TRUE
-	max_genetic_damage = 10
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"
 	silent = TRUE
@@ -350,9 +343,7 @@
 	button_icon_state = "organic_shield"
 	chemical_cost = 20
 	dna_cost = 1
-	genetic_damage = 12
 	req_human = TRUE
-	max_genetic_damage = 20
 	weapon_type = /obj/item/shield/changeling
 	weapon_name_simple = "shield"
 	power_type = CHANGELING_PURCHASABLE_POWER
@@ -401,9 +392,7 @@
 	button_icon_state = "organic_suit"
 	chemical_cost = 20
 	dna_cost = 2
-	genetic_damage = 8
 	req_human = TRUE
-	max_genetic_damage = 20
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/space/changeling
 	helmet_type = /obj/item/clothing/head/helmet/space/changeling
@@ -449,9 +438,7 @@
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 25
 	dna_cost = 2
-	genetic_damage = 11
 	req_human = TRUE
-	max_genetic_damage = 20
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/armor/changeling
 	helmet_type = /obj/item/clothing/head/helmet/changeling

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -9,7 +9,6 @@
 	chemical_cost = 0
 	dna_cost = 1
 	req_human = TRUE
-	max_genetic_damage = 0
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/strained_muscles/Remove(mob/living/L)

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -6,7 +6,6 @@
 	power_type = CHANGELING_INNATE_POWER
 	req_dna = 1
 	req_human = TRUE
-	max_genetic_damage = 3
 
 //Change our DNA to that of somebody we've absorbed.
 /datum/action/changeling/transform/sting_action(mob/living/carbon/human/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The invisible genetic damage mechanic that limits how often they can use some of their abilities (pretty arbitrarily) is now gone from changelings, making their powers be based on just one resource they can actually see.

This is completely unrelated to cellular damage, which is sometimes called "genetic damage" in character and caused mostly by slimes and cloning.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The "genetic damage" resource is completely invisible to the player, causing confusion when they cannot use two of their powers in quick succession. This is particularly bad, because it does not even apply to all abilities - some of them can be used after one another just fine. This entire mechanic is utterly unnecessary, because changelings already have another, visible resource all of their powers operate on - chemicals. Usually, changelings get to use two, maybe three abilities in a fight before they are out of chemicals, which do not regenerate quickly enough for a fourth.

Changelings are not in a good spot balance-wise, and not particularly fun to play for a lot of people. Their abilities (which they should be able to afford according to their chemical meter) seemingly randomly failing to work (many people aren't even aware why) is one of the reasons why. 

## Changelog
:cl:
del: Changelings no longer have a completely invisible "genetic damage" resource meter that prevents them from using certain abilities. Their visible chemicals resource is still there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
