### PR TITLE
Fixes the knockout trait and simple mob sleeping

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -539,10 +539,10 @@
 	. = ..()
 	if(!.)
 		return
-	ADD_TRAIT(src, TRAIT_KNOCKEDOUT, "[id]")
+	ADD_TRAIT(owner, TRAIT_KNOCKEDOUT, "[id]")
 
 /datum/status_effect/incapacitating/sleeping/on_remove()
-	REMOVE_TRAIT(src, TRAIT_KNOCKEDOUT, "[id]")
+	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, "[id]")
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/tick()

--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -6,7 +6,7 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		if(IsParalyzed() || IsSleeping() || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
+		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
 			if(stat == CONSCIOUS)
 				KnockOut()
 				create_debug_log("fell unconscious, trigger reason: [reason]")

--- a/code/modules/mob/living/silicon/ai/update_status.dm
+++ b/code/modules/mob/living/silicon/ai/update_status.dm
@@ -6,9 +6,10 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		else if(IsSleeping()) //Required for adminfreezing
-			KnockOut()
-			create_debug_log("fell unconscious, trigger reason: [reason]")
+		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT))
+			if(stat == CONSCIOUS)
+				KnockOut()
+				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else if(stat == UNCONSCIOUS)
 			WakeUp()
 			create_debug_log("woke up, trigger reason: [reason]")

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -17,12 +17,10 @@
 		if(!is_component_functioning("actuator") || !is_component_functioning("power cell") || HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || IsStunned() || IsWeakened() || getOxyLoss() > maxHealth * 0.5) // Borgs need to be able to sleep for adminfreeze
 			if(stat == CONSCIOUS)
 				KnockOut()
-				update_headlamp()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
 			if(stat == UNCONSCIOUS)
 				WakeUp()
-				update_headlamp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	else
 		if(health > 0)

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -14,7 +14,7 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		if(!is_component_functioning("actuator") || !is_component_functioning("power cell") || HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || IsStunned() || IsWeakened() || IsSleeping() || getOxyLoss() > maxHealth * 0.5) // Borgs need to be able to sleep for adminfreeze
+		if(!is_component_functioning("actuator") || !is_component_functioning("power cell") || HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || IsStunned() || IsWeakened() || getOxyLoss() > maxHealth * 0.5) // Borgs need to be able to sleep for adminfreeze
 			if(stat == CONSCIOUS)
 				KnockOut()
 				update_headlamp()
@@ -37,6 +37,15 @@
 	diag_hud_set_status()
 	diag_hud_set_health()
 	update_health_hud()
+
+/mob/living/silicon/robot/KnockOut(updating = TRUE)
+	. = ..()
+	update_headlamp()
+
+/mob/living/silicon/robot/WakeUp(updating = TRUE)
+	. = ..()
+	update_headlamp()
+
 
 /mob/living/silicon/robot/update_revive(updating = TRUE)
 	. = ..(updating)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -185,9 +185,11 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 		else
-			if(IsSleeping() && (stat == CONSCIOUS))
-				KnockOut()
-			else
+			if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT))
+				if(stat == CONSCIOUS)
+					KnockOut()
+					create_debug_log("knocked out, trigger reason: [reason]")
+			else if(stat == UNCONSCIOUS)
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	med_hud_set_status()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a fuckup from crawling. the knockout trait shouldn't be applied to the status effect datum
makes things actually check for this trait instead of `IsSleeping() || IsParalyzed()` as both these traits apply that.
also makes simple mob sleeping actually work.

## Why It's Good For The Game
one step closer to removing update_stat()

## Changelog
:cl:
fix: simple mobs can actually sleep now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
