### PR TITLE
Fixes Air Alarms Bluescreening Due to Windows being constructed in front of them

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -633,8 +633,6 @@
 	var/datum/gas_mixture/environment = location.return_air()
 	var/known_total = environment.oxygen + environment.nitrogen + environment.carbon_dioxide + environment.toxins
 	var/total = environment.total_moles()
-	if(total == 0)
-		return null
 
 	var/datum/tlv/cur_tlv
 	var/GET_PP = R_IDEAL_GAS_EQUATION*environment.temperature/environment.volume
@@ -645,24 +643,24 @@
 
 	cur_tlv = TLV["oxygen"]
 	var/oxygen_dangerlevel = cur_tlv.get_danger_level(environment.oxygen*GET_PP)
-	var/oxygen_percent = environment.oxygen / total * 100
+	var/oxygen_percent = total ? environment.oxygen / total * 100 : 0
 
 	cur_tlv = TLV["nitrogen"]
 	var/nitrogen_dangerlevel = cur_tlv.get_danger_level(environment.nitrogen*GET_PP)
-	var/nitrogen_percent = environment.nitrogen / total * 100
+	var/nitrogen_percent = total ? environment.nitrogen / total * 100 : 0
 
 	cur_tlv = TLV["carbon dioxide"]
 	var/co2_dangerlevel = cur_tlv.get_danger_level(environment.carbon_dioxide*GET_PP)
-	var/co2_percent = environment.carbon_dioxide / total * 100
+	var/co2_percent = total ? environment.carbon_dioxide / total * 100 : 0
 
 	cur_tlv = TLV["plasma"]
 	var/plasma_dangerlevel = cur_tlv.get_danger_level(environment.toxins*GET_PP)
-	var/plasma_percent = environment.toxins / total * 100
+	var/plasma_percent = total ? environment.toxins / total * 100 : 0
 
 	cur_tlv = TLV["other"]
 	var/other_moles = total - known_total
 	var/other_dangerlevel = cur_tlv.get_danger_level(other_moles*GET_PP)
-	var/other_percent = other_moles / total * 100
+	var/other_percent = total ? other_moles / total * 100 : 0
 
 	cur_tlv = TLV["temperature"]
 	var/temperature_dangerlevel = cur_tlv.get_danger_level(environment.temperature)


### PR DESCRIPTION
## What Does This PR Do
fixes #18517

Ensures that a very important list being passed to the air alarm is not null by adding in some ternary operators to check for mole total of return air alarm turf location.

## Why It's Good For The Game
While air alarms now will show a bunch of 0% values if a window is placed in front of it it, it won't bluescreen the TGUI now which is much much better.

## Changelog
:cl:
fix: Air alarms will no longer bluescreen when windows are constructed in front of them
/:cl: