### PR TITLE
Map voting is now ticket-based

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -351,6 +351,7 @@ CREATE TABLE `karma_totals` (
 ) ENGINE=InnoDB AUTO_INCREMENT=25715 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+DROP TABLE IF EXISTS `karma_purchases`;
 CREATE TABLE `karma_purchases` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
 	`ckey` VARCHAR(32) NOT NULL COLLATE 'utf8_general_ci',
@@ -591,6 +592,7 @@ CREATE TABLE `round` (
 --
 -- Table structure for table `2fa_secrets`
 --
+DROP TABLE IF EXISTS `2fa_secrets`;
 CREATE TABLE `2fa_secrets` (
 	`ckey` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`secret` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
@@ -602,6 +604,7 @@ CREATE TABLE `2fa_secrets` (
 --
 -- Table structure for table `pai_saves`
 --
+DROP TABLE IF EXISTS `pai_saves`;
 CREATE TABLE `pai_saves` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
 	`ckey` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
@@ -616,6 +619,7 @@ CREATE TABLE `pai_saves` (
 --
 -- Table structure for table `instance_data_cache`
 --
+DROP TABLE IF EXISTS `instance_data_cache`;
 CREATE TABLE `instance_data_cache` (
 	`server_id` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`key_name` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',

--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -351,7 +351,6 @@ CREATE TABLE `karma_totals` (
 ) ENGINE=InnoDB AUTO_INCREMENT=25715 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
-DROP TABLE IF EXISTS `karma_purchases`;
 CREATE TABLE `karma_purchases` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
 	`ckey` VARCHAR(32) NOT NULL COLLATE 'utf8_general_ci',
@@ -592,7 +591,6 @@ CREATE TABLE `round` (
 --
 -- Table structure for table `2fa_secrets`
 --
-DROP TABLE IF EXISTS `2fa_secrets`;
 CREATE TABLE `2fa_secrets` (
 	`ckey` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`secret` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
@@ -604,7 +602,6 @@ CREATE TABLE `2fa_secrets` (
 --
 -- Table structure for table `pai_saves`
 --
-DROP TABLE IF EXISTS `pai_saves`;
 CREATE TABLE `pai_saves` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
 	`ckey` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
@@ -619,7 +616,6 @@ CREATE TABLE `pai_saves` (
 --
 -- Table structure for table `instance_data_cache`
 --
-DROP TABLE IF EXISTS `instance_data_cache`;
 CREATE TABLE `instance_data_cache` (
 	`server_id` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
 	`key_name` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',

--- a/code/modules/vote/vote_datum.dm
+++ b/code/modules/vote/vote_datum.dm
@@ -124,8 +124,6 @@
 
 			var/lucky_winner_ck = pick(voted)
 			var/lucky_winner_vote = voted[lucky_winner_ck]
-			var/lucky_mob = get_mob_by_ckey(lucky_winner_ck)
-			lucky_winner_ck = safe_get_ckey(lucky_mob)  // anonymize, if requested
 
 			// Print all results
 			for(var/res in results)
@@ -133,7 +131,7 @@
 				to_chat(world, "<span class='info'><code>[res]</code> - [results[res]] vote\s ([percentage]%)</span>")
 			// And then the winner
 			to_chat(world, "<span class='interface'>Reaching into the bag of votes to draw one at random...</span>")
-			to_chat(world, "<span class='interface'>...and the lucky winner is <b><code>[lucky_winner_vote]</code></b>! (ticket cast by [lucky_mob] ([lucky_winner_ck]))</span>")
+			to_chat(world, "<span class='interface'>...and the lucky winner is <b><code>[lucky_winner_vote]</code></b>!</span>")
 
 			if(!is_custom)
 				SSblackbox.record_feedback("text", "vote_winner", 1, lucky_winner_vote, ignore_seal = TRUE)

--- a/code/modules/vote/vote_presets.dm
+++ b/code/modules/vote/vote_presets.dm
@@ -17,6 +17,8 @@
 /datum/vote/map
 	question = "Map Vote"
 	vote_type_text = "map"
+	vote_counting = VOTE_COUNTING_TICKET
+	show_counts = TRUE
 
 /datum/vote/map/generate_choices()
 	for(var/x in subtypesof(/datum/map))

--- a/code/modules/vote/vote_verb.dm
+++ b/code/modules/vote/vote_verb.dm
@@ -52,10 +52,10 @@
 		choices |= option
 
 	var/c2 = alert(usr, "Show counts while vote is happening?", "Counts", "Yes", "No")
-	var/c3 = input(usr, "Select a result calculation type", "Vote", VOTE_RESULT_TYPE_MAJORITY) as anything in list(VOTE_RESULT_TYPE_MAJORITY)
+	var/c3 = input(usr, "Select a result calculation type", "Vote", VOTE_COUNTING_MAJORITY) as anything in list(VOTE_COUNTING_MAJORITY, VOTE_COUNTING_TICKET)
 
 	var/datum/vote/V = new /datum/vote(usr.ckey, question, choices, TRUE)
 	V.show_counts = (c2 == "Yes")
-	V.vote_result_type = c3
+	V.vote_counting = c3
 	SSvote.start_vote(V)
 


### PR DESCRIPTION
## What Does This PR Do
Switched map vote counting to ticket (aka. urn) mode. Details at #17869

TL;DR:
each voting person casts a vote into the bag, then we draw one vote from the bag at random, and declare that to be the vote result.
Alternative way of visualizing that: Each vote candidate gets weighted by the amount of votes cast for them, then a random one is chosen. So an candidate with twice as many votes behind it is twice as likely to be chosen.

## Why It's Good For The Game
See #17869
TL;DR: promotes map variety, while being democratic.

## Images of changes
![20220721-050716-dreamseeker](https://user-images.githubusercontent.com/7831163/180134800-c1a35cb9-3c16-42f5-80a6-a6b533097876.png)

Wording suggestions are welcome (either here or on discord - both work).

One thing i'm a bit torn about is displaying the winning ticket holder in the message:
- on one hand i really like that it gives excellent feedback about how the system works, that it is *fair*, and that your vote *truly* counts no matter how many are already cast
- on the other hand, i slightly worry that it reveals that person's vote, which might subject them to bullying for voting "wrong".

I'm open to removing that part if that would be preferable.
Or maybe going halfway, and tying it to anon mode in prefs. So that instead of merely anonymizing the ckey, it stops even showing the player mob.

## Changelog
:cl:
tweak: Map vote counting is changed to be ticket-based (cast all votes into the bag; draw out a single random one - declare it as the winer)
/:cl:

stealth-change: effectively reverts #17838 and shows the vote count while the map vote is in progress again. There is no reason to be herdy anymore - each individual vote truly counts, no matter how small of a minority you are.