### PR TITLE
BoxStation: Remaps Vacant Office

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -1489,6 +1489,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/hos)
+"ahy" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "44"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "ahC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5051,6 +5064,15 @@
 	icon_state = "red"
 	},
 /area/security/seceqstorage)
+"apF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "apG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13052,7 +13074,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aIF" = (
-/turf/simulated/wall/r_wall,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aIG" = (
 /obj/machinery/door/airlock/external{
@@ -13123,6 +13150,10 @@
 /area/hallway/primary/fore)
 "aIP" = (
 /obj/structure/closet/secure_closet/clown,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aIQ" = (
@@ -13933,19 +13964,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aKQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
 	c_tag = "Holodeck West";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"aKR" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "aKS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13969,6 +13993,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aKU" = (
@@ -15142,10 +15169,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
-"aNL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "aNM" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -15183,7 +15206,9 @@
 /area/crew_quarters/courtroom)
 "aNQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
 /area/crew_quarters/dorms)
 "aNR" = (
 /obj/structure/cable{
@@ -15353,13 +15378,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
-"aOh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/dorms)
 "aOi" = (
 /obj/item/clothing/suit/officercoat,
 /obj/item/clothing/head/armyofficer,
@@ -15779,16 +15797,16 @@
 /turf/simulated/wall,
 /area/maintenance/fpmaint)
 "aPk" = (
-/obj/structure/chair/stool{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
 /area/crew_quarters/dorms)
 "aPm" = (
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
-"aPn" = (
-/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aPs" = (
@@ -16768,12 +16786,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
-"aRv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "aRw" = (
 /turf/simulated/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -16858,18 +16870,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"aRH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "aRI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17349,9 +17349,8 @@
 	},
 /area/crew_quarters/dorms)
 "aSR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -17523,21 +17522,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"aTq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "aTr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18445,8 +18429,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -18456,19 +18440,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
-"aVw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Dormitories East";
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -18501,9 +18472,7 @@
 	},
 /area/medical/chemistry)
 "aVz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -18694,20 +18663,6 @@
 	icon_state = "dark"
 	},
 /area/ai_monitored/storage/eva)
-"aVP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/grille/broken,
-/obj/structure/window/basic{
-	dir = 4
-	},
-/obj/structure/window/basic,
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "aVQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "maint1";
@@ -19210,15 +19165,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/dorms)
-"aWX" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/vending/artvend,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/dorms)
 "aWY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19630,33 +19576,6 @@
 	icon_state = "vault"
 	},
 /area/security/nuke_storage)
-"aXU" = (
-/obj/item/flag/mime,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
-"aXV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "aXW" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -20459,59 +20378,25 @@
 	},
 /area/crew_quarters/dorms)
 "aZH" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/chair/stool{
+	dir = 4
 	},
-/obj/machinery/vending/autodrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
-	},
-/area/crew_quarters/dorms)
-"aZI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aZJ" = (
 /obj/machinery/light,
-/obj/structure/closet/boxinggloves,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/dorms)
-"aZK" = (
-/obj/structure/closet/masks,
+/obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/crew_quarters/dorms)
 "aZL" = (
-/obj/structure/table/wood,
-/obj/item/pen/red{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/paper_bin,
-/obj/item/toy/crayon/mime,
 /turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_state = "cafeteria"
 	},
-/area/mimeoffice)
-"aZM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
+/area/crew_quarters/dorms)
 "aZN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21257,27 +21142,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"bbA" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
-"bbB" = (
-/obj/structure/closet/secure_closet/mime,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "bbC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21297,31 +21161,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "bbD" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/machinery/door/airlock/tranquillite{
+	name = "Mime's Office";
+	req_access_txt = "44"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/landmark/start/mime,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
-"bbE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/random_spawners/grille_often,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "bbF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21443,11 +21292,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -21460,13 +21310,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "bbX" = (
@@ -22123,31 +21972,19 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "bds" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/spray/waterflower,
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Mime's Office";
-	dir = 1
-	},
+/obj/item/flag/mime,
 /turf/simulated/floor/plasteel{
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bdt" = (
-/obj/structure/statue/tranquillite/mime,
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/toy/crayon/mime,
+/obj/item/pen/red{
+	pixel_x = 2;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_regular_floor = "yellowsiding";
@@ -22984,18 +22821,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
-"bfa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/tranquillite{
-	name = "Mime's Office";
-	req_access_txt = "44"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "bfb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23587,6 +23412,13 @@
 	icon_state = "darkbluecorners"
 	},
 /area/chapel/main)
+"bgd" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/dorms)
 "bgf" = (
 /obj/structure/table/wood,
 /obj/item/candle,
@@ -24053,10 +23885,16 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "bhl" = (
-/obj/item/clothing/suit/hooded/hoodie/nt,
-/obj/structure/table,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
+/obj/machinery/camera{
+	c_tag = "Mime's Office";
+	dir = 4
+	},
+/obj/structure/statue/tranquillite/mime,
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "bhm" = (
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry)
@@ -24066,27 +23904,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"bho" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
-"bhp" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "bhq" = (
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -25254,12 +25071,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"bjM" = (
-/obj/item/clothing/suit/ianshirt,
-/obj/structure/table,
-/obj/item/clothing/under/mime,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "bjN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25684,6 +25495,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "bkE" = (
@@ -29090,9 +28902,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bst" = (
@@ -29523,14 +29332,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "btA" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -29546,17 +29354,13 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "btF" = (
-/obj/structure/closet,
-/obj/item/pen,
-/obj/item/pen/blue,
-/obj/item/pen/gray,
-/obj/item/pen/red,
-/obj/item/pen/multi,
+/obj/structure/chair/office/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "btG" = (
-/obj/item/flashlight/lamp,
-/obj/structure/table/wood,
 /turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "btH" = (
@@ -30144,8 +29948,11 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "buX" = (
-/obj/effect/spawner/window/reinforced/polarized,
-/turf/simulated/floor/plating,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "buY" = (
 /obj/structure/cable{
@@ -30175,13 +29982,9 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bvb" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/obj/item/flashlight/lamp,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bvc" = (
 /obj/machinery/alarm{
@@ -30264,9 +30067,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "bvm" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bvn" = (
@@ -30821,16 +30622,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bwx" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/button/windowtint{
-	dir = 4;
-	id = "Magistrate";
-	pixel_x = -24;
-	pixel_y = 6;
-	range = 8
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry)
 "bwy" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -32488,6 +32284,9 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bzP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bzQ" = (
@@ -33112,9 +32911,8 @@
 	},
 /area/hallway/primary/central/west)
 "bBr" = (
-/obj/item/pen/red,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/purple,
+/obj/structure/chair/office/light,
+/turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bBs" = (
 /obj/structure/cable{
@@ -33122,13 +32920,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bBt" = (
-/obj/structure/chair/office/light,
-/turf/simulated/floor/wood,
+/obj/effect/spawner/window/reinforced/polarized,
+/turf/simulated/floor/plating,
 /area/security/vacantoffice)
 "bBu" = (
 /obj/structure/table/wood,
@@ -33217,7 +33019,12 @@
 	},
 /area/hallway/primary/central/east)
 "bBG" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/closet,
+/obj/item/pen,
+/obj/item/pen/blue,
+/obj/item/pen/gray,
+/obj/item/pen/red,
+/obj/item/pen/multi,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bBH" = (
@@ -34944,11 +34751,14 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -72693,6 +72503,13 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"dhW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Vacant Office"
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "dhY" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
@@ -76076,6 +75893,16 @@
 /area/aisat{
 	name = "\improper AI Satellite Hallway"
 	})
+"dqo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "dqp" = (
 /turf/simulated/wall,
 /area/aisat{
@@ -76871,6 +76698,19 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"duz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/spray/waterflower,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "dvD" = (
 /obj/machinery/camera{
 	c_tag = "Prison Cafeteria External";
@@ -76928,12 +76768,6 @@
 	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
-"dEP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/fore)
 "dFG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
@@ -77033,13 +76867,6 @@
 /obj/item/chair,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"dVs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/dorms)
 "ebh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77219,6 +77046,25 @@
 	icon_state = "bar"
 	},
 /area/security/permabrig)
+"etX" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/mime,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "euu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -77276,6 +77122,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/engine/supermatter)
+"eDY" = (
+/obj/structure/table/wood,
+/obj/item/paper/crumpled/bloody{
+	info = "Mr. Ducky, I shall miss you!";
+	desc = "A scrap of paper with dried blood on it."
+	},
+/obj/item/bikehorn/rubberducky,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "eES" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -77318,6 +77173,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
+"eJe" = (
+/obj/machinery/vending/autodrobe,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/dorms)
 "eJr" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77336,12 +77197,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"eJA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/maintenance/fore)
 "eLB" = (
 /obj/item/seeds/potato,
 /turf/simulated/floor/plating,
@@ -77424,10 +77279,6 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"eTE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall,
-/area/crew_quarters/dorms)
 "eWK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -77440,11 +77291,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
-"eYG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/dorms)
 "eZu" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1;
@@ -77454,12 +77300,6 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
-"fax" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/purple,
-/area/security/vacantoffice)
 "fbx" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -77477,6 +77317,12 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
+"fcu" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
+/area/crew_quarters/dorms)
 "fcH" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -77520,8 +77366,6 @@
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
 "fho" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
@@ -77616,6 +77460,13 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
+"fxz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "fxP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -77734,12 +77585,6 @@
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"fQx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/purple,
-/area/security/vacantoffice)
 "fRp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -77761,7 +77606,6 @@
 	},
 /area/security/permabrig)
 "fRL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
 	name = "west bump";
 	pixel_x = -28
@@ -77834,12 +77678,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"ghD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "giQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77868,17 +77706,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
-"gln" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "gmW" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -77913,6 +77740,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
+"gsJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "gsQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -78050,9 +77886,6 @@
 	},
 /area/hallway/primary/aft)
 "gFG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -78132,13 +77965,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
-"gPr" = (
-/obj/structure/chair/office/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "gRE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78192,6 +78018,21 @@
 	icon_state = "darkred"
 	},
 /area/security/brig)
+"gWB" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "gYV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -78233,6 +78074,17 @@
 	icon_state = "black"
 	},
 /area/security/permabrig)
+"haQ" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Magistrate";
+	pixel_x = -24;
+	pixel_y = 6;
+	range = 8
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "hbq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78362,6 +78214,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"hlX" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/remains/human{
+	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
+	name = "human remains"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "hoB" = (
 /obj/docking_port/stationary{
 	dwidth = 2;
@@ -78504,6 +78367,21 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
+"hBS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "hCs" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt,
@@ -78698,6 +78576,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"ifo" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
+/area/crew_quarters/dorms)
 "ihJ" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 4;
@@ -78718,6 +78605,14 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"imM" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "ioM" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -78842,11 +78737,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
-"iZs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/dorms)
 "iZI" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -78939,12 +78829,6 @@
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
-"jhD" = (
-/obj/machinery/camera{
-	c_tag = "Vacant Office"
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "jkw" = (
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass,
@@ -79120,7 +79004,6 @@
 	},
 /area/security/permabrig)
 "jPN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/computer/mob_battle_terminal/blue{
 	pixel_x = -32
 	},
@@ -79132,15 +79015,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/apmaint)
-"jRV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "jSq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79212,6 +79086,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
+"kaI" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/maintenance/fsmaint)
 "kbU" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -79237,18 +79115,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "kiu" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
-"kjI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
+/obj/structure/weightmachine/weightlifter,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "kjN" = (
@@ -79398,16 +79265,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/space,
 /area/space/nearstation)
-"kLF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "kLR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
@@ -79422,12 +79279,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"kNZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/crew_quarters/dorms)
 "kOE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
@@ -79612,6 +79463,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "lqn" = (
@@ -79792,6 +79644,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"lPM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/crew_quarters/dorms)
 "lQS" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
@@ -80069,9 +79930,10 @@
 	},
 /area/engine/engineering)
 "mzv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "mzL" = (
@@ -80088,6 +79950,17 @@
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
+"mCL" = (
+/obj/structure/closet/secure_closet/mime,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "mEh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/air{
@@ -80269,12 +80142,6 @@
 	},
 /turf/simulated/floor/noslip,
 /area/engine/engineering)
-"nhb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/fore)
 "nhn" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -80420,6 +80287,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
+"nyl" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "nCm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80428,16 +80304,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
-"nCT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "nDZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80514,7 +80380,6 @@
 	},
 /area/engine/engineering)
 "nXr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
@@ -80572,6 +80437,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"odR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "ofW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -80631,10 +80507,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
-"oyv" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
+"owb" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "oAs" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -80713,6 +80597,10 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
+"oGB" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "oOZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/wall/r_wall,
@@ -80745,6 +80633,18 @@
 	icon_state = "dark"
 	},
 /area/tcommsat/chamber)
+"oRU" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "oSF" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
@@ -80814,14 +80714,6 @@
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
-"oYN" = (
-/obj/item/camera,
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "paK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81154,6 +81046,18 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"qbn" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/alarm{
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "qdi" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Prison Gate";
@@ -81320,12 +81224,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
-"qsT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/wall,
-/area/crew_quarters/dorms)
 "qws" = (
 /obj/structure/marker_beacon/dock_marker,
 /obj/structure/sign/securearea{
@@ -81493,13 +81391,6 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)
-"qOo" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "qQy" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -81545,6 +81436,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)
+"rby" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/security/vacantoffice)
 "rcm" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -81690,27 +81587,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"rFd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "rHR" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "44"
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
-"rIF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
-/area/crew_quarters/dorms)
+/area/mimeoffice)
 "rLa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
@@ -81804,6 +81687,11 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
+"rUV" = (
+/obj/structure/punching_bag,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "rWq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81855,6 +81743,15 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"sbC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "scM" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -81947,6 +81844,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"szf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "sAi" = (
 /obj/structure/chair/stool,
 /obj/item/wrench,
@@ -82058,6 +81961,18 @@
 /obj/item/plant_analyzer,
 /turf/simulated/floor/grass,
 /area/security/permabrig)
+"sGg" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "sHt" = (
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
@@ -82100,9 +82015,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "sSb" = (
@@ -82169,13 +82082,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engine_smes)
-"tfk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Vacant Office"
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "thV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82510,6 +82416,12 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/apmaint2)
+"udI" = (
+/obj/machinery/camera{
+	c_tag = "Vacant Office"
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "ufc" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -82621,6 +82533,11 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"uyh" = (
+/obj/item/pen/red,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/purple,
+/area/security/vacantoffice)
 "uBJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
@@ -82685,6 +82602,16 @@
 "uLp" = (
 /turf/simulated/floor/wood,
 /area/security/permabrig)
+"uNO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/closet/boxinggloves,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution";
+	dir = 10
+	},
+/area/crew_quarters/dorms)
 "uPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82901,6 +82828,20 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"vtZ" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/dorms)
+"vxp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "vxy" = (
 /obj/structure/bed,
 /obj/item/radio/intercom/locked/prison{
@@ -82968,9 +82909,6 @@
 	},
 /area/engine/engineering)
 "vFZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Holodeck East";
 	dir = 1
@@ -82980,6 +82918,9 @@
 	pixel_y = -28
 	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "vMv" = (
@@ -83059,12 +83000,6 @@
 	icon_state = "bar"
 	},
 /area/security/permabrig)
-"vUG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/maintenance/fore)
 "vVZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -83485,6 +83420,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "xed" = (
@@ -83499,9 +83435,6 @@
 /turf/simulated/wall/r_wall,
 /area/engine/engine_smes)
 "xfQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -83523,12 +83456,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
-"xlr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "xmN" = (
 /obj/machinery/firealarm{
 	name = "north bump";
@@ -83583,16 +83510,6 @@
 /obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"xyo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "xAn" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -83613,6 +83530,17 @@
 "xBl" = (
 /turf/simulated/floor/grass,
 /area/security/permabrig)
+"xBz" = (
+/obj/machinery/camera{
+	c_tag = "Dormitories East";
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/deck/cards,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/dorms)
 "xDw" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -83626,6 +83554,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)
+"xIl" = (
+/obj/machinery/vending/cola,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/crew_quarters/dorms)
 "xJa" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -83734,6 +83669,13 @@
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall/r_wall,
 /area/security/permabrig)
+"xRd" = (
+/obj/structure/closet/masks,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "caution"
+	},
+/area/crew_quarters/dorms)
 "xRI" = (
 /obj/machinery/camera{
 	c_tag = "Prison Solitary External";
@@ -83750,10 +83692,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prisonlockers)
-"xVt" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "xVC" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/item/radio/intercom{
@@ -83861,9 +83799,10 @@
 	icon_state = "redfull"
 	},
 /area/security/permabrig)
-"ycq" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+"ycX" = (
+/obj/item/camera,
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -96947,7 +96886,7 @@ bgG
 bqr
 bqr
 bqr
-buX
+bBt
 bqr
 bqr
 bqr
@@ -97200,13 +97139,13 @@ bgt
 bkc
 bmo
 brk
-aSf
-buX
 bwx
+bBt
+haQ
+szf
 bvm
 bBG
-btF
-ycq
+buX
 bqr
 bFZ
 bCg
@@ -97458,12 +97397,12 @@ bjO
 bmo
 brk
 aSf
-tfk
+dhW
 brU
 brU
 brU
 brU
-gln
+btA
 bqr
 bFY
 bCf
@@ -97714,13 +97653,13 @@ bhm
 bhm
 aSX
 brk
-aSf
-buX
+bpF
+bBt
 brU
-bzP
-bvn
 btG
+bvn
 bvb
+nyl
 bqr
 bFY
 bCf
@@ -97973,11 +97912,11 @@ bmo
 brl
 bss
 bqr
-bBt
 bBr
-fQx
+uyh
+rby
 bBH
-oYN
+ycX
 bqr
 bFY
 bCf
@@ -98228,11 +98167,11 @@ bhv
 bhv
 aSY
 brk
-bpF
+boT
 bqr
-jhD
+udI
 btB
-fax
+bzP
 bBJ
 byh
 bqr
@@ -98485,10 +98424,10 @@ aMs
 aMs
 aMs
 brn
-boT
+aSf
 bqr
 brU
-bzP
+btG
 bzL
 bBI
 byg
@@ -99001,10 +98940,10 @@ biA
 brp
 bsx
 bqr
-gPr
+btF
 btE
 bvo
-btA
+oRU
 byi
 bqr
 bBa
@@ -121330,20 +121269,20 @@ aHp
 aPm
 aPm
 lkw
-ghD
+aPm
 nXr
 aKQ
 fRL
-rFd
+aPm
 jPN
-nCT
+lkw
 fho
-aWY
-aWY
+aPm
+aPm
 aSR
 aVu
 aWY
-aZI
+bbw
 bbw
 bdm
 bfz
@@ -121587,19 +121526,19 @@ arR
 fes
 tbC
 tbC
-qFg
+aPm
 tbC
 tbC
-xlr
-qOo
-qOo
-jRV
+aPm
+tbC
+tbC
+tbC
 aPm
 aPm
 aPm
 aPm
 aVt
-aWX
+aXf
 aZH
 aIc
 aIc
@@ -121840,24 +121779,24 @@ aEI
 awH
 ayg
 aOY
-eJA
-iZs
-iZs
-iZs
-kLF
+awl
+aFK
 aFK
 aFK
 gFG
-eYG
-eYG
-eYG
-dVs
+aFK
+aFK
+gFG
+aFK
+aFK
+aFK
+aFK
 aPk
-aPm
-aPm
+ifo
+uNO
 aVt
 aXf
-aXf
+bgd
 aIe
 bdo
 aIP
@@ -122097,7 +122036,7 @@ avb
 aAQ
 aNH
 ava
-vUG
+awl
 sHt
 sHt
 sHt
@@ -122108,10 +122047,10 @@ sHt
 sHt
 sHt
 sHt
-aOh
+aFK
 kiu
-oyv
 aPm
+aSM
 aVv
 aXf
 aXf
@@ -122354,7 +122293,7 @@ avc
 avq
 avq
 avq
-vUG
+awl
 sHt
 sHt
 sHt
@@ -122365,13 +122304,13 @@ sHt
 sHt
 sHt
 sHt
-aOh
-xVt
+aFK
+kiu
 aPm
 aNQ
 aVz
 aXf
-aZK
+aXf
 aIe
 bdr
 aUA
@@ -122611,7 +122550,7 @@ atG
 atG
 avs
 atG
-dEP
+atG
 sHt
 sHt
 sHt
@@ -122622,11 +122561,11 @@ pwU
 sHt
 sHt
 sHt
-aOh
-aPn
+aFK
 aPm
-aNL
-aVw
+aPm
+aSM
+aVv
 aXf
 aZJ
 aIc
@@ -122868,7 +122807,7 @@ atG
 aup
 avq
 avq
-dEP
+atG
 sHt
 sHt
 sHt
@@ -122879,18 +122818,18 @@ sHt
 sHt
 sHt
 sHt
-kNZ
 aOI
-aMn
-aOI
+rUV
+aPm
+aSM
+dqo
+aZL
+eJe
 aLA
-bfa
-aIh
 aLA
 aLA
 aLA
-aGX
-aGX
+aLA
 bbh
 aGY
 beb
@@ -123125,7 +123064,7 @@ axh
 lQS
 avt
 lQS
-dEP
+atG
 sHt
 sHt
 sHt
@@ -123136,18 +123075,18 @@ sHt
 sHt
 sHt
 sHt
-kNZ
-aHb
-aGY
-aGY
-aLA
-aXi
+aOI
+aPm
+aPm
+aSM
+aVv
 aZL
-bbA
+aZL
+aIh
 bds
-aLA
+mCL
 bhl
-bjM
+aLA
 bbI
 aGY
 beb
@@ -123382,29 +123321,29 @@ axh
 auq
 avp
 auq
-nhb
-iZs
-iZs
-eTE
-kjI
+atG
 aFK
 aFK
-xyo
-rIF
-rIF
-rIF
-qsT
-aQL
-aGY
-aGY
-aLA
-aXV
-aRH
+aOI
+gFG
+aFK
+aFK
+gFG
+aOI
+aOI
+aOI
+aOI
+oGB
+aPm
+fcu
+fxz
+aZL
+aZL
 bbD
-aTq
+aXi
 rHR
-bho
-bho
+gWB
+aLA
 bbV
 aGY
 beb
@@ -123650,18 +123589,18 @@ vFZ
 aOI
 aUW
 aLc
-aGX
-aHP
-aRv
-aGY
-aLA
-aXU
-aZM
-bbB
+aOI
+oGB
+aPm
+aSM
+aVv
+aZL
+aZL
+aIh
 bdt
-aLA
-aGY
-aGY
+sGg
+hBS
+ahy
 bbU
 beJ
 beb
@@ -123904,21 +123843,21 @@ sPb
 lop
 xcB
 mzv
+imM
+sbC
+aGY
 aOI
-aGY
-aGY
-aGY
-aMn
-aGY
-aGY
+xIl
+lPM
+xRd
+aVv
+xBz
+vtZ
 aLA
+qbn
+etX
+duz
 aLA
-aLA
-aLA
-aLA
-aLA
-aQI
-aGY
 bbY
 bfO
 beb
@@ -124162,20 +124101,20 @@ aFK
 aFK
 aOI
 aOI
-aIF
+baP
 aHb
-aHb
-aGX
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGX
+aOI
+aOI
+aOI
+aOI
+owb
+aOI
+aOI
+aLA
+aLA
+aLA
+aLA
+aLA
 bbX
 bfG
 bhu
@@ -124418,21 +124357,21 @@ aaa
 aab
 aab
 aab
-aab
+kaI
+apF
 aIF
-aIF
-aIF
-aGX
-aGX
-aGX
-aGX
+aRX
+aRX
+aRX
+vxp
+gsJ
 aGY
-aGY
-aGX
-aGX
-aGX
+eDY
+hlX
 aMz
-aGX
+aLc
+aNh
+aQL
 bcg
 bfQ
 beb
@@ -124677,21 +124616,21 @@ aGT
 aGT
 aGT
 aGT
-aKR
-aMi
-aMo
-aOF
+aMz
+aMz
+aMn
+aGX
 aHP
 aQC
 aGY
 aGY
-aGX
-aLc
 aGY
-bhp
+aGY
+aGY
+aXW
 bjX
 bcb
-bfP
+odR
 beb
 bfD
 bjV
@@ -124935,17 +124874,17 @@ aHK
 aIB
 aGT
 aKT
+aMi
 aGY
-aYC
-aGY
+aOF
 aHP
 aVA
 aXW
 aZQ
-bbE
 aZQ
 aZQ
-aVP
+aZQ
+bfP
 bkD
 bcm
 beb

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -81011,6 +81011,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"pMM" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "pMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83341,14 +83349,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"wNB" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "wOM" = (
 /obj/machinery/camera{
 	c_tag = "Prison Solitary 1";
@@ -83504,6 +83504,12 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
+"xpt" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "xrG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -83700,6 +83706,13 @@
 	},
 /turf/space,
 /area/space)
+"xRP" = (
+/obj/structure/chair/office/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "xSD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -97414,7 +97427,7 @@ brU
 brU
 brU
 brU
-wNB
+pMM
 bqr
 bFY
 bCf
@@ -98181,7 +98194,7 @@ aSY
 brk
 bpF
 bqr
-brU
+xpt
 btB
 bzP
 bBJ
@@ -98952,7 +98965,7 @@ biA
 brp
 bsx
 bqr
-bBt
+xRP
 btE
 bvo
 btA

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -31674,9 +31674,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/camera{
-	c_tag = "Vacant Office";
-	dir = 1
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -79544,6 +79543,14 @@
 	icon_state = "red"
 	},
 /area/security/prisonlockers)
+"lhK" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "lkw" = (
 /obj/machinery/light{
 	dir = 8
@@ -80944,6 +80951,13 @@
 /obj/effect/landmark/battle_mob_point,
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
+"pxs" = (
+/obj/structure/chair/office/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "pxP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81011,14 +81025,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"pMM" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "pMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83504,12 +83510,6 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
-"xpt" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "xrG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -83557,6 +83557,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"xzo" = (
+/obj/machinery/camera{
+	c_tag = "Vacant Office"
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "xAn" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -83706,13 +83712,6 @@
 	},
 /turf/space,
 /area/space)
-"xRP" = (
-/obj/structure/chair/office/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "xSD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -97427,7 +97426,7 @@ brU
 brU
 brU
 brU
-pMM
+lhK
 bqr
 bFY
 bCf
@@ -98194,7 +98193,7 @@ aSY
 brk
 bpF
 bqr
-xpt
+brU
 btB
 bzP
 bBJ
@@ -98451,7 +98450,7 @@ aMs
 brn
 boT
 bqr
-brU
+xzo
 bzP
 bzL
 bBI
@@ -98965,7 +98964,7 @@ biA
 brp
 bsx
 bqr
-xRP
+pxs
 btE
 bvo
 btA

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -33096,7 +33096,6 @@
 "bBr" = (
 /obj/item/pen/red,
 /obj/structure/table/wood,
-/obj/structure/table/wood,
 /turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bBs" = (
@@ -77844,6 +77843,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
+"gln" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "gmW" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -78097,6 +78104,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"gPr" = (
+/obj/structure/chair/office/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "gRE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78897,6 +78911,12 @@
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
+"jhD" = (
+/obj/machinery/camera{
+	c_tag = "Vacant Office"
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "jkw" = (
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass,
@@ -79543,14 +79563,6 @@
 	icon_state = "red"
 	},
 /area/security/prisonlockers)
-"lhK" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "lkw" = (
 /obj/machinery/light{
 	dir = 8
@@ -80951,13 +80963,6 @@
 /obj/effect/landmark/battle_mob_point,
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
-"pxs" = (
-/obj/structure/chair/office/light,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "pxP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83557,12 +83562,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"xzo" = (
-/obj/machinery/camera{
-	c_tag = "Vacant Office"
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
 "xAn" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -97426,7 +97425,7 @@ brU
 brU
 brU
 brU
-lhK
+gln
 bqr
 bFY
 bCf
@@ -98450,7 +98449,7 @@ aMs
 brn
 boT
 bqr
-xzo
+jhD
 bzP
 bzL
 bBI
@@ -98964,7 +98963,7 @@ biA
 brp
 bsx
 bqr
-pxs
+gPr
 btE
 bvo
 btA

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -29555,12 +29555,6 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "btG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/item/flashlight/lamp,
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet/purple,
@@ -30150,7 +30144,7 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "buX" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized,
 /turf/simulated/floor/plating,
 /area/security/vacantoffice)
 "buY" = (
@@ -30181,11 +30175,6 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bvb" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/structure/chair/office/light{
 	dir = 1
 	},
@@ -30278,12 +30267,19 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bvn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bvo" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -30823,6 +30819,13 @@
 /area/maintenance/port)
 "bwx" = (
 /obj/item/twohanded/required/kirbyplants,
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Magistrate";
+	pixel_x = -24;
+	pixel_y = 6;
+	range = 8
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bwy" = (
@@ -31674,9 +31677,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "byh" = (
@@ -32271,12 +32273,17 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bzt" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/security/vacantoffice)
 "bzu" = (
 /obj/structure/toilet{
@@ -33203,23 +33210,21 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bBH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/item/clipboard,
 /obj/item/paper,
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bBI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bBJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
@@ -34931,12 +34936,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bGb" = (
@@ -77441,6 +77442,12 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
+"fax" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/purple,
+/area/security/vacantoffice)
 "fbx" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -77715,6 +77722,12 @@
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"fQx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/security/vacantoffice)
 "fRp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -82139,10 +82152,10 @@
 	},
 /area/engine/engine_smes)
 "tfk" = (
-/obj/machinery/door/airlock/public/glass{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
 	name = "Vacant Office"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "thV" = (
@@ -97937,7 +97950,7 @@ bss
 bqr
 bBt
 bBr
-bzP
+fQx
 bBH
 oYN
 bqr
@@ -98192,9 +98205,9 @@ aSY
 brk
 bpF
 bqr
-brU
+jhD
 btB
-bzP
+fax
 bBJ
 byh
 bqr
@@ -98449,7 +98462,7 @@ aMs
 brn
 boT
 bqr
-jhD
+brU
 bzP
 bzL
 bBI

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -29090,6 +29090,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bst" = (
@@ -29520,51 +29523,51 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "btA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/table/wood,
-/obj/item/pen/red,
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
-"btB" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
-"btE" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
+"btB" = (
+/obj/item/folder/blue,
 /obj/structure/table/wood,
+/turf/simulated/floor/carpet/purple,
+/area/security/vacantoffice)
+"btE" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "btF" = (
-/obj/structure/table/wood,
+/obj/structure/closet,
+/obj/item/pen,
+/obj/item/pen/blue,
+/obj/item/pen/gray,
+/obj/item/pen/red,
+/obj/item/pen/multi,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "btG" = (
-/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /obj/item/flashlight/lamp,
-/turf/simulated/floor/wood,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "btH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/item/flashlight/lamp,
+/obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "btI" = (
@@ -30147,10 +30150,8 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "buX" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/security/vacantoffice)
 "buY" = (
 /obj/structure/cable{
@@ -30180,8 +30181,13 @@
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bvb" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/chair/office/light{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -30266,24 +30272,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "bvm" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bvn" = (
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bvo" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bvp" = (
@@ -30821,11 +30822,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bwx" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "bwy" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30908,7 +30907,8 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bwM" = (
-/obj/structure/chair/office/dark,
+/obj/item/flashlight/lamp/green,
+/obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bwN" = (
@@ -31670,11 +31670,14 @@
 /area/bridge)
 "byg" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/table/wood,
+/obj/machinery/camera{
+	c_tag = "Vacant Office";
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "byh" = (
@@ -31685,21 +31688,24 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "byi" = (
-/obj/structure/table/wood,
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "byj" = (
-/obj/machinery/camera{
-	c_tag = "Vacant Office";
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/item/newspaper,
 /obj/structure/table/wood,
-/obj/item/folder/blue,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "byk" = (
@@ -32440,15 +32446,8 @@
 	},
 /area/quartermaster/office)
 "bzL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bzM" = (
 /obj/machinery/status_display{
@@ -32472,10 +32471,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bzP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bzQ" = (
 /obj/machinery/door/airlock{
@@ -33099,17 +33095,10 @@
 	},
 /area/hallway/primary/central/west)
 "bBr" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Vacant Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/obj/item/pen/red,
+/obj/structure/table/wood,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bBs" = (
 /obj/structure/cable{
@@ -33117,22 +33106,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bBt" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/chair/office/light,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bBu" = (
@@ -33222,42 +33201,29 @@
 	},
 /area/hallway/primary/central/east)
 "bBG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bBH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/obj/item/clipboard,
+/obj/item/paper,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bBI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/security/vacantoffice)
-"bBJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/turf/simulated/floor/carpet/purple,
+/area/security/vacantoffice)
+"bBJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/security/vacantoffice)
 "bBK" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
@@ -80801,6 +80767,11 @@
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
+"oYN" = (
+/obj/item/camera,
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "paK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82148,6 +82119,13 @@
 	icon_state = "dark"
 	},
 /area/engine/engine_smes)
+"tfk" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Vacant Office"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "thV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83363,6 +83341,14 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"wNB" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "wOM" = (
 /obj/machinery/camera{
 	c_tag = "Prison Solitary 1";
@@ -96912,8 +96898,8 @@ bgG
 bqr
 bqr
 bqr
+buX
 bqr
-bBr
 bqr
 bqr
 bRH
@@ -97165,11 +97151,11 @@ bgt
 bkc
 bmo
 brk
+aSf
+buX
 bwx
-bqr
-brU
-brU
 bvm
+bBG
 bBG
 btF
 bqr
@@ -97423,12 +97409,12 @@ bjO
 bmo
 brk
 aSf
-bqr
-buX
-btF
+tfk
 brU
-bBt
-btF
+brU
+brU
+brU
+wNB
 bqr
 bFY
 bCf
@@ -97679,13 +97665,13 @@ bhm
 bhm
 aSX
 brk
-bpF
-bqr
-btF
-btG
+aSf
+buX
+brU
+bzP
 bvn
-bBH
-btF
+btG
+bvb
 bqr
 bFY
 bCf
@@ -97938,11 +97924,11 @@ bmo
 brl
 bss
 bqr
-brU
-brU
-bvn
+bBt
+bBr
+bzP
 bBH
-brU
+oYN
 bqr
 bFY
 bCf
@@ -98193,9 +98179,9 @@ bhv
 bhv
 aSY
 brk
-boT
+bpF
 bqr
-btF
+brU
 btB
 bzP
 bBJ
@@ -98450,10 +98436,10 @@ aMs
 aMs
 aMs
 brn
-aSf
+boT
 bqr
-bvb
-btA
+brU
+bzP
 bzL
 bBI
 byg
@@ -98966,10 +98952,10 @@ biA
 brp
 bsx
 bqr
-btF
+bBt
 btE
 bvo
-brU
+btA
 byi
 bqr
 bBa

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -30178,6 +30178,9 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bvc" = (
@@ -31679,12 +31682,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "byh" = (
 /obj/item/radio/intercom{
 	name = "south bump";
 	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -32283,6 +32293,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/security/vacantoffice)
 "bzu" = (
@@ -34933,11 +34944,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bGb" = (
@@ -77862,6 +77874,9 @@
 	name = "south bump";
 	pixel_y = -24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "gmW" = (
@@ -80802,6 +80817,9 @@
 "oYN" = (
 /obj/item/camera,
 /obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "paK" = (
@@ -83843,6 +83861,13 @@
 	icon_state = "redfull"
 	},
 /area/security/permabrig)
+"ycq" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "ydz" = (
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -97180,8 +97205,8 @@ buX
 bwx
 bvm
 bBG
-bBG
 btF
+ycq
 bqr
 bFZ
 bCg


### PR DESCRIPTION
This PR remaps Vacant Office in Arrivals. They are a quite ugly and empty, so a new touch would be nice to new players to see, even old players too.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR rempas vacant office.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It can improve people outside to have more safety to engage in the inside, and at the same the maint door can make the melee antags a better escape.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/62888630/180614423-d8ad7f64-fc0e-49f0-b314-cc49b719baaa.png)
![image](https://user-images.githubusercontent.com/62888630/180608762-254532d0-decd-4a16-a3d7-f9771628b992.png)
![image](https://user-images.githubusercontent.com/62888630/180608767-805f6717-0e81-4293-b469-9ccda8fc8991.png)


## Changelog
:cl:
tweak: Remaps Vacant Office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
