### PR TITLE
Optimises gas canisters

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -258,7 +258,6 @@ update_flag
 	else
 		can_label = FALSE
 
-	return
 
 /obj/machinery/portable_atmospherics/canister/return_air()
 	return air_contents

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -258,7 +258,6 @@ update_flag
 	else
 		can_label = FALSE
 
-	updateDialog()
 	return
 
 /obj/machinery/portable_atmospherics/canister/return_air()


### PR DESCRIPTION
## What Does This PR Do
Optimises gas canister `process_atmos` by removing 98% of the processing load. This image should help.

![image](https://user-images.githubusercontent.com/25063394/179732620-cd4f85e6-5bf8-48cc-a90d-142dd9e526d0.png)

Canister `process_atmos` uses 580us of CPU time, and 570us of that is just updating the dialogue, which is a proc thats defined right down at `/obj`

```dm
/obj/proc/updateDialog()
	// Check that people are actually using the machine. If not, don't update anymore.
	if(in_use)
		var/list/nearby = viewers(1, src)
		var/is_in_use = FALSE
		for(var/mob/M in nearby)
			if((M.client && M.machine == src))
				is_in_use = TRUE
				src.interact(M)
		var/ai_in_use = AutoUpdateAI(src)

		if(!ai_in_use && !is_in_use)
			in_use = FALSE
```

Nothing in the entire atmos machinery chain has `/interact` or `AutoUpdateAI`

This also stems why the entire old `use_machine` system needs removing.

If you look in more detail, you can see in context how much of this time is wasted compared to actual atmos running
![image](https://user-images.githubusercontent.com/25063394/179736221-f4c36ddf-38ae-4daf-8c28-c9f88f92994e.png)


## Why It's Good For The Game
This is probably the biggest microoptimisation I will ever make, but if we can turn 30 seconds of CPU time to 1 second each round on gas canister processing, why shouldnt we.

## Changelog
:cl: AffectedArc07
add: Added performance
/:cl:
