### PR TITLE
Fix pills checking wrong container flags on transfer attempt

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -32,7 +32,7 @@
 	return FALSE
 
 /obj/item/reagent_containers/food/pill/afterattack(obj/target, mob/user, proximity)
-	if(!proximity || !target.is_open_container())
+	if(!proximity || !target.is_refillable())
 		return
 	to_chat(user, "<span class='notice'>You [!target.reagents.total_volume ? "break open" : "dissolve"] [src] in [target].</span>")
 	for(var/mob/O in oviewers(2, user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes pills requiring the `DRAINABLE` flag on target reagent container to be dissolvable in it.
Should only affect auto-menders, wooden fermenting barrels, and snow machines, as those seem to be the only objects that are `REFILLABLE` but not `DRAINABLE`.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Game shouldn't care whether you can remove reagents from a container if you're only adding to it. Logic Good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. Grabed a pill
2. Clicked an auto-mender/fermenting barrel/snow machine with it
3. Observed the successful reagent transfer

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can now open and dissolve pills into a few more objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
