### PR TITLE
Removes the majority of brute/burn mods from species, replaces them with interesting downsides.

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -34,18 +34,21 @@
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, RAD)
-	if(prob(40))
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if(!HAS_TRAIT(H, TRAIT_RADIMMUNE))
-				if(prob(max(0, 100 - resist)))
-					randmuti(H) // Applies bad mutation
-					if(prob(50))
-						if(prob(90))
-							randmutb(H)
-						else
-							randmutg(H)
-					domutcheck(H, MUTCHK_FORCED)
+	if(!prob(60))
+		return
+	if(!ishuman(L))
+		return
+	var/mob/living/carbon/human/H = L
+	if(HAS_TRAIT(H, TRAIT_RADIMMUNE))
+		return
+	if(prob(max(0, 100 - resist)) && !HAS_TRAIT(H, TRAIT_GENELESS))
+		randmuti(H) // Applies bad mutation
+		if(prob(50))
+			if(prob(90))
+				randmutb(H)
+			else
+				randmutg(H)
+		domutcheck(H, MUTCHK_FORCED)
 
 		L.rad_act(20)
 

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -36,11 +36,14 @@
 	var/resist = L.getarmor(null, RAD)
 	if(!prob(60))
 		return
+
 	if(!ishuman(L))
 		return
+
 	var/mob/living/carbon/human/H = L
 	if(HAS_TRAIT(H, TRAIT_RADIMMUNE))
 		return
+
 	if(prob(max(0, 100 - resist)) && !HAS_TRAIT(H, TRAIT_GENELESS))
 		randmuti(H) // Applies bad mutation
 		if(prob(50))
@@ -48,6 +51,7 @@
 				randmutb(H)
 			else
 				randmutg(H)
+
 		domutcheck(H, MUTCHK_FORCED)
 
 		L.rad_act(20)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -597,6 +597,11 @@
 
 	dna.species.spec_electrocute_act(src, shock_damage, source, siemens_coeff, flags = NONE)
 
+/mob/living/carbon/human/rad_act(amount)
+	if(!dna.species.spec_rad_act(src, amount))
+		return
+	. = ..()
+
 /mob/living/carbon/human/Topic(href, href_list)
 	if(!usr.stat && !HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED) && !usr.restrained() && in_range(src, usr))
 		var/thief_mode = 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -597,11 +597,6 @@
 
 	dna.species.spec_electrocute_act(src, shock_damage, source, siemens_coeff, flags = NONE)
 
-/mob/living/carbon/human/rad_act(amount)
-	if(!dna.species.spec_rad_act(src, amount))
-		return
-	. = ..()
-
 /mob/living/carbon/human/Topic(href, href_list)
 	if(!usr.stat && !HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED) && !usr.restrained() && in_range(src, usr))
 		var/thief_mode = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -603,8 +603,7 @@
 		return
 
 	if(getBrainLoss() >= 100) // braindeath
-		AdjustLoseBreath(20 SECONDS, bound_lower = 0, bound_upper = 50 SECONDS)
-		Weaken(60 SECONDS)
+		dna.species.handle_brain_death(src)
 
 	if(!check_death_method())
 		if(health <= HEALTH_THRESHOLD_DEAD)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -422,6 +422,10 @@
 /datum/species/proc/spec_electrocute_act(mob/living/carbon/human/H, shock_damage, source, siemens_coeff = 1, flags = NONE)
 	return
 
+/// returning false will prevent the normal radiation behaviour.
+/datum/species/proc/spec_rad_act(mob/living/carbon/human/H, amount)
+	return TRUE
+
 /datum/species/proc/help(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.help_act(user, target) == TRUE)//adminfu only...
 		return TRUE

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -422,10 +422,6 @@
 /datum/species/proc/spec_electrocute_act(mob/living/carbon/human/H, shock_damage, source, siemens_coeff = 1, flags = NONE)
 	return
 
-/// returning false will prevent the normal radiation behaviour.
-/datum/species/proc/spec_rad_act(mob/living/carbon/human/H, amount)
-	return TRUE
-
 /datum/species/proc/help(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.help_act(user, target) == TRUE)//adminfu only...
 		return TRUE
@@ -1005,6 +1001,10 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 
 /datum/species/proc/spec_WakeUp(mob/living/carbon/human/H)
 	return FALSE
+
+/datum/species/proc/handle_brain_death(mob/living/carbon/human/H)
+	H.AdjustLoseBreath(20 SECONDS, bound_lower = 0, bound_upper = 50 SECONDS)
+	H.Weaken(60 SECONDS)
 
 /**
   * Species-specific runechat colour handler

--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -8,8 +8,7 @@
 	unarmed_type = /datum/unarmed_attack/diona
 	remains_type = /obj/effect/decal/cleanable/ash
 
-	burn_mod = 1.25
-	heatmod = 1.5
+	heatmod = 3
 	var/pod = FALSE //did they come from a pod? If so, they're stronger than normal Diona.
 
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
@@ -103,7 +102,6 @@
 			if(!pod && H.health <= 0)
 				return
 			H.adjustBruteLoss(-1)
-			H.adjustFireLoss(-1)
 			H.adjustToxLoss(-1)
 			H.adjustOxyLoss(-1)
 

--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -14,7 +14,7 @@
 	male_sneeze_sound = 'sound/voice/drasksneeze.ogg'
 	female_sneeze_sound = 'sound/voice/drasksneeze.ogg'
 
-	burn_mod = 2
+	burn_mod = 1.5
 	//exotic_blood = "cryoxadone"
 	body_temperature = 273
 
@@ -45,7 +45,7 @@
 	heat_level_1 = 310 //Default 370 - Higher is better
 	heat_level_2 = 340 //Default 400
 	heat_level_3 = 400 //Default 460
-	heatmod = 2
+	heatmod = 3 // 4.5 * more damage from body temp
 
 	flesh_color = "#a3d4eb"
 	reagent_tag = PROCESS_ORG

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -38,7 +38,7 @@
 	. = ..()
 
 	if(method == REAGENT_TOUCH)
-		if(H.head?.flags & THICKMATERIAL && H.wear_suit?.flags & THICKMATERIAL) // fully pierce proof clothing is also water proof!
+		if((H.head?.flags & THICKMATERIAL) && (H.wear_suit?.flags & THICKMATERIAL)) // fully pierce proof clothing is also water proof!
 			return
 		if(volume > 25)
 			if(prob(75))

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -16,8 +16,6 @@
 		"eyes" =     /obj/item/organ/internal/eyes/grey //5 darksight.
 		)
 
-	brute_mod = 1.25 //greys are fragile
-
 	species_traits = list(LIPS, IS_WHITELISTED, CAN_WINGDINGS, NO_HAIR)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags =  HAS_BODY_MARKINGS | HAS_BODYACC_COLOR
@@ -40,14 +38,8 @@
 	. = ..()
 
 	if(method == REAGENT_TOUCH)
-		if(H.wear_mask)
-			to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
+		if(H.head?.flags & THICKMATERIAL && H.wear_suit?.flags & THICKMATERIAL) // fully pierce proof clothing is also water proof!
 			return
-
-		if(H.head)
-			to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
-			return
-
 		if(volume > 25)
 			if(prob(75))
 				H.take_organ_damage(5, 10)

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -183,10 +183,12 @@
 								"Error -1: poafejOIDAIJjamfooooWADm!afe!",
 								"Error -1: PIKFAjgaiosafjiGGIGHasksid!!",
 								"Error 534: Arithmetic result exceeded 512 bits.",
-								"Errror 0: Operation completed successfully.",
+								"Error 0: Operation completed successfully.",
 								"WARNING, CRITICAL COMPONENT ERROR, attempting to troubleshoot....",
 								"runtime in sentience.dm, cannot modify null.som, STACK TRACE:",
 								"master controller timed out, likely infinite recursion loop.",
+								"Error 6344: Cannot delete file ~/2tmp1/8^33, no space left on device",
+								"Error 42: Unable to display error message.",
 								"Daisy.... Daisy...."
 								)
 		var/error_message = pick(error_messages)

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -176,7 +176,7 @@
 	H.Weaken(60 SECONDS)
 	H.adjustBrainLoss(1) // 40 seconds to live
 	if(prob(20))
-		var/list/error_messages = list("Error 196: motor functions failing.",
+		var/static/list/error_messages = list("Error 196: motor functions failing.",
 								"Error 32: Process %^~#/£ cannot be reached, being used by another file.",
 								"Error 39: Cannot write to central memory unit, storage full.",
 								"Error -1: isogjiohrj90903744kfgkgrpopK!!",

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -166,7 +166,28 @@
 	H.adjustBrainLoss(shock_damage)
 	H.adjust_nutrition(shock_damage)
 
-/datum/species/machine/spec_rad_act(mob/living/carbon/human/H, amount)
-	H.adjustBrainLoss(amount / 100)
-	H.AdjustHallucinate(amount)
-	return FALSE
+/datum/species/machine/handle_mutations_and_radiation(mob/living/carbon/human/H)
+	H.adjustBrainLoss(H.radiation / 100)
+	H.AdjustHallucinate(H.radiation)
+	H.radiation = 0
+	return TRUE
+
+/datum/species/machine/handle_brain_death(mob/living/carbon/human/H)
+	H.Weaken(60 SECONDS)
+	H.adjustBrainLoss(1) // 40 seconds to live
+	if(prob(20))
+		var/list/error_messages = list("Error 196: motor functions failing.",
+								"Error 32: Process %^~#/£ cannot be reached, being used by another file.",
+								"Error 39: Cannot write to central memory unit, storage full.",
+								"Error -1: isogjiohrj90903744kfgkgrpopK!!",
+								"Error -1: poafejOIDAIJjamfooooWADm!afe!",
+								"Error -1: PIKFAjgaiosafjiGGIGHasksid!!",
+								"Error 534: Arithmetic result exceeded 512 bits.",
+								"Errror 0: Operation completed successfully.",
+								"WARNING, CRITICAL COMPONENT ERROR, attempting to troubleshoot....",
+								"runtime in sentience.dm, cannot modify null.som, STACK TRACE:",
+								"master controller timed out, likely infinite recursion loop.",
+								"Daisy.... Daisy...."
+								)
+		var/error_message = pick(error_messages)
+		to_chat(H, "<span class='boldwarning'>[error_message]</span>")

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -14,7 +14,7 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 1.52 // 1 * 0.66 (robolimbs) * 1.51 = 1
+	brute_mod = 1.52 // 1 * 0.66 (robolimbs) * 1.52 = ~1
 	burn_mod = 1.52 // so no damage mod overall.
 	tox_mod = 0
 	clone_mod = 0

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -176,20 +176,21 @@
 	H.Weaken(60 SECONDS)
 	H.adjustBrainLoss(1) // 40 seconds to live
 	if(prob(20))
-		var/list/error_messages = list("Error 196: motor functions failing.",
-								"Error 32: Process %^~#/£ cannot be reached, being used by another file.",
-								"Error 39: Cannot write to central memory unit, storage full.",
-								"Error -1: isogjiohrj90903744kfgkgrpopK!!",
-								"Error -1: poafejOIDAIJjamfooooWADm!afe!",
-								"Error -1: PIKFAjgaiosafjiGGIGHasksid!!",
-								"Error 534: Arithmetic result exceeded 512 bits.",
-								"Error 0: Operation completed successfully.",
-								"WARNING, CRITICAL COMPONENT ERROR, attempting to troubleshoot....",
-								"runtime in sentience.dm, cannot modify null.som, STACK TRACE:",
-								"master controller timed out, likely infinite recursion loop.",
-								"Error 6344: Cannot delete file ~/2tmp1/8^33, no space left on device",
-								"Error 42: Unable to display error message.",
-								"Daisy.... Daisy...."
-								)
+		var/list/error_messages = list(
+			"Error 196: motor functions failing.",
+			"Error 32: Process %^~#/£ cannot be reached, being used by another file.",
+			"Error 39: Cannot write to central memory unit, storage full.",
+			"Error -1: isogjiohrj90903744kfgkgrpopK!!",
+			"Error -1: poafejOIDAIJjamfooooWADm!afe!",
+			"Error -1: PIKFAjgaiosafjiGGIGHasksid!!",
+			"Error 534: Arithmetic result exceeded 512 bits.",
+			"Error 0: Operation completed successfully.",
+			"WARNING, CRITICAL COMPONENT ERROR, attempting to troubleshoot....",
+			"runtime in sentience.dm, cannot modify null.som, STACK TRACE:",
+			"master controller timed out, likely infinite recursion loop.",
+			"Error 6344: Cannot delete file ~/2tmp1/8^33, no space left on device",
+			"Error 42: Unable to display error message.",
+			"Daisy.... Daisy...."
+		)
 		var/error_message = pick(error_messages)
 		to_chat(H, "<span class='boldwarning'>[error_message]</span>")

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -14,8 +14,8 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 1.52 // 1 * 0.66 (robolimbs) * 1.52 = ~1
-	burn_mod = 1.52 // so no damage mod overall.
+	brute_mod = 1 / 0.66 // 1 * 0.66 (robolimbs) * 1/0.66 = 1
+	burn_mod = 1 / 0.66 // so no damage mod overall.
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."
@@ -176,21 +176,20 @@
 	H.Weaken(60 SECONDS)
 	H.adjustBrainLoss(1) // 40 seconds to live
 	if(prob(20))
-		var/list/error_messages = list(
-			"Error 196: motor functions failing.",
-			"Error 32: Process %^~#/£ cannot be reached, being used by another file.",
-			"Error 39: Cannot write to central memory unit, storage full.",
-			"Error -1: isogjiohrj90903744kfgkgrpopK!!",
-			"Error -1: poafejOIDAIJjamfooooWADm!afe!",
-			"Error -1: PIKFAjgaiosafjiGGIGHasksid!!",
-			"Error 534: Arithmetic result exceeded 512 bits.",
-			"Error 0: Operation completed successfully.",
-			"WARNING, CRITICAL COMPONENT ERROR, attempting to troubleshoot....",
-			"runtime in sentience.dm, cannot modify null.som, STACK TRACE:",
-			"master controller timed out, likely infinite recursion loop.",
-			"Error 6344: Cannot delete file ~/2tmp1/8^33, no space left on device",
-			"Error 42: Unable to display error message.",
-			"Daisy.... Daisy...."
-		)
+		var/list/error_messages = list("Error 196: motor functions failing.",
+								"Error 32: Process %^~#/£ cannot be reached, being used by another file.",
+								"Error 39: Cannot write to central memory unit, storage full.",
+								"Error -1: isogjiohrj90903744kfgkgrpopK!!",
+								"Error -1: poafejOIDAIJjamfooooWADm!afe!",
+								"Error -1: PIKFAjgaiosafjiGGIGHasksid!!",
+								"Error 534: Arithmetic result exceeded 512 bits.",
+								"Error 0: Operation completed successfully.",
+								"WARNING, CRITICAL COMPONENT ERROR, attempting to troubleshoot....",
+								"runtime in sentience.dm, cannot modify null.som, STACK TRACE:",
+								"master controller timed out, likely infinite recursion loop.",
+								"Error 6344: Cannot delete file ~/2tmp1/8^33, no space left on device",
+								"Error 42: Unable to display error message.",
+								"Daisy.... Daisy...."
+								)
 		var/error_message = pick(error_messages)
 		to_chat(H, "<span class='boldwarning'>[error_message]</span>")

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -14,15 +14,15 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
-	burn_mod = 2.28  // So they take 50% extra damage from brute/burn overall
+	brute_mod = 1.52 // 1 * 0.66 (robolimbs) * 1.51 = 1
+	burn_mod = 1.52 // so no damage mod overall.
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."
 	death_sounds = list('sound/voice/borg_deathsound.ogg') //I've made this a list in the event we add more sounds for dead robots.
 
 	species_traits = list(IS_WHITELISTED, NO_BLOOD, NO_CLONESCAN, NO_INTORGANS)
-	inherent_traits = list(TRAIT_VIRUSIMMUNE, TRAIT_NOBREATH, TRAIT_RADIMMUNE, TRAIT_NOGERMS, TRAIT_NODECAY, TRAIT_NOPAIN, TRAIT_GENELESS) //Computers that don't decay? What a lie!
+	inherent_traits = list(TRAIT_VIRUSIMMUNE, TRAIT_NOBREATH, TRAIT_NOGERMS, TRAIT_NODECAY, TRAIT_NOPAIN, TRAIT_GENELESS) //Computers that don't decay? What a lie!
 	inherent_biotypes = MOB_ROBOTIC | MOB_HUMANOID
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS
@@ -161,3 +161,12 @@
 			H.change_hair(new_style, 1)							// The 1 is to enable custom sprites
 		if(new_color)
 			H.change_hair_color(new_color)
+
+/datum/species/machine/spec_electrocute_act(mob/living/carbon/human/H, shock_damage, source, siemens_coeff, flags)
+	H.adjustBrainLoss(shock_damage)
+	H.adjust_nutrition(shock_damage)
+
+/datum/species/machine/spec_rad_act(mob/living/carbon/human/H, amount)
+	H.adjustBrainLoss(amount / 100)
+	H.AdjustHallucinate(amount)
+	return FALSE

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -36,7 +36,6 @@
 	default_headacc = "Simple"
 	default_headacc_colour = "#404040"
 	butt_sprite = "unathi"
-	brute_mod = 1.05
 
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart/unathi,

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -16,7 +16,7 @@
 	smell.<br/><br/>Most humans will never meet a Vox raider, instead learning of this insular species through \
 	dealing with their traders and merchants; those that do rarely enjoy the experience."
 
-	brute_mod = 1.2 //20% more brute damage. Fragile bird bones.
+	oxy_mod = 2 // die slightly faster in crit or areas without N2
 
 	breathid = "n2"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
the only ones that remain are drask, and plasmamen

IPCs:
brute/burn mods gone
Shocks now cause brain damage and give you nutrition.
no longer immune to rads, rads cause brain damage and hallucinations.
Being in the "brain damage" state no longer just perma stuns you, it gives you error messages and ticks of brain damage, eventually killing you.
![image](https://user-images.githubusercontent.com/69320440/180430442-a4f5eaec-279d-4c2f-b219-eead1be7341a.png)


Vox:
Brute mod replaced with oxyloss mod, they will die double as fast in crit.

Diona:
no more burn mod
they no longer heal burn damage
they take more damage from overheating

Drask:
burn mod from 2 to 1.5
heat mod from 2 to 3

Unathi:
Brute mod gone, it was a joke anyway

Grey:
brute mod gone
you require full syringe proof clothing (helm + exosuit slot) to protect from water now

Plasmamen:
still have a burn mod, I cannot think of a good idea for them. open to suggestions.

## Why It's Good For The Game
Brute/burn mods are an awful way to balance a species. they feel super backhanded and quite frankly, insulting to the people who play these races. they aren't fun and they don't offer any extra flavour to the species outside of the extreme case of drask. this is why I opted to keep the drask burn mod.

## Changelog
:cl:
tweak: removed the majority of species brute/burn mods, replaced them with different downsides. check the PR for more details.
tweak: IPCs actually die from brain damage rather than being stunlocked when their brainloss is between 100 and 120
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
