### PR TITLE
Rework disease outbreak event

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -32,7 +32,7 @@
 	AddDisease(D)
 
 
-/mob/proc/AddDisease(datum/disease/D)
+/mob/proc/AddDisease(datum/disease/D, respect_carrier = FALSE)
 	var/datum/disease/DD = new D.type(1, D, 0)
 	viruses += DD
 	DD.affected_mob = src
@@ -40,6 +40,8 @@
 
 	//Copy properties over. This is so edited diseases persist.
 	var/list/skipped = list("affected_mob","holder","carrier","stage","type","parent_type","vars","transformed")
+	if(respect_carrier)
+		skipped -= "carrier"
 	for(var/V in DD.vars)
 		if(V in skipped)
 			continue
@@ -132,12 +134,13 @@
  *
  * Arguments:
  * * D - the disease the mob will try to contract
+ * * respect_carrier - if set to TRUE will not ignore the disease carrier flag
  */
 //Same as ContractDisease, except never overidden clothes checks
-/mob/proc/ForceContractDisease(datum/disease/D)
+/mob/proc/ForceContractDisease(datum/disease/D, respect_carrier)
 	if(!CanContractDisease(D))
 		return FALSE
-	AddDisease(D)
+	AddDisease(D, respect_carrier)
 	return TRUE
 
 

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -144,7 +144,7 @@
 	var/is_carrier = D.carrier == src
 	if(notify_ghosts)
 		for(var/mob/ghost as anything in GLOB.dead_mob_list) //Announce outbreak to dchat
-			to_chat(ghost, "<span class='deadsay'><b>Disease outbreak:</b>[src] ([ghost_follow_link(src, ghost)]) [is_carrier ? "is now a carrier of" : "has contracted"] [D]!</span>")
+			to_chat(ghost, "<span class='deadsay'><b>Disease outbreak: </b>[src] ([ghost_follow_link(src, ghost)]) [is_carrier ? "is now a carrier of" : "has contracted"] [D]!</span>")
 	AddDisease(D, respect_carrier)
 	return TRUE
 

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -144,7 +144,7 @@
 	var/is_carrier = D.carrier == src
 	if(notify_ghosts)
 		for(var/mob/ghost as anything in GLOB.dead_mob_list) //Announce outbreak to dchat
-			to_chat(ghost, "<span class='deadsay'><b>Disease outbreak:</b>[src] ([ghost_follow_link(src, ghost)]) [is_carrier ? "is now a carrier of" : "has contracted"] [GLOB.current_pending_disease]!</span>")
+			to_chat(ghost, "<span class='deadsay'><b>Disease outbreak:</b>[src] ([ghost_follow_link(src, ghost)]) [is_carrier ? "is now a carrier of" : "has contracted"] [D]!</span>")
 	AddDisease(D, respect_carrier)
 	return TRUE
 

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -141,10 +141,9 @@
 /mob/proc/ForceContractDisease(datum/disease/D, respect_carrier, notify_ghosts = FALSE)
 	if(!CanContractDisease(D))
 		return FALSE
-	var/is_carrier = D.carrier == src
 	if(notify_ghosts)
 		for(var/mob/ghost as anything in GLOB.dead_mob_list) //Announce outbreak to dchat
-			to_chat(ghost, "<span class='deadsay'><b>Disease outbreak: </b>[src] ([ghost_follow_link(src, ghost)]) [is_carrier ? "is now a carrier of" : "has contracted"] [D]!</span>")
+			to_chat(ghost, "<span class='deadsay'><b>Disease outbreak: </b>[src] ([ghost_follow_link(src, ghost)]) [D.carrier ? "is now a carrier of" : "has contracted"] [D]!</span>")
 	AddDisease(D, respect_carrier)
 	return TRUE
 

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -135,11 +135,16 @@
  * Arguments:
  * * D - the disease the mob will try to contract
  * * respect_carrier - if set to TRUE will not ignore the disease carrier flag
+ * * notify_ghosts - will notify ghosts of infection if set to TRUE
  */
 //Same as ContractDisease, except never overidden clothes checks
-/mob/proc/ForceContractDisease(datum/disease/D, respect_carrier)
+/mob/proc/ForceContractDisease(datum/disease/D, respect_carrier, notify_ghosts = FALSE)
 	if(!CanContractDisease(D))
 		return FALSE
+	var/is_carrier = D.carrier == src
+	if(notify_ghosts)
+		for(var/mob/ghost as anything in GLOB.dead_mob_list) //Announce outbreak to dchat
+			to_chat(ghost, "<span class='deadsay'><b>Disease outbreak:</b>[src] ([ghost_follow_link(src, ghost)]) [is_carrier ? "is now a carrier of" : "has contracted"] [GLOB.current_pending_disease]!</span>")
 	AddDisease(D, respect_carrier)
 	return TRUE
 

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -79,7 +79,7 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 	var/cure = has_cure()
 
 	if(carrier && !cure)
-		return TRUE
+		return FALSE
 
 	stage = min(stage, max_stages)
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 
 	return generated
 
-/datum/disease/advance/proc/Refresh(new_name = 0)
+/datum/disease/advance/proc/Refresh(new_name = FALSE, archive = FALSE)
 	var/list/properties = GenerateProperties()
 	AssignProperties(properties)
 	id = null

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -137,10 +137,10 @@ GLOBAL_LIST_INIT(advance_cures, list(
 			if(!HasSymptom(S))
 				possible_symptoms += S
 
-	if(!possible_symptoms.len)
+	if(!length(possible_symptoms))
 		return generated
 
-	for(var/i = 1; amount >= i && possible_symptoms.len; i++)
+	for(var/i = 1 to amount)
 		generated += pick_n_take(possible_symptoms)
 
 	return generated

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -126,6 +126,26 @@ GLOBAL_LIST_INIT(advance_cures, list(
 			return 1
 	return 0
 
+/datum/disease/advance/proc/GenerateSymptomsBySeverity(sev_min, sev_max, amount = 1)
+
+	var/list/generated = list() // Symptoms we generated.
+
+	var/list/possible_symptoms = list()
+	for(var/symp in GLOB.list_symptoms)
+		var/datum/symptom/S = new symp
+		if(S.severity >= sev_min && S.severity <= sev_max)
+			if(!HasSymptom(S))
+				possible_symptoms += S
+
+	if(!possible_symptoms.len)
+		return generated
+
+	for(var/i = 1; amount >= i && possible_symptoms.len; i++)
+		generated += pick_n_take(possible_symptoms)
+
+	return generated
+
+
 // Will generate new unique symptoms, use this if there are none. Returns a list of symptoms that were generated.
 /datum/disease/advance/proc/GenerateSymptoms(level_min, level_max, amount_get = 0)
 

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -4,7 +4,7 @@ GLOBAL_VAR(current_pending_disease)
 	var/datum/disease/chosen_disease
 
 	var/list/disease_blacklist = list(/datum/disease/advance, /datum/disease/appendicitis, /datum/disease/kuru, /datum/disease/critical, /datum/disease/rhumba_beat, /datum/disease/fake_gbs,
-										/datum/disease/gbs, /datum/disease/transformation, /datum/disease/food_poisoning, /datum/disease/advance/cold, /datum/disease/advance/flu, /datum/disease/advance/heal,
+										/datum/disease/gbs, /datum/disease/transformation,  /datum/disease/food_poisoning, /datum/disease/advance/cold, /datum/disease/advance/flu, /datum/disease/advance/heal,
 										/datum/disease/advance/hullucigen, /datum/disease/advance/sensory_restoration, /datum/disease/advance/voice_change)
 	var/static/list/transmissable_symptoms = list()
 	var/static/list/diseases_minor = list()
@@ -74,8 +74,8 @@ GLOBAL_VAR(current_pending_disease)
 
 /datum/event/disease_outbreak/proc/populate_diseases()
 	for(var/candidate in subtypesof(/datum/disease))
-		var/datum/disease/CD = candidate
-		if(candidate in disease_blacklist)
+		var/datum/disease/CD = new candidate
+		if(is_type_in_list(CD, disease_blacklist))
 			continue
 		switch(initial(CD.severity))
 			if(NONTHREAT, MINOR)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 		var/datum/disease/CD = new candidate
 		if(is_type_in_list(CD, disease_blacklist))
 			continue
-		switch(initial(CD.severity))
+		switch(CD.severity)
 			if(NONTHREAT, MINOR)
 				diseases_minor += candidate
 			if(MEDIUM, HARMFUL)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -4,7 +4,7 @@ GLOBAL_VAR(current_pending_disease)
 	var/datum/disease/chosen_disease
 
 	var/list/disease_blacklist = list(/datum/disease/advance, /datum/disease/appendicitis, /datum/disease/kuru, /datum/disease/critical, /datum/disease/rhumba_beat, /datum/disease/fake_gbs,
-										/datum/disease/gbs, /datum/disease/transformation,  /datum/disease/food_poisoning, /datum/disease/advance/cold, /datum/disease/advance/flu, /datum/disease/advance/heal,
+										/datum/disease/gbs, /datum/disease/transformation, /datum/disease/food_poisoning, /datum/disease/advance/cold, /datum/disease/advance/flu, /datum/disease/advance/heal,
 										/datum/disease/advance/hullucigen, /datum/disease/advance/sensory_restoration, /datum/disease/advance/voice_change)
 	var/static/list/transmissable_symptoms = list()
 	var/static/list/diseases_minor = list()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,4 +1,4 @@
-GLOBAL_VAR(current_pending_disease)
+GLOBAL_LIST_EMPTY(current_pending_diseases)
 /datum/event/disease_outbreak
 	/// The type of disease that patient zero will be infected with.
 	var/datum/disease/chosen_disease
@@ -34,7 +34,7 @@ GLOBAL_VAR(current_pending_disease)
 	chosen_disease.carrier = TRUE
 
 /datum/event/disease_outbreak/start()
-	GLOB.current_pending_disease = chosen_disease
+	GLOB.current_pending_diseases += chosen_disease
 	var/severity_text = "undefined (contact a coder)"
 	switch(severity)
 		if(EVENT_LEVEL_MUNDANE)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -54,7 +54,7 @@ GLOBAL_VAR(current_pending_disease)
 	A.symptoms = A.GenerateSymptomsBySeverity(max_severity - 1, max_severity, 2) //Choose "Payload" symptoms
 	A.AssignProperties(A.GenerateProperties())
 	var/list/symptoms_to_try = transmissable_symptoms.Copy()
-	for(var/sanity=0, sanity<25, sanity++)
+	while(length(symptoms_to_try))
 		if(A.spread_text != "Blood")
 			break
 		if(length(A.symptoms) < VIRUS_SYMPTOM_LIMIT)	//Ensure the virus is spreadable by adding symptoms that boost transmission

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -46,7 +46,11 @@ GLOBAL_VAR(current_pending_disease)
 
 
 	for(var/mob/M as anything in GLOB.dead_mob_list) //Announce outbreak to dchat
-		to_chat(M, "<span class='deadsay'><b>Disease outbreak:</b> The next new arrival is a carrier of a [severity_text] disease!</span>")
+		if(istype(chosen_disease, /datum/disease/advance))
+			var/datum/disease/advance/temp_disease = chosen_disease.Copy()
+			to_chat(M, "<span class='deadsay'><b>Disease outbreak:</b> The next new arrival is a carrier of [temp_disease.name]! A [severity_text] disease with the following symptoms: [english_list(temp_disease.symptoms)]</span>")
+		else
+			to_chat(M, "<span class='deadsay'><b>Disease outbreak:</b> The next new arrival is a carrier of a [severity_text] disease: [chosen_disease.name]!</span>")
 
 //Creates a virus with a harmful effect, guaranteed to be spreadable by contact or airborne
 /datum/event/disease_outbreak/proc/create_virus(max_severity = 6)
@@ -64,6 +68,7 @@ GLOBAL_VAR(current_pending_disease)
 			popleft(A.symptoms)	//We have a full symptom list but are still not transmittable. Try removing one of the "payloads"
 
 		A.AssignProperties(A.GenerateProperties())
+	A.name = pick(GLOB.alphabet_uppercase) + num2text(rand(1,9)) + pick(GLOB.alphabet_uppercase) + num2text(rand(1,9)) + pick("v", "V", "-" + num2text(GLOB.game_year), "")
 	A.Refresh()
 	return A
 

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -26,9 +26,15 @@ GLOBAL_VAR(current_pending_disease)
 
 /datum/event/disease_outbreak/start()
 	GLOB.current_pending_disease = D
+	var/severity_text = "undefined (contact a coder)"
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE) severity_text = "mundane"
+		if(EVENT_LEVEL_MODERATE) severity_text = "moderate"
+		if(EVENT_LEVEL_MAJOR) severity_text = "major"
+
 
 	for(var/mob/M as anything in GLOB.dead_mob_list) //Announce outbreak to dchat
-		to_chat(M, "<span class='deadsay'><b>Disease outbreak:</b> The next new arrival is a carrier of a disease!</span>")
+		to_chat(M, "<span class='deadsay'><b>Disease outbreak:</b> The next new arrival is a carrier of a [severity_text] disease!</span>")
 
 //Creates a virus with a harmful effect, guaranteed to be spreadable by contact or airborne
 /datum/event/disease_outbreak/proc/create_virus(max_severity = 6)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -53,7 +53,7 @@ GLOBAL_VAR(current_pending_disease)
 	var/datum/disease/advance/A = new /datum/disease/advance
 	A.symptoms = A.GenerateSymptomsBySeverity(max_severity - 1, max_severity, 2) //Choose "Payload" symptoms
 	A.AssignProperties(A.GenerateProperties())
-	var/list/symptoms_to_try = deepCopyList(transmissable_symptoms)
+	var/list/symptoms_to_try = transmissable_symptoms.Copy()
 	for(var/sanity=0, sanity<25, sanity++)
 		if(A.spread_text != "Blood")
 			break

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -141,7 +141,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80,)
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			100,		list(ASSIGNMENT_MEDICAL = 150), FALSE)
 	)
 
 /datum/event_container/moderate
@@ -198,7 +199,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		//new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			85, is_one_shot = TRUE),										// 8.4% on high pop, 9.4% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",	/datum/event/spider_terror, 	20,						list(ASSIGNMENT_SECURITY = 4), TRUE),	// 7.1% on high pop, 5.3% on low pop
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	10,  is_one_shot = TRUE)	// 3% on high pop, 2.1% on low pop
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	10,  is_one_shot = TRUE),	// 3% on high pop, 2.1% on low pop
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Disease Outbreak",/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), TRUE),
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = TRUE)
 	)
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -142,7 +142,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			100,		list(ASSIGNMENT_MEDICAL = 150), FALSE)
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			50,		list(ASSIGNMENT_MEDICAL = 50), FALSE)
 	)
 
 /datum/event_container/moderate

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -142,7 +142,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			50,		list(ASSIGNMENT_MEDICAL = 50), FALSE)
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			50,		list(ASSIGNMENT_MEDICAL = 50), TRUE)
 	)
 
 /datum/event_container/moderate

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -367,7 +367,7 @@
 			GLOB.data_core.manifest_inject(character)
 			AnnounceArrival(character, rank, join_message)
 
-			if(GLOB.current_pending_disease && character.ForceContractDisease(GLOB.current_pending_disease))
+			if(GLOB.current_pending_disease && character.ForceContractDisease(GLOB.current_pending_disease, TRUE))
 				GLOB.current_pending_disease = null
 			if(GLOB.summon_guns_triggered)
 				give_guns(character)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -367,6 +367,8 @@
 			GLOB.data_core.manifest_inject(character)
 			AnnounceArrival(character, rank, join_message)
 
+			if(GLOB.current_pending_disease && character.ForceContractDisease(GLOB.current_pending_disease))
+				GLOB.current_pending_disease = null
 			if(GLOB.summon_guns_triggered)
 				give_guns(character)
 			if(GLOB.summon_magic_triggered)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -367,7 +367,7 @@
 			GLOB.data_core.manifest_inject(character)
 			AnnounceArrival(character, rank, join_message)
 
-			if(GLOB.current_pending_disease && character.ForceContractDisease(GLOB.current_pending_disease, TRUE))
+			if(GLOB.current_pending_disease && character.ForceContractDisease(GLOB.current_pending_disease, TRUE, TRUE))
 				GLOB.current_pending_disease = null
 			if(GLOB.summon_guns_triggered)
 				give_guns(character)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -367,8 +367,8 @@
 			GLOB.data_core.manifest_inject(character)
 			AnnounceArrival(character, rank, join_message)
 
-			if(GLOB.current_pending_disease && character.ForceContractDisease(GLOB.current_pending_disease, TRUE, TRUE))
-				GLOB.current_pending_disease = null
+			if(length(GLOB.current_pending_diseases) && character.ForceContractDisease(GLOB.current_pending_diseases[1], TRUE, TRUE))
+				popleft(GLOB.current_pending_diseases)
 			if(GLOB.summon_guns_triggered)
 				give_guns(character)
 			if(GLOB.summon_magic_triggered)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Splits the disease outbreak event into mundane, moderate and major versions.
Removes the level 7 biohazard announcement
Reworks the random advanced disease generation to make a disease with a severity that fits the event level.
Makes the event infect a new arrival instead of a random person on the station level. That person becomes an infectious carrier, but unaffected by the disease itself.
Fixes buggy random disease generation ( Fixes #13787 )

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removal of the level 7 biohazard announcement provides plausible deniability for antagonist virologists.
Makes mild diseases more common, making the virologists job a bit more important.
Infecting a new arrival instead of a person on the station no longer has the potential to screw up a random antags run. And it is more realistic.

## Testing

Tested locally. Works as intended as far as I can tell.

## Notes

A test merge might be useful to test if the chosen values and diseases make sense

## Changelog
:cl: uc_guy
fix: Fixed randomly generated viruses showing incorrect cures and spread methods.
del: Removed Level 7 Biohazard annoucement.
tweak: The disease outbreak event now can appear in multiple severities.
tweak: Disease outbreak event infects a new arrival instead of a random person. That person becomes an infectious carrier, but unaffected by the disease itself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
