### PR TITLE
Changes the cyborg death message on examine.

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -42,7 +42,7 @@
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
 			if(!suiciding)
-				msg += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>\n"
+				msg += "<span class='deadsay'>It looks like its internal subsystems are beyond repair and require replacing.</span>\n"
 			else
 				msg += "<span class='warning'>It looks like its system is corrupted beyond repair. There is no hope of recovery.</span>\n"
 	msg += "*---------*</span>"


### PR DESCRIPTION
## What Does This PR Do
A simple change to Cyborg's death message on examine
from: "It looks like its subsystems is corrupted and requires a reset."
to: "It looks like its internal subsystems are beyond repair and require replacing."

## Why It's Good For The Game
It should help newer players to figure out how to fix a cyborg from examining alone, the current examination text very often leads to newer roboticists trying to use "reset" upgrade board on dead cyborgs, leading to confusion.

This way its more clear what needs to be done.

## Images of changes
![1](https://user-images.githubusercontent.com/46283583/182008198-50f44ef0-55e1-4c04-8172-5d226affd9bd.PNG)

## Changelog
:cl:
tweak: changed the cyborg death message on examining.
/:cl: