### PR TITLE
turns hover over tooltips for inventory items into a preference

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -57,6 +57,7 @@
 #define PREFTOGGLE_2_FORCE_WHITE_RUNECHAT	1024
 #define PREFTOGGLE_2_SIMPLE_STAT_PANEL	2048
 #define PREFTOGGLE_2_SEE_ITEM_OUTLINES 	4096
+#define PREFTOGGLE_2_SEE_ITEM_TOOLTIPS  8192
 
 #define TOGGLES_2_TOTAL 			8191 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -59,7 +59,7 @@
 #define PREFTOGGLE_2_SEE_ITEM_OUTLINES 	4096
 #define PREFTOGGLE_2_SEE_ITEM_TOOLTIPS  8192
 
-#define TOGGLES_2_TOTAL 			8191 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
+#define TOGGLES_2_TOTAL 			12288 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 
 #define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_2_DEATHMESSAGE|PREFTOGGLE_2_EMOTE_BUBBLE|PREFTOGGLE_2_SEE_ITEM_OUTLINES)
 

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -57,9 +57,9 @@
 #define PREFTOGGLE_2_FORCE_WHITE_RUNECHAT	1024
 #define PREFTOGGLE_2_SIMPLE_STAT_PANEL	2048
 #define PREFTOGGLE_2_SEE_ITEM_OUTLINES 	4096
-#define PREFTOGGLE_2_SEE_ITEM_TOOLTIPS  8192
+#define PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS  8192
 
-#define TOGGLES_2_TOTAL 			12288 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
+#define TOGGLES_2_TOTAL 			16383 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 
 #define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_2_DEATHMESSAGE|PREFTOGGLE_2_EMOTE_BUBBLE|PREFTOGGLE_2_SEE_ITEM_OUTLINES)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -715,12 +715,13 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 /obj/item/MouseEntered(location, control, params)
 	. = ..()
 	if(in_inventory || in_storage)
-		var/timedelay = 8
 		var/mob/user = usr
-		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
+		var/mob/living/L = user
+		if(!(user.client.prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_TOOLTIPS))
+			var/timedelay = 8
+			tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
 		if(QDELETED(src))
 			return
-		var/mob/living/L = user
 		if(!(user.client.prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_OUTLINES))
 			return
 		if(istype(L) && HAS_TRAIT(L, TRAIT_HANDS_BLOCKED))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -717,8 +717,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if(in_inventory || in_storage)
 		var/mob/user = usr
 		if(!(user.client.prefs.toggles2 & PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS))
-			var/timedelay = 8
-			tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
+			tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), 8, TIMER_STOPPABLE)
 		if(QDELETED(src))
 			return
 		if(!(user.client.prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_OUTLINES))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -716,14 +716,14 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	. = ..()
 	if(in_inventory || in_storage)
 		var/mob/user = usr
-		var/mob/living/L = user
-		if(!(user.client.prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_TOOLTIPS))
+		if(!(user.client.prefs.toggles2 & PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS))
 			var/timedelay = 8
 			tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
 		if(QDELETED(src))
 			return
 		if(!(user.client.prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_OUTLINES))
 			return
+		var/mob/living/L = user
 		if(istype(L) && HAS_TRAIT(L, TRAIT_HANDS_BLOCKED))
 			apply_outline(L, COLOR_RED_GRAY) //if they're dead or handcuffed, let's show the outline as red to indicate that they can't interact with that right now
 		else

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -342,6 +342,14 @@
 	prefs.save_preferences(src)
 	to_chat(usr, "You will [(prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_OUTLINES) ? "now" : "no longer"] see item outlines on hover.")
 
+/client/verb/toggle_item_tooltips()
+	set name = "Toggle Hover-over Item Tooltips"
+	set category = "Preferences"
+	set desc = "Toggles textboxes with the item descriptions after hovering on them in your inventory."
+	prefs.toggles2 ^= PREFTOGGLE_2_SEE_ITEM_TOOLTIPS
+	prefs.save_preferences(src)
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_TOOLTIPS) ? "no longer" : "now"] see item tooltips on hover.")
+
 /mob/verb/toggle_anonmode()
 	set name = "Toggle Anonymous Mode"
 	set category = "Preferences"

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -348,7 +348,7 @@
 	set desc = "Toggles textboxes with the item descriptions after hovering on them in your inventory."
 	prefs.toggles2 ^= PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS
 	prefs.save_preferences(src)
-	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS) ? "no longer" : "now"] see item tooltips on hover.")
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS) ? "no longer" : "now"] see item tooltips when you hover over items on your HUD.")
 
 /mob/verb/toggle_anonmode()
 	set name = "Toggle Anonymous Mode"

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -346,9 +346,9 @@
 	set name = "Toggle Hover-over Item Tooltips"
 	set category = "Preferences"
 	set desc = "Toggles textboxes with the item descriptions after hovering on them in your inventory."
-	prefs.toggles2 ^= PREFTOGGLE_2_SEE_ITEM_TOOLTIPS
+	prefs.toggles2 ^= PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS
 	prefs.save_preferences(src)
-	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_SEE_ITEM_TOOLTIPS) ? "no longer" : "now"] see item tooltips on hover.")
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS) ? "no longer" : "now"] see item tooltips on hover.")
 
 /mob/verb/toggle_anonmode()
 	set name = "Toggle Anonymous Mode"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

this allows people to toggle the tooltip boxes that appear when hovering over items in your inventory

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

the tooltip boxes are not useful at all for people like me, who naturally use shift click to read item descriptions.
however, since they are completely opaque and do not scale with UI alpha preference they tend to block a bit of the game window- this is especially noticeable when hovering your mouse over a laser gun in your suit storage ready to draw it while patrolling maintenance. since the laser gun doesn't have a short examine text the box can occlude up to 5 tiles.

it's annoying and redundant- for players in more mechanical roles

for players that care less about edge of screen sight or would rather use the tooltips this is implemented as a preference that can be toggled on or off.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/41054538/180857346-735c5c7c-6322-4617-8fba-3941cf138a6d.mp4

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: preference option to toggle item description boxes that appear after hovering over an inventory item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
