### PR TITLE
Adds emp effect to detectives revolver

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -361,6 +361,13 @@
 	if(istype(I, /obj/item/gun/energy/detective))
 		link_gun(I.UID())
 
+/obj/item/pinpointer/crew/emp_act(severity)
+	var/obj/item/gun/energy/detective/D = locateUID(linked_gun_UID)
+	if(!D)
+		return
+	D.unlink()
+	atom_say("EMP detected. Connection to revolver tracking system lost.")
+
 /obj/item/pinpointer/crew/proc/link_gun(gun_UID)
 	var/obj/item/gun/energy/detective/D = locateUID(gun_UID)
 	if(!D)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -792,6 +792,12 @@
 	. = ..()
 	. += "<span class='notice'>Ctrl-click to clear active tracked target or clear linked pinpointer.</span>"
 
+/obj/item/gun/energy/detective/emp_act(severity)
+	. = ..()
+	unlink()
+	atom_say("EMP detected. Pinpointer and tracker system reset.")
+
+
 /obj/item/gun/energy/detective/CtrlClick(mob/user)
 	. = ..()
 	if(!isliving(loc)) //don't do this next bit if this gun is on the floor
@@ -804,14 +810,18 @@
 	if(linked_pinpointer_UID)
 		if(alert("Do you want to clear the linked pinpointer?", "Pinpointer reset", "Yes", "No") == "Yes")
 			to_chat(user, "<span class='notice'>[src] is ready to be linked to a new pinpointer.</span>")
-			var/obj/item/pinpointer/crew/C = locateUID(linked_pinpointer_UID)
-			C.linked_gun_UID = null
-			if(C.mode == MODE_DET)
-				C.stop_tracking()
-			linked_pinpointer_UID = null
+			unlink()
 
 /obj/item/gun/energy/detective/proc/link_pinpointer(pinpointer_UID)
 	linked_pinpointer_UID = pinpointer_UID
+
+/obj/item/gun/energy/detective/proc/unlink()
+	var/obj/item/pinpointer/crew/C = locateUID(linked_pinpointer_UID)
+	C.linked_gun_UID = null
+	if(C.mode == MODE_DET)
+		C.stop_tracking()
+	linked_pinpointer_UID = null
+	tracking_target_UID = null
 
 /obj/item/gun/energy/detective/multitool_act(mob/living/user, obj/item/I)
 	. = TRUE

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -817,6 +817,8 @@
 
 /obj/item/gun/energy/detective/proc/unlink()
 	var/obj/item/pinpointer/crew/C = locateUID(linked_pinpointer_UID)
+	if(!C)
+		return
 	C.linked_gun_UID = null
 	if(C.mode == MODE_DET)
 		C.stop_tracking()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

EMPing detectives revolver, or the pinpointer, disables the tracker and unlinks the pointer.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A way to get the detective off your back with the tracker is good. Also makes giving the pinpointer to another officer a slight risk, as if you are emp'd, you must re link it manually again, which means meeting up with said officer, rather than just loosing the tracker and just emping them again.

## Changelog
:cl:
tweak: EMPING the detective's revolver or linked pinpointer, clears the tracker and unlinks the pinpointer from the revolver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
