### PR TITLE
Blob captured nuke displays its icon properly

### DIFF
--- a/code/game/gamemodes/blob/blobs/captured_nuke.dm
+++ b/code/game/gamemodes/blob/blobs/captured_nuke.dm
@@ -10,6 +10,7 @@
 	. = ..()
 	START_PROCESSING(SSobj, src)
 	N?.forceMove(src)
+	update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/blob/captured_nuke/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes sure the captured nuke updates its overlays when initialized.

## Why It's Good For The Game
Fixes #18580

## Images of changes
![Blob](https://user-images.githubusercontent.com/80771500/181028894-4ecfe51c-6e81-445c-a765-9f947a2772d4.PNG)

## Changelog
:cl:
fix: Blob captured nukes display properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
