### PR TITLE
Potentially fix a runtime when deconstructing a machinery with signaller attached

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -51,9 +51,9 @@
 		colors = GLOB.wire_color_directory[holder_type]
 
 /datum/wires/Destroy()
-	holder = null
 	for(var/color in colors)
 		detach_assembly(color)
+	holder = null
 	return ..()
 
 /**


### PR DESCRIPTION
## What Does This PR Do
Potentially fixes this runtime (observed on live):

```
[2022-07-24T21:50:36] Runtime in wires.dm,433: Cannot execute null.drop location().
[2022-07-24T21:50:36]   proc name: detach assembly (/datum/wires/proc/detach_assembly)
[2022-07-24T21:50:36]   usr: *REDACTED USER*
[2022-07-24T21:50:36]   usr.loc: The floor (75,147,2) (/turf/simulated/floor/plasteel)
[2022-07-24T21:50:36]   src: /datum/wires/vending (/datum/wires/vending)
[2022-07-24T21:50:36]   call stack:
[2022-07-24T21:50:36]   /datum/wires/vending (/datum/wires/vending): detach assembly("purple")
[2022-07-24T21:50:36]   /datum/wires/vending (/datum/wires/vending): Destroy(0)
[2022-07-24T21:50:36]   qdel(/datum/wires/vending (/datum/wires/vending), 0)
[2022-07-24T21:50:36]   the YouTool (/obj/machinery/vending/tool): Destroy(0)
[2022-07-24T21:50:36]   qdel(the YouTool (/obj/machinery/vending/tool), 0)
[2022-07-24T21:50:36]   the YouTool (/obj/machinery/vending/tool): deconstruct(1)
[2022-07-24T21:50:36]   the YouTool (/obj/machinery/vending/tool): deconstruct(1)
[2022-07-24T21:50:36]   the YouTool (/obj/machinery/vending/tool): default deconstruction crowbar(P.U.R.P.L.E (/mob/living/carbon/human), the pocket crowbar (/obj/item/crowbar/red), 0)
[2022-07-24T21:50:36]   the YouTool (/obj/machinery/vending/tool): crowbar act(P.U.R.P.L.E (/mob/living/carbon/human), the pocket crowbar (/obj/item/crowbar/red))
[2022-07-24T21:50:36]   the YouTool (/obj/machinery/vending/tool): tool act(P.U.R.P.L.E (/mob/living/carbon/human), the pocket crowbar (/obj/item/crowbar/red), "crowbar")
[2022-07-24T21:50:36]   the pocket crowbar (/obj/item/crowbar/red): tool attack chain(P.U.R.P.L.E (/mob/living/carbon/human), the YouTool (/obj/machinery/vending/tool))
[2022-07-24T21:50:36]   the pocket crowbar (/obj/item/crowbar/red): melee attack chain(P.U.R.P.L.E (/mob/living/carbon/human), the YouTool (/obj/machinery/vending/tool), "icon-x=18;icon-y=13;left=1;scr...")
[2022-07-24T21:50:36]   P.U.R.P.L.E (/mob/living/carbon/human): ClickOn(the YouTool (/obj/machinery/vending/tool), "icon-x=18;icon-y=13;left=1;scr...")
[2022-07-24T21:50:36]   the YouTool (/obj/machinery/vending/tool): Click(the floor (76,148,2) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=18;icon-y=13;left=1;scr...")
```

Stemming from the fact that `/wires` first sets `.holder` to null, and *then* tries to drop the assembly onto the `holder`'s location.

Disclaimer: This PR is untested, I'm only assuming it works.

## Why It's Good For The Game
bugfix

## Changelog
Trivial