### PR TITLE
Changes Xenomorph instastuns to knockdown+stamina

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -82,7 +82,8 @@
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
 				if(ishuman(L))
 					var/mob/living/carbon/human/H = L
-					H.apply_effect(10 SECONDS, WEAKEN, H.run_armor_check(null, MELEE))
+					H.apply_effect(10 SECONDS, KNOCKDOWN, H.run_armor_check(null, MELEE))
+					H.adjustStaminaLoss(30)
 				else
 					L.Weaken(10 SECONDS)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -83,7 +83,7 @@
 				if(ishuman(L))
 					var/mob/living/carbon/human/H = L
 					H.apply_effect(10 SECONDS, KNOCKDOWN, H.run_armor_check(null, MELEE))
-					H.adjustStaminaLoss(30)
+					H.adjustStaminaLoss(40)
 				else
 					L.Weaken(10 SECONDS)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -646,7 +646,8 @@ emp_act
 			else
 				var/obj/item/organ/external/affecting = get_organ(ran_zone(M.zone_selected))
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-				apply_effect(10 SECONDS, WEAKEN, run_armor_check(affecting, MELEE))
+				apply_effect(10 SECONDS, KNOCKDOWN, run_armor_check(affecting, MELEE))
+				adjustStaminaLoss(30)
 				add_attack_logs(M, src, "Alien tackled")
 				visible_message("<span class='danger'>[M] has tackled down [src]!</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes Xenomorph "weaken" instastuns (disarm, hunter pounce) to knockdowns. Disarm now does 30 stamina damage per hit, pounce does 40. A xenomorph must now wrestle their victim into stamcrit (3-4 hits) before they can be abducted alive.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xenomorphs might be out of rotation, but they see their way into rounds often enough (wizards, admin hijinks) that they should nevertheless align with the direction Paracode combat is heading. No instant stuns.

I have no illusions that this PR makes Xenos even remotely balanced, but it's a step in the right direction.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Xenomorph disarms now cause knockdown and stamina damage instead of stun.
tweak: Alien Hunter pounce now causes knockdown and stamina damage instead of stun. Self-inflicted stun (pouncing into a wall) is **not** changed.
/:cl:

(This is my first PR that touches actual code, apologies if I did something horribly wrong!)
