### PR TITLE
Moves mining GPS into their storage units

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -609,8 +609,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "bC" = (
-/obj/structure/closet/crate,
-/obj/item/dice/d4,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 2;
+	pixel_x = 1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -636,19 +643,6 @@
 	},
 /area/mine/eva)
 "bE" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -159,6 +159,7 @@
 	name = "mining suit storage unit"
 	suit_type = /obj/item/clothing/suit/hooded/explorer
 	mask_type = /obj/item/clothing/mask/gas/explorer
+	storage_type = /obj/item/gps/mining
 	req_access = list(ACCESS_MINING_STATION)
 
 /obj/machinery/suit_storage_unit/cmo


### PR DESCRIPTION
## What Does This PR Do

1. Moves the mining GPS from the table to the mining suit storage units
2. Removes the table from the suit storage room
3. Moves the toolbox out of the suit storage room to the lobby
4. Adds one (1) extra blue toolbox to the lobby
5. Removes a crate and the d4 in it to make space for the rack + 2 toolboxes

## Why It's Good For The Game

1. It is cooler to gear up from a storage unit
2. Having a bunch of objects spawned on a table looks ugly
3. The room is more easily navigable, less pushing around
4. Should the admins want to set up a separate mining outpost, it is now easier to spawn everything
5. The real reason: disgusting and shameless hand-holding for the miners to TAKE THE DAMN GPS (please)

## Images of changes

https://user-images.githubusercontent.com/33333517/182043986-ebc3df07-cc5e-453e-acb8-32cc4f3b46ca.mp4

## Testing

By doing the video above!

## Changelog
:cl:
tweak: Moved the mining outposts' handheld GPS from the table to the storage units.
tweak: Moved the toolbox and the table out of the mining station suit storage room to make the space more navigable.
add: Added an extra toolbox to the mining outpost.
/:cl:
