### PR TITLE
Make cursed heart delete itself on death

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -107,6 +107,23 @@
 		else
 			last_pump = world.time //lets be extra fair *sigh*
 
+/obj/item/organ/internal/heart/cursed/on_owner_death()
+	. = ..()
+	owner.visible_message(
+		"<span class='warning'>A purple cloud seems to emerge from [owner]'s [parent_organ], leaving a clear cavity!</span>",
+		"<span class='userdanger'>The [src] in your [parent_organ] turns to dust, leaving behind another victim of its curse!</span>",
+	)
+	owner.do_jitter_animation(1000)  // So it's clear something happened
+	owner.internal_organs -= src
+
+	for(var/datum/action/item_action/organ_action/cursed_heart/A in owner.actions)
+		qdel(A)  // this gets stuck for some reason
+	owner.update_action_buttons()
+	owner = null
+	remove()
+	qdel(src)
+
+
 /obj/item/organ/internal/heart/cursed/insert(mob/living/carbon/M, special = 0)
 	..()
 	if(owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the cursed heart delete itself from your body on death, leaving behind nothing where your heart used to be.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So I'll be honest, my main motivation for this comes from the medbay side. As of late, there have been a lot of patients coming in with a cursed heart. Of course, they have no blood, so they get pumped full of blood and revived, possibly a few times, before the doctors realize the best course is a) clone or b) superspeed heart transplant. It makes the cursed heart a noob trap in quite a few ways. By the time people realize the patient has a cursed heart, there's already been some blood supply burned on the patient, and the defib timer has just been ticking. Now, it'll pretty quickly be clear that the patient needs a new heart fast.

On the side of the item itself, it's supposed to be something that kills you. The fact that it's already nearly impossible to revive someone with it makes this seem like an acceptable move.

To the person who died with the heart, the end behavior should be about the same, you die and (hopefully) come back with a new, non-cursed heart once you get treated.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
tweak: The cursed heart now disappears when its owner dies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
