### PR TITLE
Change default dropper transfer rate to 1u

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -8,7 +8,7 @@
 	icon_state = "dropper"
 	item_state = "dropper"
 	belt_icon = "dropper"
-	amount_per_transfer_from_this = 5
+	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
 
@@ -107,7 +107,6 @@
 	name = "pipette"
 	desc = "A high precision pippette. Holds 1 unit."
 	icon_state = "pipette"
-	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = list(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1)
 	volume = 1
 

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -4,7 +4,7 @@
 
 /obj/item/reagent_containers/dropper
 	name = "dropper"
-	desc = "A dropper. Transfers 5 units."
+	desc = "A dropper. Transfers up to 5 units."
 	icon_state = "dropper"
 	item_state = "dropper"
 	belt_icon = "dropper"
@@ -98,14 +98,14 @@
 
 /obj/item/reagent_containers/dropper/cyborg
 	name = "Industrial Dropper"
-	desc = "A larger dropper. Transfers 10 units."
+	desc = "A larger dropper. Transfers up to 10 units."
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 	volume = 10
 
 /obj/item/reagent_containers/dropper/precision
 	name = "pipette"
-	desc = "A high precision pippette. Holds 1 unit."
+	desc = "A high precision pippette. Transfers up to 1 unit."
 	icon_state = "pipette"
 	possible_transfer_amounts = list(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1)
 	volume = 1

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -105,7 +105,7 @@
 
 /obj/item/reagent_containers/dropper/precision
 	name = "pipette"
-	desc = "A high precision pippette. Transfers up to 1 unit."
+	desc = "A high precision pipette. Transfers up to 1 unit."
 	icon_state = "pipette"
 	possible_transfer_amounts = list(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1)
 	volume = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
`"[title]"`
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
99% of the times you want to use a dropper, it's for transfer rates lower than 5u (which is achievable with normal beakers!), most often 1u. This tweak lets you skip the part where you have to set that on every dropper you use.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Droppers now have a default transfer rate of 1u
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
