### PR TITLE
Fix mechas gc'ing

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -113,7 +113,7 @@
 	if(stat & NOPOWER || !recharge_console)
 		return
 	if(!recharging_mecha)
-		recharging_mecha = locate(/obj/mecha) in recharging_turf
+		update_recharging_mecha()
 		if(recharging_mecha)
 			recharge_console.update_icon()
 	if(recharging_mecha && recharging_mecha.cell)

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -35,6 +35,15 @@
 	RefreshParts()
 	update_recharge_turf()
 
+/obj/machinery/mech_bay_recharge_port/Destroy()
+	if(recharge_console)
+		recharge_console.recharge_port = null
+		recharge_console.update_icon()
+	recharge_console = null
+	recharging_mecha = null
+	recharging_turf = null
+	return ..()
+
 /obj/machinery/mech_bay_recharge_port/proc/update_recharge_turf()
 	recharging_turf = get_step(loc, dir)
 
@@ -51,9 +60,24 @@
 	RefreshParts()
 	update_recharge_turf()
 
+/obj/machinery/mech_bay_recharge_port/proc/update_recharging_mecha()
+	if(recharging_mecha)
+		if(recharging_mecha.loc == recharging_turf)
+			return  // no need to update anything
+		// it wandered away
+		UnregisterSignal(recharging_mecha, COMSIG_PARENT_QDELETING)
+		recharging_mecha = null
+	recharging_mecha = locate(/obj/mecha) in recharging_turf
+	if(recharging_mecha)
+		// so that we don't hold references to it after it's gone, and not causing GC issues
+		RegisterSignal(recharging_mecha, COMSIG_PARENT_QDELETING, .proc/on_mecha_qdel)
+
+/obj/machinery/mech_bay_recharge_port/proc/on_mecha_qdel()
+	recharging_mecha = null
+
 /obj/machinery/mech_bay_recharge_port/upgraded/unsimulated/process()
 	if(!recharging_mecha)
-		recharging_mecha = locate(/obj/mecha) in recharging_turf
+		update_recharging_mecha()
 	if(recharging_mecha && recharging_mecha.cell)
 		if(recharging_mecha.cell.charge < recharging_mecha.cell.maxcharge)
 			var/delta = min(max_charge, recharging_mecha.cell.maxcharge - recharging_mecha.cell.charge)
@@ -84,12 +108,6 @@
 /obj/machinery/mech_bay_recharge_port/crowbar_act(mob/user, obj/item/I)
 	if(default_deconstruction_crowbar(user, I))
 		return TRUE
-
-/obj/machinery/mech_bay_recharge_port/Destroy()
-	if(recharge_console)
-		recharge_console.recharge_port = null
-		recharge_console.update_icon()
-	return ..()
 
 /obj/machinery/mech_bay_recharge_port/process()
 	if(stat & NOPOWER || !recharge_console)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -57,7 +57,7 @@
 	var/list/operation_req_access = list()//required access level for mecha operation
 	var/list/internals_req_access = list(ACCESS_ENGINE,ACCESS_ROBOTICS)//required access level to open cell compartment
 
-	var/wreckage
+	var/obj/structure/mecha_wreckage/wreckage = null  // type that the mecha becomes when destroyed
 
 	var/list/equipment = new
 	var/obj/item/mecha_parts/mecha_equipment/selected
@@ -612,21 +612,21 @@
 	if(occupant)
 		occupant.SetSleeping(destruction_sleep_duration)
 	go_out()
-	var/mob/living/silicon/ai/AI
 	for(var/mob/M in src) //Let's just be ultra sure
 		if(isAI(M))
-			occupant = null
-			AI = M //AIs are loaded into the mech computer itself. When the mech dies, so does the AI. They can be recovered with an AI card from the wreck.
+			var/mob/living/silicon/ai/AI = M //AIs are loaded into the mech computer itself. When the mech dies, so does the AI. They can be recovered with an AI card from the wreck.
+			AI.gib() //No wreck, no AI to recover
 		else
 			M.forceMove(loc)
+	occupant = null
+	selected = null
 	for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
 		E.detach(loc)
 		qdel(E)
 	equipment.Cut()
 	QDEL_NULL(cell)
 	QDEL_NULL(internal_tank)
-	if(AI)
-		AI.gib() //No wreck, no AI to recover
+	QDEL_NULL(radio)
 	STOP_PROCESSING(SSobj, src)
 	GLOB.poi_list.Remove(src)
 	if(loc)
@@ -635,9 +635,11 @@
 	else
 		qdel(cabin_air)
 	cabin_air = null
+	connected_port = null
 	QDEL_NULL(spark_system)
 	QDEL_NULL(smoke_system)
 	QDEL_LIST(trackers)
+	remove_from_all_data_huds()
 	GLOB.mechas_list -= src //global mech list
 	return ..()
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -609,6 +609,7 @@
 		trackers -= A
 
 /obj/mecha/Destroy()
+	STOP_PROCESSING(SSobj, src)
 	if(occupant)
 		occupant.SetSleeping(destruction_sleep_duration)
 	go_out()
@@ -627,7 +628,6 @@
 	QDEL_NULL(cell)
 	QDEL_NULL(internal_tank)
 	QDEL_NULL(radio)
-	STOP_PROCESSING(SSobj, src)
 	GLOB.poi_list.Remove(src)
 	if(loc)
 		loc.assume_air(cabin_air)


### PR DESCRIPTION
## What Does This PR Do
Fixes the following when trying to delete a mecha (specifically one standing in centcomm)
```
[2022-07-24T19:46:58] GC: -- [0x2100000d] | /obj/item/radio was unable to be GC'd --
[2022-07-24T19:47:18] Beginning search for references to a /obj/mecha/combat/marauder/loaded.
[2022-07-24T19:47:18] Finished searching globals
[2022-07-24T19:47:18] Found /obj/mecha/combat/marauder/loaded [0x20005b3] in /obj/machinery/mech_bay_recharge_port/upgraded/unsimulated's [0x20005c5] recharging_mecha var. World -> /obj/machinery/mech_bay_recharge_port/upgraded/unsimulated
[2022-07-24T19:48:19] Finished searching atoms
[2022-07-24T19:48:19] Found /obj/mecha/combat/marauder/loaded [0x20005b3] in list World -> /datum/atom_hud/data/diagnostic/basic [0x210000d5] -> hudatoms (list).
[2022-07-24T19:48:19] Found /obj/mecha/combat/marauder/loaded [0x20005b3] in list World -> /datum/atom_hud/data/diagnostic/advanced [0x210000d6] -> hudatoms (list).
[2022-07-24T19:48:21] Finished searching datums
[2022-07-24T19:48:21] Finished searching clients
[2022-07-24T19:48:21] Completed search for references to a /obj/mecha/combat/marauder/loaded.
[2022-07-24T19:48:21] GC: -- [0x2100000d] | /obj/mecha/combat/marauder/loaded was unable to be GC'd --
```

## Why It's Good For The Game
gc bork bad

## Changelog
N/A