### PR TITLE
Fixes the robotic cryo storage not linking to the robotic cryo console if there is a human cryo console nearby

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -255,7 +255,7 @@
 	for(var/obj/machinery/computer/cryopod/C in get_area(src).contents)
 		if(C.type == console_type)
 			control_computer = C
-		break
+			break
 
 	// Don't send messages unless we *need* the computer, and less than five minutes have passed since last time we messaged
 	if(!control_computer && urgent && last_no_computer_message + 5*60*10 < world.time)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -206,6 +206,7 @@
 	var/obj/item/radio/intercom/announce
 	var/silent = FALSE
 
+	var/console_type = /obj/machinery/computer/cryopod	// The type of control console it should link itself to
 	var/obj/machinery/computer/cryopod/control_computer
 	var/last_no_computer_message = 0
 
@@ -252,7 +253,8 @@
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent=0)
 	for(var/obj/machinery/computer/cryopod/C in get_area(src).contents)
-		control_computer = C
+		if(C.type == console_type)
+			control_computer = C
 		break
 
 	// Don't send messages unless we *need* the computer, and less than five minutes have passed since last time we messaged
@@ -699,6 +701,7 @@
 	on_store_message = "has entered robotic storage."
 	on_store_name = "Robotic Storage Oversight"
 	on_enter_occupant_message = "The storage unit broadcasts a sleep signal to you. Your systems start to shut down, and you enter low-power mode."
+	console_type = /obj/machinery/computer/cryopod/robot
 	allow_occupant_types = list(/mob/living/silicon/robot)
 	disallow_occupant_types = list(/mob/living/silicon/robot/drone)
 


### PR DESCRIPTION
## What Does This PR Do

If there was a human cryo console and a robot console in the same room, the robot cryo storage linked to the human console. This PR ensures that cryo storages connect to their respective cryo consoles.

## Why It's Good For The Game

Less bugs in the upcoming #18515!

Fixes #18544 

## Images of changes

Now:

![image](https://user-images.githubusercontent.com/33333517/180949259-3fec4468-91ed-476b-8b55-6e10c8101456.png)

![image](https://user-images.githubusercontent.com/33333517/180949405-fb2ee424-4c62-4804-8e17-b5eabb469c94.png)

Fixed:

![image](https://user-images.githubusercontent.com/33333517/180949485-e8924698-aec6-40be-8e6e-7919f2c5f5e3.png) 

![image](https://user-images.githubusercontent.com/33333517/180949535-c314ebe3-9505-44f1-9f50-6a36fd07a9c2.png)


## Changelog
:cl:
fix: Fixes all cryo storage units always linking to the human cryo storage console first.
/:cl:
