### PR TITLE
`handle_atom_del` subscription and its application to slimes

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1055,10 +1055,8 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 // You can use the `key` variable to be able to unsubscribe later
 /atom/proc/subscribe_atom_del(atom/movable/A, key)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	if(isnull(A))  // should this maybe runtime instead?..
-		return
 	if(!istype(A))
-		CRASH("subscribe_atom_del called with non-movable atom ([A] - [A.type]) as an argument. This has no effect, and is likely a bug")
+		CRASH("subscribe_atom_del called with non-movable atom ([A] - [A?.type]) as an argument. This has no effect, and is likely a bug")
 	var/my_uid = UID()
 	LAZYINITLIST(A.del_subscribers)
 	LAZYINITLIST(A.del_subscribers[my_uid])

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1059,14 +1059,15 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		return
 	if(!istype(A))
 		CRASH("subscribe_atom_del called with non-movable atom ([A] - [A.type]) as an argument. This has no effect, and is likely a bug")
+	var/my_uid = UID()
 	LAZYINITLIST(A.del_subscribers)
-	LAZYINITLIST(A.del_subscribers[src])
-	A.del_subscribers[src][key] = TRUE
+	LAZYINITLIST(A.del_subscribers[my_uid])
+	A.del_subscribers[my_uid][key] = TRUE
 
 // The reverse of `subscribe_atom_del` above
 /atom/proc/unsubscribe_atom_del(atom/movable/A, key)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	A?.del_subscribers?[src]?.Remove(key)
+	A?.del_subscribers?[UID()]?.Remove(key)
 
 /atom/proc/atom_say(message)
 	if(!message)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1055,8 +1055,12 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 // You can use the `key` variable to be able to unsubscribe later
 /atom/proc/subscribe_atom_del(atom/movable/A, key)
 	SHOULD_NOT_OVERRIDE(TRUE)
+	if(isnull(A))
+		return  // on the second thought, being able to pass in null makes for a nicer API
 	if(!istype(A))
 		CRASH("subscribe_atom_del called with non-movable atom ([A] - [A?.type]) as an argument. This has no effect, and is likely a bug")
+	if(QDELETED(A))
+		return
 	var/my_uid = UID()
 	LAZYINITLIST(A.del_subscribers)
 	LAZYINITLIST(A.del_subscribers[my_uid])

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -35,6 +35,10 @@
 	var/blocks_emissive = FALSE
 	///Internal holder for emissive blocker object, do not use directly use blocks_emissive
 	var/atom/movable/emissive_blocker/em_block
+	/// List of extra things to call `handle_atom_del` on when this gets destroyed.
+	/// Internal var; don't mess with outside of atom-level procs.
+	/// Is an nested associative list: {atom1 => {key_a=1, key_b=1}, atom2 => {}}
+	var/list/list/del_subscribers = null
 
 /atom/movable/attempt_init(loc, ...)
 	var/turf/T = get_turf(src)
@@ -69,6 +73,11 @@
 	. = ..()
 	if(loc)
 		loc.handle_atom_del(src)
+	if(length(del_subscribers))
+		for(var/atom/sub in del_subscribers)
+			if(length(del_subscribers[sub])) // a check that the subscriber is still actually subscribed.
+				sub.handle_atom_del(src)
+		del_subscribers.Cut()
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
 	LAZYCLEARLIST(client_mobs_in_contents)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -76,7 +76,7 @@
 	if(length(del_subscribers))
 		for(var/sub_uid in del_subscribers)
 			if(length(del_subscribers[sub_uid])) // a check that the subscriber is still actually subscribed.
-				var/atom/sub_atom = locate(sub_uid)
+				var/atom/sub_atom = locateUID(sub_uid)
 				sub_atom?.handle_atom_del(src)
 		del_subscribers.Cut()
 	for(var/atom/movable/AM in contents)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -36,8 +36,8 @@
 	///Internal holder for emissive blocker object, do not use directly use blocks_emissive
 	var/atom/movable/emissive_blocker/em_block
 	/// List of extra things to call `handle_atom_del` on when this gets destroyed.
-	/// Internal var; don't mess with outside of atom-level procs.
-	/// Is an nested associative list: {atom1 => {key_a=1, key_b=1}, atom2 => {}}
+	/// Internal var; don't mess with it outside of atom-level procs.
+	/// Is an nested associative list: {atom1_UID => {key_a=1, key_b=1}, atom2_UID => {}}
 	var/list/list/del_subscribers = null
 
 /atom/movable/attempt_init(loc, ...)
@@ -74,9 +74,10 @@
 	if(loc)
 		loc.handle_atom_del(src)
 	if(length(del_subscribers))
-		for(var/atom/sub in del_subscribers)
-			if(length(del_subscribers[sub])) // a check that the subscriber is still actually subscribed.
-				sub.handle_atom_del(src)
+		for(var/sub_uid in del_subscribers)
+			if(length(del_subscribers[sub_uid])) // a check that the subscriber is still actually subscribed.
+				var/atom/sub_atom = locate(sub_uid)
+				sub_atom?.handle_atom_del(src)
 		del_subscribers.Cut()
 	for(var/atom/movable/AM in contents)
 		qdel(AM)

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -137,8 +137,8 @@
 	owner.vomit(20)
 
 	var/mob/living/simple_animal/slime/Slime = new(get_turf(owner), "grey")
-	Slime.Friends = list(owner)
-	Slime.Leader = owner
+	Slime.set_Friend(owner)
+	Slime.set_Leader(owner)
 
 /obj/item/organ/internal/heart/gland/mindshock
 	origin_tech = "materials=4;biotech=4;magnets=6;abductor=3"

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -52,6 +52,7 @@
 	if(A == storedpda)
 		storedpda = null
 		update_icon()
+	..()
 
 /obj/machinery/pdapainter/attackby(obj/item/I, mob/user, params)
 	if(default_unfasten_wrench(user, I))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -553,6 +553,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	if(A == occupant)
 		occupant = null
 		countdown.stop()
+	..()
 
 /obj/machinery/clonepod/deconstruct(disassembled = TRUE)
 	if(occupant)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -189,6 +189,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	if(A == note)
 		note = null
 		update_icon()
+	..()
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
 	if(!issilicon(usr))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -607,6 +607,7 @@
 		setDir(dir_in)
 	if(A in trackers)
 		trackers -= A
+	..()
 
 /obj/mecha/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -60,6 +60,7 @@
 	if(A == has_extinguisher)
 		has_extinguisher = null
 		update_icon(UPDATE_ICON_STATE)
+	..()
 
 /obj/structure/extinguisher_cabinet/attackby(obj/item/O, mob/user, params)
 	if(isrobot(user) || isalien(user))

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -54,13 +54,13 @@
 			break
 
 		if(Target.health <= -70 || Target.stat == DEAD)
-			Target = null
+			set_Target(null)
 			AIproc = FALSE
 			break
 
 		if(Target)
 			if(locate(/mob/living/simple_animal/slime) in Target.buckled_mobs)
-				Target = null
+				set_Target(null)
 				AIproc = FALSE
 				break
 			if(!AIproc)
@@ -98,7 +98,7 @@
 				// Bug of the month candidate: slimes were attempting to move to target only if it was directly next to them, which caused them to target things, but not approach them
 					step_to(src, Target)
 			else
-				Target = null
+				set_Target(null)
 				AIproc = FALSE
 				break
 
@@ -291,7 +291,7 @@
 			--target_patience
 			if (target_patience <= 0 || SStun > world.time || Discipline || attacked || docile) // Tired of chasing or something draws out attention
 				target_patience = 0
-				Target = null
+				set_Target(null)
 
 		if(AIproc && SStun > world.time)
 			return
@@ -340,16 +340,16 @@
 
 				if(targets.len > 0)
 					if(attacked || rabid || hungry == 2)
-						Target = targets[1] // I am attacked and am fighting back or so hungry I don't even care
+						set_Target(targets[1]) // I am attacked and am fighting back or so hungry I don't even care
 					else
 						for(var/mob/living/carbon/C in targets)
 							if(!Discipline && prob(5))
 								if(ishuman(C) || isalienadult(C))
-									Target = C
+									set_Target(C)
 									break
 
 							if(islarva(C) || issmall(C))
-								Target = C
+								set_Target(C)
 								break
 
 			if (Target)
@@ -423,13 +423,13 @@
 					if(Leader == who) // Already following him
 						to_say = pick("Yes...", "Lead...", "Follow...")
 					else if(Friends[who] > Friends[Leader]) // VIVA
-						Leader = who
+						set_Leader(who)
 						to_say = "Yes... I follow [who]..."
 					else
 						to_say = "No... I follow [Leader]..."
 				else
 					if(Friends[who] >= SLIME_FRIENDSHIP_FOLLOW)
-						Leader = who
+						set_Leader(who)
 						to_say = "I follow..."
 					else // Not friendly enough
 						to_say = pick("No...", "I no follow...")
@@ -437,7 +437,7 @@
 				if(buckled) // We are asked to stop feeding
 					if (Friends[who] >= SLIME_FRIENDSHIP_STOPEAT)
 						Feedstop()
-						Target = null
+						set_Target(null)
 						if (Friends[who] < SLIME_FRIENDSHIP_STOPEAT_NOANGRY)
 							--Friends[who]
 							to_say = "Grrr..." // I'm angry but I do it
@@ -445,7 +445,7 @@
 							to_say = "Fine..."
 				else if(Target) // We are asked to stop chasing
 					if(Friends[who] >= SLIME_FRIENDSHIP_STOPCHASE)
-						Target = null
+						set_Target(null)
 						if(Friends[who] < SLIME_FRIENDSHIP_STOPCHASE_NOANGRY)
 							--Friends[who]
 							to_say = "Grrr..." // I'm angry but I do it
@@ -454,10 +454,10 @@
 				else if(Leader) // We are asked to stop following
 					if(Leader == who)
 						to_say = "Yes... I stay..."
-						Leader = null
+						set_Leader(null)
 					else
 						if(Friends[who] > Friends[Leader])
-							Leader = null
+							set_Leader(null)
 							to_say = "Yes... I stop..."
 						else
 							to_say = "No... keep follow..."
@@ -479,7 +479,7 @@
 						to_say = "No... won't stay..."
 			else if(findtext(phrase, "attack"))
 				if(rabid && prob(20))
-					Target = who
+					set_Target(who)
 					AIprocess() //Wake up the slime's Target AI, needed otherwise this doesn't work
 					to_say = "ATTACK!?!?"
 				else if(Friends[who] >= SLIME_FRIENDSHIP_ATTACK)
@@ -489,7 +489,7 @@
 								to_say = "NO... [L] slime friend..."
 								--Friends[who] //Don't ask a slime to attack its friend
 							else if(!Friends[L] || Friends[L] < 1)
-								Target = L
+								set_Target(L)
 								AIprocess()//Wake up the slime's Target AI, needed otherwise this doesn't work
 								to_say = "Ok... I attack [Target]..."
 							else

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -173,10 +173,8 @@
 			if(!rabid && !attacked)
 				if(M.LAssailant && M.LAssailant != M)
 					if(prob(50))
-						if(!(M.LAssailant in Friends))
-							Friends[M.LAssailant] = 1
-						else
-							++Friends[M.LAssailant]
+						set_Friend(M.LAssailant)
+						Friends[M.LAssailant] += 1
 		else
 			to_chat(src, "<i>This subject does not have a strong enough life energy anymore...</i>")
 

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -188,7 +188,9 @@
 				M.powerlevel = new_powerlevel
 				if(i != 1)
 					step_away(M,src)
-				M.Friends = Friends.Copy()
+				for(var/friend in Friends)
+					M.set_Friend(friend)
+					M.Friends[friend] = Friends[friend]
 				babies += M
 				M.mutation_chance = clamp(mutation_chance+(rand(5,-5)),0,100)
 				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -521,9 +521,6 @@
 		return
 	..()
 
-//these setters below handle graceful nulling of slime's vars for GC purposes.
-// TODO: this doc is bad
-//The API is robust, but the code inside is extremely fragile - please handle with care.
 /mob/living/simple_animal/slime/proc/set_Leader(mob/living/leader)
 	unsubscribe_atom_del(Leader, "Leader")
 	subscribe_atom_del(leader, "Leader")
@@ -539,29 +536,3 @@
 	subscribe_atom_del(friend, "Friends")
 	if(!(friend in Friends))
 		Friends[friend] = 0
-
-// /mob/living/simple_animal/slime/proc/slime_start_tracking(/mob/living/who)
-// 	if((who == Leader) || (who == Target) || (who in Friends))
-// 		return  // already tracking
-// 	RegisterSignal(who, COMSIG_PARENT_QDELETING, .proc/on_tracked_qdel)
-
-// /mob/living/simple_animal/slime/proc/slime_maybe_stop_tracking(/mob/living/who)
-// 	var/occurences = 0
-// 	if(who == Leader)
-// 		occurences += 1
-// 	if(who == Target)
-// 		occurences += 1
-// 	if(who in Friends)
-// 		occurences += 1
-// 	// only stop tracking if no references left
-// 	UnregisterSignal(who, COMSIG_PARENT_QDELETING)
-
-// /mob/living/simple_animal/slime/proc/on_tracked_qdel(/mob/living/who)
-// 	if(who == Leader)
-// 		Leader = null
-// 	if(who == Target)
-// 		Target = null
-// 	if(who in Friends)
-// 		Friends -= who
-
-// end gc handling procs

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -102,8 +102,8 @@
 	for(var/A in actions)
 		var/datum/action/AC = A
 		AC.Remove(src)
-	Target = null
-	Leader = null
+	set_Target(null)
+	set_Leader(null)
 	Friends.Cut()
 	speech_buffer.Cut()
 	return ..()
@@ -439,7 +439,7 @@
 	var/water_damage = rand(10, 15) * volume
 	adjustBruteLoss(water_damage)
 	if(!client && Target && volume >= 3) // Like cats
-		Target = null
+		set_Target(null)
 		++Discipline
 
 /mob/living/simple_animal/slime/examine(mob/user)
@@ -485,7 +485,7 @@
 				attacked = 0
 
 	if(Target)
-		Target = null
+		set_Target(null)
 	if(buckled)
 		Feedstop(silent = TRUE) //we unbuckle the slime from the mob it latched onto.
 
@@ -523,12 +523,14 @@
 
 /mob/living/simple_animal/slime/proc/set_Leader(mob/living/leader)
 	unsubscribe_atom_del(Leader, "Leader")
-	subscribe_atom_del(leader, "Leader")
+	if(leader)
+		subscribe_atom_del(leader, "Leader")
 	Leader = leader
 
 /mob/living/simple_animal/slime/proc/set_Target(mob/living/target)
 	unsubscribe_atom_del(Target, "Target")
-	subscribe_atom_del(target, "Target")
+	if(target)
+		subscribe_atom_del(target, "Target")
 	Target = target
 
 /// Adds the mob to the Friends list. DOES NOT increase friendliness.

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -127,6 +127,7 @@
 	if(A == beaker)
 		beaker = null
 		update_icon(UPDATE_ICON_STATE)
+	..()
 
 /obj/machinery/reagentgrinder/update_icon_state()
 	if(beaker)


### PR DESCRIPTION
## What Does This PR Do
Partially (but not fully) addresses #18611 

Expands `handle_atom_del` functionality to be called on qdel not only of the atoms in your `.contents` but also for any arbitrary one you might be interested in and hold a ref in your vars

Sample API usage:
```dm
/obj/some/thing
  var/obj/foo/tracked_foo = null // something we care about

/obj/some/thing/proc/track_foo(obj/foo/F)
  tracked_foo = F
  subscribe_atom_del(F, "foo")  // remember to release the ref when it gets qdel'd

/obj/some/thing/proc/stop_tracking_foo()
  tracked_foo = null
  unsubscribe_atom_del(tracked_foo, "foo") // we don't care about it anymore

/obj/some/thing/handle_atom_del(atom/A)
  if(tracked_foo == A)
    tracked_foo = null  // release the ref
  ..()
```

Applies this new framework to xenobio slimes as a proof of concept.

## Why It's Good For The Game
I tried to fix slimes gc issues by doing what i did in my couple last PRs - that is, `RegisterSignal(target COMSIG_PARENT_QDELETING, .proc/on_target_delete)`, however that turned out to be unworkable

<details> <summary>Here's why exactly</summary>
To be specific, here are relevant slime vars:
```dm
/mob/living/simple_animal/slime
	var/mob/living/Target = null // AI variable - tells the slime to hunt this down
	varmob/living/Leader = null // AI variable - tells the slime to follow this person
	var/list/Friends = list() // A list of friends; they are not considered targets for feeding; passed down after splitting
```

It's fairly easy to wrap their modification into a wrapper (or just do those shenanigans in-line without a dedicated proc, but for the sake of illustration), like this:
```dm
/mob/living/simple_animal/slime/proc/set_Target(mob/living/new_target)
  src.Target = new_target
  RegisterSignal(new_target, COMSIG_PARENT_QDELETING, .proc/on_target_delete)

/mob/living/simple_animal/slime/proc/on_target_delete(atom/target)
  src.Target = null
```

However, Target is not the only var that can hold references, so let's add another handler for the Leader:
```dm
/mob/living/simple_animal/slime/proc/set_Leader(mob/living/new_leader)
  src.Leader = new_leader
  RegisterSignal(new_leader, COMSIG_PARENT_QDELETING, .proc/on_leader_delete)

/mob/living/simple_animal/slime/proc/on_target_delete(atom/target)
  src.Leader = null
```

Except that runtimes, because you cannot register more than one signal handler for each (atom, signal) pair - you can only overwrite old ones.
But surely, that is surmountable? Just merge the on_delete procs into one! And indeed it sorta works:
```dm
/mob/living/simple_animal/slime/proc/set_Target(mob/living/new_target)
  src.Target = new_target
  RegisterSignal(new_target, COMSIG_PARENT_QDELETING, .proc/on_thing_delete, override=TRUE)

/mob/living/simple_animal/slime/proc/set_Leader(mob/living/new_leader)
  src.Leader = new_leader
  RegisterSignal(new_leader, COMSIG_PARENT_QDELETING, .proc/on_thing_delete, override=TRUE)

/mob/living/simple_animal/slime/proc/on_thing_delete(atom/thing)
  if(thing==src.Leader)  src.Leader = null
  if(thing==src.Target)  src.Target = null
```

Except the `override=TRUE` is kinda crude. Maybe a better idea is something like
```dm
/mob/living/simple_animal/slime/proc/set_Target(mob/living/new_target)
  maybe_start_tracking(new_target) // this MUST be before the assignment line below
  Target = new_target

/mob/living/simple_animal/slime/proc/maybe_start_tracking(atom/thing)
  if((thing == Leader) || (thing == Target) || (thing in Friends))
    return // already tracking
  RegisterSignal(thing, COMSIG_PARENT_QDELETING, .proc/on_thing_delete)
```

Well, that's kinda brittle but it works.
Oh, but we probably want to un-register from things we are no longer interested in, now how exactly do we do that?..

```dm
/mob/living/simple_animal/slime/proc/set_Target(mob/living/new_target)
  var/old_target = Target
  Target = null
  maybe_stop_tracking(old_target ) // this MUST be after `Target = null`
  maybe_start_tracking(new_target) // this MUST be before the assignment line below
  Target = new_target

/mob/living/simple_animal/slime/proc/maybe_stop_tracking(atom/thing)
  var/refcount = 0
  if(thing == Leader)
    refcount += 1
  if(thing == Target)
    refcount += 1
  if(thing in Friends)
    refcount += 1
  if(refcount == 0)
    UnregisterSignal(thing, COMSIG_PARENT_QDELETING)
```

That sure sounds like fun...

But most crucially - this whole thingymajingy absolutely does not play well with inheritance. Like, how do you integrate the same sort of fix for the 
```dm
/mob/living/simple_animal
  var/mob/living/carbon/human/master_commander = null //holding var for determining who own/controls a sentient simple animal (for sentience potions).
```

into the system? Like.. you cannot...
</details>

So i reasoned it's better to solve the issue at the framework level, and apply it to the slimes as a proof of concept that it works.

## For reviewers
There are three parts to this PR:
1) code/game/atoms.dm + code/game/atoms_movable.dm , which create the framework
2) mob/living/animal/slime/*.dm, which applies that to the slimes and
3) random occurences of `handle_atom_del` that used to not call parent, which became an SDMM error now.

## Testing
Feed slime plasma ; atomProcCall set_Leader with a mob as an argument
Feed another slime plasma ; feed it monkeys, wait for it to split
VV the slimes, both the originals and the newly created - see that they have me in the Friends list.
gib self

Observe Leader and Friends being properly cleaned up
Observe no slime-releated GC issues; more specifically:
```
[2022-07-29T22:43:37] Starting up. Round ID is NULL
[2022-07-29T22:43:37] -------------------------
[2022-07-29T22:52:37] Beginning search for references to a /mob/living/carbon/human/tajaran.
[2022-07-29T22:52:37] Finished searching globals
[2022-07-29T22:54:22] Finished searching atoms
[2022-07-29T22:54:31] Found /mob/living/carbon/human/tajaran [0x3000006] in /datum/mind's [0x21014985] current var. World -> /datum/mind
[2022-07-29T22:54:34] Finished searching datums
[2022-07-29T22:54:34] Finished searching clients
[2022-07-29T22:54:34] Completed search for references to a /mob/living/carbon/human/tajaran.
[2022-07-29T22:54:34] GC: -- [0x2100000d] | /mob/living/carbon/human/tajaran was unable to be GC'd --
[2022-07-29T22:58:20] Beginning search for references to a /mob/living/carbon/human/skrell.
[2022-07-29T22:58:20] Finished searching globals
[2022-07-29T23:00:08] Finished searching atoms
[2022-07-29T23:00:21] Finished searching datums
[2022-07-29T23:00:21] Finished searching clients
[2022-07-29T23:00:21] Completed search for references to a /mob/living/carbon/human/skrell.
[2022-07-29T23:00:21] GC: -- [0x2100000d] | /mob/living/carbon/human/skrell was unable to be GC'd --
```


## Changelog
Not player-facing