### PR TITLE
Balances explosions for stamina combat

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -240,7 +240,7 @@
 				limbs_amount = 4
 
 		if(EXPLODE_HEAVY)
-			var/stuntime = 5 SECONDS - (bomb_armor / 20) SECONDS //Between no stun and 5 seconds of stun depending on bomb armor
+			var/stuntime = 5 SECONDS - (bomb_armor / 2) //Between no stun and 5 seconds of stun depending on bomb armor
 			brute_loss = 60
 			burn_loss = 60
 			if(bomb_armor)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -240,6 +240,7 @@
 				limbs_amount = 4
 
 		if(EXPLODE_HEAVY)
+			var/stuntime = 5 SECONDS - (bomb_armor / 20) SECONDS //Between no stun and 5 seconds of stun depending on bomb armor
 			brute_loss = 60
 			burn_loss = 60
 			if(bomb_armor)
@@ -247,7 +248,8 @@
 				burn_loss = brute_loss				//Damage gets reduced from 120 to up to 60 combined brute+burn
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(30, 120)
-			Weaken(20 SECONDS - (bomb_armor * 1.6 / 10) SECONDS) 	//Between ~4 and ~20 seconds of knockdown depending on bomb armor
+			Weaken(stuntime)
+			KnockDown(stuntime * 3) //Up to 15 seconds of knockdown
 
 		if(EXPLODE_LIGHT)
 			brute_loss = 30
@@ -255,7 +257,7 @@
 				brute_loss = 15 * (2 - round(bomb_armor * 0.01, 0.05)) //Reduced from 30 to up to 15
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(15, 60)
-			Weaken(16 SECONDS - (bomb_armor * 1.6 / 10) SECONDS) //Between no knockdown to ~16 seconds depending on bomb armor
+			KnockDown(10 SECONDS - (bomb_armor / 10) SECONDS) //Between no knockdown to 10 seconds of knockdown depending on bomb armor
 			valid_limbs = list("l_hand", "l_foot", "r_hand", "r_foot")
 			limb_loss_chance = 25
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -257,7 +257,7 @@
 				brute_loss = 15 * (2 - round(bomb_armor * 0.01, 0.05)) //Reduced from 30 to up to 15
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(15, 60)
-			KnockDown(10 SECONDS - (bomb_armor / 10) SECONDS) //Between no knockdown to 10 seconds of knockdown depending on bomb armor
+			KnockDown(10 SECONDS - bomb_armor) //Between no knockdown to 10 seconds of knockdown depending on bomb armor
 			valid_limbs = list("l_hand", "l_foot", "r_hand", "r_foot")
 			limb_loss_chance = 25
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -2,7 +2,6 @@
 Contains most of the procs that are called when a mob is attacked by something
 
 bullet_act
-ex_act
 meteor_act
 emp_act
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -194,7 +194,6 @@
 /obj/item/projectile/bullet/frag12
 	name ="explosive slug"
 	damage = 15
-	weaken = 2 SECONDS
 	alwayslog = TRUE
 
 /obj/item/projectile/bullet/frag12/on_hit(atom/target, blocked = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
- Heavy explosion now stuns for up to 5 seconds depending on bomb armor, and knocks down for triple the duration.
- Light explosion now knocks down for up to 10 seconds depending on bomb armor.
- Frag-12 rounds no longer apply a direct stun on top of the effects of their explosion.

Part of #18179 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Long stuns feel pretty awful to play with, and we are moving away from them in favor of knockdowns or stamina where appropriate. 

Frag-12 rounds are one of the last (maybe the last?) instant stun projectiles available to the crew remaining in the game.

## Image of a Skrell Catching a Frag-12
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_RVkhqp9kS2](https://user-images.githubusercontent.com/107632879/181266885-a25ddcec-50a5-46ce-a114-25bcafe32a6d.gif)

## Changelog
:cl:
tweak: Explosion stuns have been reduced significantly. Check the PR for numbers. Frag-12 no longer stuns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
