### PR TITLE
Closes Cyborg Module on Reset

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -437,6 +437,9 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 /mob/living/silicon/robot/proc/reset_module()
 	notify_ai(2)
 
+	shown_robot_modules = 0
+	client.screen -= robot_modules_background
+	client.screen -= hud_used.module_store_icon
 	uneq_all()
 	SStgui.close_user_uis(src)
 	sight_mode = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Makes `reset_module()` close your module's UI when you're reset. So for example when someone baps you with the reset thingy. Basically #15534 without scuffed commit history and with addressed changes.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes #15341

## Testing
<!-- How did you test the PR, if at all? -->
1. Spawn in a borg
2. Possess the borg
3. Choose a module
4. Open the module
5. Call `reset_module` on self
6. Smile seeing it closes the menu

## Changelog
:cl: CkeyLurapa, Inadvizable
fix: Cyborg module now closes on reset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
