### PR TITLE
Update bug report template for security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,16 @@ labels: ''
 assignees: ''
 
 ---
-<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable -->
+<!--
+
+IMPORTANT
+
+If your issue is an ingame exploit that allows players to gain an unfair advantage, or an issue which could affect server stability or security,
+please file it at https://www.paradisestation.org/forum/179-exploit-reports/ so that it is safe from prying eyes
+
+-->
+
+<!-- Write **BELOW** the headers and **ABOVE** the comments else it may not be viewable -->
 **Issue Description**:
 <!---What is the problem?-->
 


### PR DESCRIPTION
## What Does This PR Do
Adds a link to https://www.paradisestation.org/forum/179-exploit-reports/ in the issue template

## Why It's Good For The Repo
We need a place to report issues that could be abused by the unfavourable.
