### PR TITLE
Removes RNG Stuns From a Bunch of Xenobio Mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -32,12 +32,3 @@
 
 /mob/living/simple_animal/hostile/faithless/Process_Spacemove(movement_dir = 0)
 	return 1
-
-/mob/living/simple_animal/hostile/faithless/AttackingTarget()
-	. = ..()
-	if(. && iscarbon(target))
-		var/mob/living/carbon/C = target
-		if(prob(12))
-			C.Weaken(6 SECONDS)
-			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
-					"<span class='userdanger'>\The [src] knocks you down!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
@@ -36,11 +36,3 @@
 	layer = 3.1		//so they can stay hidde under the /obj/structure/bush
 	var/stalk_tick_delay = 3
 	gold_core_spawnable = HOSTILE_SPAWN
-
-/mob/living/simple_animal/hostile/panther/AttackingTarget()
-	. = ..()
-	if(.)
-		if(prob(15) && iscarbon(target))
-			var/mob/living/carbon/C = target
-			C.Weaken(6 SECONDS)
-			C.visible_message("<span class='danger'>\the [src] knocks down \the [C]!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -36,11 +36,3 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	deathmessage = "is hacked into pieces!"
 	del_on_death = TRUE
-
-/mob/living/simple_animal/hostile/tree/AttackingTarget()
-	. = ..()
-	if(. && iscarbon(target))
-		var/mob/living/carbon/C = target
-		if(prob(15))
-			C.Weaken(6 SECONDS)
-			C.visible_message("<span class='danger'>\the [src] knocks down \the [C]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
The Faithless, panther, and... pine tree...? no longer have their RNG stuns.

Part of #18179

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Stuns bad in stamina combat. RNG combat bad. I remove it now.

## Changelog
:cl:
tweak: Faithless, panther, and pine tree no longer RNG stun people they attack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
