### PR TITLE
Fix Grape Granade allowing player to launch infinite items

### DIFF
--- a/code/modules/reagents/chemistry/reagents/paradise_pop.dm
+++ b/code/modules/reagents/chemistry/reagents/paradise_pop.dm
@@ -120,7 +120,7 @@
 /datum/reagent/consumable/drink/grape_granade/on_mob_life(mob/living/M)
 	if(prob(1))
 		var/turf/simulated/T = get_turf(M)
-		goonchem_vortex(T, FALSE, 0, TRUE) // Ignore the 0 volume
+		goonchem_vortex(T, FALSE, 100) //Capped at 100 to prevent sorium abuse
 		M.emote("burp")
 		to_chat(M, "<span class='notice'>You feel ready to burst! Oh wait, just a burp...</span>")
 	else if(prob(25))

--- a/code/modules/reagents/chemistry/reagents/paradise_pop.dm
+++ b/code/modules/reagents/chemistry/reagents/paradise_pop.dm
@@ -120,7 +120,7 @@
 /datum/reagent/consumable/drink/grape_granade/on_mob_life(mob/living/M)
 	if(prob(1))
 		var/turf/simulated/T = get_turf(M)
-		goonchem_vortex(T, FALSE, 100) //Capped at 100 to prevent sorium abuse
+		goonchem_vortex(T, FALSE, 30) //Capped at 30 to prevent sorium abuse
 		M.emote("burp")
 		to_chat(M, "<span class='notice'>You feel ready to burst! Oh wait, just a burp...</span>")
 	else if(prob(25))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Resolves #16636

When sorium was nerfed to require at least 5 units of reagent per item launched (#16284), Grape Granade was left uncapped, meaning you can still launch every item one tile away from you on an RNG timer for massive damage. This PR caps Grape Granade's reaction volume to 30, the volume needed to launch 6 items in a sorium grenade.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Weaponized sorium was adjusted out of balance considerations, any equivalents should also be adjusted for consistency.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Capped Grape Granade's megaburp potency to 30, similar to a low-yield sorium grenade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
