### PR TITLE
Garlic juice no longer rng stuns vampires

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -350,18 +350,9 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/datum/antagonist/vampire/V = H.mind?.has_antag_datum(/datum/antagonist/vampire)
-		if(V && !V.get_ability(/datum/vampire_passive/full)) //incapacitating but not lethal.
-			if(prob(min(25, current_cycle)))
-				to_chat(H, "<span class='danger'>You can't get the scent of garlic out of your nose! You can barely think...</span>")
-				H.Weaken(2 SECONDS)
-				H.Jitter(20 SECONDS)
-				H.fakevomit()
-		else
-			if(H.job == "Chef")
-				if(prob(20)) //stays in the system much longer than sprinkles/banana juice, so heals slower to partially compensate
-					update_flags |= H.adjustBruteLoss(-1, FALSE)
-					update_flags |= H.adjustFireLoss(-1, FALSE)
+		if(H.job == "Chef" && prob(20)) //stays in the system much longer than sprinkles/banana juice, so heals slower to partially compensate
+			update_flags |= H.adjustBruteLoss(-1, FALSE)
+			update_flags |= H.adjustFireLoss(-1, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/sprinkles


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
title.

## Why It's Good For The Game
botany shouldn't be able to make seemling harmless plants filled with AOE vampire metacheck/stun gas. They already have holy water, thats enough.
and its also silly.

## Changelog
:cl:
del: garlic juice no longer effects vampires
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
