### PR TITLE
fixes the dead holding items

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -68,6 +68,7 @@
 	update_sight()
 	update_action_buttons_icon()
 	ADD_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
+	ADD_TRAIT(src, TRAIT_HANDS_BLOCKED, STAT_TRAIT) // immobilized is superfluous as moving when dead ghosts you.
 	update_damage_hud()
 	update_health_hud()
 	med_hud_set_health()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
if you get decapped and are lying you no longer hold onto your items.
funny bug, 
> So normally this isn't an issue because you fall to sleep in crit
But decap skips this 
So the only thing that would make you drop your items is the fall proc
But that doesn't drop your items if you are already horizontal

## Why It's Good For The Game
bugs bad
~~rigor mortis~~

## Changelog
:cl:
fix: people who are decapped will not hold onto their items if they are lying down anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
