### PR TITLE
Replaces RNG Hardstuns on Terror Spiders with Knockdowns

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -38,9 +38,5 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/prince/spider_specialattack(mob/living/carbon/human/L)
-	if(prob(15))
-		visible_message("<span class='danger'>[src] rams into [L], knocking [L.p_them()] to the floor!</span>")
-		do_attack_animation(L)
-		L.Weaken(10 SECONDS)
-	else
-		..()
+	L.KnockDown(10 SECONDS)
+	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
@@ -41,6 +41,7 @@
 		return
 	var/inject_target = pick("chest","head")
 	L.attack_animal(src)
+	L.KnockDown(10 SECONDS)
 	if(L.IsStunned() || L.IsParalyzed() || L.can_inject(null, FALSE, inject_target, FALSE))
 		if(!IsTSInfected(L) && ishuman(L))
 			visible_message("<span class='danger'>[src] buries its long fangs deep into the [inject_target] of [L]!</span>")
@@ -48,9 +49,6 @@
 			if(!ckey)
 				LoseTarget()
 				walk_away(src,L,2,1)
-		else if(prob(25))
-			visible_message("<span class='danger'>[src] pounces on [L]!</span>")
-			L.Weaken(10 SECONDS)
 
 /proc/IsTSInfected(mob/living/carbon/C) // Terror AI requires this
 	if(C.get_int_organ(/obj/item/organ/internal/body_egg))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
White and Prince terror spiders now knock you down for 10 seconds on bite, instead of having RNG hardstuns.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hard stuns bad. RNG deciding fights bad. White needs some means of escaping people after biting them. Prince needs to be a threat if it manages to get you.

## Changelog
:cl:
tweak: Prince and White terrors knock down for 10 seconds instead of RNG hard stunning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
