### PR TITLE
Removes the Recipes for Brain- and Roburgers

### DIFF
--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -70,20 +70,6 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/monkeyburger
 
-/datum/recipe/microwave/brainburger
-	items = list(
-		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/organ/internal/brain
-	)
-	result = /obj/item/reagent_containers/food/snacks/brainburger
-
-/datum/recipe/microwave/roburger
-	items = list(
-		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/robot_parts/head
-	)
-	result = /obj/item/reagent_containers/food/snacks/roburger
-
 /datum/recipe/microwave/xenoburger
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The aforementioned two items are no longer possible to make in a microwave. Other means of acquiring them still exist.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Both of these items can be made with minimal effort, yet each contains a reagent that induces death and makes the body unrevivable.

Brain burger:
Prions cause space kuru, which is a lethal disease incurable by any means. Cloning or a brain transplant into a new body is your only hope. For slimes and especially vox this means that a single hit of this chemical prevents you from playing as your character post-revival. Powergamers love to use this chem with gas bombs, syringe guns, and sleepy pens to maximize the chances of killing people while minimizing the effort. Sleepy pen prions is perhaps one of the most boring ways to go.

Roburger:
These also cause a disease, this time curable by copper, a dispenser chemical. Often you will not have time for this to happen. This turns you into a borg, which is basically a permakill, as you're now a lawed synthetic... And to add insult to the injury, your brain is turned into a robotic brain. This means that IRC is preeeetty much the best you'd get anyway. And your original body is gone. Also, robotics sometimes uses this to absolutely cheese borging people by just feeding them a burger and calling it a day, no surgery or effort. Oh, also you can feed them to a monkey to make a mindless borg to bump into doors for free AA. :) Exploit city.

Neither of these effects would be TOO bad if the means of acquiring the chemicals were not reliable, infinite, and possible roundstart. The way it is, people can load syringe guns, sleepy pens, and stock up on gas grenades of these chemicals very, very quickly - and they do! They already explicitly can't be grown in botany or made by bees, the fact that you can rapidly infinitely farm them from wheat and monkeys/robot fabricators just feels like an oversight. 

Restricting this to things like floor pills and silver xenobio slimes add a thick layer of RNG that makes the chemicals unviable for powergaming.

## Changelog
:cl:
del: Brainburgers and Roburgers are no longer possible to make in a microwave.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
