### PR TITLE
You only die once now if you have an explosive/dust implant

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -48,8 +48,8 @@
 		// Whew! Good thing I'm indestructible! (or already dead)
 		return FALSE
 
-	..()
 	set_stat(DEAD)
+	..()
 
 	timeofdeath = world.time
 	create_log(ATTACK_LOG, "died[gibbed ? " (Gibbed)": ""]")


### PR DESCRIPTION
## What Does This PR Do
Puts the stat on DEAD before sending the COMSIG_MOB_DEATH signal. Fixing dying twice due to explosive implants or such.

The signal being send before the stat was set led to the implanter gibbing the user. Which made him die again. This was possible since his stat was not set to `DEAD`.
This caused the mob to be added twice to the `dead_mob_list`.

This caused a GC issue where the mob wasn't removed from the `dead_mob_list`. Which also caused a fair few runtimes all across the game. Including emotes checking if they could send it to dead mobs from the list. Which had a null value.

## Why It's Good For The Game
Bug fix good yo

## Testing
Implant self with the explosive implanter, the small one will do `/obj/item/implanter/explosive`.
Die of something. I used the chain of command to get my char into crit.

![image](https://user-images.githubusercontent.com/15887760/181846682-2d1ca40b-0bb5-4c73-a4b5-99ef7fd295a3.png)
This breakpoint should be called twice by the human mob. But only once does it go past the check.

## Changelog
N/A
