### PR TITLE
Cult desc changes

### DIFF
--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -339,7 +339,7 @@
 		button_icon_state = "veiling"
 	if(charges <= 0)
 		qdel(src)
-	desc = (revealing? "Reveals" : "Conceals")+ " nearby cult structures, airlocks, and runes."
+	desc = "[revealing ? "Reveals" : "Conceals"] nearby cult structures, airlocks, and runes."
 	desc += "<br><b><u>Has [charges] use\s remaining</u></b>."
 	UpdateButtonIcon()
 

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -144,7 +144,7 @@
 
 /datum/action/innate/cult/blood_spell/stun
 	name = "Stun"
-	desc = "Empowers your hand to stun and mute a victim on contact."
+	desc = "Will knock down and mute a victim on contact. Strike them with a cult blade to complete the invocation, stunning them and extending the mute."
 	button_icon_state = "stun"
 	magic_path = /obj/item/melee/blood_magic/stun
 	health_cost = 10
@@ -158,7 +158,7 @@
 
 /datum/action/innate/cult/blood_spell/emp
 	name = "Electromagnetic Pulse"
-	desc = "Channel an electromagnetic pulse inside your body, then release it, affecting nearby non-cultists. <b>The pulse will still affect you.</b>"
+	desc = "Releases an Electromagnetic Pulse, affecting nearby non-cultists. <b>The pulse will still affect you.</b>"
 	button_icon_state = "emp"
 	health_cost = 10
 	invocation = "Ta'gh fara'qha fel d'amar det!"
@@ -235,7 +235,7 @@
 
 /datum/action/innate/cult/blood_spell/equipment
 	name = "Summon Equipment"
-	desc = "Allows you to empower your hand to summon combat gear onto a cultist you touch, including cult armor, a cult bola, and a cult sword."
+	desc = "Empowers your hand to summon combat gear onto a cultist you touch, including cult armor (if not wearing a jacket), a cult bola, and a cult sword."
 	button_icon_state = "equip"
 	magic_path = /obj/item/melee/blood_magic/armor
 
@@ -339,7 +339,7 @@
 		button_icon_state = "veiling"
 	if(charges <= 0)
 		qdel(src)
-	desc = base_desc
+	desc = (revealing? "Reveals" : "Conceals")+ " nearby cult structures, airlocks, and runes."
 	desc += "<br><b><u>Has [charges] use\s remaining</u></b>."
 	UpdateButtonIcon()
 
@@ -424,7 +424,7 @@
 //stun
 /obj/item/melee/blood_magic/stun
 	name = "Stunning Aura"
-	desc = "Will stun and mute a victim on contact."
+	desc = "Will knock down and mute a victim on contact. Strike them with a cult blade to complete the invocation, stunning them and extending the mute."
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -235,7 +235,7 @@
 
 /datum/action/innate/cult/blood_spell/equipment
 	name = "Summon Equipment"
-	desc = "Empowers your hand to summon combat gear onto a cultist you touch, including cult armor (if not wearing a jacket), a cult bola, and a cult sword."
+	desc = "Empowers your hand to summon combat gear onto a cultist you touch, including cult armor into open slots, a cult bola, and a cult sword."
 	button_icon_state = "equip"
 	magic_path = /obj/item/melee/blood_magic/armor
 

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -235,7 +235,7 @@
 
 /datum/action/innate/cult/blood_spell/equipment
 	name = "Summon Equipment"
-	desc = "Empowers your hand to summon combat gear onto a cultist you touch, including cult armor into open slots, a cult bola, and a cult sword."
+	desc = "Empowers your hand to summon combat gear onto a cultist you touch, including cult armor (if not wearing a jacket), a cult bola, and a cult sword."
 	button_icon_state = "equip"
 	magic_path = /obj/item/melee/blood_magic/armor
 
@@ -339,7 +339,7 @@
 		button_icon_state = "veiling"
 	if(charges <= 0)
 		qdel(src)
-	desc = "[revealing ? "Reveals" : "Conceals"] nearby cult structures, airlocks, and runes."
+	desc = (revealing? "Reveals" : "Conceals")+ " nearby cult structures, airlocks, and runes."
 	desc += "<br><b><u>Has [charges] use\s remaining</u></b>."
 	UpdateButtonIcon()
 


### PR DESCRIPTION
## What Does This PR Do
Changes cultist spell descriptions to be more helpful. Stun hand will actually tell you to stab now, EMP won't use the word "channel", which typically implies a delay instead of instantly going off, and conceal presence will now switch between revealing and concealing in its description after the first use.

## Why It's Good For The Game
This should help newer players, or anybody who reads the spell descriptions, so they can understand what their spells do. Especially relevant with the stun hand change.

## Changelog
:cl: Iwanabeu
tweak: Changes Cultist spell descriptions to be more helpful.
/:cl:

