### PR TITLE
Adds Weekend at Bernie's'ing people

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -125,13 +125,13 @@
 
 
 	var/appears_dead = FALSE
-	var/just_sleeping = FALSE
+	var/just_sleeping = FALSE //We don't appear as dead upon casual examination, just sleeping
 
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		appears_dead = TRUE
 
 		var/obj/item/clothing/glasses/E = get_item_by_slot(slot_glasses)
-		var/are_we_in_weekend_at_bernies = E?.tint && buckled && istype(buckled, /obj/structure/chair/wheelchair)
+		var/are_we_in_weekend_at_bernies = E?.tint && istype(buckled, /obj/structure/chair/wheelchair) //Are we in a wheelchair with our eyes obscured?
 
 		if(isliving(user) && are_we_in_weekend_at_bernies)
 			just_sleeping = TRUE

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -128,13 +128,13 @@
 	var/just_sleeping = FALSE //We don't appear as dead upon casual examination, just sleeping
 
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
-		appears_dead = TRUE
-
 		var/obj/item/clothing/glasses/E = get_item_by_slot(slot_glasses)
 		var/are_we_in_weekend_at_bernies = E?.tint && istype(buckled, /obj/structure/chair/wheelchair) //Are we in a wheelchair with our eyes obscured?
 
 		if(isliving(user) && are_we_in_weekend_at_bernies)
 			just_sleeping = TRUE
+		else
+			appears_dead = TRUE
 
 		if(suiciding)
 			msg += "<span class='warning'>[p_they(TRUE)] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>\n"
@@ -277,11 +277,8 @@
 
 	msg += "</span>"
 
-	if(just_sleeping)
-		msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
-
 	if(!appears_dead)
-		if(stat == UNCONSCIOUS)
+		if(stat == UNCONSCIOUS || just_sleeping)
 			msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
 		else if(getBrainLoss() >= 60)
 			msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -125,24 +125,34 @@
 
 
 	var/appears_dead = FALSE
+	var/just_sleeping = FALSE
+
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		appears_dead = TRUE
+
+		var/obj/item/clothing/glasses/E = get_item_by_slot(slot_glasses)
+		var/are_we_in_weekend_at_bernies = E?.tint && buckled && istype(buckled, /obj/structure/chair/wheelchair)
+
+		if(isliving(user) && are_we_in_weekend_at_bernies)
+			just_sleeping = TRUE
+
 		if(suiciding)
 			msg += "<span class='warning'>[p_they(TRUE)] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>\n"
-		msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive; there are no signs of life"
-		if(get_int_organ(/obj/item/organ/internal/brain))
-			if(!key)
-				var/foundghost = FALSE
-				if(mind)
-					for(var/mob/dead/observer/G in GLOB.player_list)
-						if(G.mind == mind)
-							foundghost = TRUE
-							if(G.can_reenter_corpse == 0)
-								foundghost = FALSE
-							break
-				if(!foundghost)
-					msg += " and [p_their()] soul has departed"
-		msg += "...</span>\n"
+		if(!just_sleeping)
+			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive; there are no signs of life"
+			if(get_int_organ(/obj/item/organ/internal/brain))
+				if(!key)
+					var/foundghost = FALSE
+					if(mind)
+						for(var/mob/dead/observer/G in GLOB.player_list)
+							if(G.mind == mind)
+								foundghost = TRUE
+								if(G.can_reenter_corpse == 0)
+									foundghost = FALSE
+								break
+					if(!foundghost)
+						msg += " and [p_their()] soul has departed"
+			msg += "...</span>\n"
 
 	if(!get_int_organ(/obj/item/organ/internal/brain))
 		msg += "<span class='deadsay'>It appears that [p_their()] brain is missing...</span>\n"
@@ -266,6 +276,9 @@
 		msg += "[p_they(TRUE)] [p_are()] emitting a gentle blue glow!\n"
 
 	msg += "</span>"
+
+	if(just_sleeping)
+		msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
 
 	if(!appears_dead)
 		if(stat == UNCONSCIOUS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
![image](https://user-images.githubusercontent.com/3611705/182003761-fbea9188-04d3-47de-9ec4-31c77ef06766.png)
![image](https://user-images.githubusercontent.com/3611705/182003765-0aa6f8cb-d2d9-48d1-b35d-2538b796722e.png)

## What Does This PR Do
Ports https://github.com/tgstation/tgstation/pull/49749

Dead people propped up in a wheelchair and wearing sunglasses (or other tinted eyewear) will now appear to be sleeping upon casual observation, allowing the unscrupulous to hide victims in plain sight... so long as no one uses a Health Analyzer on them.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The original PR said it best:
>As much of a meme as this idea is, the thought of moving a dead body through a public space with only the absolute thinnest of cover stories and praying to God no one notices you or walks by with a MedHUD sounds like exactly the kind of desperate bluff SS13's social gameplay thrives on.
>Also, there is the distinct possibility that at some point a paraplegic security officer will die in a public place and no one will even realize he's dead until someone walks by with a MedHUD or tries to loot him, which is going to be equal parts tragic and hilarious.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested on local debug server

## Changelog
:cl:
add: Dead bodies with tinted eyewear that are propped in a wheelchair will now appear to be sleeping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
