### PR TITLE
Delays "Level 7 Biohazard" announcement

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -36,7 +36,6 @@
 		if(!H.ForceContractDisease(D))
 			continue
 		patient_zero = H
-		for(var/p in GLOB.dead_mob_list) //Announce patient zero to dchat
-			var/mob/M = p
+		for(var/mob/M as anything in GLOB.dead_mob_list) //Announce patient zero to dchat
 			to_chat(M, "<span class='deadsay'><b>[patient_zero]</b> has been infected with <b>[D.name]</b> ([ghost_follow_link(patient_zero, M)])</span>")
 		break

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,12 +1,11 @@
 /datum/event/disease_outbreak
-	announceWhen = 15
+	announceWhen = 180
 	/// The type of disease that patient zero will be infected with.
 	var/datum/disease/D
 	/// The initial target of the disease.
 	var/mob/living/carbon/human/patient_zero
 
 /datum/event/disease_outbreak/setup()
-	announceWhen = rand(15, 30)
 	if(prob(25))
 		var/virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/fluspanish, /datum/disease/pierrot_throat, /datum/disease/lycan)
 		D = new virus_type()
@@ -21,9 +20,6 @@
 
 /datum/event/disease_outbreak/announce()
 	GLOB.event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak7.ogg')
-	for(var/p in GLOB.dead_mob_list)
-		var/mob/M = p
-		to_chat(M, "<span class='deadsay'><b>[patient_zero]</b> has been infected with <b>[D.name]</b> ([ghost_follow_link(patient_zero, M)])</span>")
 
 /datum/event/disease_outbreak/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.alive_mob_list))
@@ -40,4 +36,7 @@
 		if(!H.ForceContractDisease(D))
 			continue
 		patient_zero = H
+		for(var/p in GLOB.dead_mob_list) //Announce patient zero to dchat
+			var/mob/M = p
+			to_chat(M, "<span class='deadsay'><b>[patient_zero]</b> has been infected with <b>[D.name]</b> ([ghost_follow_link(patient_zero, M)])</span>")
 		break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR increases the disease outbreak event's `announceWhen` from a random number between 15 and 30 to a fixed 180, the same as blob. This introduces a delay of several minutes before the "Level 7 Biohazard" station announcement is broadcast.

The patient zero dchat notice has been moved from `/datum/event/disease_outbreak/announce()` to `/datum/event/disease_outbreak/start()`, so dchat remains aware of the event from the moment it starts.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Disease outbreaks are announced very shortly after they begin, which allows medbay to organize and cure the virus before it ever has a chance to impact the round. Adding a delay will give the virus a longer grace period to spread and progress before the CMO is screaming at everyone to go to medbay.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Significantly increased time before virus outbreak is announced to station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
