### PR TITLE
Improves sleepy pen logging

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -110,8 +110,6 @@
 /obj/item/pen/sleepy
 	container_type = OPENCONTAINER
 	origin_tech = "engineering=4;syndicate=2"
-	var/reagent_amount = 100
-	var/starting_reagents = list("ketamine" = 100)
 
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
@@ -122,11 +120,14 @@
 		return
 	var/transfered = 0
 	var/contained = list()
+
 	for(var/R in reagents.reagent_list)
 		var/datum/reagent/reagent = R
 		contained += "[round(reagent.volume, 0.01)]u [reagent]"
+
 	if(reagents.total_volume && M.reagents)
 		transfered = reagents.trans_to(M, 50)
+
 	to_chat(user, "<span class='warning'>You sneakily stab [M] with the pen.</span>")
 	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered from pen containing [english_list(contained)].")
 	return TRUE
@@ -134,9 +135,8 @@
 
 /obj/item/pen/sleepy/Initialize(mapload)
 	. = ..()
-	create_reagents(reagent_amount)
-	for(var/key in starting_reagents)
-		reagents.add_reagent(key, starting_reagents[key])
+	create_reagents(100)
+	reagents.add_reagent("ketamine", 100)
 
 
 /*

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -119,10 +119,15 @@
 	if(!M.can_inject(user, TRUE))
 		return
 	var/transfered = 0
+	var/reagent_names = list()
+	for(var/R in O.reagents.reagent_list)
+		var/datum/reagent/reagent = R
+		reagent_names += "[reagent.volume]u [reagent]"
 	if(reagents.total_volume && M.reagents)
 		transfered = reagents.trans_to(M, 50)
 	to_chat(user, "<span class='warning'>You sneakily stab [M] with the pen.</span>")
-	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered.")
+	var/contained = english_list(injected)
+	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered from pen containing [english_list(reagent_names)].")
 	return TRUE
 
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -124,7 +124,7 @@
 	var/contained = list()
 	for(var/R in reagents.reagent_list)
 		var/datum/reagent/reagent = R
-		contained += "[reagent.volume]u [reagent]"
+		contained += "[round(reagent.volume, 0.01)]u [reagent]"
 	if(reagents.total_volume && M.reagents)
 		transfered = reagents.trans_to(M, 50)
 	to_chat(user, "<span class='warning'>You sneakily stab [M] with the pen.</span>")

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -110,6 +110,9 @@
 /obj/item/pen/sleepy
 	container_type = OPENCONTAINER
 	origin_tech = "engineering=4;syndicate=2"
+	var/transfer_amount = 50
+	var/reagent_amount = 100
+	var/starting_reagents = list("ketamine" = 100)
 
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
@@ -119,23 +122,28 @@
 	if(!M.can_inject(user, TRUE))
 		return
 	var/transfered = 0
-	var/reagent_names = list()
-	for(var/R in O.reagents.reagent_list)
+	var/contained = list()
+	for(var/R in reagents.reagent_list)
 		var/datum/reagent/reagent = R
-		reagent_names += "[reagent.volume]u [reagent]"
+		contained += "[reagent.volume]u [reagent]"
 	if(reagents.total_volume && M.reagents)
-		transfered = reagents.trans_to(M, 50)
+		transfered = reagents.trans_to(M, transfer_amount)
 	to_chat(user, "<span class='warning'>You sneakily stab [M] with the pen.</span>")
-	var/contained = english_list(injected)
-	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered from pen containing [english_list(reagent_names)].")
+	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered from pen containing [english_list(contained)].")
 	return TRUE
 
 
 /obj/item/pen/sleepy/Initialize(mapload)
 	. = ..()
-	create_reagents(100)
-	reagents.add_reagent("ketamine", 100)
+	create_reagents(reagent_amount)
+	for(var/key in starting_reagents)
+		reagents.add_reagent(key, starting_reagents[key])
 
+/obj/item/pen/sleepy/vv_edit_var(var_name, var_value)
+	. = ..()
+	switch(var_name)
+		if("reagent_amount")
+			reagents.maximum_volume = var_value
 
 /*
  * (Alan) Edaggers

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -110,7 +110,6 @@
 /obj/item/pen/sleepy
 	container_type = OPENCONTAINER
 	origin_tech = "engineering=4;syndicate=2"
-	var/transfer_amount = 50
 	var/reagent_amount = 100
 	var/starting_reagents = list("ketamine" = 100)
 
@@ -127,7 +126,7 @@
 		var/datum/reagent/reagent = R
 		contained += "[reagent.volume]u [reagent]"
 	if(reagents.total_volume && M.reagents)
-		transfered = reagents.trans_to(M, transfer_amount)
+		transfered = reagents.trans_to(M, 50)
 	to_chat(user, "<span class='warning'>You sneakily stab [M] with the pen.</span>")
 	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered from pen containing [english_list(contained)].")
 	return TRUE
@@ -139,11 +138,6 @@
 	for(var/key in starting_reagents)
 		reagents.add_reagent(key, starting_reagents[key])
 
-/obj/item/pen/sleepy/vv_edit_var(var_name, var_value)
-	. = ..()
-	switch(var_name)
-		if("reagent_amount")
-			reagents.maximum_volume = var_value
 
 /*
  * (Alan) Edaggers


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Improves the logging of the sleepy pen to show the reagents that were in the pen on injection.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sleepy pens are a nasty way to dump 50u of whatever into someone, and the logs don't clearly show what exactly was transferred. This seems like an oversight.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/89928798/181102890-e8af956c-c90b-4a28-9105-79ba90cd0981.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
