### PR TITLE
Balances Xenobio Slimes for Stamina Combat

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -51,21 +51,14 @@
 /mob/living/carbon/attack_slime(mob/living/simple_animal/slime/M)
 	if(..()) //successful slime attack
 		if(M.powerlevel > 0)
-			var/stunprob = M.powerlevel * 7 + 10  // 17 at level 1, 80 at level 10
-			if(prob(stunprob))
-				M.powerlevel -= 3
-				if(M.powerlevel < 0)
-					M.powerlevel = 0
-
-				visible_message("<span class='danger'>[M] has shocked [src]!</span>", "<span class='userdanger'>[M] has shocked you!</span>")
-
-				do_sparks(5, TRUE, src)
-				var/power = (M.powerlevel + rand(0,3)) STATUS_EFFECT_CONSTANT
-				Stun(power)
-				Stuttering(power)
-				if(prob(stunprob) && M.powerlevel >= 8)
-					adjustFireLoss(M.powerlevel * rand(6,10))
-					updatehealth("slime attack")
+			do_sparks(5, TRUE, src)
+			adjustStaminaLoss(M.powerlevel * 5) //5-50 stamina damage, at starting power level 10 this means 50, 35, 20 on consecutive hits - stamina crit in 3 hits
+			KnockDown(M.powerlevel SECONDS)
+			Stuttering(M.powerlevel SECONDS)
+			visible_message("<span class='danger'>[M] has shocked [src]!</span>", "<span class='userdanger'>[M] has shocked you!</span>")
+			M.powerlevel -= 3
+			if(M.powerlevel < 0)
+				M.powerlevel = 0
 		return 1
 
 /mob/living/carbon/is_mouth_covered(head_only = FALSE, mask_only = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
- Slimes attacking people no longer has any RNG effects, including their random chance to deal extra burn damage,
- Slimes attacking people knocks them down instead of stunning,
- Slimes attacking people now deals stamina damage based on their power level (5-50, 3 hits to stamina crit from max power factoring in the power decreasing between hits).

These changes apply to carbon mobs. Also the code has been made simpler. Part of #18179 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
For how easily xenobio can mass produce them, slimes are insanely powerful. Their glomps can instantly stun you for easily more than enough time to be absolutely murdered, and it is all based on RNG. My approach makes them still very powerful (it's no instant stun, but you aren't likely to get away), but leaves room for a skilled player to defend themself. 

Also looks kind of cooler when they attack people and they hopelessly try to crawl away instead of just standing there immobilized.

## Changelog
:cl:
tweak: Xenobio slimes now deal stamina damage and cause knockdown instead of stuns and random extra burn damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
