### PR TITLE
Slaughter Demon no longer heals from consuming simplemob

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
+++ b/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
@@ -71,13 +71,15 @@
 
 			if(kidnapped)
 				if(ishuman(kidnapped) || isrobot(kidnapped))
-					to_chat(src, "<B>You devour [kidnapped]. Your health is fully restored.</B>")
+					to_chat(src, "<span class='warning'>You devour [kidnapped]. Your health is fully restored.</span>")
 					adjustBruteLoss(-1000)
 					adjustFireLoss(-1000)
 					adjustOxyLoss(-1000)
 					adjustToxLoss(-1000)
 				else
-					to_chat(src, "<span class='warning'>You devour [kidnapped], but this measly meal does not sate your appetite!</span>")
+					to_chat(src, "<span class='warning'>You devour [kidnapped], but this measly meal barely sates your appetite!</span>")
+					adjustBruteLoss(-25)
+					adjustFireLoss(-25)
 				if(istype(src, /mob/living/simple_animal/slaughter)) //rason, do not want humans to get this
 					var/mob/living/simple_animal/slaughter/demon = src
 					demon.devoured++

--- a/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
+++ b/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
@@ -68,13 +68,16 @@
 			for(var/i in 1 to 3)
 				playsound(get_turf(src), sound, 100, 1)
 				sleep(30)
-			if(kidnapped)
-				to_chat(src, "<B>You devour [kidnapped]. Your health is fully restored.</B>")
-				adjustBruteLoss(-1000)
-				adjustFireLoss(-1000)
-				adjustOxyLoss(-1000)
-				adjustToxLoss(-1000)
 
+			if(kidnapped)
+				if(ishuman(kidnapped))
+					to_chat(src, "<B>You devour [kidnapped]. Your health is fully restored.</B>")
+					adjustBruteLoss(-1000)
+					adjustFireLoss(-1000)
+					adjustOxyLoss(-1000)
+					adjustToxLoss(-1000)
+				else
+					to_chat(src, "<B>You devour [kidnapped], but this measly meal does not sate your appetite.")
 				if(istype(src, /mob/living/simple_animal/slaughter)) //rason, do not want humans to get this
 					var/mob/living/simple_animal/slaughter/demon = src
 					demon.devoured++

--- a/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
+++ b/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
@@ -70,7 +70,7 @@
 				sleep(30)
 
 			if(kidnapped)
-				if(ishuman(kidnapped))
+				if(ishuman(kidnapped) || isrobot(kidnapped))
 					to_chat(src, "<B>You devour [kidnapped]. Your health is fully restored.</B>")
 					adjustBruteLoss(-1000)
 					adjustFireLoss(-1000)

--- a/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
+++ b/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
@@ -77,7 +77,7 @@
 					adjustOxyLoss(-1000)
 					adjustToxLoss(-1000)
 				else
-					to_chat(src, "<B>You devour [kidnapped], but this measly meal does not sate your appetite.")
+					to_chat(src, "<span class='warning'>You devour [kidnapped], but this measly meal does not sate your appetite!</span>")
 				if(istype(src, /mob/living/simple_animal/slaughter)) //rason, do not want humans to get this
 					var/mob/living/simple_animal/slaughter/demon = src
 					demon.devoured++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Slaughter demons only heal for 25 damage from eating simplemobs.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Simplemobs are relatively plentiful compared to carbons, and are easier to kill and consume, making it incredibly easy for a slaughter demon to heal.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Slaughter demons only heal for 25 damage from eating simplemobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
