### PR TITLE
[s]Stops thrown things finalizing twice after hitting something

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -109,10 +109,6 @@ SUBSYSTEM_DEF(throwing)
 
 		AM.Move(step, get_dir(AM, step))
 
-		if(!AM.throwing) // we hit something during our move
-			finalize(hit = TRUE)
-			return
-
 		dist_travelled++
 
 		if(dist_travelled > MAX_THROWING_DIST)


### PR DESCRIPTION
## What Does This PR Do
Things currently call `finalize` twice when they are thrown and hit something. This causes some wack behaviour in certain situations.
`throwing` only gets set in two spots in the entire code. When an item is thrown initially. And when it is done throwing, `finalize` does this.
So it doesn't make sense to call `finalize` again when it already was called.

## Why It's Good For The Game
Bug fix

## Testing
Throw items against another humanoid. Have them catch it. Throw it against a wall. Throw it against nothing.
Do this all in space as well.

## Changelog
:cl:
fix: Thrown objects now finalize only once. Stopping some weird behaviour from happening when you throw items in certain situations
/:cl: