### PR TITLE
Atmospherics refactor

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -6165,7 +6165,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "axK" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
@@ -7020,7 +7020,7 @@
 /turf/simulated/floor/plating,
 /area/engine/supermatter)
 "azU" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -8339,7 +8339,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aCV" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -8353,7 +8353,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aCY" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
@@ -8368,7 +8368,7 @@
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "aDa" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
 	level = 1
@@ -8387,7 +8387,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aDd" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
@@ -9582,7 +9582,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aFW" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -9642,7 +9642,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aGa" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -12016,7 +12016,7 @@
 	},
 /area/maintenance/incinerator)
 "aLe" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -12615,7 +12615,7 @@
 	},
 /area/engine/controlroom)
 "aMF" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
@@ -15910,7 +15910,7 @@
 	},
 /area/atmos)
 "aUf" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
@@ -15955,7 +15955,7 @@
 /area/crew_quarters/bar)
 "aUk" = (
 /obj/structure/grille,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -16821,7 +16821,7 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "aVS" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1443;
 	id_tag = "air_sensor";
 	output = 7
@@ -17473,7 +17473,7 @@
 /area/atmos)
 "aXd" = (
 /obj/structure/grille,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -17528,7 +17528,7 @@
 	},
 /area/atmos)
 "aXl" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -18023,7 +18023,7 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "aYw" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
@@ -18955,7 +18955,7 @@
 /area/atmos)
 "bah" = (
 /obj/structure/grille,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -19015,7 +19015,7 @@
 	},
 /area/atmos)
 "bao" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -19730,7 +19730,7 @@
 	},
 /area/atmos)
 "bbO" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -19804,7 +19804,7 @@
 	},
 /area/atmos)
 "bbY" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
@@ -20355,7 +20355,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bdp" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
@@ -20962,7 +20962,7 @@
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
 "beG" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
@@ -22019,7 +22019,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/securearmoury)
 "bhj" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
@@ -22107,7 +22107,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/atmos)
 "bhs" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
@@ -23652,7 +23652,7 @@
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "bkx" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "n2o_sensor"
 	},
@@ -23689,13 +23689,13 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bkB" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bkC" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -26975,7 +26975,7 @@
 /turf/simulated/floor/engine/vacuum,
 /area/atmos)
 "bry" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "waste_sensor";
 	output = 63
@@ -27013,7 +27013,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "brB" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -28188,7 +28188,7 @@
 	},
 /area/atmos)
 "bup" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4;
 	initialize_directions = 11
@@ -28817,7 +28817,7 @@
 	},
 /area/atmos)
 "bvH" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
@@ -28834,7 +28834,7 @@
 	},
 /area/atmos)
 "bvJ" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -39807,7 +39807,7 @@
 	},
 /area/hallway/primary/port)
 "bSr" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -60363,7 +60363,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical)
 "cMV" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -61927,7 +61927,7 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/misc_lab)
 "cQx" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -76637,7 +76637,7 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/mixing)
 "dxm" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
@@ -92166,7 +92166,7 @@
 	},
 /area/security/permabrig)
 "mTO" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1222;
 	id_tag = "burn_sensor"
 	},
@@ -93396,7 +93396,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -94202,7 +94202,7 @@
 	},
 /area/security/warden)
 "qWp" = (
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.31
 	},
 /obj/structure/window/plasmareinforced{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2280,7 +2280,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /turf/simulated/floor/plating,
@@ -7216,7 +7216,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aFY" = (
@@ -10879,7 +10879,7 @@
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "aPv" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
@@ -11540,7 +11540,7 @@
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "aRg" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
 	initialize_directions = 11
@@ -13878,7 +13878,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -18610,7 +18610,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
 "biC" = (
@@ -19165,7 +19165,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bjN" = (
@@ -22287,7 +22287,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "brh" = (
@@ -24921,7 +24921,7 @@
 	dir = 4;
 	initialize_directions = 11
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/item/wrench,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -28933,7 +28933,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "bGW" = (
@@ -30141,7 +30141,7 @@
 	},
 /area/engine/engineering)
 "bKh" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "waste_sensor";
 	output = 63
@@ -30747,7 +30747,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 2.9
 	},
 /turf/simulated/wall/r_wall,
@@ -31871,7 +31871,7 @@
 "bPj" = (
 /obj/effect/landmark/spawner/xeno,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bPl" = (
@@ -32466,7 +32466,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "bRj" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "n2o_sensor"
 	},
@@ -34800,7 +34800,7 @@
 	},
 /area/library)
 "bXz" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
@@ -35047,7 +35047,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "bYb" = (
@@ -36599,7 +36599,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/brig)
 "cch" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
@@ -37149,7 +37149,7 @@
 	dir = 8;
 	initialize_directions = 11
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "cdG" = (
@@ -40608,7 +40608,7 @@
 "cnY" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 2.9
 	},
 /turf/simulated/wall/r_wall,
@@ -40616,7 +40616,7 @@
 "cnZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	id = "mair_in_meter";
 	layer = 2.9;
 	name = "Mixed Air Tank In"
@@ -40626,7 +40626,7 @@
 "coa" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	id = "mair_out_meter";
 	layer = 2.9;
 	name = "Mixed Air Tank Out"
@@ -40987,7 +40987,7 @@
 /turf/simulated/floor/engine/n2,
 /area/atmos)
 "cpi" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
@@ -41012,7 +41012,7 @@
 /turf/simulated/floor/engine/o2,
 /area/atmos)
 "cpl" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
@@ -41038,7 +41038,7 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "cpo" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1443;
 	id_tag = "air_sensor";
 	output = 7
@@ -45989,7 +45989,7 @@
 "cEC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
 "cEE" = (
@@ -46719,7 +46719,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cGX" = (
@@ -53003,7 +53003,7 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "ddZ" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53019,7 +53019,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -53350,7 +53350,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "dfo" = (
@@ -55054,7 +55054,7 @@
 	},
 /area/hallway/primary/aft)
 "dXb" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -61861,7 +61861,7 @@
 	name = "\improper Cafe"
 	})
 "huo" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
@@ -62732,7 +62732,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -64324,7 +64324,7 @@
 /area/medical/research)
 "iBO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "iBR" = (
@@ -65573,7 +65573,7 @@
 	},
 /area/medical/cmo)
 "jpF" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1222;
 	id_tag = "burn_sensor"
 	},
@@ -69938,7 +69938,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "lug" = (
@@ -71760,7 +71760,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /turf/simulated/floor/plating,
@@ -73453,7 +73453,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "nej" = (
@@ -74362,7 +74362,7 @@
 /area/space/nearstation)
 "nzX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -76804,7 +76804,7 @@
 /area/maintenance/fore2)
 "oWt" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "oWE" = (
@@ -77127,7 +77127,7 @@
 /area/quartermaster/office)
 "peo" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "pep" = (
@@ -77352,7 +77352,7 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "pmh" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81773,7 +81773,7 @@
 	dir = 8;
 	initialize_directions = 11
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "rAE" = (
@@ -82051,7 +82051,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "rGJ" = (
@@ -84243,7 +84243,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
 "sNb" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -84267,7 +84267,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/door/window/westleft{
 	dir = 1;
 	name = "gas ports"
@@ -86061,7 +86061,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 8
 	},
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	id = "wloop_atm_meter";
 	name = "Waste Loop"
 	},
@@ -87887,8 +87887,8 @@
 /area/hallway/primary/port)
 "uJN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter{
-	id = "dloop_atm_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "dloop_atm_meter";
 	name = "Distribution Loop"
 	},
 /turf/simulated/floor/plasteel{
@@ -89027,7 +89027,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "vnt" = (
@@ -93280,7 +93280,7 @@
 	name = "Toxins Launch Room"
 	})
 "xDw" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -93731,7 +93731,7 @@
 	dir = 4;
 	initialize_directions = 11
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "xPR" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -4055,7 +4055,7 @@
 /area/ruin/ancientstation)
 "jy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -258,7 +258,7 @@
 	dir = 4;
 	initialize_directions = 11
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "cE" = (
@@ -706,7 +706,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "hB" = (
@@ -980,7 +980,7 @@
 	dir = 4;
 	initialize_directions = 11
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2036,7 +2036,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "wc" = (
@@ -2159,7 +2159,7 @@
 	dir = 4;
 	initialize_directions = 11
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4392,7 +4392,7 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "VB" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -8312,7 +8312,7 @@
 	dir = 6;
 	level = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/awaycontent/a1{
 	name = "MO19 Arrivals"

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -6811,7 +6811,7 @@
 /turf/simulated/floor/engine/air,
 /area/awaymission/UO71/eng)
 "pv" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1443;
 	id_tag = "UO71_air_sensor";
 	output = 7
@@ -7244,8 +7244,8 @@
 	},
 /area/awaymission/UO71/centralhall)
 "qr" = (
-/obj/machinery/meter{
-	id = "UO71_mair_out_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "UO71_mair_out_meter";
 	layer = 3.3;
 	name = "Mixed Air Tank Out"
 	},
@@ -7254,8 +7254,8 @@
 /area/awaymission/UO71/eng)
 "qs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/meter{
-	id = "UO71_mair_in_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "UO71_mair_in_meter";
 	layer = 3.3;
 	name = "Mixed Air Tank In"
 	},
@@ -8478,8 +8478,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/meter{
-	id = "UO71_dloop_atm_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "UO71_dloop_atm_meter";
 	name = "Distribution Loop"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -8503,7 +8503,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /turf/simulated/wall,
@@ -8893,7 +8893,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "tw" = (
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -8914,7 +8914,7 @@
 	},
 /area/awaymission/UO71/eng)
 "ty" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "UO71_waste_sensor";
 	output = 63
@@ -9155,8 +9155,8 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "ud" = (
-/obj/machinery/meter{
-	id = "UO71_wloop_atm_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "UO71_wloop_atm_meter";
 	name = "Waste Loop"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
@@ -9406,12 +9406,12 @@
 /area/awaymission/UO71/centralhall)
 "uB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/wall,
 /area/awaymission/UO71/eng)
 "uC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/wall,
 /area/awaymission/UO71/eng)
 "uD" = (
@@ -9690,14 +9690,14 @@
 /turf/simulated/wall,
 /area/awaymission/UO71/eng)
 "vg" = (
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/wall,
 /area/awaymission/UO71/eng)
 "vh" = (
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -10222,7 +10222,7 @@
 	},
 /area/awaymission/UO71/eng)
 "wl" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "UO71_n2_sensor"
 	},
@@ -10234,7 +10234,7 @@
 /turf/simulated/floor/engine/n2,
 /area/awaymission/UO71/eng)
 "wn" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "UO71_o2_sensor"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -6933,7 +6933,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/computer/cryopod{
 	pixel_y = -30;
 	dir = 1
@@ -9657,7 +9657,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13582,7 +13582,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/pod_1)
 "aJU" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13928,7 +13928,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aKP" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -15679,7 +15679,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aPb" = (
@@ -18222,7 +18222,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aUS" = (
@@ -30891,7 +30891,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bwy" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -30946,7 +30946,7 @@
 	},
 /area/medical/medbay2)
 "bwK" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -32725,7 +32725,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -50438,7 +50438,7 @@
 /area/quartermaster/miningdock)
 "cjV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -50479,7 +50479,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1222;
 	id_tag = "burn_sensor"
 	},
@@ -51897,7 +51897,7 @@
 /area/toxins/mixing)
 "cne" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /obj/structure/window/plasmareinforced,
@@ -51911,7 +51911,7 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "cnf" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -56952,7 +56952,7 @@
 	},
 /area/hallway/primary/aft)
 "cwK" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -59144,7 +59144,7 @@
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -60476,7 +60476,7 @@
 	pixel_y = -24;
 	req_access_txt = "12"
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -61577,7 +61577,7 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "cGN" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 1
 	},
@@ -65690,8 +65690,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/meter{
-	id = "wloop_atm_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "wloop_atm_meter";
 	name = "Waste Loop"
 	},
 /obj/machinery/light_switch{
@@ -65714,8 +65714,8 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cQh" = (
-/obj/machinery/meter{
-	id = "dloop_atm_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "dloop_atm_meter";
 	name = "Distribution Loop"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
@@ -66102,7 +66102,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cRb" = (
@@ -66157,7 +66157,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -66725,7 +66725,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 2.9
 	},
 /turf/simulated/wall/r_wall,
@@ -67216,7 +67216,7 @@
 	},
 /area/atmos/distribution)
 "cTv" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "waste_sensor";
 	output = 63
@@ -67633,7 +67633,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -68114,7 +68114,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/light,
 /obj/structure/disaster_counter/supermatter{
 	pixel_y = -32
@@ -68566,7 +68566,7 @@
 /area/hallway/secondary/exit)
 "cWR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWT" = (
@@ -68601,7 +68601,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWX" = (
@@ -68616,7 +68616,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWZ" = (
@@ -69080,7 +69080,7 @@
 	},
 /area/hallway/secondary/exit)
 "cYf" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "n2o_sensor"
 	},
@@ -69230,7 +69230,7 @@
 /area/hallway/secondary/exit)
 "cYy" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
@@ -69371,7 +69371,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cYW" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -70401,7 +70401,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dbN" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -70451,7 +70451,7 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "dbS" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
@@ -70655,7 +70655,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcv" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
@@ -70965,7 +70965,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -71614,7 +71614,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deH" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
@@ -71772,7 +71772,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "deX" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
@@ -71903,7 +71903,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -72076,7 +72076,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfH" = (
@@ -72312,7 +72312,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgy" = (
@@ -72564,7 +72564,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -73373,7 +73373,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
 "djw" = (
@@ -73412,7 +73412,7 @@
 "djB" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 2.9
 	},
 /turf/simulated/wall/r_wall,
@@ -73570,8 +73570,8 @@
 "djS" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
-/obj/machinery/meter{
-	id = "mair_in_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "mair_in_meter";
 	layer = 2.9;
 	name = "Mixed Air Tank In"
 	},
@@ -73586,8 +73586,8 @@
 "djU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
-/obj/machinery/meter{
-	id = "mair_out_meter";
+/obj/machinery/atmospherics/meter{
+	id_tag = "mair_out_meter";
 	layer = 2.9;
 	name = "Mixed Air Tank Out"
 	},
@@ -73734,7 +73734,7 @@
 	},
 /area/turret_protected/aisat_interior)
 "dkh" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
@@ -73799,7 +73799,7 @@
 	},
 /area/hallway/primary/central/ne)
 "dkp" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
@@ -73835,7 +73835,7 @@
 /turf/simulated/wall,
 /area/maintenance/aft)
 "dku" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/air_sensor{
 	frequency = 1443;
 	id_tag = "air_sensor";
 	output = 7
@@ -74039,7 +74039,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dkR" = (
@@ -75878,7 +75878,7 @@
 	name = "\improper AI Satellite Atmospherics"
 	})
 "dpe" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
@@ -77210,7 +77210,7 @@
 	},
 /area/security/prisonlockers)
 "egO" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
@@ -77233,7 +77233,7 @@
 /area/security/brig)
 "eil" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter{
+/obj/machinery/atmospherics/meter{
 	layer = 3.3
 	},
 /obj/structure/window/plasmareinforced,
@@ -77419,7 +77419,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -79522,7 +79522,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "kUR" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
@@ -81925,7 +81925,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "siM" = (
@@ -82286,7 +82286,7 @@
 	},
 /area/security/permabrig)
 "tAm" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
 	initialize_directions = 11
@@ -82659,7 +82659,7 @@
 /area/space/nearstation)
 "uBJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engine/engineering)

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1441,7 +1441,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
@@ -3629,7 +3629,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "lP" = (

--- a/code/__DEFINES/pipes.dm
+++ b/code/__DEFINES/pipes.dm
@@ -72,3 +72,9 @@
 
 #define PIPETYPE_ATMOS		1
 #define PIPETYPE_DISPOSAL	2
+
+// Connection types
+
+#define CONNECT_TYPE_NORMAL 1
+#define CONNECT_TYPE_SUPPLY 2
+#define CONNECT_TYPE_SCRUBBER 3

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -1,4 +1,4 @@
-/obj/machinery/air_sensor
+/obj/machinery/atmospherics/air_sensor
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor1"
 	resistance_flags = FIRE_PROOF
@@ -14,7 +14,7 @@
 	Mtoollink = TRUE
 	settagwhitelist = list("id_tag")
 
-	var/on = TRUE
+	on = TRUE
 	var/output = 3
 	//Flags:
 	// 1 for pressure
@@ -25,10 +25,10 @@
 	// 16 for nitrogen concentration
 	// 32 for carbon dioxide concentration
 
-/obj/machinery/air_sensor/update_icon()
+/obj/machinery/atmospherics/air_sensor/update_icon()
 	icon_state = "gsensor[on]"
 
-/obj/machinery/air_sensor/multitool_menu(mob/user, obj/item/multitool/P)
+/obj/machinery/atmospherics/air_sensor/multitool_menu(mob/user, obj/item/multitool/P)
 	return {"
 	<b>Main</b>
 	<ul>
@@ -43,7 +43,7 @@
 		<li>Monitor Carbon Dioxide Concentration: <a href="?src=[UID()];toggle_out_flag=32">[output&32 ? "Yes" : "No"]</a>
 	</ul>"}
 
-/obj/machinery/air_sensor/multitool_topic(mob/user, list/href_list, obj/O)
+/obj/machinery/atmospherics/air_sensor/multitool_topic(mob/user, list/href_list, obj/O)
 	. = ..()
 	if(.)
 		return .
@@ -57,33 +57,40 @@
 		else//can't not be off
 			output |= bitflag_value
 		return TRUE
+
 	if("toggle_bolts" in href_list)
 		bolts = !bolts
 		visible_message("<span class='notice'>You hear a quiet click as [src][bolts ? " bolts to the floor" : "'s bolts raise"].</span>", "<span class='notice>You hear a quiet click.</span>")
 		return TRUE
 
-/obj/machinery/air_sensor/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/air_sensor/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/multitool))
 		update_multitool_menu(user)
-		return 1
+		return TRUE
+
 	if(istype(W, /obj/item/wrench))
 		if(bolts)
 			to_chat(usr, "[src] is bolted to the floor! You can't detach it like this.")
-			return 1
+			return TRUE
+
 		playsound(loc, W.usesound, 50, 1)
 		to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
+
 		if(do_after(user, 40 * W.toolspeed, target = src))
 			user.visible_message("[user] unfastens \the [src].", "<span class='notice'>You have unfastened \the [src].</span>", "You hear ratchet.")
 			new /obj/item/pipe_gsensor(src.loc)
 			qdel(src)
-			return 1
+			return TRUE
+
 		return
+
 	return ..()
 
-/obj/machinery/air_sensor/process_atmos()
+/obj/machinery/atmospherics/air_sensor/process_atmos()
 	if(on)
 		if(!radio_connection)
 			return
+
 		var/datum/signal/signal = new
 		signal.transmission_method = 1 //radio signal
 		signal.data["tag"] = id_tag
@@ -91,21 +98,21 @@
 
 		var/datum/gas_mixture/air_sample = return_air()
 
-		if(output&1)
+		if(output & 1)
 			signal.data["pressure"] = num2text(round(air_sample.return_pressure(),0.1),)
-		if(output&2)
+		if(output & 2)
 			signal.data["temperature"] = round(air_sample.temperature,0.1)
 
-		if(output>4)
+		if(output > 4)
 			var/total_moles = air_sample.total_moles()
 			if(total_moles > 0)
-				if(output&4)
+				if(output & 4)
 					signal.data["oxygen"] = round(100*air_sample.oxygen/total_moles,0.1)
-				if(output&8)
+				if(output & 8)
 					signal.data["toxins"] = round(100*air_sample.toxins/total_moles,0.1)
-				if(output&16)
+				if(output & 16)
 					signal.data["nitrogen"] = round(100*air_sample.nitrogen/total_moles,0.1)
-				if(output&32)
+				if(output & 32)
 					signal.data["carbon_dioxide"] = round(100*air_sample.carbon_dioxide/total_moles,0.1)
 			else
 				signal.data["oxygen"] = 0
@@ -115,20 +122,19 @@
 		signal.data["sigtype"]="status"
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
-/obj/machinery/air_sensor/set_frequency(new_frequency)
+/obj/machinery/atmospherics/air_sensor/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
 	frequency = new_frequency
 	radio_connection = SSradio.add_object(src, frequency, RADIO_ATMOSIA)
 
-/obj/machinery/air_sensor/Initialize()
-	..()
-	SSair.atmos_machinery += src
+/obj/machinery/atmospherics/air_sensor/Initialize()
+	. = ..()
 	set_frequency(frequency)
 
-/obj/machinery/air_sensor/Destroy()
-	SSair.atmos_machinery -= src
+/obj/machinery/atmospherics/air_sensor/Destroy()
 	if(SSradio)
 		SSradio.remove_object(src, frequency)
+
 	radio_connection = null
 	return ..()
 
@@ -152,30 +158,34 @@
 /obj/machinery/computer/general_air_control/Destroy()
 	if(SSradio)
 		SSradio.remove_object(src, frequency)
+
 	radio_connection = null
 	return ..()
 
 /obj/machinery/computer/general_air_control/attack_hand(mob/user)
 	if(..(user))
 		return
-	var/html=return_text()
+
 	var/datum/browser/popup = new(user, "gac", name, 400, 400)
-	popup.set_content(html)
-	popup.open(0)
+	popup.set_content(return_text())
+	popup.open(FALSE)
 	user.set_machine(src)
 	onclose(user, "gac")
 
 /obj/machinery/computer/general_air_control/process()
 	..()
+
 	if(!sensors)
 		//warning("[src.type] at [x],[y],[z] has null sensors.  Please fix.")//commenting this line out because the admins will get a warning like this every time somebody builds another GAC
 		sensors = list()
-	src.updateUsrDialog()
+
+	updateUsrDialog()
 
 /obj/machinery/computer/general_air_control/attackby(I as obj, user as mob, params)
 	if(istype(I, /obj/item/multitool))
 		update_multitool_menu(user)
-		return 1
+		return TRUE
+
 	return ..()
 
 
@@ -183,14 +193,15 @@
 	if(!signal || signal.encryption) return
 
 	var/id_tag = signal.data["tag"]
-	if(!id_tag || !sensors || !sensors.Find(id_tag)) return
+	if(!id_tag || !sensors || !sensors.Find(id_tag))
+		return
 
 	sensor_information[id_tag] = signal.data
 
 /obj/machinery/computer/general_air_control/proc/return_text()
 	var/sensor_data
 	if(show_sensors)
-		if(sensors.len)
+		if(length(sensors))
 			for(var/id_tag in sensors)
 				var/long_name = sensors[id_tag]
 				var/list/data = sensor_information[id_tag]
@@ -200,18 +211,24 @@
 					sensor_part += "<table>"
 					if(data["pressure"])
 						sensor_part += "<tr><th>Pressure:</th><td>[data["pressure"]] kPa</td></tr>"
+
 					if(data["temperature"])
 						sensor_part += "<tr><th>Temperature:</th><td>[data["temperature"]] K</td></tr>"
+
 					if(data["oxygen"]||data["toxins"]||data["nitrogen"]||data["carbon_dioxide"])
 						sensor_part += "<tr><th>Gas Composition :</th><td><ul>"
 						if(data["oxygen"])
 							sensor_part += "<li>[data["oxygen"]]% O<sub>2</sub></li>"
+
 						if(data["nitrogen"])
 							sensor_part += "<li>[data["nitrogen"]]% N</li>"
+
 						if(data["carbon_dioxide"])
 							sensor_part += "<li>[data["carbon_dioxide"]]% CO<sub>2</sub></li>"
+
 						if(data["toxins"])
 							sensor_part += "<li>[data["toxins"]]% Plasma</li>"
+
 						sensor_part += "</ul></td></tr>"
 					sensor_part += "</table>"
 
@@ -285,15 +302,18 @@
 
 /obj/machinery/computer/general_air_control/multitool_topic(mob/user,list/href_list,obj/O)
 	. = ..()
-	if(.) return .
-	if("add_sensor" in href_list)
+	if(.)
+		return
 
+	if("add_sensor" in href_list)
 		// Make a list of all available sensors on the same frequency
 		var/list/sensor_list = list()
-		for(var/obj/machinery/air_sensor/G in GLOB.machines)
+
+		for(var/obj/machinery/atmospherics/air_sensor/G in GLOB.machines)
 			if(!isnull(G.id_tag) && G.frequency == frequency)
-				sensor_list|=G.id_tag
-		if(!sensor_list.len)
+				sensor_list |= G.id_tag
+
+		if(!length(sensor_list))
 			to_chat(user, "<span class=\"warning\">No sensors on this frequency.</span>")
 			return FALSE
 
@@ -301,6 +321,7 @@
 		var/sensor = input(user, "Select a sensor:", "Sensor Data") as null|anything in sensor_list
 		if(!sensor)
 			return FALSE
+
 		var/label = reject_bad_name( input(user, "Choose a sensor label:", "Sensor Label")  as text|null, allow_numbers=1)
 		if(!label)
 			return FALSE
@@ -311,48 +332,54 @@
 
 	if("edit_sensor" in href_list)
 		var/list/sensor_list = list()
-		for(var/obj/machinery/air_sensor/G in GLOB.machines)
+
+		for(var/obj/machinery/atmospherics/air_sensor/G in GLOB.machines)
 			if(!isnull(G.id_tag) && G.frequency == frequency)
-				sensor_list|=G.id_tag
-		if(!sensor_list.len)
+				sensor_list |= G.id_tag
+
+		if(!length(sensor_list))
 			to_chat(user, "<span class=\"warning\">No sensors on this frequency.</span>")
 			return FALSE
+
 		var/label = sensors[href_list["edit_sensor"]]
 		var/sensor = input(user, "Select a sensor:", "Sensor Data", href_list["edit_sensor"]) as null|anything in sensor_list
 		if(!sensor)
 			return FALSE
+
 		sensors.Remove(href_list["edit_sensor"])
 		sensors[sensor] = label
 		return TRUE
 
 /obj/machinery/computer/general_air_control/unlinkFrom(mob/user, obj/O)
 	..()
-	if("id_tag" in O.vars && (istype(O,/obj/machinery/air_sensor) || istype(O, /obj/machinery/meter)))
+
+	if("id_tag" in O.vars && (istype(O,/obj/machinery/atmospherics/air_sensor) || istype(O, /obj/machinery/atmospherics/meter)))
 		sensors.Remove(O:id_tag)
-		return 1
-	return 0
+		return TRUE
+
+	return FALSE
 
 /obj/machinery/computer/general_air_control/linkMenu(obj/O)
 	if(isLinkedWith(O))
 		return
 
-	var/dat=""
+	var/dat = ""
 
-	if(istype(O,/obj/machinery/air_sensor) || istype(O, /obj/machinery/meter))
+	if(istype(O, /obj/machinery/atmospherics/air_sensor) || istype(O, /obj/machinery/atmospherics/meter))
 		dat += " <a href='?src=[UID()];link=1'>\[New Sensor\]</a> "
 	return dat
 
 /obj/machinery/computer/general_air_control/canLink(obj/O, list/context)
-	if(istype(O,/obj/machinery/air_sensor) || istype(O, /obj/machinery/meter))
+	if(istype(O, /obj/machinery/atmospherics/air_sensor) || istype(O, /obj/machinery/atmospherics/meter))
 		return O:id_tag
 
 /obj/machinery/computer/general_air_control/isLinkedWith(obj/O)
-	if(istype(O,/obj/machinery/air_sensor) || istype(O, /obj/machinery/meter))
+	if(istype(O, /obj/machinery/atmospherics/air_sensor) || istype(O, /obj/machinery/atmospherics/meter))
 		return O:id_tag in sensors
 
 /obj/machinery/computer/general_air_control/linkWith(mob/user, obj/O, context)
 	sensors[O:id_tag] = reject_bad_name(clean_input(user, "Choose a sensor label:", "Sensor Label"), allow_numbers=1)
-	return 1
+	return TRUE
 
 /obj/machinery/computer/general_air_control/large_tank_control
 	circuit = /obj/item/circuitboard/large_tank_control
@@ -379,7 +406,8 @@
 /obj/machinery/computer/general_air_control/large_tank_control/attackby(I as obj, user as mob)
 	if(istype(I, /obj/item/multitool))
 		update_multitool_menu(user)
-		return 1
+		return TRUE
+
 	return ..()
 
 
@@ -392,8 +420,10 @@
 	</ul>
 	<b>Sensors:</b>
 	<ul>"}
+
 	for(var/id_tag in sensors)
 		dat += {"<li><a href="?src=[UID()];edit_sensor=[id_tag]">[sensors[id_tag]]</a></li>"}
+
 	dat += {"<li><a href="?src=[UID()];add_sensor=1">\[+\]</a></li></ul>"}
 	return dat
 
@@ -425,35 +455,41 @@
 /obj/machinery/computer/general_air_control/large_tank_control/unlinkFrom(mob/user, obj/O)
 	if("id_tag" in O.vars)
 		if(O:id_tag == input_tag)
-			input_tag=null
-			input_info=null
-			return 1
+			input_tag = null
+			input_info = null
+			return TRUE
+
 		if(O:id_tag == output_tag)
-			output_tag=null
-			output_info=null
-			return 1
-	return 0
+			output_tag = null
+			output_info = null
+			return TRUE
+
+	return FALSE
 
 /obj/machinery/computer/general_air_control/large_tank_control/linkMenu(obj/O)
-	var/dat=""
-	if(canLink(O,list("slot"="input")))
+	var/dat = ""
+	if(canLink(O, list("slot"="input")))
 		dat += " <a href='?src=[UID()];link=1;slot=input'>\[Link @ Input\]</a> "
-	if(canLink(O,list("slot"="output")))
+
+	if(canLink(O, list("slot"="output")))
 		dat += " <a href='?src=[UID()];link=1;slot=output'>\[Link @ Output\]</a> "
+
 	return dat
 
 /obj/machinery/computer/general_air_control/large_tank_control/canLink(obj/O, list/context)
-	return (context["slot"]=="input" && is_type_in_list(O,input_linkable)) || (context["slot"]=="output" && is_type_in_list(O,output_linkable))
+	return (context["slot"] == "input" && is_type_in_list(O,input_linkable)) || (context["slot"] == "output" && is_type_in_list(O,output_linkable))
 
 /obj/machinery/computer/general_air_control/large_tank_control/isLinkedWith(obj/O)
 	if(O:id_tag == input_tag)
-		return 1
+		return TRUE
 	if(O:id_tag == output_tag)
-		return 1
-	return 0
+		return TRUE
+
+	return FALSE
 
 /obj/machinery/computer/general_air_control/large_tank_control/process()
 	..()
+
 	if(!input_info && input_tag)
 		request_device_refresh(input_tag)
 	if(!output_info && output_tag)
@@ -486,6 +522,7 @@
 "}
 		else
 			output += "<FONT color='red'>ERROR: Can not find input port</FONT> <A href='?src=[UID()];in_refresh_status=1'>Search</A><BR>"
+
 	if(output_tag)
 		if(output_info)
 			var/power = (output_info["power"])
@@ -518,28 +555,31 @@
 	if(input_tag == id_tag)
 		input_info = signal.data
 		updateUsrDialog()
+
 	else if(output_tag == id_tag)
 		output_info = signal.data
 		updateUsrDialog()
+
 	else
 		..(signal)
 
 /obj/machinery/computer/general_air_control/large_tank_control/proc/request_device_refresh(device)
-	send_signal(list("tag"=device, "status"))
+	send_signal(list("tag" = device, "status"))
 
 /obj/machinery/computer/general_air_control/large_tank_control/proc/send_signal(list/data)
 	if(!radio_connection)
 		return
+
 	var/datum/signal/signal = new
 	signal.transmission_method = 1 //radio signal
 	signal.source = src
 	signal.data=data
-	signal.data["sigtype"]="command"
+	signal.data["sigtype"] = "command"
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
 /obj/machinery/computer/general_air_control/large_tank_control/Topic(href, href_list)
 	if(..())
-		return 1
+		return TRUE
 
 	add_fingerprint(usr)
 
@@ -549,10 +589,12 @@
 		pressure_setting = clamp(pressure_setting, 0, 50*ONE_ATMOSPHERE)
 
 	if(!radio_connection)
-		return 0
+		return FALSE
+
 	var/datum/signal/signal = new
 	signal.transmission_method = 1 //radio signal
 	signal.source = src
+
 	if(href_list["in_refresh_status"])
 		input_info = null
 		signal.data = list ("tag" = input_tag, "status" = 1)
@@ -578,165 +620,11 @@
 
 	signal.data["sigtype"] = "command"
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
-	src.updateUsrDialog()
+	updateUsrDialog()
 
-/obj/machinery/computer/general_air_control/fuel_injection
-	icon = 'icons/obj/computer.dmi'
-	icon_screen = "atmos"
-	circuit = /obj/item/circuitboard/injector_control
 
-	var/device_tag
-	var/list/device_info
 
-	var/automation = 0
-
-	var/cutoff_temperature = 2000
-	var/on_temperature = 1200
-
-/obj/machinery/computer/general_air_control/fuel_injection/attackby(I as obj, user as mob, params)
-	if(istype(I, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	return ..()
-
-/obj/machinery/computer/general_air_control/fuel_injection/process()
-	if(automation)
-		if(!radio_connection)
-			return 0
-
-		var/injecting = FALSE
-		for(var/id_tag in sensor_information)
-			var/list/data = sensor_information[id_tag]
-			if(data["temperature"])
-				if(data["temperature"] >= cutoff_temperature)
-					injecting = FALSE
-					break
-				if(data["temperature"] <= on_temperature)
-					injecting = TRUE
-
-		var/datum/signal/signal = new
-		signal.transmission_method = 1 //radio signal
-		signal.source = src
-
-		signal.data = list(
-			"tag" = device_tag,
-			"power" = injecting,
-			"sigtype"="command"
-		)
-
-		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
-
-	..()
-
-/obj/machinery/computer/general_air_control/fuel_injection/return_text()
-	var/output = ..()
-	output += "<fieldset><legend>Fuel Injection System (<A href='?src=[UID()];refresh_status=1'>Refresh</A>)</legend>"
-	if(device_info)
-		var/power = device_info["power"]
-		var/volume_rate = device_info["volume_rate"]
-		output += {"<table>
-		<tr>
-			<th>Status:</th>
-			<td>[power?"Injecting":"On Hold"]</td>
-		</tr>
-		<tr>
-			<th>Rate:</th>
-			<td>[volume_rate] L/sec</td>
-		</tr>
-		<tr>
-			<th>Automated Fuel Injection:</th>
-			<td><A href='?src=[UID()];toggle_automation=1'>[automation?"Engaged":"Disengaged"]</A></td>
-		</tr>"}
-
-		if(automation)
-
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\Documents\Projects\vgstation13\code\game\machinery\atmo_control.dm:372: output += "Automated Fuel Injection: <A href='?src=[UID()];toggle_automation=1'>Engaged</A><BR>"
-			output += {"
-			<tr>
-				<td colspan="2">Injector Controls Locked Out</td>
-			</tr>"}
-			// END AUTOFIX
-		else
-
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\Documents\Projects\vgstation13\code\game\machinery\atmo_control.dm:375: output += "Automated Fuel Injection: <A href='?src=[UID()];toggle_automation=1'>Disengaged</A><BR>"
-			output += {"
-			<tr>
-				<th>Injector:</th>
-				<td><A href='?src=[UID()];toggle_injector=1'>Toggle Power</A> <A href='?src=[UID()];injection=1'>Inject (1 Cycle)</A></td>
-			</td>"}
-			// END AUTOFIX
-		output += "</table>"
-	else
-		output += {"<p style="color:red"><b>ERROR:</b> Can not find device. <A href='?src=[UID()];refresh_status=1'>Search</A></p>"}
-	output += "</fieldset>"
-
-	return output
-
-/obj/machinery/computer/general_air_control/fuel_injection/receive_signal(datum/signal/signal)
-	if(!signal || signal.encryption) return
-
-	var/id_tag = signal.data["tag"]
-
-	if(device_tag == id_tag)
-		device_info = signal.data
-	else
-		..(signal)
-
-/obj/machinery/computer/general_air_control/fuel_injection/Topic(href, href_list)
-	if(..())
-		return
-
-	if(href_list["refresh_status"])
-		device_info = null
-		if(!radio_connection)
-			return 0
-
-		var/datum/signal/signal = new
-		signal.transmission_method = 1 //radio signal
-		signal.source = src
-		signal.data = list(
-			"tag" = device_tag,
-			"status",
-			"sigtype"="command"
-		)
-		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
-
-	if(href_list["toggle_automation"])
-		automation = !automation
-
-	if(href_list["toggle_injector"])
-		device_info = null
-		if(!radio_connection)
-			return 0
-
-		var/datum/signal/signal = new
-		signal.transmission_method = 1 //radio signal
-		signal.source = src
-		signal.data = list(
-			"tag" = device_tag,
-			"power_toggle",
-			"sigtype"="command"
-		)
-
-		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
-
-	if(href_list["injection"])
-		if(!radio_connection)
-			return 0
-
-		var/datum/signal/signal = new
-		signal.transmission_method = 1 //radio signal
-		signal.source = src
-		signal.data = list(
-			"tag" = device_tag,
-			"inject",
-			"sigtype"="command"
-		)
-
-		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
-
+// Central atmos control //
 /obj/machinery/computer/atmoscontrol
 	name = "\improper central atmospherics computer"
 	icon = 'icons/obj/computer.dmi'

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -175,10 +175,6 @@
 	board_name = "Atmospheric Monitor"
 	build_path = /obj/machinery/computer/general_air_control
 
-/obj/item/circuitboard/injector_control
-	board_name = "Injector Control"
-	build_path = /obj/machinery/computer/general_air_control/fuel_injection
-
 /obj/item/circuitboard/robotics
 	board_name = "Robotics Control Console"
 	build_path = /obj/machinery/computer/robotics

--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -132,25 +132,27 @@ th.cost.toomuch {background:maroon;}
 
 /obj/machinery/computer/merch/Topic(href, href_list)
 	if(..())
-		return 1
+		return TRUE
 
-	//testing(href)
-
-	src.add_fingerprint(usr)
+	add_fingerprint(usr)
 
 	if(href_list["buy"])
 		var/itemID = text2num(href_list["buy"])
 		var/datum/storeitem/item = GLOB.centcomm_store.items[itemID]
-		var/sure = alert(usr,"Are you sure you wish to purchase [item.name] for $[item.cost]?","You sure?","Yes","No") in list("Yes","No")
+		var/sure = alert(usr, "Are you sure you wish to purchase [item.name] for $[item.cost]?", "You sure?", "Yes", "No") in list("Yes", "No")
+
 		if(!Adjacent(usr))
 			to_chat(usr, "<span class='warning'>You are not close enough to do that.</span>")
 			return
-		if(sure=="No")
+
+		if(sure == "No")
 			updateUsrDialog()
 			return
-		if(!GLOB.centcomm_store.PlaceOrder(usr,itemID))
+
+		if(!GLOB.centcomm_store.PlaceOrder(usr, itemID))
 			to_chat(usr, "<span class='warning'>Unable to charge your account.</span>")
 		else
 			to_chat(usr, "<span class='notice'>You've successfully purchased the item. It should be in your hands or on the floor.</span>")
-	src.updateUsrDialog()
+
+	updateUsrDialog()
 	return

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -124,6 +124,7 @@ Class Procs:
 	var/datum/radio_frequency/radio_connection
 	/// This is if the machinery is being repaired
 	var/being_repaired = FALSE
+	armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)
 
 /*
  * reimp, attempts to flicker this machinery if the behavior is supported.
@@ -139,13 +140,13 @@ Class Procs:
 	return FALSE
 
 /obj/machinery/Initialize(mapload)
-	if(!armor)
-		armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)
 	. = ..()
+
 	GLOB.machines += src
 
 	if(use_power)
 		myArea = get_area(src)
+
 	if(!speed_process)
 		START_PROCESSING(SSmachines, src)
 	else

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -5,7 +5,7 @@
 	name = "pipe"
 	var/pipe_type = 0
 	var/pipename
-	var/connect_types[] = list(1) //1=regular, 2=supply, 3=scrubber
+	var/list/connect_types = list(CONNECT_TYPE_NORMAL) //1=regular, 2=supply, 3=scrubber
 	force = 7
 	icon = 'icons/obj/pipe-item.dmi'
 	icon_state = "simple"
@@ -14,126 +14,159 @@
 	level = 2
 	var/flipped = FALSE
 
-/obj/item/pipe/New(loc, pipe_type, dir, obj/machinery/atmospherics/make_from)
-	..()
+/obj/item/pipe/Initialize(mapload, pipe_type, dir, obj/machinery/atmospherics/make_from)
+	. = ..()
 	if(make_from)
-		src.dir = make_from.dir
-		src.pipename = make_from.name
+		dir = make_from.dir
+		pipename = make_from.name
 		color = make_from.pipe_color
 		var/is_bent
+
 		if(make_from.initialize_directions in list(NORTH|SOUTH, WEST|EAST))
-			is_bent = 0
+			is_bent = FALSE
 		else
-			is_bent = 1
+			is_bent = TRUE
+
+
 		if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction))
-			src.pipe_type = PIPE_JUNCTION
+			pipe_type = PIPE_JUNCTION
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/heat_exchanging))
-			src.pipe_type = PIPE_HE_STRAIGHT + is_bent
+			pipe_type = PIPE_HE_STRAIGHT + is_bent
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/insulated))
-			src.pipe_type = PIPE_INSULATED_STRAIGHT + is_bent
+			pipe_type = PIPE_INSULATED_STRAIGHT + is_bent
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/simple/hidden/supply))
-			src.pipe_type = PIPE_SUPPLY_STRAIGHT + is_bent
-			connect_types = list(2)
-			src.color = PIPE_COLOR_BLUE
+			pipe_type = PIPE_SUPPLY_STRAIGHT + is_bent
+			connect_types = list(CONNECT_TYPE_SUPPLY)
+			color = PIPE_COLOR_BLUE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers))
-			src.pipe_type = PIPE_SCRUBBERS_STRAIGHT + is_bent
-			connect_types = list(3)
-			src.color = PIPE_COLOR_RED
+			pipe_type = PIPE_SCRUBBERS_STRAIGHT + is_bent
+			connect_types = list(CONNECT_TYPE_SCRUBBER)
+			color = PIPE_COLOR_RED
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/visible/universal) || istype(make_from, /obj/machinery/atmospherics/pipe/simple/hidden/universal))
-			src.pipe_type = PIPE_UNIVERSAL
-			connect_types = list(1,2,3)
+			pipe_type = PIPE_UNIVERSAL
+			connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SUPPLY, CONNECT_TYPE_SCRUBBER)
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/simple))
-			src.pipe_type = PIPE_SIMPLE_STRAIGHT + is_bent
+			pipe_type = PIPE_SIMPLE_STRAIGHT + is_bent
+
 		else if(istype(make_from, /obj/machinery/atmospherics/unary/portables_connector))
-			src.pipe_type = PIPE_CONNECTOR
+			pipe_type = PIPE_CONNECTOR
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold/hidden/supply))
-			src.pipe_type = PIPE_SUPPLY_MANIFOLD
-			connect_types = list(2)
-			src.color = PIPE_COLOR_BLUE
+			pipe_type = PIPE_SUPPLY_MANIFOLD
+			connect_types = list(CONNECT_TYPE_SUPPLY)
+			color = PIPE_COLOR_BLUE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers))
-			src.pipe_type = PIPE_SCRUBBERS_MANIFOLD
-			connect_types = list(3)
-			src.color = PIPE_COLOR_RED
+			pipe_type = PIPE_SCRUBBERS_MANIFOLD
+			connect_types = list(CONNECT_TYPE_SCRUBBER)
+			color = PIPE_COLOR_RED
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold))
-			src.pipe_type = PIPE_MANIFOLD
+			pipe_type = PIPE_MANIFOLD
+
 		else if(istype(make_from, /obj/machinery/atmospherics/unary/vent_pump))
-			src.pipe_type = PIPE_UVENT
+			pipe_type = PIPE_UVENT
+
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/valve/digital))
-			src.pipe_type = PIPE_DVALVE
+			pipe_type = PIPE_DVALVE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/valve))
-			src.pipe_type = PIPE_MVALVE
+			pipe_type = PIPE_MVALVE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/pump))
-			src.pipe_type = PIPE_PUMP
+			pipe_type = PIPE_PUMP
+
 		else if(istype(make_from, /obj/machinery/atmospherics/trinary/filter))
-			src.pipe_type = PIPE_GAS_FILTER
+			pipe_type = PIPE_GAS_FILTER
+
 		else if(istype(make_from, /obj/machinery/atmospherics/trinary/mixer))
-			src.pipe_type = PIPE_GAS_MIXER
+			pipe_type = PIPE_GAS_MIXER
+
 		else if(istype(make_from, /obj/machinery/atmospherics/unary/vent_scrubber))
-			src.pipe_type = PIPE_SCRUBBER
+			pipe_type = PIPE_SCRUBBER
+
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/passive_gate))
-			src.pipe_type = PIPE_PASSIVE_GATE
+			pipe_type = PIPE_PASSIVE_GATE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/volume_pump))
-			src.pipe_type = PIPE_VOLUME_PUMP
+			pipe_type = PIPE_VOLUME_PUMP
+
 		else if(istype(make_from, /obj/machinery/atmospherics/unary/heat_exchanger))
-			src.pipe_type = PIPE_HEAT_EXCHANGE
+			pipe_type = PIPE_HEAT_EXCHANGE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/trinary/tvalve/digital))
-			src.pipe_type = PIPE_DTVALVE
+			pipe_type = PIPE_DTVALVE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/trinary/tvalve))
-			src.pipe_type = PIPE_TVALVE
+			pipe_type = PIPE_TVALVE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply))
-			src.pipe_type = PIPE_SUPPLY_MANIFOLD4W
-			connect_types = list(2)
-			src.color = PIPE_COLOR_BLUE
+			pipe_type = PIPE_SUPPLY_MANIFOLD4W
+			connect_types = list(CONNECT_TYPE_SUPPLY)
+			color = PIPE_COLOR_BLUE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers))
-			src.pipe_type = PIPE_SCRUBBERS_MANIFOLD4W
-			connect_types = list(3)
-			src.color = PIPE_COLOR_RED
+			pipe_type = PIPE_SCRUBBERS_MANIFOLD4W
+			connect_types = list(CONNECT_TYPE_SCRUBBER)
+			color = PIPE_COLOR_RED
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/manifold4w))
-			src.pipe_type = PIPE_MANIFOLD4W
+			pipe_type = PIPE_MANIFOLD4W
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/cap/visible/supply) || istype(make_from, /obj/machinery/atmospherics/pipe/cap/hidden/supply))
-			src.pipe_type = PIPE_SUPPLY_CAP
-			connect_types = list(2)
-			src.color = PIPE_COLOR_BLUE
+			pipe_type = PIPE_SUPPLY_CAP
+			connect_types = list(CONNECT_TYPE_SUPPLY)
+			color = PIPE_COLOR_BLUE
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/cap/visible/scrubbers) || istype(make_from, /obj/machinery/atmospherics/pipe/cap/hidden/scrubbers))
-			src.pipe_type = PIPE_SCRUBBERS_CAP
-			connect_types = list(3)
-			src.color = PIPE_COLOR_RED
+			pipe_type = PIPE_SCRUBBERS_CAP
+			connect_types = list(CONNECT_TYPE_SCRUBBER)
+			color = PIPE_COLOR_RED
+
 		else if(istype(make_from, /obj/machinery/atmospherics/pipe/cap))
-			src.pipe_type = PIPE_CAP
+			pipe_type = PIPE_CAP
 
 		else if(istype(make_from, /obj/machinery/atmospherics/unary/outlet_injector))
-			src.pipe_type = PIPE_INJECTOR
+			pipe_type = PIPE_INJECTOR
+
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/dp_vent_pump))
-			src.pipe_type = PIPE_DP_VENT
+			pipe_type = PIPE_DP_VENT
+
 		else if(istype(make_from, /obj/machinery/atmospherics/unary/passive_vent))
-			src.pipe_type = PIPE_PASV_VENT
+			pipe_type = PIPE_PASV_VENT
 
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/circulator))
-			src.pipe_type = PIPE_CIRCULATOR
+			pipe_type = PIPE_CIRCULATOR
 
 		var/obj/machinery/atmospherics/trinary/triP = make_from
 		if(istype(triP) && triP.flipped)
-			src.flipped = TRUE
+			flipped = TRUE
 
 		var/obj/machinery/atmospherics/binary/circulator/circP = make_from
 		if(istype(circP) && circP.side == CIRC_RIGHT)
-			src.flipped = TRUE
+			flipped = TRUE
 
 	else
-		src.pipe_type = pipe_type
-		src.dir = dir
+		pipe_type = pipe_type
+		dir = dir
 		if(pipe_type == PIPE_SUPPLY_STRAIGHT || pipe_type == PIPE_SUPPLY_BENT || pipe_type == PIPE_SUPPLY_MANIFOLD || pipe_type == PIPE_SUPPLY_MANIFOLD4W || pipe_type == PIPE_SUPPLY_CAP)
-			connect_types = list(2)
-			src.color = PIPE_COLOR_BLUE
+			connect_types = list(CONNECT_TYPE_SUPPLY)
+			color = PIPE_COLOR_BLUE
 		else if(pipe_type == PIPE_SCRUBBERS_STRAIGHT || pipe_type == PIPE_SCRUBBERS_BENT || pipe_type == PIPE_SCRUBBERS_MANIFOLD || pipe_type == PIPE_SCRUBBERS_MANIFOLD4W || pipe_type == PIPE_SCRUBBERS_CAP)
-			connect_types = list(3)
-			src.color = PIPE_COLOR_RED
+			connect_types = list(CONNECT_TYPE_SCRUBBER)
+			color = PIPE_COLOR_RED
 		else if(pipe_type == PIPE_UNIVERSAL)
-			connect_types = list(1,2,3)
+			connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SUPPLY, CONNECT_TYPE_SCRUBBER)
 
 	update(make_from)
-	src.pixel_x = rand(-5, 5)
-	src.pixel_y = rand(-5, 5)
+	pixel_x = rand(-5, 5)
+	pixel_y = rand(-5, 5)
 
 //update the name and icon of the pipe item depending on the type
 
@@ -141,12 +174,16 @@
 	. = TRUE
 	if(our_rpd.mode == RPD_ROTATE_MODE)
 		rotate()
+
 	else if(our_rpd.mode == RPD_FLIP_MODE)
 		flip()
+
 	else if(our_rpd.mode == RPD_DELETE_MODE)
 		if(pipe_type == PIPE_CIRCULATOR) //Skip TEG heat circulators, they aren't really pipes
 			return ..()
+
 		our_rpd.delete_single_pipe(user, src)
+
 	else
 		return ..()
 
@@ -157,12 +194,15 @@
 /obj/item/pipe/proc/update(obj/machinery/atmospherics/make_from)
 	name = "[get_pipe_name(pipe_type, PIPETYPE_ATMOS)] fitting"
 	icon_state = get_pipe_icon(pipe_type)
+
 	var/obj/machinery/atmospherics/trinary/triP = make_from
 	if(istype(triP) && triP.flipped)
 		icon_state = "m_[icon_state]"
+
 	var/obj/machinery/atmospherics/binary/circulator/circP = make_from
 	if(istype(circP) && circP.side == CIRC_RIGHT)
 		icon_state = "m_[icon_state]"
+
 	if(istype(make_from, /obj/machinery/atmospherics/pipe/simple/heat_exchanging))
 		resistance_flags |= FIRE_PROOF | LAVA_PROOF
 
@@ -182,14 +222,14 @@
 	set name = "Rotate Pipe"
 	set src in view(1)
 
-	if( usr.stat || usr.restrained() )
+	if(usr.stat || usr.restrained())
 		return
 
 	if(pipe_type == PIPE_CIRCULATOR)
 		flip()
 		return
 
-	src.dir = turn(src.dir, -90)
+	dir = turn(dir, -90)
 
 	fixdir()
 
@@ -211,7 +251,7 @@
 		flipped = !flipped
 		return
 
-	src.dir = turn(src.dir, -180)
+	dir = turn(dir, -180)
 
 	fixdir()
 
@@ -219,21 +259,24 @@
 
 /obj/item/pipe/Move()
 	..()
-	if(is_bent_pipe() \
-		&& (src.dir in GLOB.cardinal))
-		src.dir = src.dir|turn(src.dir, 90)
+	if(is_bent_pipe() && (dir in GLOB.cardinal))
+		dir = dir | turn(dir, 90)
+
 	else if(pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_INSULATED_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE))
+
 		if(dir==2)
 			dir = 1
+
 		else if(dir==8)
 			dir = 4
-	return
 
 // returns all pipe's endpoints
 
 /obj/item/pipe/proc/get_pipe_dir()
+	. = 0
+
 	if(!dir)
-		return 0
+		return
 
 	var/direct = dir
 	if(flipped)
@@ -244,71 +287,64 @@
 	var/acw = turn(direct, 90)
 
 	switch(pipe_type)
-		if(	PIPE_SIMPLE_STRAIGHT, \
-			PIPE_INSULATED_STRAIGHT, \
-			PIPE_HE_STRAIGHT, \
-			PIPE_JUNCTION ,\
-			PIPE_PUMP ,\
-			PIPE_VOLUME_PUMP ,\
-			PIPE_PASSIVE_GATE ,\
-			PIPE_MVALVE, \
-			PIPE_DVALVE, \
-			PIPE_DP_VENT, \
-			PIPE_SUPPLY_STRAIGHT, \
-			PIPE_SCRUBBERS_STRAIGHT, \
-			PIPE_UNIVERSAL, \
-		)
+		if(PIPE_SIMPLE_STRAIGHT, PIPE_INSULATED_STRAIGHT, PIPE_HE_STRAIGHT, PIPE_JUNCTION,\
+			PIPE_PUMP, PIPE_VOLUME_PUMP, PIPE_PASSIVE_GATE, PIPE_MVALVE, PIPE_DVALVE, PIPE_DP_VENT,
+			PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL)
 			return dir|flip
+
 		if(PIPE_SIMPLE_BENT, PIPE_INSULATED_BENT, PIPE_HE_BENT, PIPE_SUPPLY_BENT, PIPE_SCRUBBERS_BENT)
 			return dir //dir|acw
+
 		if(PIPE_CONNECTOR,  PIPE_HEAT_EXCHANGE, PIPE_INJECTOR)
 			return dir|flip
+
 		if(PIPE_UVENT, PIPE_PASV_VENT, PIPE_SCRUBBER)
 			return dir
+
 		if(PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W)
 			return dir|flip|cw|acw
+
 		if(PIPE_MANIFOLD, PIPE_SUPPLY_MANIFOLD, PIPE_SCRUBBERS_MANIFOLD)
 			return flip|cw|acw
+
 		if(PIPE_GAS_FILTER, PIPE_GAS_MIXER, PIPE_TVALVE, PIPE_DTVALVE)
 			if(!flipped)
 				return dir|flip|cw
-			else
-				return flip|cw|acw
+
+			return flip|cw|acw
+
 		if(PIPE_CAP, PIPE_SUPPLY_CAP, PIPE_SCRUBBERS_CAP)
 			return dir|flip
-	return 0
 
 /obj/item/pipe/proc/get_pdir() //endpoints for regular pipes
-
 	var/flip = turn(dir, 180)
-//	var/cw = turn(dir, -90)
-//	var/acw = turn(dir, 90)
 
 	if(!(pipe_type in list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION)))
 		return get_pipe_dir()
+
 	switch(pipe_type)
 		if(PIPE_HE_STRAIGHT,PIPE_HE_BENT)
 			return 0
+
 		if(PIPE_JUNCTION)
 			return flip
+
 	return 0
 
 // return the h_dir (heat-exchange pipes) from the type and the dir
 
 /obj/item/pipe/proc/get_hdir() //endpoints for h/e pipes
-
-//	var/flip = turn(dir, 180)
-//	var/cw = turn(dir, -90)
-
 	switch(pipe_type)
 		if(PIPE_HE_STRAIGHT)
 			return get_pipe_dir()
+
 		if(PIPE_HE_BENT)
 			return get_pipe_dir()
+
 		if(PIPE_JUNCTION)
 			return dir
-		else
-			return 0
+
+	return 0
 
 /obj/item/pipe/proc/unflip(direction)
 	if(!(direction in GLOB.cardinal))
@@ -321,8 +357,10 @@
 	if(pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_HE_STRAIGHT, PIPE_INSULATED_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE))
 		if(dir==2)
 			dir = 1
+
 		else if(dir==8)
 			dir = 4
+
 	else if(pipe_type in list(PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W))
 		dir = 2
 
@@ -331,184 +369,197 @@
 
 /obj/item/pipe/wrench_act(mob/user, obj/item/I)
 	. = TRUE
+
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 
-	if(!isturf(src.loc))
-		return 1
+	if(!isturf(loc))
+		return
 
 	fixdir()
 
 	var/pipe_dir = get_pipe_dir()
 	var/turf/T = get_turf(loc)
 
-	for(var/obj/machinery/atmospherics/M in src.loc)
-		if((M.initialize_directions & pipe_dir) && M.check_connect_types_construction(M,src))	// matches at least one direction on either type of pipe
+	for(var/obj/machinery/atmospherics/M in loc)
+		if((M.initialize_directions & pipe_dir) && M.check_connect_types_construction(M, src))	// matches at least one direction on either type of pipe
 			to_chat(user, "<span class='warning'>There is already a pipe of the same type at this location.</span>")
-			return 1
+			return
 
 	if(pipe_type in list(PIPE_SUPPLY_STRAIGHT, PIPE_SUPPLY_BENT, PIPE_SCRUBBERS_STRAIGHT, PIPE_SCRUBBERS_BENT, PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_SUPPLY_MANIFOLD, PIPE_SCRUBBERS_MANIFOLD, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_UVENT, PIPE_SUPPLY_CAP, PIPE_SCRUBBERS_CAP, PIPE_PASV_VENT, PIPE_DP_VENT, PIPE_PASSIVE_GATE))
 		if(T.transparent_floor) //stops jank with transparent floors and pipes
 			to_chat(user, "<span class='warning'>You can only fix simple pipes and devices over glass floors!</span>")
-			return 1
+			return
 
 	switch(pipe_type) //What kind of heartless person thought of doing this?
 		if(PIPE_SIMPLE_STRAIGHT, PIPE_SIMPLE_BENT)
-			var/obj/machinery/atmospherics/pipe/simple/P = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/simple/P = new(loc)
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SUPPLY_STRAIGHT, PIPE_SUPPLY_BENT)
-			var/obj/machinery/atmospherics/pipe/simple/hidden/supply/P = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/simple/hidden/supply/P = new(loc)
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SCRUBBERS_STRAIGHT, PIPE_SCRUBBERS_BENT)
-			var/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers/P = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers/P = new(loc)
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_UNIVERSAL)
-			var/obj/machinery/atmospherics/pipe/simple/hidden/universal/P = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/simple/hidden/universal/P = new(loc)
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_HE_STRAIGHT, PIPE_HE_BENT)
-			var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/P = new ( src.loc )
+			var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/P = new (loc)
 			P.initialize_directions_he = pipe_dir
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_CONNECTOR)		// connector
-			var/obj/machinery/atmospherics/unary/portables_connector/C = new( src.loc )
+			var/obj/machinery/atmospherics/unary/portables_connector/C = new(loc)
 			if(pipename)
 				C.name = pipename
 			C.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_MANIFOLD)		//manifold
-			var/obj/machinery/atmospherics/pipe/manifold/M = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/manifold/M = new(loc)
 			M.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SUPPLY_MANIFOLD)		//manifold
-			var/obj/machinery/atmospherics/pipe/manifold/hidden/supply/M = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/manifold/hidden/supply/M = new(loc)
 			M.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SCRUBBERS_MANIFOLD)		//manifold
-			var/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers/M = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers/M = new(loc)
 			M.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_MANIFOLD4W)		//4-way manifold
-			var/obj/machinery/atmospherics/pipe/manifold4w/M = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/manifold4w/M = new(loc)
 			M.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SUPPLY_MANIFOLD4W)		//4-way manifold
-			var/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply/M = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply/M = new(loc)
 			M.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SCRUBBERS_MANIFOLD4W)		//4-way manifold
-			var/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers/M = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers/M = new(loc)
 			M.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_JUNCTION)
-			var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/P = new ( src.loc )
-			P.initialize_directions_he = src.get_hdir()
+			var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/P = new (loc)
+			P.initialize_directions_he = get_hdir()
 			P.on_construction(dir, get_pdir(), color)
 
 		if(PIPE_UVENT)		//unary vent
-			var/obj/machinery/atmospherics/unary/vent_pump/V = new( src.loc )
+			var/obj/machinery/atmospherics/unary/vent_pump/V = new(loc)
 			V.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_MVALVE)		//manual valve
-			var/obj/machinery/atmospherics/binary/valve/V = new( src.loc)
+			var/obj/machinery/atmospherics/binary/valve/V = new(loc)
 			if(pipename)
 				V.name = pipename
 			V.on_construction(dir, get_pdir(), color)
 
 		if(PIPE_DVALVE)
-			var/obj/machinery/atmospherics/binary/valve/digital/V = new( src.loc )
+			var/obj/machinery/atmospherics/binary/valve/digital/V = new(loc)
 			if(pipename)
 				V.name = pipename
 			V.on_construction(dir, get_pdir(), color)
 
 		if(PIPE_PUMP)		//gas pump
-			var/obj/machinery/atmospherics/binary/pump/P = new(src.loc)
+			var/obj/machinery/atmospherics/binary/pump/P = new(loc)
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_GAS_FILTER, PIPE_GAS_MIXER, PIPE_TVALVE, PIPE_DTVALVE)
 			var/obj/machinery/atmospherics/trinary/P
 			switch(pipe_type)
 				if(PIPE_GAS_FILTER)
-					P = new /obj/machinery/atmospherics/trinary/filter(src.loc)
+					P = new /obj/machinery/atmospherics/trinary/filter(loc)
 				if(PIPE_GAS_MIXER)
-					P = new /obj/machinery/atmospherics/trinary/mixer(src.loc)
+					P = new /obj/machinery/atmospherics/trinary/mixer(loc)
 				if(PIPE_TVALVE)
-					P = new /obj/machinery/atmospherics/trinary/tvalve(src.loc)
+					P = new /obj/machinery/atmospherics/trinary/tvalve(loc)
 				if(PIPE_DTVALVE)
-					P = new /obj/machinery/atmospherics/trinary/tvalve/digital(src.loc)
+					P = new /obj/machinery/atmospherics/trinary/tvalve/digital(loc)
+
 			P.flipped = flipped
+
 			if(pipename)
 				P.name = pipename
+
 			P.on_construction(unflip(dir), pipe_dir, color)
 
 		if(PIPE_CIRCULATOR) //circulator
-			var/obj/machinery/atmospherics/binary/circulator/C = new(src.loc)
+			var/obj/machinery/atmospherics/binary/circulator/C = new(loc)
 			if(flipped)
 				C.side = CIRC_RIGHT
+
 			if(pipename)
 				C.name = pipename
+
 			C.on_construction(C.dir, C.initialize_directions, color)
 
 		if(PIPE_SCRUBBER)		//scrubber
-			var/obj/machinery/atmospherics/unary/vent_scrubber/S = new(src.loc)
+			var/obj/machinery/atmospherics/unary/vent_scrubber/S = new(loc)
 			if(pipename)
 				S.name = pipename
+
 			S.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_INSULATED_STRAIGHT, PIPE_INSULATED_BENT)
-			var/obj/machinery/atmospherics/pipe/simple/insulated/P = new( src.loc )
+			var/obj/machinery/atmospherics/pipe/simple/insulated/P = new(loc)
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_CAP)
-			var/obj/machinery/atmospherics/pipe/cap/C = new(src.loc)
+			var/obj/machinery/atmospherics/pipe/cap/C = new(loc)
 			C.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SUPPLY_CAP)
-			var/obj/machinery/atmospherics/pipe/cap/hidden/supply/C = new(src.loc)
+			var/obj/machinery/atmospherics/pipe/cap/hidden/supply/C = new(loc)
 			C.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_SCRUBBERS_CAP)
-			var/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers/C = new(src.loc)
+			var/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers/C = new(loc)
 			C.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_PASSIVE_GATE)		//passive gate
-			var/obj/machinery/atmospherics/binary/passive_gate/P = new(src.loc)
+			var/obj/machinery/atmospherics/binary/passive_gate/P = new(loc)
 			if(pipename)
 				P.name = pipename
+
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_VOLUME_PUMP)		//volume pump
-			var/obj/machinery/atmospherics/binary/volume_pump/P = new(src.loc)
+			var/obj/machinery/atmospherics/binary/volume_pump/P = new(loc)
 			if(pipename)
 				P.name = pipename
+
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_HEAT_EXCHANGE)		// heat exchanger
-			var/obj/machinery/atmospherics/unary/heat_exchanger/C = new( src.loc )
+			var/obj/machinery/atmospherics/unary/heat_exchanger/C = new(loc)
 			if(pipename)
 				C.name = pipename
+
 			C.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_INJECTOR)		// air injector
-			var/obj/machinery/atmospherics/unary/outlet_injector/P = new( src.loc )
+			var/obj/machinery/atmospherics/unary/outlet_injector/P = new(loc)
 			if(pipename)
 				P.name = pipename
+
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_DP_VENT)
-			var/obj/machinery/atmospherics/binary/dp_vent_pump/P = new(src.loc)
+			var/obj/machinery/atmospherics/binary/dp_vent_pump/P = new(loc)
 			if(pipename)
 				P.name = pipename
+
 			P.on_construction(dir, pipe_dir, color)
 
 		if(PIPE_PASV_VENT)
-			var/obj/machinery/atmospherics/unary/passive_vent/P  = new(src.loc)
+			var/obj/machinery/atmospherics/unary/passive_vent/P  = new(loc)
 			if(pipename)
 				P.name = pipename
+
 			P.on_construction(dir, pipe_dir, color)
 
 	user.visible_message( \
@@ -528,19 +579,22 @@
 /obj/item/pipe_meter/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(!istype(W, /obj/item/wrench))
 		return ..()
-	if(!locate(/obj/machinery/atmospherics/pipe, src.loc))
+
+	if(!locate(/obj/machinery/atmospherics/pipe, loc))
 		to_chat(user, "<span class='warning'>You need to fasten it to a pipe</span>")
-		return 1
-	new /obj/machinery/meter(loc)
-	playsound(src.loc, W.usesound, 50, 1)
+		return TRUE
+
+	new /obj/machinery/atmospherics/meter(loc)
+	playsound(loc, W.usesound, 50, 1)
 	to_chat(user, "<span class='notice'>You have fastened the meter to the pipe.</span>")
 	qdel(src)
 
 /obj/item/pipe_meter/rpd_act(mob/user, obj/item/rpd/our_rpd)
 	if(our_rpd.mode == RPD_DELETE_MODE)
 		our_rpd.delete_single_pipe(user, src)
-	else
-		..()
+		return
+
+	..()
 
 /obj/item/pipe_gsensor
 	name = "gas sensor"
@@ -553,7 +607,8 @@
 /obj/item/pipe_gsensor/attackby(obj/item/W as obj, mob/user as mob)
 	if(!istype(W, /obj/item/wrench))
 		return ..()
-	new/obj/machinery/air_sensor( src.loc )
+
+	new /obj/machinery/atmospherics/air_sensor(loc)
 	playsound(get_turf(src), W.usesound, 50, 1)
 	to_chat(user, "<span class='notice'>You have fastened the gas sensor.</span>")
 	qdel(src)
@@ -561,15 +616,18 @@
 /obj/item/pipe_gsensor/rpd_act(mob/user, obj/item/rpd/our_rpd)
 	if(our_rpd.mode == RPD_DELETE_MODE)
 		our_rpd.delete_single_pipe(user, src)
-	else
-		..()
+		return
+
+	..()
 
 /obj/item/pipe/AltClick(mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))
 		return
+
 	rotate()
 
 /obj/item/pipe/AltShiftClick(mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))
 		return
+
 	flip()

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -86,17 +86,22 @@
 
 	if(world.time < wait + 4)
 		return
+
 	wait = world.time
+
 	if(href_list["make"])
 		var/p_type = text2num(href_list["make"])
 		var/p_dir = text2num(href_list["dir"])
-		var/obj/item/pipe/P = new (loc, pipe_type=p_type, dir=p_dir)
+		var/obj/item/pipe/P = new(loc, p_type, p_dir)
 		P.update()
 		P.add_fingerprint(usr)
+
 	if(href_list["makemeter"])
 		new /obj/item/pipe_meter(loc)
+
 	if(href_list["makegsensor"])
 		new /obj/item/pipe_gsensor(loc)
+
 	return TRUE
 
 /obj/machinery/pipedispenser/wrench_act(mob/user, obj/item/I)
@@ -113,6 +118,7 @@
 			stat &= ~MAINT
 			unwrenched = FALSE
 			power_change()
+
 	else
 		playsound(loc, I.usesound, 50, 1)
 		to_chat(user, "<span class='notice'>You begin to unfasten \the [src] from the floor...</span>")
@@ -129,11 +135,13 @@
 
 /obj/machinery/pipedispenser/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(usr)
+
 	if(istype(W, /obj/item/pipe) || istype(W, /obj/item/pipe_meter) || istype(W, /obj/item/pipe_gsensor))
 		to_chat(usr, "<span class='notice'>You put [W] back to [src].</span>")
 		user.drop_item()
 		qdel(W)
 		return
+
 	return ..()
 
 
@@ -143,11 +151,11 @@
 	icon_state = "pipe_d"
 
 //Allow you to drag-drop disposal pipes into it
-/obj/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe, mob/usr)
-	if(usr.incapacitated())
+/obj/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe, mob/user)
+	if(user.incapacitated())
 		return
 
-	if(!istype(pipe) || get_dist(usr, src) > 1 || get_dist(src, pipe) > 1 )
+	if(!istype(pipe) || get_dist(user, src) > 1 || get_dist(src, pipe) > 1 )
 		return
 
 	if(pipe.anchored)

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -18,13 +18,14 @@ Pipelines + Other Objects -> Pipe network
 	active_power_usage = 0
 	power_channel = ENVIRON
 	on_blueprints = TRUE
+	armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 100, ACID = 70)
 	var/nodealert = FALSE
 	var/can_unwrench = FALSE
 	/// If the machine is currently operating or not.
 	var/on = FALSE
 	/// The amount of pressure the machine wants to operate at.
 	var/target_pressure = 0
-	var/connect_types[] = list(1) //1=regular, 2=supply, 3=scrubber
+	var/list/connect_types = list(CONNECT_TYPE_NORMAL)
 	var/connected_to = 1 //same as above, currently not used for anything
 	var/icon_connect_type = "" //"-supply" or "-scrubbers"
 
@@ -33,21 +34,19 @@ Pipelines + Other Objects -> Pipe network
 	var/pipe_color
 	var/image/pipe_image
 
-/obj/machinery/atmospherics/New()
-	if (!armor)
-		armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 100, ACID = 70)
-	..()
-
-	if(!pipe_color)
-		pipe_color = color
-	color = null
-
-	if(!pipe_color_check(pipe_color))
-		pipe_color = null
 
 /obj/machinery/atmospherics/Initialize()
 	. = ..()
 	SSair.atmos_machinery += src
+
+
+	if(!pipe_color)
+		pipe_color = color
+
+	color = null
+
+	if(!pipe_color_check(pipe_color))
+		pipe_color = null
 
 /obj/machinery/atmospherics/proc/atmos_init()
 	// Updates all pipe overlays and underlays
@@ -112,31 +111,24 @@ Pipelines + Other Objects -> Pipe network
 			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "exposed" + icon_connect_type)
 
 /obj/machinery/atmospherics/proc/update_underlays()
-	if(check_icon_cache())
-		return 1
-	else
-		return 0
+	return check_icon_cache()
 
 // Connect types
 /obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/atmos1, obj/machinery/atmospherics/atmos2)
-	var/i
-	var/list1[] = atmos1.connect_types
-	var/list2[] = atmos2.connect_types
-	for(i=1,i<=list1.len,i++)
-		var/j
-		for(j=1,j<=list2.len,j++)
+	var/list/list1 = atmos1.connect_types
+	var/list/list2 = atmos2.connect_types
+	for(var/i in 1 to length(list1))
+		for(var/j in 1 to length(list2))
 			if(list1[i] == list2[j])
 				var/n = list1[i]
 				return n
 	return 0
 
 /obj/machinery/atmospherics/proc/check_connect_types_construction(obj/machinery/atmospherics/atmos1, obj/item/pipe/pipe2)
-	var/i
-	var/list1[] = atmos1.connect_types
-	var/list2[] = pipe2.connect_types
-	for(i=1,i<=list1.len,i++)
-		var/j
-		for(j=1,j<=list2.len,j++)
+	var/list/list1 = atmos1.connect_types
+	var/list/list2 = pipe2.connect_types
+	for(var/i in 1 to length(list1))
+		for(var/j in 1 to length(list2))
 			if(list1[i] == list2[j])
 				var/n = list1[i]
 				return n
@@ -240,7 +232,7 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))
 		if(can_unwrench)
-			var/obj/item/pipe/stored = new(loc, make_from = src)
+			var/obj/item/pipe/stored = new(loc, null, null, src)
 			if(!disassembled)
 				stored.obj_integrity = stored.max_integrity * 0.5
 			transfer_fingerprints_to(stored)

--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -27,15 +27,16 @@
 /obj/item/pipe/circulator
 	name = "circulator/heat exchanger fitting"
 
-/obj/item/pipe/circulator/New(loc)
-	var/obj/machinery/atmospherics/binary/circulator/C = new /obj/machinery/atmospherics/binary/circulator(null)
-	..(loc, make_from = C)
+/obj/item/pipe/circulator/Initialize(mapload, pipe_type, dir, obj/machinery/atmospherics/make_from)
+	. = ..(make_from = new /obj/machinery/atmospherics/binary/circulator(null))
 
 /obj/machinery/atmospherics/binary/circulator/Destroy()
 	if(generator && generator.cold_circ == src)
 		generator.cold_circ = null
+
 	else if(generator && generator.hot_circ == src)
 		generator.hot_circ = null
+
 	return ..()
 
 /obj/machinery/atmospherics/binary/circulator/proc/return_transfer_air()

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -14,7 +14,7 @@
 
 	level = 1
 
-	connect_types = list(1,2,3) //connects to regular, supply and scrubbers pipes
+	connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SUPPLY, CONNECT_TYPE_SCRUBBER) //connects to regular, supply and scrubbers pipes
 
 	var/releasing = TRUE //FALSE = siphoning, TRUE = releasing
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -44,7 +44,7 @@
 	var/radio_filter_out
 	var/radio_filter_in
 
-	connect_types = list(1,2) //connects to regular and supply pipes
+	connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SUPPLY) //connects to regular and supply pipes
 
 /obj/machinery/atmospherics/unary/vent_pump/detailed_examine()
 	return "This pumps the contents of the attached pipe out into the atmosphere, if needed. It can be controlled from an Air Alarm."

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -36,7 +36,7 @@
 	var/radio_filter_out
 	var/radio_filter_in
 
-	connect_types = list(1,3) //connects to regular and scrubber pipes
+	connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SCRUBBER) //connects to regular and scrubber pipes
 
 /obj/machinery/atmospherics/unary/vent_scrubber/on
 	on = TRUE

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -1,4 +1,4 @@
-/obj/machinery/meter
+/obj/machinery/atmospherics/meter
 	name = "gas flow meter"
 	desc = "It measures something."
 	icon = 'icons/obj/meter.dmi'
@@ -12,7 +12,6 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 40, ACID = 0)
 	power_channel = ENVIRON
 	frequency = ATMOS_DISTRO_FREQ
-	var/id
 	var/id_tag
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
@@ -21,28 +20,18 @@
 	Mtoollink = TRUE
 	settagwhitelist = list("id_tag")
 
-/obj/machinery/meter/New()
-	..()
-	SSair.atmos_machinery += src
+/obj/machinery/atmospherics/meter/Initialize()
+	. = ..()
 	target = locate(/obj/machinery/atmospherics/pipe) in loc
-	if(id && !id_tag)//i'm not dealing with further merge conflicts, fuck it
-		id_tag = id
-	return 1
 
-/obj/machinery/meter/Destroy()
-	SSair.atmos_machinery -= src
+/obj/machinery/atmospherics/meter/Destroy()
 	target = null
 	return ..()
 
-/obj/machinery/meter/Initialize()
-	..()
-	if(!target)
-		target = locate(/obj/machinery/atmospherics/pipe) in loc
-
-/obj/machinery/meter/detailed_examine()
+/obj/machinery/atmospherics/meter/detailed_examine()
 	return "Measures the volume and temperature of the pipe under the meter."
 
-/obj/machinery/meter/process_atmos()
+/obj/machinery/atmospherics/meter/process_atmos()
 	if(!target)
 		icon_state = "meterX"
 		return 0
@@ -87,7 +76,7 @@
 		)
 		radio_connection.post_signal(src, signal)
 
-/obj/machinery/meter/proc/status()
+/obj/machinery/atmospherics/meter/proc/status()
 	var/t = ""
 	if(target)
 		var/datum/gas_mixture/environment = target.return_air()
@@ -99,7 +88,7 @@
 		t += "The connect error light is blinking."
 	return t
 
-/obj/machinery/meter/examine(mob/user)
+/obj/machinery/atmospherics/meter/examine(mob/user)
 	var/t = "A gas flow meter. "
 
 	if(get_dist(user, src) > 3 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/dead)))
@@ -119,14 +108,14 @@
 
 	. = list(t)
 
-/obj/machinery/meter/Click()
+/obj/machinery/atmospherics/meter/Click()
 	if(istype(usr, /mob/living/silicon/ai)) // ghosts can call ..() for examine
 		usr.examinate(src)
 		return 1
 
 	return ..()
 
-/obj/machinery/meter/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/machinery/atmospherics/meter/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/multitool))
 		update_multitool_menu(user)
 		return 1
@@ -142,33 +131,17 @@
 			"You hear ratchet.")
 		deconstruct(TRUE)
 
-/obj/machinery/meter/deconstruct(disassembled = TRUE)
+/obj/machinery/atmospherics/meter/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))
 		new /obj/item/pipe_meter(loc)
 	qdel(src)
 
-/obj/machinery/meter/singularity_pull(S, current_size)
+/obj/machinery/atmospherics/meter/singularity_pull(S, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()
 
-// TURF METER - REPORTS A TILE'S AIR CONTENTS
-
-/obj/machinery/meter/turf/New()
-	..()
-	target = loc
-	return 1
-
-
-/obj/machinery/meter/turf/Initialize()
-	if(!target)
-		target = loc
-	..()
-
-/obj/machinery/meter/turf/attackby(obj/item/W as obj, mob/user as mob, params)
-	return
-
-/obj/machinery/meter/multitool_menu(mob/user, obj/item/multitool/P)
+/obj/machinery/atmospherics/meter/multitool_menu(mob/user, obj/item/multitool/P)
 	return {"
 	<b>Main</b>
 	<ul>

--- a/code/modules/atmospherics/machinery/pipes/cap.dm
+++ b/code/modules/atmospherics/machinery/pipes/cap.dm
@@ -92,7 +92,7 @@
 	name = "scrubbers pipe endcap"
 	desc = "An endcap for scrubbers pipes"
 	icon_state = "cap-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -101,7 +101,7 @@
 	name = "supply pipe endcap"
 	desc = "An endcap for supply pipes"
 	icon_state = "cap-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -115,7 +115,7 @@
 	name = "scrubbers pipe endcap"
 	desc = "An endcap for scrubbers pipes"
 	icon_state = "cap-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -124,7 +124,7 @@
 	name = "supply pipe endcap"
 	desc = "An endcap for supply pipes"
 	icon_state = "cap-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -167,7 +167,7 @@
 	name="Scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -180,7 +180,7 @@
 	name="Air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -216,7 +216,7 @@
 	name="Scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -229,7 +229,7 @@
 	name="Air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -177,7 +177,7 @@
 	name="4-way scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map_4way-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -190,7 +190,7 @@
 	name="4-way air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map_4way-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -220,7 +220,7 @@
 	name="4-way scrubbers pipe manifold"
 	desc = "A manifold composed of scrubbers pipes"
 	icon_state = "map_4way-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -233,7 +233,7 @@
 	name="4-way air supply pipe manifold"
 	desc = "A manifold composed of supply pipes"
 	icon_state = "map_4way-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE

--- a/code/modules/atmospherics/machinery/pipes/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipe.dm
@@ -15,8 +15,8 @@
 
 	flags_2 = NO_MALF_EFFECT_2
 
-/obj/machinery/atmospherics/pipe/New()
-	..()
+/obj/machinery/atmospherics/pipe/Initialize()
+	. = ..()
 	//so pipes under walls are hidden
 	if(istype(get_turf(src), /turf/simulated/wall))
 		level = 1
@@ -26,7 +26,7 @@
 	QDEL_NULL(air_temporary)
 
 	var/turf/T = loc
-	for(var/obj/machinery/meter/meter in T)
+	for(var/obj/machinery/atmospherics/meter/meter in T)
 		if(meter.target == src)
 			var/obj/item/pipe_meter/PM = new (T)
 			meter.transfer_fingerprints_to(PM)

--- a/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_hidden.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_hidden.dm
@@ -7,7 +7,7 @@
 	name = "Scrubbers pipe"
 	desc = "A one meter section of scrubbers pipe"
 	icon_state = "intact-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -20,7 +20,7 @@
 	name = "Air supply pipe"
 	desc = "A one meter section of supply pipe"
 	icon_state = "intact-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -32,7 +32,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal
 	name="Universal pipe adapter"
 	desc = "An adapter for regular, supply and scrubbers pipes"
-	connect_types = list(1,2,3)
+	connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SUPPLY, 3)
 	icon_state = "map_universal"
 
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/detailed_examine()

--- a/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_visible.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_visible.dm
@@ -6,7 +6,7 @@
 	name = "Scrubbers pipe"
 	desc = "A one meter section of scrubbers pipe"
 	icon_state = "intact-scrubbers"
-	connect_types = list(3)
+	connect_types = list(CONNECT_TYPE_SCRUBBER)
 	layer = 2.38
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
@@ -19,7 +19,7 @@
 	name = "Air supply pipe"
 	desc = "A one meter section of supply pipe"
 	icon_state = "intact-supply"
-	connect_types = list(2)
+	connect_types = list(CONNECT_TYPE_SUPPLY)
 	layer = 2.39
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
@@ -49,7 +49,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal
 	name="Universal pipe adapter"
 	desc = "An adapter for regular, supply and scrubbers pipes"
-	connect_types = list(1,2,3)
+	connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SUPPLY, CONNECT_TYPE_SCRUBBER)
 	icon_state = "map_universal"
 
 /obj/machinery/atmospherics/pipe/simple/visible/universal/detailed_examine()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -1,42 +1,46 @@
 /datum/canister_icons
-	var
-		possiblemaincolor = list( //these lists contain the possible colors of a canister
-			list("name" = "\[N2O\]", "icon" = "redws"),
-			list("name" = "\[N2\]", "icon" = "red"),
-			list("name" = "\[O2\]", "icon" = "blue"),
-			list("name" = "\[Toxin (Bio)\]", "icon" = "orange"),
-			list("name" = "\[CO2\]", "icon" = "black"),
-			list("name" = "\[Air\]", "icon" = "grey"),
-			list("name" = "\[CAUTION\]", "icon" = "yellow"),
-			list("name" = "\[SPECIAL\]", "icon" = "whiters")
-			)
-		possibleseccolor = list( // no point in having the N2O and "whiters" ones in these lists
-			list("name" = "\[None\]", "icon" = "none"),
-			list("name" = "\[N2\]", "icon" = "red-c"),
-			list("name" = "\[O2\]", "icon" = "blue-c"),
-			list("name" = "\[Toxin (Bio)\]", "icon" = "orange-c"),
-			list("name" = "\[CO2\]", "icon" = "black-c"),
-			list("name" = "\[Air\]", "icon" = "grey-c"),
-			list("name" = "\[CAUTION\]", "icon" = "yellow-c")
-			)
-		possibletertcolor = list(
-			list("name" = "\[None\]", "icon" = "none"),
-			list("name" = "\[N2\]", "icon" = "red-c-1"),
-			list("name" = "\[O2\]", "icon" = "blue-c-1"),
-			list("name" = "\[Toxin (Bio)\]", "icon" = "orange-c-1"),
-			list("name" = "\[CO2\]", "icon" = "black-c-1"),
-			list("name" = "\[Air\]", "icon" = "grey-c-1"),
-			list("name" = "\[CAUTION\]", "icon" = "yellow-c-1")
-			)
-		possiblequartcolor = list(
-			list("name" = "\[None\]", "icon" = "none"),
-			list("name" = "\[N2\]", "icon" = "red-c-2"),
-			list("name" = "\[O2\]", "icon" = "blue-c-2"),
-			list("name" = "\[Toxin (Bio)\]", "icon" = "orange-c-2"),
-			list("name" = "\[CO2\]", "icon" = "black-c-2"),
-			list("name" = "\[Air\]", "icon" = "grey-c-2"),
-			list("name" = "\[CAUTION\]", "icon" = "yellow-c-2")
-			)
+	var/list/possiblemaincolor = list( //these lists contain the possible colors of a canister
+		list("name" = "\[N2O\]", "icon" = "redws"),
+		list("name" = "\[N2\]", "icon" = "red"),
+		list("name" = "\[O2\]", "icon" = "blue"),
+		list("name" = "\[Toxin (Bio)\]", "icon" = "orange"),
+		list("name" = "\[CO2\]", "icon" = "black"),
+		list("name" = "\[Air\]", "icon" = "grey"),
+		list("name" = "\[CAUTION\]", "icon" = "yellow"),
+		list("name" = "\[SPECIAL\]", "icon" = "whiters")
+	)
+
+	var/list/possibleseccolor = list( // no point in having the N2O and "whiters" ones in these lists
+		list("name" = "\[None\]", "icon" = "none"),
+		list("name" = "\[N2\]", "icon" = "red-c"),
+		list("name" = "\[O2\]", "icon" = "blue-c"),
+		list("name" = "\[Toxin (Bio)\]", "icon" = "orange-c"),
+		list("name" = "\[CO2\]", "icon" = "black-c"),
+		list("name" = "\[Air\]", "icon" = "grey-c"),
+		list("name" = "\[CAUTION\]", "icon" = "yellow-c")
+	)
+
+	var/list/possibletertcolor = list(
+		list("name" = "\[None\]", "icon" = "none"),
+		list("name" = "\[N2\]", "icon" = "red-c-1"),
+		list("name" = "\[O2\]", "icon" = "blue-c-1"),
+		list("name" = "\[Toxin (Bio)\]", "icon" = "orange-c-1"),
+		list("name" = "\[CO2\]", "icon" = "black-c-1"),
+		list("name" = "\[Air\]", "icon" = "grey-c-1"),
+		list("name" = "\[CAUTION\]", "icon" = "yellow-c-1")
+	)
+
+	var/list/possiblequartcolor = list(
+		list("name" = "\[None\]", "icon" = "none"),
+		list("name" = "\[N2\]", "icon" = "red-c-2"),
+		list("name" = "\[O2\]", "icon" = "blue-c-2"),
+		list("name" = "\[Toxin (Bio)\]", "icon" = "orange-c-2"),
+		list("name" = "\[CO2\]", "icon" = "black-c-2"),
+		list("name" = "\[Air\]", "icon" = "grey-c-2"),
+		list("name" = "\[CAUTION\]", "icon" = "yellow-c-2")
+	)
+
+
 GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 
 /obj/machinery/portable_atmospherics/canister
@@ -71,15 +75,18 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 	var/release_log = ""
 	var/update_flag = 0
 
-/obj/machinery/portable_atmospherics/canister/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/Initialize(mapload)
+	. = ..()
+
 	canister_color = list(
 		"prim" = "yellow",
 		"sec" = "none",
 		"ter" = "none",
 		"quart" = "none"
 	)
-	oldcolor = new /list()
+
+	oldcolor = list()
+
 	colorcontainer = list(
 		"prim" = list(
 			"options" = GLOB.canister_icon_container.possiblemaincolor,
@@ -98,7 +105,9 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 			"name" = "Quaternary color",
 		)
 	)
+
 	color_index = list()
+
 	update_icon()
 
 /obj/machinery/portable_atmospherics/canister/detailed_examine()
@@ -137,17 +146,17 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 		return 0
 
 /obj/machinery/portable_atmospherics/canister/update_icon()
-/*
-update_flag
-1 = holding
-2 = connected_port
-4 = tank_pressure < 10
-8 = tank_pressure < ONE_ATMOS
-16 = tank_pressure < 15*ONE_ATMOS
-32 = tank_pressure go boom.
-64 = colors
-(note: colors has to be applied every icon update)
-*/
+	/*
+	update_flag
+	1 = holding
+	2 = connected_port
+	4 = tank_pressure < 10
+	8 = tank_pressure < ONE_ATMOS
+	16 = tank_pressure < 15*ONE_ATMOS
+	32 = tank_pressure go boom.
+	64 = colors
+	(note: colors has to be applied every icon update)
+	*/
 
 	if(stat & BROKEN)
 		cut_overlays()
@@ -259,7 +268,6 @@ update_flag
 		can_label = FALSE
 
 	updateDialog()
-	return
 
 /obj/machinery/portable_atmospherics/canister/return_air()
 	return air_contents
@@ -268,6 +276,7 @@ update_flag
 	var/datum/gas_mixture/GM = return_air()
 	if(GM && GM.volume>0)
 		return GM.temperature
+
 	return 0
 
 /obj/machinery/portable_atmospherics/canister/proc/return_pressure()
@@ -278,11 +287,13 @@ update_flag
 
 /obj/machinery/portable_atmospherics/canister/replace_tank(mob/living/user, close_valve)
 	. = ..()
+
 	if(.)
 		if(close_valve)
 			valve_open = FALSE
 			update_icon()
 			investigate_log("Valve was <b>closed</b> by [key_name(user)].<br>", "atmos")
+
 		else if(valve_open && holding)
 			investigate_log("[key_name(user)] started a transfer into [holding].<br>", "atmos")
 
@@ -323,9 +334,11 @@ update_flag
 /obj/machinery/portable_atmospherics/canister/ui_act(action, params)
 	if(..())
 		return
+
 	var/can_min_release_pressure = round(ONE_ATMOSPHERE / 10)
 	var/can_max_release_pressure = round(ONE_ATMOSPHERE * 10)
 	. = TRUE
+
 	switch(action)
 		if("relabel")
 			if(can_label)
@@ -338,6 +351,7 @@ update_flag
 				else
 					to_chat(usr, "<span class='warning'>As you attempted to rename it the pressure rose!</span>")
 					. = FALSE
+
 		if("pressure")
 			var/pressure = params["pressure"]
 			if(pressure == "reset")
@@ -355,40 +369,50 @@ update_flag
 			if(.)
 				release_pressure = clamp(round(pressure), can_min_release_pressure, can_max_release_pressure)
 				investigate_log("was set to [release_pressure] kPa by [key_name(usr)].", "atmos")
+
 		if("valve")
 			var/logmsg
 			valve_open = !valve_open
 			if(valve_open)
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into the [holding || "air"].<br>"
+
 				if(!holding)
 					logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into the air.<br>"
+
 					if(air_contents.toxins > 0)
 						message_admins("[key_name_admin(usr)] opened a canister that contains plasma in [get_area(src)]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 						log_admin("[key_name(usr)] opened a canister that contains plasma at [get_area(src)]: [x], [y], [z]")
+
 					if(air_contents.sleeping_agent > 0)
 						message_admins("[key_name_admin(usr)] opened a canister that contains N2O in [get_area(src)]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 						log_admin("[key_name(usr)] opened a canister that contains N2O at [get_area(src)]: [x], [y], [z]")
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into the [holding || "air"].<br>"
+
 			investigate_log(logmsg, "atmos")
 			release_log += logmsg
+
 		if("eject")
 			if(holding)
 				if(valve_open)
 					valve_open = FALSE
 					release_log += "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into the [holding]<br>"
 				replace_tank(usr, FALSE)
+
 		if("recolor")
 			if(can_label)
 				var/ctype = params["ctype"]
 				var/cnum = text2num(params["nc"])
+
 				if(isnull(colorcontainer[ctype]))
 					message_admins("[key_name_admin(usr)] passed an invalid ctype var to a canister.")
 					return
+
 				var/newcolor = sanitize_integer(cnum, 0, length(colorcontainer[ctype]["options"]))
 				color_index[ctype] = newcolor
 				newcolor++ // javascript starts arrays at 0, byond (for some reason) starts them at 1, this converts JS values to byond values
 				canister_color[ctype] = colorcontainer[ctype]["options"][newcolor]["icon"]
+
 	add_fingerprint(usr)
 	update_icon()
 
@@ -423,75 +447,71 @@ update_flag
 	can_label = FALSE
 
 
-/obj/machinery/portable_atmospherics/canister/toxins/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/toxins/Initialize(mapload)
+	. = ..()
 
 	canister_color["prim"] = "orange"
 	air_contents.toxins = (maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 	update_icon()
-	return 1
 
-/obj/machinery/portable_atmospherics/canister/oxygen/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/oxygen/Initialize(mapload)
+	. = ..()
 
 	canister_color["prim"] = "blue"
 	air_contents.oxygen = (maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 	update_icon()
-	return 1
 
-/obj/machinery/portable_atmospherics/canister/sleeping_agent/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/sleeping_agent/Initialize(mapload)
+	. = ..()
 
 	canister_color["prim"] = "redws"
 	air_contents.sleeping_agent = (maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 	update_icon()
-	return 1
 
-/obj/machinery/portable_atmospherics/canister/nitrogen/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/nitrogen/Initialize(mapload)
+	. = ..()
 
 	canister_color["prim"] = "red"
 	air_contents.nitrogen = (maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 	update_icon()
-	return 1
 
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/New()
-	..()
+
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/Initialize(mapload)
+	. = ..()
 
 	canister_color["prim"] = "black"
 	air_contents.carbon_dioxide = (maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 	update_icon()
-	return 1
 
 
-/obj/machinery/portable_atmospherics/canister/air/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/air/Initialize(mapload)
+	. = ..()
 
 	canister_color["prim"] = "grey"
 	air_contents.oxygen = (O2STANDARD * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 	air_contents.nitrogen = (N2STANDARD * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 	update_icon()
-	return 1
 
-/obj/machinery/portable_atmospherics/canister/custom_mix/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/custom_mix/Initialize(mapload)
+	. = ..()
 
 	canister_color["prim"] = "whiters"
 	update_icon() // Otherwise new canisters do not have their icon updated with the pressure light, likely want to add this to the canister class constructor, avoiding at current time to refrain from screwing up code for other canisters. --DZD
-	return 1
 
 /obj/machinery/portable_atmospherics/canister/welder_act(mob/user, obj/item/I)
 	if(!(stat & BROKEN))
 		return
+
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+
 	WELDER_ATTEMPT_SLICING_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		to_chat(user, "<span class='notice'>You salvage whats left of [src]!</span>")

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -12,29 +12,34 @@
 
 	var/maximum_pressure = 90*ONE_ATMOSPHERE
 
-/obj/machinery/portable_atmospherics/New()
-	..()
+/obj/machinery/portable_atmospherics/Initialize(mapload)
+	. = ..()
 	SSair.atmos_machinery += src
 
 	air_contents.volume = volume
 	air_contents.temperature = T20C
 
-	return 1
+	if(mapload)
+		return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/portable_atmospherics/Initialize()
-	. = ..()
-	spawn()
-		var/obj/machinery/atmospherics/unary/portables_connector/port = locate() in loc
-		if(port)
-			connect(port)
-			update_icon()
+	check_for_port()
+
+// Late init this otherwise it shares with the port and it tries to div temperature by 0
+/obj/machinery/portable_atmospherics/LateInitialize()
+	check_for_port()
+
+/obj/machinery/portable_atmospherics/proc/check_for_port()
+	var/obj/machinery/atmospherics/unary/portables_connector/port = locate() in loc
+	if(port)
+		connect(port)
 
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port) //only react when pipe_network will ont it do it for you
 		//Allow for reactions
 		air_contents.react()
-	else
-		update_icon()
+		return
+
+	update_icon()
 
 /obj/machinery/portable_atmospherics/Destroy()
 	SSair.atmos_machinery -= src

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -178,28 +178,35 @@ GLOBAL_DATUM(error_cache, /datum/ErrorViewer/ErrorCache)
 /datum/ErrorViewer/ErrorEntry/showTo(user, datum/ErrorViewer/back_to, linear)
 	if(!istype(back_to))
 		back_to = error_source
+
 	var/html = buildHeader(back_to, linear)
 	html += "<div class='bad'><b>Be sure to censor out ckeys when copying runtimes!</b></div><br>"
 	html += "<div class='runtime'>[html_encode(name)]<br>[desc]</div>"
+
 	if(srcRef)
 		html += "<br>src: <a href='?_src_=vars;Vars=[srcUID]'>VV</a>"
+
 		if(ispath(srcType, /mob))
 			html += " <a href='?_src_=holder;adminplayeropts=[srcUID]'>PP</a>"
 			html += " <a href='?_src_=holder;adminplayerobservefollow=[srcUID]'>Follow</a>"
+
 		if(istype(srcLoc))
 			html += "<br>src.loc: <a href='?_src_=vars;Vars=[srcLoc.UID()]'>VV</a>"
 			html += " <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[srcLoc.x];Y=[srcLoc.y];Z=[srcLoc.z]'>JMP</a>"
+
 	if(usrRef)
 		html += "<br>usr: <a href='?_src_=vars;Vars=[usrUID]'>VV</a>"
 		html += " <a href='?_src_=holder;adminplayeropts=[usrUID]'>PP</a>"
 		html += " <a href='?_src_=holder;adminplayerobservefollow=[usrUID]'>Follow</a>"
+
 		if(istype(usrLoc))
 			html += "<br>usr.loc: <a href='?_src_=vars;Vars=[usrLoc.UID()]'>VV</a>"
 			html += " <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[usrLoc.x];Y=[usrLoc.y];Z=[usrLoc.z]'>JMP</a>"
+
 	browseTo(user, html)
 
 /datum/ErrorViewer/ErrorEntry/makeLink(linktext, datum/ErrorViewer/back_to, linear)
 	if(isSkipCount)
 		return html_encode(name)
-	else
-		return ..()
+
+	return ..()

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -2,21 +2,22 @@
 // Store Item
 /////////////////////////////
 /datum/storeitem
-	var/name="Thing"
-	var/desc="It's a thing."
-	var/typepath=/obj/item/storage/box
-	var/cost=0
+	var/name = "Thing"
+	var/desc = "It's a thing."
+	var/typepath = /obj/item/storage/box
+	var/cost = 0
 
-/datum/storeitem/proc/deliver(mob/usr)
+/datum/storeitem/proc/deliver(mob/user)
 	if(!istype(typepath,/obj/item/storage))
-		var/obj/item/storage/box/box=new(usr.loc)
+		var/obj/item/storage/box/box=new(user.loc)
 		new typepath(box)
 		box.name="[name] package"
 		box.desc="A special gift for doing your job."
-		usr.put_in_hands(box)
+		user.put_in_hands(box)
+
 	else
-		var/thing = new typepath(usr.loc)
-		usr.put_in_hands(thing)
+		var/thing = new typepath(user.loc)
+		user.put_in_hands(thing)
 
 
 /////////////////////////////

--- a/code/modules/store/store.dm
+++ b/code/modules/store/store.dm
@@ -52,14 +52,16 @@ GLOBAL_DATUM_INIT(centcomm_store, /datum/store, new())
 			linked_db = DB
 			break
 
-/datum/store/proc/PlaceOrder(mob/living/usr, itemID)
+/datum/store/proc/PlaceOrder(mob/living/user, itemID)
 	// Get our item, first.
 	var/datum/storeitem/item = items[itemID]
 	if(!item)
-		return 0
+		return FALSE
+
 	// Try to deduct funds.
-	if(!charge(usr.mind,item.cost,item))
-		return 0
+	if(!charge(user.mind,item.cost,item))
+		return FALSE
+
 	// Give them the item.
-	item.deliver(usr)
-	return 1
+	item.deliver(user)
+	return TRUE


### PR DESCRIPTION
## What Does This PR Do

DNM till @Fox-McCloud looks it over

This PR:
- Majorly improves readability in atmos
- Canisters now initialize
- Pipes (placed) now initialize
- Pipes (items) now initialize
- Repathed `/obj/machinery/air_sensor` to `/obj/machinery/atmospherics/air_sensor`
- Repathed `/obj/machinery/meter` to `/obj/machinery/atmospherics/meter`
- Removed injector control console (Unused and unable to be constructed)
- Cleans up a bunch of other args in places that I found while hopping around
- Increases my booze intake

## Why It's Good For The Game
This needs doing. I need to repath those 2 devices to make way for an upcoming PR (removing reliance on radio signals for atmos stuff)

As for why the above needs doing, see below
![image](https://user-images.githubusercontent.com/25063394/179857508-e28a109f-8277-4553-a816-1cb89252b01e.png)

The whole magical radio bollocks system is terrible and the cause for so much extra tick usage for no reason. We have refs for a reason, and we can write code that cleans them up. Using proper refs with a 0.8us overhead compared to a radio signal with **581us** is a no brainer. I have a list of things that need doing, including:

- Signallers
- Simplemob bots
- Atmos devices
- Airlock controllers
- Probably more that ill find

This PR paves the way for that (I need atmos devices to be in the same common path so I can share vars for them being in an atmos device "list" to assist linking).

I am also going to rip out `set_machine()` code because thats long overdue now that we have TGUI and proper updates. So much of the tick is wasted on that and this can be majorly improved.

## Changelog
:cl: AffectedArc07
del: Removed some old atmos thing you probably didnt know existed
add: Sanity to atmos code
/ :cl: