### PR TITLE
Makes cell chargers buildable and upgradeable

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -11,6 +11,14 @@
 	pass_flags = PASSTABLE
 	var/obj/item/stock_parts/cell/charging = null
 	var/chargelevel = -1
+	var/charge_rate = 500
+
+/obj/machinery/cell_charger/Initialize(mapload)
+	. = ..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/cell_charger(null)
+	component_parts += new /obj/item/stock_parts/capacitor(null)
+	RefreshParts()
 
 /obj/machinery/cell_charger/deconstruct()
 	if(charging)
@@ -43,7 +51,7 @@
 		. += "Current charge: [round(charging.percent(), 1)]%"
 
 /obj/machinery/cell_charger/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/stock_parts/cell))
+	if(istype(I, /obj/item/stock_parts/cell) && !panel_open)
 		if(stat & BROKEN)
 			to_chat(user, "<span class='warning'>[src] is broken!</span>")
 			return
@@ -71,6 +79,14 @@
 	else
 		return ..()
 
+/obj/machinery/cell_charger/crowbar_act(mob/user, obj/item/I)
+	if(panel_open && !charging && default_deconstruction_crowbar(user, I))
+		return TRUE
+
+/obj/machinery/cell_charger/screwdriver_act(mob/user, obj/item/I)
+	if(anchored && !charging && default_deconstruction_screwdriver(user, icon_state, icon_state, I))
+		return TRUE
+
 /obj/machinery/cell_charger/wrench_act(mob/user, obj/item/I)
 	. = TRUE
 	if(charging)
@@ -83,7 +99,6 @@
 		WRENCH_ANCHOR_MESSAGE
 	else
 		WRENCH_UNANCHOR_MESSAGE
-
 
 /obj/machinery/cell_charger/proc/removecell()
 	charging.update_icon()
@@ -123,6 +138,10 @@
 
 	..(severity)
 
+/obj/machinery/cell_charger/RefreshParts()
+	charge_rate = 500
+	for(var/obj/item/stock_parts/capacitor/C in component_parts)
+		charge_rate *= C.rating
 
 /obj/machinery/cell_charger/process()
 	if(!charging || !anchored || (stat & (BROKEN|NOPOWER)))
@@ -131,7 +150,7 @@
 	if(charging.percent() >= 100)
 		return
 
-	use_power(200)		//this used to use CELLRATE, but CELLRATE is fucking awful. feel free to fix this properly!
-	charging.give(175)	//inefficiency.
+	use_power(charge_rate)
+	charging.give(charge_rate)
 
 	updateicon()

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -851,8 +851,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/cell_charger
 	board_type = "machine"
 	origin_tech = "powerstorage=3;materials=2"
-	req_components = list(
-							/obj/item/stock_parts/capacitor = 1)
+	req_components = list(/obj/item/stock_parts/capacitor = 1)
 
 /obj/item/circuitboard/cyborgrecharger
 	board_name = "Cyborg Recharger"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -846,6 +846,14 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stack/cable_coil = 1,
 							/obj/item/stack/sheet/glass = 4)
 
+/obj/item/circuitboard/cell_charger
+	board_name = "Cell Charger"
+	build_path = /obj/machinery/cell_charger
+	board_type = "machine"
+	origin_tech = "powerstorage=3;materials=2"
+	req_components = list(
+							/obj/item/stock_parts/capacitor = 1)
+
 /obj/item/circuitboard/cyborgrecharger
 	board_name = "Cyborg Recharger"
 	build_path = /obj/machinery/recharge_station

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -13,10 +13,20 @@
 	category = list ("Engineering Machinery")
 
 /datum/design/recharger
-	name = "Machine Board(Weapon Recharger)"
+	name = "Machine Board (Weapon Recharger)"
 	desc = "The circuit board for a weapon recharger"
 	id = "recharger"
 	build_path = /obj/item/circuitboard/recharger
+	materials = list(MAT_GLASS = 1000)
+	build_type = IMPRINTER
+	req_tech = list("powerstorage" = 3, "materials" = 3)
+	category = list("Misc. Machinery")
+
+/datum/design/cell_charger
+	name = "Machine Board (Cell Charger)"
+	desc = "The circuit board for a cell charger"
+	id = "cell_charger"
+	build_path = /obj/item/circuitboard/cell_charger
 	materials = list(MAT_GLASS = 1000)
 	build_type = IMPRINTER
 	req_tech = list("powerstorage" = 3, "materials" = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cell chargers can now be built and upgraded with capacitors just like rechargers! You can print the board from the protolathe

This PR is mostly a port of https://github.com/tgstation/tgstation/pull/35517/ and thus is credited in the changelog.

Also, I added a space in the rechargers sci console listing to make it consistent.
## Why It's Good For The Game
I can upgrade rechargers why can't I upgrade cell chargers?

Plus this is needed for #18459 but even if that doesn't get merged this still makes sense on its own.

## Changelog
:cl: Bmon, DaxDupont
add: Cell chargers can now be built and upgraded like other machines. The new cell charger machine board is printable at the protolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
