### PR TITLE
Reduces mindswap jitter time from 1000 seconds to 10

### DIFF
--- a/code/modules/antagonists/changeling/powers/swap_form.dm
+++ b/code/modules/antagonists/changeling/powers/swap_form.dm
@@ -35,8 +35,8 @@
 	var/mob/living/carbon/human/target = G.affecting
 
 	to_chat(user, "<span class='notice'>We tighten our grip. We must hold still....</span>")
-	target.Jitter(1000 SECONDS)
-	user.Jitter(1000 SECONDS)
+	target.Jitter(10 SECONDS)
+	user.Jitter(10 SECONDS)
 
 	if(!do_mob(user, target, 10 SECONDS))
 		to_chat(user, "<span class='warning'>The body swap has been interrupted!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reduces the amount of time a changeling/victim will jitter from the mindswap ability from 1000 seconds to 10 seconds.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
During stun/status effect refactor this got incorrect converted, this PR should fix is so changelings don't endlessly jitter around after performing a mindswap.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Reduced mindswap jitter time from 1000 seconds to 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
