### PR TITLE
Improves unexpected RegisterSignal override logging

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -189,7 +189,7 @@
 	for(var/sig_type in sig_types)
 		if(!override && procs[target][sig_type])
 			stack_trace("RegisterSignal overrode a signal without having 'override = TRUE' set.\n \
-						src: [src], signal type: [sig_type], target: [target], proc: [proctype].")
+						src: [src], signal type: [sig_type], target: [target], new proc: [proctype], previous proc: [procs[target][sig_type]].")
 
 		procs[target][sig_type] = proctype
 


### PR DESCRIPTION
## What Does This PR Do
Adds the previous proc to call to the unexpected RegisterSignal override logging. Currently, it just says what the new value is. Which isn't that useful since you (should) already have the stacktrace.

## Why It's Good For The Game
Makes debugging issues surrounding this easier.

## Testing
I've not tested this due to the type of change. But you could test it by calling register signal twice in a row.

## Changelog
N/A