### PR TITLE
Reworks glare.

### DIFF
--- a/code/datums/spell_cooldown/spell_charges.dm
+++ b/code/datums/spell_cooldown/spell_charges.dm
@@ -31,7 +31,18 @@
 		charge_time = world.time + charge_duration
 	..()
 
-
 /datum/spell_cooldown/charges/revert_cast()
 	..()
 	charge_time = world.time
+
+/datum/spell_cooldown/charges/statpanel_info()
+	return "[current_charges] / [max_charges], [..()]"
+
+/datum/spell_cooldown/charges/get_availability_percentage()
+	if(max_charges == current_charges)
+		return 1
+
+	if(charge_time > world.time)
+		return (charge_duration - (charge_time - world.time)) / charge_duration
+
+	return (recharge_duration - (recharge_time - world.time)) / recharge_duration //parent proc without the on cooldown check

--- a/code/datums/spell_cooldown/spell_cooldown.dm
+++ b/code/datums/spell_cooldown/spell_cooldown.dm
@@ -57,3 +57,5 @@
 /datum/spell_cooldown/proc/revert_cast()
 	recharge_time = world.time
 
+/datum/spell_cooldown/proc/statpanel_info()
+	return "[round(get_availability_percentage(), 0.01) * 100]%"

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -164,6 +164,13 @@
 	T.range = 1
 	return T
 
+/obj/effect/proc_holder/spell/vampire/glare/create_new_cooldown()
+	var/datum/spell_cooldown/charges/C = new
+	C.max_charges = 2
+	C.recharge_duration = base_cooldown
+	C.charge_duration = 2 SECONDS
+	return C
+
 /// No deviation at all. Flashed from the front or front-left/front-right. Alternatively, flashed in direct view.
 #define DEVIATION_NONE 3
 /// Partial deviation. Flashed from the side. Alternatively, flashed out the corner of your eyes.
@@ -187,22 +194,23 @@
 			continue
 
 		var/deviation
-		if(user.IsWeakened() || IS_HORIZONTAL(user))
+		if(IS_HORIZONTAL(user))
 			deviation = DEVIATION_PARTIAL
 		else
 			deviation = calculate_deviation(target, user)
 
 		if(deviation == DEVIATION_FULL)
-			target.AdjustConfused(6 SECONDS)
-			target.adjustStaminaLoss(40)
+			target.Confused(6 SECONDS)
+			target.adjustStaminaLoss(20)
 		else if(deviation == DEVIATION_PARTIAL)
-			target.Weaken(2 SECONDS)
-			target.AdjustConfused(6 SECONDS)
+			target.KnockDown(5 SECONDS)
+			target.Confused(6 SECONDS)
 			target.adjustStaminaLoss(40)
 		else
-			target.adjustStaminaLoss(120)
-			target.Weaken(12 SECONDS)
-			target.AdjustSilence(6 SECONDS)
+			target.Confused(10 SECONDS)
+			target.adjustStaminaLoss(70)
+			target.KnockDown(12 SECONDS)
+			target.AdjustSilence(8 SECONDS)
 			target.flash_eyes(1, TRUE, TRUE)
 		to_chat(target, "<span class='warning'>You are blinded by [user]'s glare.</span>")
 		add_attack_logs(user, target, "(Vampire) Glared at")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1052,7 +1052,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 			statpanel(listed_turf.name, null, statpanel_things)
 
 /mob/proc/add_spell_to_statpanel(obj/effect/proc_holder/spell/S)
-	statpanel(S.panel,"[round(S.cooldown_handler.get_availability_percentage(), 0.01) * 100]%",S)
+	statpanel(S.panel,"[S.cooldown_handler.statpanel_info()]", S)
 
 // facing verbs
 /mob/proc/canface()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
makes glare have 2 charges, each charge does 70 stam, forces crawling, mutes for 8 seconds and confuses (from the front)
using 2 charges. the charges have a 2 second cooldown between uses.

the effects from side glare no longer weaken, insteads knocks down for a longer duration

back glare does less stamina damage.

glare now uses `Confuse` instead of `AdjustConfuse` to prevent the confusion stacking up from the two glares.

Also cleans up some of the spell cooldown datum stuff. the number of charges are now shown in the stat panel, if I can figure out how to add it to the spell overlay I will, but I am not very familar with maptext.

## Why It's Good For The Game
Removal of instant stuns, glare is super blegh to play against as security. very few instant stuns remain, this is one of them.

also having multiple charges allows you to outplay security in different ways, only one glare is needed to steal an item or make an escape, so you can escape from two groups of officers at once. or it can be comboed into a stunprod to keep a charge of glare but still mute.

The duration of the mute was increased due to the increase in difficulty to actually stun them.

and before you say "what if you miss your glare!!", 2 front glares stun, a front and a side glare stun. 

## Changelog
:cl:
tweak: reworks glare, it now has two charges, each charge doing stamina damage, multiple glares are required to stun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
