### PR TITLE
Light icon behavior tweaks and fixes

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -391,8 +391,8 @@
 			return
 
 	use_power = ACTIVE_POWER_USE
-	set_light(BR, PO, CO)
 	update_icon()
+	set_light(BR, PO, CO)
 	if(play_sound)
 		playsound(src, 'sound/machines/light_on.ogg', 60, TRUE)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -398,7 +398,6 @@
 
 /obj/machinery/light/proc/burnout()
 	status = LIGHT_BURNED
-	icon_state = "[base_state]-burned"
 
 	visible_message("<span class='boldwarning'>[src] burns out!</span>")
 	do_sparks(2, 1, src)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -302,7 +302,7 @@
 
 	if(status != LIGHT_OK || !on || !turning_on)
 		return
-	if(nightshift_enabled || emergency_mode || fire_mode)
+	if(nightshift_enabled || emergency_mode || fire_mode || turning_on)
 		underlays += emissive_appearance(icon, "[base_state]_emergency_lightmask")
 	else
 		underlays += emissive_appearance(icon, "[base_state]_lightmask")
@@ -391,8 +391,8 @@
 			return
 
 	use_power = ACTIVE_POWER_USE
-	update_icon()
 	set_light(BR, PO, CO)
+	update_icon()
 	if(play_sound)
 		playsound(src, 'sound/machines/light_on.ogg', 60, TRUE)
 
@@ -405,6 +405,7 @@
 
 	on = FALSE
 	set_light(0)
+	update_icon()
 
 // attempt to set the light's on/off status
 // will not switch on if broken/burned/empty
@@ -583,11 +584,11 @@
 		return
 	if(fire_mode)
 		set_light(nightshift_light_range, nightshift_light_power, bulb_emergency_colour)
-		update_icon(UPDATE_ICON_STATE | UPDATE_OVERLAYS)
+		update_icon()
 		return
 	emergency_mode = TRUE
 	set_light(3, 1.7, bulb_emergency_colour)
-	update_icon(UPDATE_ICON_STATE | UPDATE_OVERLAYS)
+	update_icon()
 	RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, .proc/update, override = TRUE)
 
 /obj/machinery/light/proc/emergency_lights_off(area/current_area, obj/machinery/power/apc/current_apc)
@@ -782,6 +783,7 @@
 	force = 2
 	throwforce = 5
 	w_class = WEIGHT_CLASS_TINY
+	blocks_emissive = FALSE
 	/// Light status (LIGHT_OK | LIGHT_BURNED | LIGHT_BROKEN)
 	var/status = LIGHT_OK
 	var/base_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the lights to use the less intense lightmask when they're in the process of turning on. They don't stick out as much as a result. `burnout()` also wasn't updating the whole icon properly.

The alternative is to make it tied to `light` instead. Code is cleaned up just in case, with `update_icon(UPDATE_ICON_STATE | UPDATE_OVERAYS)` being identical to `update_icon()`.

Being glass, the light bulb objects are not blockers anymore. Not too major by itself, but it's more objects that don't have to manage their emissive blocker.

## Why It's Good For The Game
Fixes #18549.

## Images of changes
https://user-images.githubusercontent.com/80771500/181016083-24babdb4-0896-45e6-b748-dfe3f0f25775.mp4

## Changelog
:cl:
fix: Lights in the process of turning on don't stick out as much in the dark
fix: Burned out lights do not glow
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
