### PR TITLE
Fix gc issue with RD armor spawner

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -130,8 +130,6 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 
 /obj/item/New()
 	..()
-	for(var/path in actions_types)
-		new path(src, action_icon[path], action_icon_state[path])
 
 	if(!hitsound)
 		if(damtype == "fire")
@@ -144,6 +142,8 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 
 /obj/item/Initialize(mapload)
 	. = ..()
+	for(var/path in actions_types)
+		new path(src, action_icon[path], action_icon_state[path])
 	if(istype(loc, /obj/item/storage)) //marks all items in storage as being such
 		in_storage = TRUE
 

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -59,7 +59,6 @@
 /obj/item/clothing/head/helmet/space/plasmaman/update_icon_state()
 	icon_state = "[initial(icon_state)][on ? "-light":""]"
 	item_state = icon_state
-	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 
 /obj/item/clothing/head/helmet/space/plasmaman/update_overlays()
 	. = ..()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -449,7 +449,7 @@
 	. = ..()
 	var/spawnpath = pick(subtypesof(/obj/item/clothing/suit/armor/reactive) - /obj/item/clothing/suit/armor/reactive/random)
 	new spawnpath(loc)
-	qdel(src)
+	return INITIALIZE_HINT_QDEL
 
 //All of the armor below is mostly unused
 


### PR DESCRIPTION
## What Does This PR Do
Fixes this gc woe when loading a map:
```
[2022-07-24T17:39:59] Starting up. Round ID is 8
[2022-07-24T17:39:59] -------------------------
[2022-07-24T17:42:22] Beginning search for references to a /obj/item/clothing/suit/armor/reactive/random.
[2022-07-24T17:42:22] Finished searching globals
[2022-07-24T17:43:08] Finished searching atoms
[2022-07-24T17:43:13] Found /obj/item/clothing/suit/armor/reactive/random [0x200c706] in /datum/action/item_action/toggle's [0x21013f1e] target var. World -> /datum/action/item_action/toggle
[2022-07-24T17:43:14] Finished searching datums
[2022-07-24T17:43:14] Finished searching clients
[2022-07-24T17:43:14] Completed search for references to a /obj/item/clothing/suit/armor/reactive/random.
[2022-07-24T17:43:14] GC: -- [0x2100000d] | /obj/item/clothing/suit/armor/reactive/random was unable to be GC'd --
```

The reason is that the action toggle is added in `item/New()` but by that time item itself is already `qdel`'ed, so the action does not record itself in armor's `.actions`, and thus does not get `qdel`'ed during `item/Destroy`

Moving populating of the action buttons to `item/Initialize` fixes the issue.

The plasmeme helmet changes are removing the only other use of `action_types` in code. Changing `action_types` during `update_icon` doesn't do anything, since that's only read during the object creation, and never after

## Why It's Good For The Game
gc issues bad


## Changelog
N/A