### PR TITLE
Adds special click actions for Toggle Suit Sensors and Set Transfer Amount

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -296,9 +296,7 @@ BLIND     // can't see anything
 	return TRUE
 
 /obj/item/clothing/under/proc/set_sensors(mob/user as mob)
-	var/mob/M = user
-
-	if(!user.Adjacent(src) || istype(M, /mob/dead/) || user.stat || user.restrained() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+	if(!user.Adjacent(src) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	if(has_sensor >= 2)
 		to_chat(user, "The controls are locked.")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -319,13 +319,13 @@ BLIND     // can't see anything
 
 	if(src.loc == user)
 		switch(sensor_mode)
-			if(0)
+			if(SUIT_SENSOR_OFF)
 				to_chat(user, "You disable your suit's remote sensing equipment.")
-			if(1)
+			if(SUIT_SENSOR_BINARY)
 				to_chat(user, "Your suit will now report whether you are live or dead.")
-			if(2)
+			if(SUIT_SENSOR_VITAL)
 				to_chat(user, "Your suit will now report your vital lifesigns.")
-			if(3)
+			if(SUIT_SENSOR_TRACKING)
 				to_chat(user, "Your suit will now report your vital lifesigns as well as your coordinate position.")
 		if(istype(user,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = user
@@ -334,16 +334,16 @@ BLIND     // can't see anything
 
 	else if(istype(src.loc, /mob))
 		switch(sensor_mode)
-			if(0)
+			if(SUIT_SENSOR_OFF)
 				for(var/mob/V in viewers(user, 1))
 					V.show_message("<span class='warning'>[user] disables [src.loc]'s remote sensing equipment.</span>", 1)
-			if(1)
+			if(SUIT_SENSOR_BINARY)
 				for(var/mob/V in viewers(user, 1))
 					V.show_message("[user] turns [src.loc]'s remote sensors to binary.", 1)
-			if(2)
+			if(SUIT_SENSOR_VITAL)
 				for(var/mob/V in viewers(user, 1))
 					V.show_message("[user] sets [src.loc]'s sensors to track vitals.", 1)
-			if(3)
+			if(SUIT_SENSOR_TRACKING)
 				for(var/mob/V in viewers(user, 1))
 					V.show_message("[user] sets [src.loc]'s sensors to maximum.", 1)
 		if(istype(src,/mob/living/carbon/human))
@@ -762,13 +762,13 @@ BLIND     // can't see anything
 
 	if(has_sensor >= 1)
 		switch(sensor_mode)
-			if(0)
+			if(SUIT_SENSOR_OFF)
 				. += "Its sensors appear to be disabled."
-			if(1)
+			if(SUIT_SENSOR_BINARY)
 				. += "Its binary life sensors appear to be enabled."
-			if(2)
+			if(SUIT_SENSOR_VITAL)
 				. += "Its vital tracker appears to be enabled."
-			if(3)
+			if(SUIT_SENSOR_TRACKING)
 				. += "Its vital tracker and tracking beacon appear to be enabled."
 		if(has_sensor == 1)
 			. += "Alt-shift-click to toggle the sensors mode."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -353,6 +353,10 @@ BLIND     // can't see anything
 	set src in usr
 	set_sensors(usr)
 
+/obj/item/clothing/under/AltClick(mob/user)
+	if(user.Adjacent(src))
+		set_sensors(user)
+
 //Head
 /obj/item/clothing/head
 	name = "head"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -353,7 +353,7 @@ BLIND     // can't see anything
 	set src in usr
 	set_sensors(usr)
 
-/obj/item/clothing/under/AltClick(mob/user)
+/obj/item/clothing/under/AltShiftClick(mob/user)
 	if(user.Adjacent(src))
 		set_sensors(user)
 
@@ -827,7 +827,7 @@ BLIND     // can't see anything
 			A.emp_act(severity)
 	..()
 
-/obj/item/clothing/under/AltShiftClick()
+/obj/item/clothing/under/AltClick()
 	handle_accessories_removal()
 
 /obj/item/clothing/obj_destruction(damage_flag)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -297,8 +297,8 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/proc/set_sensors(mob/user as mob)
 	var/mob/M = user
-	if(istype(M, /mob/dead/)) return
-	if(user.stat || user.restrained()) return
+	if(istype(M, /mob/dead/) || user.stat || user.restrained() || user.HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return
 	if(has_sensor >= 2)
 		to_chat(user, "The controls are locked.")
 		return 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -308,7 +308,7 @@ BLIND     // can't see anything
 
 	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
 	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[sensor_mode + 1]) in modes
-	if(get_dist(user, src) > 1)
+	if(!user.Adjacent(src))
 		to_chat(user, "You have moved too far away.")
 		return
 	sensor_mode = modes.Find(switchMode) - 1

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -352,6 +352,7 @@ BLIND     // can't see anything
 	set name = "Toggle Suit Sensors"
 	set category = "Object"
 	set src in usr
+
 	set_sensors(usr)
 
 /obj/item/clothing/under/AltShiftClick(mob/user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -297,7 +297,8 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/proc/set_sensors(mob/user as mob)
 	var/mob/M = user
-	if(istype(M, /mob/dead/) || user.stat || user.restrained() || user.HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+
+	if(!user.Adjacent(src) || istype(M, /mob/dead/) || user.stat || user.restrained() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	if(has_sensor >= 2)
 		to_chat(user, "The controls are locked.")
@@ -354,8 +355,7 @@ BLIND     // can't see anything
 	set_sensors(usr)
 
 /obj/item/clothing/under/AltShiftClick(mob/user)
-	if(user.Adjacent(src))
-		set_sensors(user)
+	set_sensors(user)
 
 //Head
 /obj/item/clothing/head

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -823,7 +823,7 @@ BLIND     // can't see anything
 			A.emp_act(severity)
 	..()
 
-/obj/item/clothing/under/AltClick()
+/obj/item/clothing/under/AltShiftClick()
 	handle_accessories_removal()
 
 /obj/item/clothing/obj_destruction(damage_flag)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -308,7 +308,7 @@ BLIND     // can't see anything
 	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
 	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[sensor_mode + 1]) in modes
 	if(!user.Adjacent(src))
-		to_chat(user, "You have moved too far away.")
+		to_chat(user, "<span class='warning'>You have moved too far away!</span>")
 		return
 	sensor_mode = modes.Find(switchMode) - 1
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -755,18 +755,26 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/examine(mob/user)
 	. = ..()
-	switch(sensor_mode)
-		if(0)
-			. += "Its sensors appear to be disabled."
-		if(1)
-			. += "Its binary life sensors appear to be enabled."
-		if(2)
-			. += "Its vital tracker appears to be enabled."
-		if(3)
-			. += "Its vital tracker and tracking beacon appear to be enabled."
+
+	if(has_sensor >= 1)
+		switch(sensor_mode)
+			if(0)
+				. += "Its sensors appear to be disabled."
+			if(1)
+				. += "Its binary life sensors appear to be enabled."
+			if(2)
+				. += "Its vital tracker appears to be enabled."
+			if(3)
+				. += "Its vital tracker and tracking beacon appear to be enabled."
+		if(has_sensor == 1)
+			. += "Alt-shift-click to toggle the sensors mode."
+	else
+		. += "This suit does not have any sensors."
+
 	if(length(accessories))
 		for(var/obj/item/clothing/accessory/A in accessories)
 			. += "\A [A] is attached to it."
+		. += "Alt-click to remove an accessory."
 
 
 /obj/item/clothing/under/verb/rollsuit()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -307,9 +307,14 @@ BLIND     // can't see anything
 
 	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
 	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[sensor_mode + 1]) in modes
+
 	if(!user.Adjacent(src))
 		to_chat(user, "<span class='warning'>You have moved too far away!</span>")
 		return
+	if(!ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		to_chat(user, "<span class='warning'>You can't use your hands!</span>")
+		return
+
 	sensor_mode = modes.Find(switchMode) - 1
 
 	if(src.loc == user)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -27,7 +27,7 @@
 		default = amount_per_transfer_from_this
 	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
 	if(!usr.Adjacent(src))
-		to_chat(usr, "You have moved too far away.")
+		to_chat(usr, "<span class='warning'>You have moved too far away!</span>")
 		return
 	if(N)
 		amount_per_transfer_from_this = N

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -26,9 +26,14 @@
 	if(amount_per_transfer_from_this in possible_transfer_amounts)
 		default = amount_per_transfer_from_this
 	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
+
 	if(!usr.Adjacent(src))
 		to_chat(usr, "<span class='warning'>You have moved too far away!</span>")
 		return
+	if(!ishuman(usr) || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
+		to_chat(usr, "<span class='warning'>You can't use your hands!</span>")
+		return
+
 	if(N)
 		amount_per_transfer_from_this = N
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -25,6 +25,9 @@
 	if(amount_per_transfer_from_this in possible_transfer_amounts)
 		default = amount_per_transfer_from_this
 	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
+	if(!usr.Adjacent(src))
+		to_chat(usr, "You have moved too far away.")
+		return
 	if(N)
 		amount_per_transfer_from_this = N
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -28,6 +28,10 @@
 	if(N)
 		amount_per_transfer_from_this = N
 
+/obj/item/reagent_containers/AltClick(mob/user)
+	if(user.Adjacent(src))
+		set_APTFT()
+
 /obj/item/reagent_containers/New()
 	create_reagents(volume, temperature_min, temperature_max)
 	..()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -19,8 +19,9 @@
 	set category = "Object"
 	set src in range(0)
 
-	if(usr.incapacitated())
+	if(!usr.Adjacent(src) || usr.incapacitated())
 		return
+
 	var/default = null
 	if(amount_per_transfer_from_this in possible_transfer_amounts)
 		default = amount_per_transfer_from_this
@@ -31,9 +32,8 @@
 	if(N)
 		amount_per_transfer_from_this = N
 
-/obj/item/reagent_containers/AltClick(mob/user)
-	if(user.Adjacent(src))
-		set_APTFT()
+/obj/item/reagent_containers/AltClick()
+	set_APTFT()
 
 /obj/item/reagent_containers/New()
 	create_reagents(volume, temperature_min, temperature_max)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -98,4 +98,5 @@
 	// Food has no valid possible_transfer_amounts, and we don't want to show
 	// this message on examining food.
 	if(possible_transfer_amounts)
-		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this > 1 ? "s" : ""] at a time."
+		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this > 1 ? "s" : ""] at a time.</span>"
+		. += "<span class='notice'>Alt-click to change the transfer amount.</span>"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -19,7 +19,7 @@
 	set category = "Object"
 	set src in usr
 
-	if(!usr.Adjacent(src) || usr.incapacitated())
+	if(!usr.Adjacent(src) || !ishuman(usr) || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
 
 	var/default = null

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -17,7 +17,7 @@
 /obj/item/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
 	set category = "Object"
-	set src in range(0)
+	set src in usr
 
 	if(!usr.Adjacent(src) || usr.incapacitated())
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Alt+Shift+Clicking jumpsuits now allows you to toggle their suit sensors.
Alt+Clicking reagent containers now allows you to change their transfer amount.

Both had some minor adjacency sanity checks added to ensure you can't interact with them from far away/through solid border objects like directional windows.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, the way to do both of these things is via the RightClick context menu, or through selecting their respective Object verbs often placed among a bunch of others. This is not very discoverable nor convenient, which isn't good for these fairly commonly used functions - especially now that since #18374, setting macros for these two verbs to alleviate the convenience issue is no longer possible.
Moving away from triggering special item functionality via the context menu to more responsive Alt(+Shift)+Click actions should be a Quality of Life tweak that also helps new players more easily discover how to do something as basic as making sure the station Paramedic knows when to save their ass.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now Alt+Shift+Click jumpsuits to toggle their suit sensors
add: You can now Alt+Click beakers and other reagent containers to set their transfer amount
fix: You can no longer set reagent container transfer amounts remotely/toggle suit sensors through solid border objects
fix: Jumpsuits with no suit sensors no longer report disabled suit sensors on examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
