### PR TITLE
Add a Testing header to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,9 @@
 ## Images of changes
 <!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
 
+## Testing
+<!-- How did you test the PR, if at all? -->
+
 ## Changelog
 :cl:
 add: Added new things


### PR DESCRIPTION
## What Does This PR Do
Adds a `## Testing` heading to the PR template

## Why It's Good For The Game
Makes people more conscious that they *should* test the changes, and also alerts reviewers in case the testing is inadequate for the change being done

## Images of changes
N/A

## Testing
N/A

## Changelog
N/A