### PR TITLE
Removes instant stuns from defibs, adds knockdown and stamina damage

### DIFF
--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -39,14 +39,10 @@
 		return
 
 	if(emagged)
-		if(attack_cooldown > world.time)
-			return
-
 		var/user_UID = user.UID()
 		if(HAS_TRAIT_FROM(H, TRAIT_WAS_BATONNED, user_UID)) // no following up with baton or dual wielding defibs for stunlock cheese purposes
 			return
 
-		cooldown = world.time + (cooldown)
 		user.visible_message("<span class='danger'>[user] violently shocks [H] with [src]!</span>", "<span class='danger'>You violently shock [H] with [src]!</span>")
 		add_attack_logs(user, H, "emag-defibbed with [src]")
 		playsound(user.loc, "sound/weapons/Egloves.ogg", 75, 1)

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -11,11 +11,12 @@
 	var/icon_base = "defib"
 	///Can the defib shock yet?
 	var/cooldown = FALSE
+	///How long will it take to recharge after a shock?
+	var/charge_time = 10 SECONDS
 	///How long until we can attack the same person with any emagged handheld defib or baton again?
 	var/attack_cooldown = 3.5 SECONDS
 	///How long does this knock the target down for?
 	var/knockdown_duration = 10 SECONDS
-	var/charge_time = 10 SECONDS
 
 /obj/item/handheld_defibrillator/emag_act(mob/user)
 	if(!emagged)

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -57,10 +57,6 @@
 			to_chat(H, "<span class='danger'>You feel a powerful jolt!</span>")
 			SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 
-			if(emagged && prob(10))
-				to_chat(user, "<span class='danger'>[src]'s on board scanner indicates that the target is undergoing a cardiac arrest!</span>")
-				H.set_heartattack(TRUE)
-
 		cooldown = TRUE
 		icon_state = "[icon_base]-shock"
 		addtimer(CALLBACK(src, .proc/short_charge), 10)

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -49,7 +49,7 @@
 		H.KnockDown(knockdown_duration)
 		H.adjustStaminaLoss(60)
 		SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
-		ADD_TRAIT(H, TRAIT_WAS_BATONNED, user.UID())
+		ADD_TRAIT(H, TRAIT_WAS_BATONNED, user_UID)
 		cooldown = TRUE
 		icon_state = "[icon_base]-shock"
 		addtimer(CALLBACK(src, .proc/allowhit, H, user_UID), attack_cooldown)

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -90,7 +90,7 @@
 	else
 		to_chat(user, "<span class='notice'>[src]'s on board medical scanner indicates that no shock is required.</span>")
 
-/obj/item/handheld_defibrillator/proc/allowhit(mob/living/target, user_UID, knockdown_duration)
+/obj/item/handheld_defibrillator/proc/allowhit(mob/living/target, user_UID)
 	REMOVE_TRAIT(target, TRAIT_WAS_BATONNED, user_UID)
 
 /obj/item/handheld_defibrillator/proc/short_charge()

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -9,8 +9,13 @@
 	belt_icon = "defib"
 
 	var/icon_base = "defib"
+	///Can the defib shock yet?
 	var/cooldown = FALSE
-	var/charge_time = 100
+	///How long until we can attack the same person with any emagged handheld defib or baton again?
+	var/attack_cooldown = 3.5 SECONDS
+	///How long does this knock the target down for?
+	var/knockdown_duration = 10 SECONDS
+	var/charge_time = 10 SECONDS
 
 /obj/item/handheld_defibrillator/emag_act(mob/user)
 	if(!emagged)
@@ -32,7 +37,30 @@
 		to_chat(user, "<span class='warning'>[src] is still charging!</span>")
 		return
 
-	if(emagged || (H.health <= HEALTH_THRESHOLD_CRIT) || (H.undergoing_cardiac_arrest()))
+	if(emagged)
+		if(attack_cooldown > world.time)
+			return
+
+		var/user_UID = user.UID()
+		if(HAS_TRAIT_FROM(H, TRAIT_WAS_BATONNED, user_UID)) // no following up with baton or dual wielding defibs for stunlock cheese purposes
+			return
+
+		cooldown = world.time + (cooldown)
+		user.visible_message("<span class='danger'>[user] violently shocks [H] with [src]!</span>", "<span class='danger'>You violently shock [H] with [src]!</span>")
+		add_attack_logs(user, H, "emag-defibbed with [src]")
+		playsound(user.loc, "sound/weapons/Egloves.ogg", 75, 1)
+		H.KnockDown(knockdown_duration)
+		H.adjustStaminaLoss(60)
+		SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
+		ADD_TRAIT(H, TRAIT_WAS_BATONNED, user.UID())
+		cooldown = TRUE
+		icon_state = "[icon_base]-shock"
+		addtimer(CALLBACK(src, .proc/allowhit, H, user_UID), attack_cooldown)
+		addtimer(CALLBACK(src, .proc/short_charge), 1 SECONDS)
+		addtimer(CALLBACK(src, .proc/recharge), charge_time)
+		return
+
+	if((H.health <= HEALTH_THRESHOLD_CRIT) || (H.undergoing_cardiac_arrest()))
 		user.visible_message("<span class='notice'>[user] shocks [H] with [src].</span>", "<span class='notice'>You shock [H] with [src].</span>")
 		add_attack_logs(user, H, "defibrillated with [src]")
 		playsound(user.loc, "sound/weapons/Egloves.ogg", 75, 1)
@@ -59,11 +87,14 @@
 
 		cooldown = TRUE
 		icon_state = "[icon_base]-shock"
-		addtimer(CALLBACK(src, .proc/short_charge), 10)
+		addtimer(CALLBACK(src, .proc/short_charge), 1 SECONDS)
 		addtimer(CALLBACK(src, .proc/recharge), charge_time)
 
 	else
 		to_chat(user, "<span class='notice'>[src]'s on board medical scanner indicates that no shock is required.</span>")
+
+/obj/item/handheld_defibrillator/proc/allowhit(mob/living/target, user_UID, knockdown_duration)
+	REMOVE_TRAIT(target, TRAIT_WAS_BATONNED, user_UID)
 
 /obj/item/handheld_defibrillator/proc/short_charge()
 	icon_state = "[icon_base]-off"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -373,11 +373,11 @@
 			busy = TRUE
 			H.visible_message("<span class='danger'>[user] has touched [H.name] with [src]!</span>", \
 					"<span class='userdanger'>[user] has touched [H.name] with [src]!</span>")
-			H.adjustStaminaLoss(50)
-			H.Weaken(10 SECONDS)
+			H.adjustStaminaLoss(60)
+			H.KnockDown(10 SECONDS)
 			playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 			H.emote("gasp")
-			if(!H.undergoing_cardiac_arrest() && (prob(10) || (defib.combat && defib.heart_attack) || prob(10) && (defib.combat))) // If the victim is not having a heart attack, and a 10% chance passes, or the defib has heart attack variable to TRUE while being a combat defib, or if another 10% chance passes with combat being TRUE
+			if((defib.combat && defib.heart_attack) || prob(10) && (defib.combat)) // If the victim is not having a heart attack, and a 10% chance passes, or the defib has heart attack variable to TRUE while being a combat defib, or if another 10% chance passes with combat being TRUE
 				H.set_heartattack(TRUE)
 			SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 			add_attack_logs(user, M, "Stunned with [src]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Emagged handheld defibs now deal 60 stamina damage and knock down for 10 seconds.
Emagged handheld defibs now have a global cooldown shared with stunbatons etc. It is 3.5 seconds.
Paddle defibs now deal 60 stamina damage and knock down for 10 seconds. 
Emagged defibs no longer have a 10% RNG chance to cause near-instant death.
Nukie combat defibs still instakill.
Non-combat uses of any of this are not affected.

I feel like handheld defibs could be done better but I suck, so if you have any suggestions on how to streamline this code, hit me with them.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Handheld defibs currently instantly sleep the target for 6 seconds. This basically kills them, especially since another defib can be chained with it. It is worse than an instant stun, since the victim cannot even call for help. This is even inconsistent with other defibs, which do not cause sleep - somehow, the weakest defib is the strongest in combat. This PR makes them strong, essentially front-loaded stunbatons (instant knockdown instead of delay), but at least not insta-lose. Giving them a cooldown prevents cheesing with multiple defibs and/or batons/prods.

Paddle defibs are an instant stun, which is bad for stamina combat, and has to be removed. However, their unwieldiness means they probably should be somewhat better than the handheld. Not having a global cooldown with batons at least gives it some sort of niche. This can be altered later if it ends up being too strong... But I think it's too unwieldy, especially without gamer macros.

The 10% chance to instakill is funny but it also sucks for fights to be decided by a 1 in 10 chance to instakill.

## Changelog
:cl:
tweak: Emagged defibs have been rebalanced to knock down and deal stamina damage. Check the PR for numbers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
