### PR TITLE
Removes AoE and RNG Instant Stuns from Honker Blast, Gives It Knockdown

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -213,12 +213,8 @@
 		M.SetSleeping(0)
 		M.Stuttering(40 SECONDS)
 		M.AdjustEarDamage(0, 30)
-		M.Weaken(6 SECONDS)
-		if(prob(30))
-			M.Stun(20 SECONDS)
-			M.Paralyse(8 SECONDS)
-		else
-			M.Jitter(1000 SECONDS)
+		M.KnockDown(6 SECONDS)
+		M.Jitter(40 SECONDS)
 		///else the mousetraps are useless
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The honk mech's honkerblast now knocks everyone down, instead of stunning. and possibly worse. The jitter has been reduced to a sane amount (40 seconds), not 16 minutes.

Part of #18179

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Instant stuns do not fit, and unbalance our new combat system. Somehow, this is one of the most robust stuns to ever exist in the game. Funny, but maybe a little too funny. 

## Changelog
:cl:
tweak: HoNkER BlAsT 5000 knocks down instead of stunning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
