### PR TITLE
Fix double-zombiefying bug

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -96,7 +96,7 @@
 		dna.species.handle_death(gibbed, src)
 
 	if(SSticker && SSticker.mode)
-		SSblackbox.ReportDeath(src)
+		INVOKE_ASYNC(SSblackbox, /datum/controller/subsystem/blackbox/proc/ReportDeath, src)
 
 /mob/living/carbon/human/update_revive(updating)
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Fixes #17691 by making death() proc not sleep [when applied to humans]

## Why It's Good For The Game
bugfix

## Testing
spawn two dummies, give one SST outfit, kill the other;
spawn 10 blobspores on the tile with the corpse
![20220730-200747-dreamseeker](https://user-images.githubusercontent.com/7831163/181994667-c354216e-a682-42ba-b460-4eda1d37e7fc.png)
observe the corpse rise up; count all the spores - see 9 spores one zombie;
kill the zombie, then kill the spores, observe no weird teleportations going on.
check the `death` table, see the death be correctly recorded

## Changelog
:cl:
fix: Blob zombies should not be randomly teleporting after being killed anymore
/:cl:
