### PR TITLE
Using :r or :l will prioritize hand radios over headsets

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -199,20 +199,20 @@
 
 		if("right ear")
 			var/obj/item/radio/R
-			if(isradio(r_ear))
-				R = r_ear
-			else if(isradio(r_hand))
+			if(isradio(r_hand))
 				R = r_hand
+			else if(isradio(r_ear))
+				R = r_ear
 			if(R)
 				used_radios += R
 				R.talk_into(src, message_pieces, null, verb)
 
 		if("left ear")
 			var/obj/item/radio/R
-			if(isradio(l_ear))
-				R = l_ear
-			else if(isradio(l_hand))
+			if(isradio(l_hand))
 				R = l_hand
+			else if(isradio(l_ear))
+				R = l_ear
 			if(R)
 				used_radios += R
 				R.talk_into(src, message_pieces, null, verb)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Using :r or :l will prioritize any radios in your hand over headsets.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->You need to purposely hold a radio in your hand to use it, meaning it is usually intended for the radio to be used over a headset. This causes particular issues when telecomms are down and you want to use the radio in your hand but it doesn't work because its prioritizing your non-working headset.

## Changelog
:cl:
tweak: Using :r or :l will prioritize radios in your hands over headsets on your ears
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
