### PR TITLE
Grammar change in End of Round Stats screen.

### DIFF
--- a/code/game/jobs/job_objective.dm
+++ b/code/game/jobs/job_objective.dm
@@ -68,7 +68,7 @@
 			count++
 
 		if(tasks_completed >= 1)
-			text += "<br>&nbsp;<font color='green'><B>[employee.name] did [employee.p_their()] fucking job!</B></font>"
+			text += "<br>&nbsp;<font color='green'><B>[employee.name] did their fucking job!</B></font>"
 			SSblackbox.record_feedback("tally", "employee_success", 1, "SUCCESS")
 		else
 			SSblackbox.record_feedback("tally", "employee_success", 1, "FAIL")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the bit of code in the End of Round Stats screen that's supposed to get a character's pronouns and replaces it with the word "their"

So now if they do their job, it'll say "Crystals of Midnight Frost did their fucking job!"
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
That bit of code has been broken forever and just spits out "its" on all my characters. Rather than worrying about fixing it, why not just change it to the increasingly accepted (and inclusive of all genders) standard of english grammar, "their"?
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Tweaked the grammar in the End of Round Stats screen to use the gender inclusive pronoun "their"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
