### PR TITLE
Box, Meta and Delta: Unresctricted sides in medbay surgery airlocks

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -73798,6 +73798,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel/dark,
 /area/medical/surgery1)
 "dqQ" = (
@@ -82827,6 +82828,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel/dark,
 /area/medical/surgery2)
 "dLQ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37358,6 +37358,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkbluefull"
@@ -42468,6 +42469,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkbluefull"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -47188,6 +47188,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -47197,6 +47198,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Observation Room"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -53286,6 +53288,9 @@
 /obj/machinery/holosign/surgery{
 	id = "surgery1"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -53405,6 +53410,9 @@
 	},
 /obj/machinery/holosign/surgery{
 	id = "surgery2"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -47188,7 +47188,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -47198,7 +47197,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Observation Room"
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
Added unresctricted sides in surgery airlocks for people that might be stuck inside the surgery room or even to get out of there faster.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR add some unresctriced sides in surgery airlocks.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Thoses sides can save a lot of time and make someone that is stuck inside the surgery rooms get out of there. Is not cool mid surgery your doctor run away from you and don't ever return. 

And I know that this can maybe make the prisioners escape, but security officers are there to don't allow the prisioner to escape.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://user-images.githubusercontent.com/62888630/181657203-5d60b842-5af5-4331-add6-f6de280e5d84.png)
![image](https://user-images.githubusercontent.com/62888630/181784894-f98fc5af-8af1-42e4-a7b9-4777cca5da41.png)
![image](https://user-images.githubusercontent.com/62888630/181784939-51a8ac67-6dd1-4dc2-adb7-da08bc000743.png)



## Testing
<!-- How did you test the PR, if at all? -->
Map was tested in my local host server. 

## Changelog
:cl:
tweak: Added unresctricted sides in surgery airlocks in the maps. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
