### PR TITLE
Prevents -lathes from producing infinite power via cells

### DIFF
--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -10,7 +10,7 @@
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell
+	build_path = /obj/item/stock_parts/cell/empty
 	category = list("Misc","Power","Machinery","initial")
 
 /datum/design/high_cell
@@ -21,7 +21,7 @@
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/high
+	build_path = /obj/item/stock_parts/cell/high/empty
 	category = list("Misc","Power")
 
 /datum/design/hyper_cell
@@ -32,7 +32,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/hyper
+	build_path = /obj/item/stock_parts/cell/hyper/empty
 	category = list("Misc","Power")
 
 /datum/design/super_cell
@@ -43,7 +43,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/super
+	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list("Misc","Power")
 
 /datum/design/bluespace_cell
@@ -54,7 +54,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 160, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/bluespace
+	build_path = /obj/item/stock_parts/cell/bluespace/empty
 	category = list("Misc","Power")
 
 /datum/design/pacman


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Newly printed power cells are empty. This is the case for autolathe, protolathe, and mech fabricator. Someone else made a PR like this but they seem to have deleted their github account.

~Requires #18465 to be merged first to not be obnoxious.~ It has been merged.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Infinite power generation should probably be reserved to xenobio's special slime cells. Cargo and science shouldn't be able to continue working by printing new cells after they are cut off from the grid.

Thermodynamics are pretty cool and it's nice to obey their laws.

## Testing
<!-- How did you test the PR, if at all? -->
1. Print some cells from either machine.
2. Check their power level.

## Changelog
:cl:
tweak: Newly printed power cells are empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
