### PR TITLE
Removes the 20 second stun from tourettes

### DIFF
--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -78,7 +78,7 @@
 	block = GLOB.twitchblock
 
 /datum/mutation/disability/tourettes/on_life(mob/living/carbon/human/H)
-	if((prob(10))
+	if(prob(10))
 		switch(rand(1, 3))
 			if(1)
 				H.emote("twitch")

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -72,7 +72,6 @@
 	name = "Tourettes"
 	activation_messages = list("You twitch.")
 	deactivation_messages = list("Your mouth tastes like soap.")
-	instability = -GENE_INSTABILITY_MODERATE
 
 /datum/mutation/disability/tourettes/New()
 	..()

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -78,7 +78,7 @@
 	block = GLOB.twitchblock
 
 /datum/mutation/disability/tourettes/on_life(mob/living/carbon/human/H)
-	if((prob(10) && H.AmountParalyzed() <= 1))
+	if((prob(10))
 		switch(rand(1, 3))
 			if(1)
 				H.emote("twitch")

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -80,7 +80,6 @@
 
 /datum/mutation/disability/tourettes/on_life(mob/living/carbon/human/H)
 	if((prob(10) && H.AmountParalyzed() <= 1))
-		H.Stun(20 SECONDS)
 		switch(rand(1, 3))
 			if(1)
 				H.emote("twitch")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes the 20 second stun from the tourettes disability. Yeah, you heard that right. Tourettes has a **20 second HARD STUN** that freezes you in place without warning, and with little to no indication to yourself or others that it's happening. I saw a pr from goof on /tg/ a while ago that did this (https://github.com/tgstation/tgstation/pull/64416), and I've been thinking about it ever since. I think he put it more eloquently than I can:

> Removes the fucking 20 second stunlock rng from tourettes because it's fucking stupid and I just had the most agonizing thirty fucking minutes of my goddamn life, holy shit, I hate this fucking mutation so goddamn much, who the fuck thought 20 second hard stun was a genius idea for a random mutation, especially the fact it gives absolutely zero indication that it's from the tourettes because the stun has no message attached

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This isn't even related to the stun project, it's just a terrible symptom from a genetic mutation that's been around for ages. The fact that it makes you swear loudly is enough, I don't understand why a 20 second stun with no indication to its source would ever have been justified. 

Again, to quote goof:
> Oh my fucking god I hate this
> Twenty fucking seconds of stunlocking
> 20 fucking whole seconds
> This can end up being a solid fucking minute in laggy situations
> This is fucking stupid
> Fuck this symptom holy shit
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: Tourettes no longer stuns you for a full 20 seconds at random
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
