### PR TITLE
Mobs will properly show adminfreeze overlays

### DIFF
--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 
 		anchored = TRUE
 		admin_prev_sleeping = AmountSleeping()
-		frozen = TRUE
+		frozen = AO
 		PermaSleeping()
 
 	else

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -68,8 +68,9 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 /mob/living/simple_animal/slime/admin_Freeze(admin)
 	if(..())
 		adjustHealth(1000) //arbitrary large value
-	else
-		revive()
+		return
+
+	revive()
 
 /mob/living/simple_animal/admin_Freeze(admin)
 	if(!..())

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -75,14 +75,6 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 	if(!..())
 		revive()
 
-/mob/living/silicon/admin_Freeze(admin)
-	if(!..())
-		revive()
-
-/mob/living/carbon/alien/admin_Freeze(admin)
-	if(!..())
-		revive()
-
 //////////////////////////Freeze Mech
 
 /obj/mecha/admin_Freeze(client/admin)

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -38,18 +38,18 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 		GLOB.frozen_atom_list += src
 
 		var/obj/effect/overlay/adminoverlay/AO = new
-		if(skip_overlays)
+		if(!skip_overlays)
 			overlays += AO
 
 		anchored = TRUE
 		admin_prev_sleeping = AmountSleeping()
-		frozen = AO
+		frozen = TRUE
 		PermaSleeping()
 
 	else
 		GLOB.frozen_atom_list -= src
 
-		if(skip_overlays)
+		if(!skip_overlays)
 			overlays -= frozen
 
 		anchored = FALSE
@@ -66,20 +66,22 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 
 
 /mob/living/simple_animal/slime/admin_Freeze(admin)
-	if(..()) // The result of the parent call here will be the value of the mob's `frozen` variable after they get (un)frozen.
+	if(..())
 		adjustHealth(1000) //arbitrary large value
 	else
 		revive()
 
-/mob/living/simple_animal/var/admin_prev_health = null
-
 /mob/living/simple_animal/admin_Freeze(admin)
-	if(..()) // The result of the parent call here will be the value of the mob's `frozen` variable after they get (un)frozen.
-		admin_prev_health = health
-		health = 0
-	else
+	if(!..())
 		revive()
-		overlays.Cut()
+
+/mob/living/silicon/admin_Freeze(admin)
+	if(!..())
+		revive()
+
+/mob/living/carbon/alien/admin_Freeze(admin)
+	if(!..())
+		revive()
 
 //////////////////////////Freeze Mech
 

--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -12,6 +12,8 @@
 	var/list/overlays_standing[X_TOTAL_LAYERS]
 
 /mob/living/carbon/alien/humanoid/update_icons()
+	if(frozen)
+		return
 	overlays.Cut()
 	for(var/image/I in overlays_standing)
 		overlays += I

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1328,7 +1328,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	apply_overlay(HALO_LAYER)
 
 
-/mob/living/carbon/human/admin_Freeze(client/admin, skip_overlays = TRUE, mech = null) // This part... never works for some reason.
+/mob/living/carbon/human/admin_Freeze(client/admin, skip_overlays = TRUE, mech = null)
 	if(..())
 		overlays_standing[FROZEN_LAYER] = mutable_appearance('icons/effects/effects.dmi', "admin", layer = -FROZEN_LAYER)
 		apply_overlay(FROZEN_LAYER)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1328,9 +1328,9 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	apply_overlay(HALO_LAYER)
 
 
-/mob/living/carbon/human/admin_Freeze(client/admin, skip_overlays = TRUE, mech = null)
+/mob/living/carbon/human/admin_Freeze(client/admin, skip_overlays = TRUE, mech = null) // This part... never works for some reason.
 	if(..())
-		overlays_standing[FROZEN_LAYER] = mutable_appearance(frozen, layer = -FROZEN_LAYER)
+		overlays_standing[FROZEN_LAYER] = mutable_appearance('icons/effects/effects.dmi', "admin", layer = -FROZEN_LAYER)
 		apply_overlay(FROZEN_LAYER)
 	else
 		remove_overlay(FROZEN_LAYER)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -984,6 +984,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	return 0
 
 /mob/living/silicon/robot/update_icons()
+	if(frozen)
+		return
 	overlays.Cut()
 	if(stat != DEAD && !(IsParalyzed() || IsStunned() || IsWeakened() || low_power_mode)) //Not dead, not stunned.
 		if(custom_panel in custom_eye_names)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -188,7 +188,7 @@
 			if(IsSleeping() && (stat == CONSCIOUS))
 				KnockOut()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
-			else
+			else if(stat == UNCONSCIOUS)
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	med_hud_set_status()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -181,12 +181,13 @@
 	if(status_flags & GODMODE)
 		return
 	if(stat != DEAD)
-		if(health <= 0)
+		if(health <= 0 && !frozen)
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 		else
 			if(IsSleeping() && (stat == CONSCIOUS))
 				KnockOut()
+				create_debug_log("fell unconscious, trigger reason: [reason]")
 			else
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
@@ -615,6 +616,8 @@
 		real_name = P.tagname
 
 /mob/living/simple_animal/regenerate_icons()
+	if(frozen)
+		return
 	cut_overlays()
 	if(pcollar && collar_type)
 		add_overlay("[collar_type]collar")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->It fixes a bunch of logic thats broken with adminfreezing overlays

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #18553 , the visual part that is, mechanically it has already been fixed.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/91113370/180766755-34dd1c9d-eca4-499e-9a06-f97b949c6185.png)

## Changelog
:cl:
fix: All mobs will now properly show if they are adminfrozen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
