### PR TITLE
Make new players and their minds gc properly

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -197,8 +197,8 @@
 			observer.real_name = client.prefs.active_character.real_name
 			observer.name = observer.real_name
 			observer.key = key
-			QDEL_NULL(mind)
 			observer.add_to_respawnable_list()
+			mind.current = null
 			qdel(src)
 			return TRUE
 		return FALSE


### PR DESCRIPTION
## What Does This PR Do
Fixes this thing that you get when joining as observer:
```
[2022-07-24T18:08:02] Starting up. Round ID is 12
[2022-07-24T18:08:02] -------------------------
[2022-07-24T18:09:06] Beginning search for references to a /datum/mind.
[2022-07-24T18:09:06] Finished searching globals
[2022-07-24T18:09:06] Found /datum/mind [0x210031a5] in /mob/dead/observer's [0x3000007] mind var. World -> /mob/dead/observer
[2022-07-24T18:10:09] Finished searching atoms
[2022-07-24T18:10:12] Finished searching datums
[2022-07-24T18:10:12] Finished searching clients
[2022-07-24T18:10:12] Completed search for references to a /datum/mind.
[2022-07-24T18:10:12] GC: -- [0x2100000d] | /datum/mind was unable to be GC'd --
```

We are trying to qdel the `new_player`'s mind, but it is held by the observer (its ref gets taken during `observer/New`), which is problematic.

## Why It's Good For The Game
gc issues bad

## Changelog
N/A