### PR TITLE
Fixes typo in plutonium core traitor objective

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -151,7 +151,7 @@
 	job_possession = FALSE //The CE / engineers / atmos techs do not carry around supermater slivers.
 
 /datum/theft_objective/plutonium_core
-	name = "the plutonium core from the stations nuclear device"
+	name = "the plutonium core from the station's nuclear device"
 	typepath = /obj/item/nuke_core/plutonium
 	location_override = "the Vault. You can use the box and instructions provided to remove the core, with some extra tools"
 	special_equipment = /obj/item/storage/box/syndie_kit/nuke


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a minor typo in the plutonium core traitor objective.

## Why It's Good For The Game
Typos bad.

## Images of changes
Before:
![image](https://user-images.githubusercontent.com/3611705/179636517-09badee3-9b7b-4845-a0c9-232fd5ac8097.png)
After:
![image](https://user-images.githubusercontent.com/3611705/179636552-9135e979-4db3-491e-b552-5daa2699c0dd.png)

## Changelog
:cl:
fix: Fixed typo in plutonium core traitor objective
/:cl: