### PR TITLE
Emagged deep fryers can deep fry non-food objects

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -41,7 +41,7 @@
 /obj/machinery/cooker/proc/checkValid(obj/item/check, mob/user)
 	if(on)
 		to_chat(user, "<span class='notice'>[src] is still active!</span>")
-		return 0
+		return FALSE
 	if(istype(check, /obj/item/grab))
 		return special_attack(check, user)
 	if(has_specials && checkSpecials(check))
@@ -49,16 +49,16 @@
 	if(istype(check, /obj/item/reagent_containers/food/snacks) || emagged)
 		if(istype(check, /obj/item/disk/nuclear)) //(1984 voice) you will not deep fry the NAD
 			to_chat(user, "<span class ='notice'>The disk is more useful raw than [thiscooktype].</span>")
-			return 0
+			return FALSE
 		var/obj/item/disk/nuclear/datdisk = locate() in check
 		if(datdisk)
 			to_chat(user, "<span class ='notice'>You get the feeling that something very important is inside this. Something that shouldn't be [thiscooktype].</span>")
-			return 0
+			return FALSE
 		if(check.flags & (ABSTRACT || DROPDEL || NODROP)) //you will not deep fry the armblade
-			return 0
-		return 1
+			return FALSE
+		return TRUE
 	to_chat(user, "<span class ='notice'>You can only process food!</span>")
-	return 0
+	return FALSE
 
 /obj/machinery/cooker/proc/setIcon(obj/item/copyme, obj/item/copyto)
 	copyto.color = foodcolor

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -128,6 +128,14 @@
 				to_chat(user, "<span class='warning'>That is already [thiscooktype], it would do nothing!</span>")
 				return
 	putIn(I, user)
+	for(var/mob/living/L in I.contents) //Emagged cookers - Any mob put in will not survive the trip
+		if(!istype(L, DEAD))
+			if(ispAI(L)) //Snowflake check because pAIs are weird
+				var/mob/living/silicon/pai/P = L
+				P.death(cleanWipe = 1)
+			else
+				L.death()
+		break
 	sleep(cooktime)
 	if(I && I.loc == src)
 		//New interaction to allow special foods to be made/cooked via deepfryer without removing original functionality

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -54,6 +54,8 @@
 		if(datdisk)
 			to_chat(user, "<span class ='notice'>You get the feeling that something very important is inside this. Something that shouldn't be [thiscooktype].</span>")
 			return 0
+		if(check.flags & (ABSTRACT || DROPDEL || NODROP)) //you will not deep fry the armblade
+			return 0
 		return 1
 	to_chat(user, "<span class ='notice'>You can only process food!</span>")
 	return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -42,12 +42,19 @@
 	if(on)
 		to_chat(user, "<span class='notice'>[src] is still active!</span>")
 		return 0
-	if(istype(check, /obj/item/reagent_containers/food/snacks))
-		return 1
 	if(istype(check, /obj/item/grab))
 		return special_attack(check, user)
 	if(has_specials && checkSpecials(check))
 		return TRUE
+	if(istype(check, /obj/item/reagent_containers/food/snacks) || emagged)
+		if(istype(check, /obj/item/disk/nuclear)) //(1984 voice) you will not deep fry the NAD
+			to_chat(user, "<span class ='notice'>The disk is more useful raw than [thiscooktype].</span>")
+			return 0
+		var/obj/item/disk/nuclear/datdisk = locate() in check
+		if(datdisk)
+			to_chat(user, "<span class ='notice'>You get the feeling that something very important is inside this. Something that shouldn't be [thiscooktype].</span>")
+			return 0
+		return 1
 	to_chat(user, "<span class ='notice'>You can only process food!</span>")
 	return 0
 

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -48,16 +48,16 @@
 		return TRUE
 	if(istype(check, /obj/item/reagent_containers/food/snacks) || emagged)
 		if(istype(check, /obj/item/disk/nuclear)) //(1984 voice) you will not deep fry the NAD
-			to_chat(user, "<span class ='notice'>The disk is more useful raw than [thiscooktype].</span>")
+			to_chat(user, "<span class='notice'>The disk is more useful raw than [thiscooktype].</span>")
 			return FALSE
 		var/obj/item/disk/nuclear/datdisk = locate() in check
 		if(datdisk)
-			to_chat(user, "<span class ='notice'>You get the feeling that something very important is inside this. Something that shouldn't be [thiscooktype].</span>")
+			to_chat(user, "<span class='notice'>You get the feeling that something very important is inside this. Something that shouldn't be [thiscooktype].</span>")
 			return FALSE
 		if(check.flags & (ABSTRACT || DROPDEL || NODROP)) //you will not deep fry the armblade
 			return FALSE
 		return TRUE
-	to_chat(user, "<span class ='notice'>You can only process food!</span>")
+	to_chat(user, "<span class='notice'>You can only process food!</span>")
 	return FALSE
 
 /obj/machinery/cooker/proc/setIcon(obj/item/copyme, obj/item/copyto)

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -54,7 +54,7 @@
 		if(datdisk)
 			to_chat(user, "<span class='notice'>You get the feeling that something very important is inside this. Something that shouldn't be [thiscooktype].</span>")
 			return FALSE
-		if(check.flags & (ABSTRACT || DROPDEL || NODROP)) //you will not deep fry the armblade
+		if(check.flags & (ABSTRACT | DROPDEL | NODROP)) //you will not deep fry the armblade
 			return FALSE
 		return TRUE
 	to_chat(user, "<span class='notice'>You can only process food!</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -129,7 +129,7 @@
 				return
 	putIn(I, user)
 	for(var/mob/living/L in I.contents) //Emagged cookers - Any mob put in will not survive the trip
-		if(!istype(L, DEAD))
+		if(L.stat != DEAD)
 			if(ispAI(L)) //Snowflake check because pAIs are weird
 				var/mob/living/silicon/pai/P = L
 				P.death(cleanWipe = 1)

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -132,7 +132,7 @@
 		if(L.stat != DEAD)
 			if(ispAI(L)) //Snowflake check because pAIs are weird
 				var/mob/living/silicon/pai/P = L
-				P.death(cleanWipe = 1)
+				P.death(cleanWipe = TRUE)
 			else
 				L.death()
 		break

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -43,6 +43,18 @@
 	var/obj/item/reagent_containers/food/snacks/deepfryholder/type = new(get_turf(src))
 	return type
 
+/obj/machinery/cooker/deepfryer/examine(mob/user)
+	. = ..()
+	if(emagged)
+		. += "<span class='warning'>The heating element is smoking slightly.</span>"
+
+/obj/machinery/cooker/deepfryer/emag_act()
+	if(!emagged)
+		to_chat(usr, "<span class='warning'>You short out the fryer's safeties, allowing non-food objects to be placed in the oil.</span>")
+		playsound(src, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		emagged = TRUE
+		return
+
 /obj/machinery/cooker/deepfryer/special_attack(obj/item/grab/G, mob/user)
 	if(ishuman(G.affecting))
 		if(G.state < GRAB_AGGRESSIVE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR allows the player to emag the deep fryer. Emagging the deep fryer will disable its safeties, allowing _any_ item (not just food!) to be fried. Any object which is deep fried becomes edible.

A sole exception is made for the NAD, which can't be deep fried because reasons.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The deep fryer is capable of frying arbitrary objects in pretty much every branch of /tg/station, including Paradise before #151. I've sorely missed this feature ever since I started playing on Para. The absurd situations that arise from the chef having the ability to deep fry any object to a crisp made me smile countless times in the past, and I would like to smile at them again.

However, I concede that Paradise is an MRP server, and it's decidedly LRP to give the chef a tool which lets him effortlessly make food by cramming forks and roller pins into the fryer every single round. By making the ability to unlock the deep fryer's potential an **antagonist** ability, chefs will veer towards using the deep fryer for subterfuge or actual gimmicks, instead of lazily deep frying every utensil in the kitchen to meet the bare minimum requirement of "cooking".

"Deep Fry Everything" will be a sometimes treat, not a plague on sensible cuisine.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/3611705/182187751-88992dae-368a-47e1-846c-0ce55139f51e.png)
![image](https://user-images.githubusercontent.com/3611705/182187883-2b9c5de6-2d98-4341-b30f-2e9501952ae4.png)
![image](https://user-images.githubusercontent.com/3611705/182188332-aca2058e-265e-4df4-96da-ea9de5eed2d0.png)
![image](https://user-images.githubusercontent.com/3611705/182188498-0370926c-6083-4f94-bee3-84fbeb8549cc.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled and tested on local debug server
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Emagged deep fryers can now deep fry anything!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->