### PR TITLE
Adds Hydroponic HUD to botany locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -18,3 +18,4 @@
 	new /obj/item/cultivator(src)
 	new /obj/item/hatchet(src)
 	new /obj/item/storage/box/disks_plantgene(src)
+	new /obj/item/clothing/glasses/hud/hydroponic(src)


### PR DESCRIPTION
## What Does This PR Do
Adds a singular regular (non night vision) hydroponics HUD to each botany locker.

## Why It's Good For The Game
Fixes an oversight. I have no idea why these aren't in the lockers to begin with. Feels like basic quality of life for newer botany players that don't know how to manage their nutrients/water/weeds and so on.

## Images of changes
![image](https://user-images.githubusercontent.com/85680653/180624971-d9f6099d-6880-47bf-800c-a9d51e222b85.png)

## Changelog
:cl:
tweak: Adds a hydroponic HUD to botany lockers.
/:cl:
