### PR TITLE
Nerfs Thermite

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -251,7 +251,7 @@
 	ChangeTurf(/turf/simulated/floor)
 
 /turf/simulated/wall/proc/thermitemelt(mob/user as mob, speed)
-	var/wait = 100
+	var/wait = 20 SECONDS
 	if(speed)
 		wait = speed
 	if(istype(sheet_type, /obj/item/stack/sheet/mineral/diamond))


### PR DESCRIPTION
## What Does This PR Do
Changes thermite's burning duration to 20 SECONDS, up from 10 SECONDS.  Additionally converts code to seconds from deciseconds for readability purposes.

## Why It's Good For The Game
Aluminium, iron, oxygen. Thermite is an incredibly problematic chemical for its ease of creation, ease of application and duration in burning down reinforced walls. It makes the AI's defenses entirely optional, and is takes away heavily from items such as c4 and the Sonic Jackhammer which both cost telecrystals, and a large amount of materials/late game RND research respectively.

## Images of changes
https://i.imgur.com/9yqhwzv.gif

:cl:
tweak: Changes duration of thermite wall burning to 20 seconds.
/:cl:
