### PR TITLE
Makes e20s Hijack Only. Removes e20s from Surplus Crates.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -377,6 +377,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/dice/d20/e20
 	cost = 3
 	job = list("Librarian")
+	surplus = 0
+	hijack_only = TRUE
 
 //Botanist
 /datum/uplink_item/jobspecific/ambrosiacruciatus


### PR DESCRIPTION
## What Does This PR Do
- Makes e20s Hijack Only. Removes e20s from Surplus Crates.

## Why It's Good For The Game
You effectively cannot use these without admin helping. They can maxcap a large area of the station entirely on RNG. They are not appropriate for normal traitors. Syndicate bombs were made hijack only for similar reasons.

![image](https://user-images.githubusercontent.com/85680653/180252240-20576a74-4a01-4ca8-88d0-277e81af8553.png)
**A 19 on an e20. Perhaps a ten hour player who random rolled librarian should not be able to use these while not knowing their status of being banned or not banned relies entirely on the random number generator.**

## Images of changes
![image](https://user-images.githubusercontent.com/85680653/180252457-688af97e-de1b-4d82-9938-f07f1d0ea5a3.png)


## Changelog
:cl:
tweak: Makes e20s Hijack Only. Removes e20s from Surplus Crates.
/:cl: