### PR TITLE
Adds Robotic Storage to Central Command and Reduces CC Toxicity

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4639,6 +4639,15 @@
 	},
 /turf/simulated/floor/plasteel/dark/nitrogen,
 /area/centcom/specops)
+"pY" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Team Storage"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/specops)
 "pZ" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/mineral/titanium,
@@ -6769,6 +6778,15 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/grass,
 /area/centcom/control)
+"ys" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Team Storage"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "vault"
+	},
+/area/centcom/specops)
 "yu" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/bot,
@@ -6871,6 +6889,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/admin)
+"zN" = (
+/obj/machinery/computer/cryopod/robot,
+/turf/simulated/wall/indestructible/riveted,
+/area/centcom/specops)
 "zV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -9105,6 +9127,7 @@
 "JE" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/centcom/specops)
 "JG" = (
@@ -9903,6 +9926,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/tdome/arena)
+"MN" = (
+/obj/machinery/cryopod/robot,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "vault"
+	},
+/area/centcom/specops)
 "MO" = (
 /obj/mecha/combat/marauder/loaded,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -9977,13 +10007,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/evac)
-"MZ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/centcom/specops)
 "Nc" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -10633,12 +10656,6 @@
 	},
 /turf/simulated/floor/transparent/glass,
 /area/centcom/specops)
-"PN" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Team Storage"
-	},
-/turf/simulated/floor/plasteel/dark/nitrogen,
-/area/centcom/specops)
 "PO" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass,
@@ -10757,14 +10774,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/admin)
-"Qn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/centcom/specops)
 "Qr" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -10779,25 +10788,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"Qt" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/centcom/specops)
 "Qu" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
-"Qv" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/grass,
-/area/centcom/specops)
 "Qx" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -34025,8 +34021,8 @@ Zr
 oN
 oN
 oN
+MN
 Zr
-MZ
 Jr
 Ji
 Ra
@@ -34281,9 +34277,9 @@ aN
 Zr
 JW
 Zf
+Zf
 DZ
 Zr
-Qn
 Jt
 Ji
 Ra
@@ -34538,9 +34534,9 @@ aN
 Zr
 Hv
 Hv
+Zf
 DZ
-PN
-Ji
+pY
 Ji
 Ra
 Ra
@@ -34795,9 +34791,9 @@ aN
 Zr
 oN
 oN
+Zf
 DZ
-PN
-Qr
+ys
 Qr
 Ra
 Ra
@@ -35049,12 +35045,12 @@ aN
 aN
 aN
 Db
-Zr
+zN
+Zf
 Zf
 Zf
 DZ
 Zr
-Qt
 Jx
 Ji
 Ra
@@ -35310,8 +35306,8 @@ Zr
 Hv
 Hv
 Hv
+MN
 Zr
-Qv
 JE
 Ji
 AV

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4487,12 +4487,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/admin)
-"pw" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/plasteel/dark/nitrogen,
-/area/centcom/specops)
 "pz" = (
 /obj/item/flag/syndi,
 /turf/simulated/floor/plasteel{
@@ -4643,10 +4637,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Team Storage"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "pZ" = (
 /obj/machinery/vending/medical,
@@ -6778,15 +6769,6 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/grass,
 /area/centcom/control)
-"ys" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Team Storage"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "vault"
-	},
-/area/centcom/specops)
 "yu" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/bot,
@@ -8304,10 +8286,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
-"Gx" = (
-/obj/structure/bookcase/random,
-/turf/simulated/floor/plasteel/dark/nitrogen,
-/area/centcom/specops)
 "Gy" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -8383,7 +8361,7 @@
 /area/admin)
 "GO" = (
 /obj/structure/closet/crate/can,
-/turf/simulated/floor/plasteel/dark/nitrogen,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "GP" = (
 /obj/effect/decal/warning_stripes/southeast,
@@ -8438,7 +8416,7 @@
 /obj/item/dice/d10{
 	pixel_x = -3
 	},
-/turf/simulated/floor/plasteel/dark/nitrogen,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "GW" = (
 /turf/simulated/floor/plasteel{
@@ -9217,7 +9195,7 @@
 	pixel_y = 32;
 	req_access_txt = "114"
 	},
-/turf/simulated/floor/plasteel/dark/nitrogen,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "JU" = (
 /obj/structure/holowindow{
@@ -9232,7 +9210,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel/dark/nitrogen,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "JY" = (
 /obj/effect/spawner/window,
@@ -10919,10 +10897,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
-"QU" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel/dark/nitrogen,
-/area/centcom/specops)
 "QV" = (
 /obj/item/clothing/under/rainbow,
 /obj/item/clothing/glasses/sunglasses_fake,
@@ -12808,9 +12782,6 @@
 "Ze" = (
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/transport)
-"Zf" = (
-/turf/simulated/floor/plasteel/dark/nitrogen,
-/area/centcom/specops)
 "Zg" = (
 /obj/machinery/door_control/no_emag{
 	id = "CCTELE";
@@ -12876,7 +12847,7 @@
 	id_tag = "CCGAMMA";
 	name = "Gamma Security"
 	},
-/turf/simulated/floor/plasteel/dark/nitrogen,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Zt" = (
 /obj/structure/closet/secure_closet/guncabinet,
@@ -31966,7 +31937,7 @@ JS
 Mq
 NU
 PM
-Gx
+NP
 Zr
 Ji
 Ra
@@ -32219,11 +32190,11 @@ aN
 aN
 aN
 Zr
-Zf
+Ra
 Mq
 iW
 PM
-pw
+Ae
 Zr
 Ji
 Ra
@@ -32480,7 +32451,7 @@ Yx
 Yx
 Yx
 Yx
-QU
+AV
 VI
 TV
 Ra
@@ -32737,7 +32708,7 @@ gY
 Mr
 Mr
 Yx
-Zf
+Ra
 pX
 Ji
 Ra
@@ -32994,7 +32965,7 @@ CH
 Mu
 Oj
 Yx
-QU
+AV
 RD
 TV
 Ra
@@ -34276,8 +34247,8 @@ GY
 aN
 Zr
 JW
-Zf
-Zf
+Ra
+Ra
 DZ
 Zr
 Jt
@@ -34534,7 +34505,7 @@ aN
 Zr
 Hv
 Hv
-Zf
+Ra
 DZ
 pY
 Ji
@@ -34791,9 +34762,9 @@ aN
 Zr
 oN
 oN
-Zf
+Ra
 DZ
-ys
+pY
 Qr
 Ra
 Ra
@@ -35046,9 +35017,9 @@ aN
 aN
 Db
 zN
-Zf
-Zf
-Zf
+Ra
+Ra
+Ra
 DZ
 Zr
 Jx

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -9905,7 +9905,7 @@
 /turf/simulated/floor/plasteel,
 /area/tdome/arena)
 "MN" = (
-/obj/machinery/cryopod/robot,
+/obj/machinery/cryopod/robot/offstation,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -702,6 +702,10 @@
 	allow_occupant_types = list(/mob/living/silicon/robot)
 	disallow_occupant_types = list(/mob/living/silicon/robot/drone)
 
+/obj/machinery/cryopod/robot/offstation
+	//For offstation cyborgs
+	silent = TRUE
+
 /obj/machinery/cryopod/robot/despawn_occupant()
 	var/mob/living/silicon/robot/R = occupant
 	if(!istype(R)) return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> Adds robotic storage for ERT Cyborgs with the ERT cryodorms.

Also changes the instances of `/turf/simulated/floor/plasteel/dark/nitrogen` to be `/turf/simulated/floor/plasteel/dark` so CC personnel stop being poisoned by the atmosphere. <strike>This is a Certified™ S34N moment.</strike>

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Sleepy borgs want to go to bed. Steve wants to stop suffocating.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://user-images.githubusercontent.com/16112919/180591124-902fe4e0-178c-4dd2-8b1e-7c3e0325375f.png)

## Changelog
:cl:
add: Added robotic storage units to CC Cryodorms
add: Adds an offstation type of robotic storage unit that won't announce when robots enter cryosleep.
fix: Central Command no longer has a toxic atmosphere in places. Note: Personnel may remain toxic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
