### PR TITLE
Adds a special suicide action to air tanks

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -119,13 +119,14 @@
 	var/mob/living/carbon/human/H = user
 	user.visible_message("<span class='suicide'>[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, TRUE, -3)
+
 	if(!QDELETED(H) && air_contents && air_contents.return_pressure() >= 1000)
 		var/obj/item/organ/external/head/head = H.get_organ("head")
 		head.disfigure()
 		H.inflate_gib()
 		return OBLITERATION
-	else
-		to_chat(user, "<span class='warning'>There isn't enough pressure in [src] to commit suicide with...</span>")
+
+	to_chat(user, "<span class='warning'>There isn't enough pressure in [src] to commit suicide with...</span>")
 	return SHAME
 
 /obj/item/tank/deconstruct(disassembled = TRUE)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -115,6 +115,19 @@
 
 		qdel(src)
 
+/obj/item/tank/suicide_act(mob/user)
+	var/mob/living/carbon/human/H = user
+	user.visible_message("<span class='suicide'>[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	playsound(loc, 'sound/effects/spray.ogg', 10, TRUE, -3)
+	if(!QDELETED(H) && air_contents && air_contents.return_pressure() >= 1000)
+		var/obj/item/organ/external/head/head = H.get_organ("head")
+		head.disfigure()
+		H.inflate_gib()
+		return OBLITERATION
+	else
+		to_chat(user, "<span class='warning'>There isn't enough pressure in [src] to commit suicide with...</span>")
+	return SHAME
+
 /obj/item/tank/deconstruct(disassembled = TRUE)
 	if(!disassembled)
 		var/turf/T = get_turf(src)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -100,3 +100,9 @@
 	Weaken(30 SECONDS)
 	do_jitter_animation(1000, -1) // jitter until they are gibbed
 	addtimer(CALLBACK(src, .proc/gib), rand(2 SECONDS, 10 SECONDS))
+
+/mob/living/carbon/proc/inflate_gib() // Plays an animation that makes mobs appear to inflate before finally gibbing
+	addtimer(CALLBACK(src, .proc/gib, null, null, TRUE, TRUE), 25)
+	var/matrix/M = matrix()
+	M.Scale(1.8, 1.2)
+	animate(src, time = 40, transform = M, easing = SINE_EASING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Taken from /tg/. 
Committing suicide with an air tank containing over 1000kpa will cause you to put the air tank to your mouth, open the latch, and...
oh god it isn't closing I-
![vXmTBMuc](https://user-images.githubusercontent.com/89928798/180938464-3e9d50db-75c4-42f9-8036-f3dda8d9639e.gif)

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The airtank suicide is one of my favorite item interactions on /tg/. It's just goofy and a fun way to go out. Being able to gib yourself on command isn't completely new (see biblefart).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/89928798/180940214-4b44d50d-0424-4974-933e-24a79d1e67f2.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Adds special suicide behavior to air tanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
