### PR TITLE
Lavaland: Remaps the Mining Outpost

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -695,7 +695,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "bM" = (

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -428,12 +428,19 @@
 	},
 /area/mine/laborcamp/security)
 "bi" = (
-/obj/structure/table,
-/obj/item/screwdriver{
-	pixel_x = 3;
-	pixel_y = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "bj" = (
 /obj/machinery/status_display{
@@ -599,15 +606,33 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "bC" = (
-/obj/effect/spawner/random_spawners/grille_often,
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Bar East";
+	network = list("Mining Outpost");
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "bD" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "bE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -626,22 +651,18 @@
 /turf/simulated/floor/plating,
 /area/mine/eva)
 "bG" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"bH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"bH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bI" = (
@@ -734,18 +755,15 @@
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
 "bP" = (
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
-	},
-/area/mine/production)
+/obj/item/toy/plushie/deer,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bQ" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/grille/broken,
+/obj/item/stack/rods{
+	amount = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bR" = (
@@ -783,34 +801,15 @@
 	},
 /area/mine/production)
 "bU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Infirmary";
-	network = list("Mining Outpost");
-	dir = 10
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bW" = (
 /obj/structure/extinguisher_cabinet{
@@ -1283,15 +1282,10 @@
 	},
 /area/mine/eva)
 "cZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
-	},
-/area/mine/production)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "da" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light,
@@ -1320,17 +1314,13 @@
 	},
 /area/mine/living_quarters)
 "dd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "de" = (
@@ -1343,15 +1333,23 @@
 	},
 /area/mine/living_quarters)
 "df" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	dir = 8;
+	icon_state = "barber"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "dg" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -1449,7 +1447,11 @@
 	},
 /area/mine/living_quarters)
 "dp" = (
-/obj/effect/spawner/random_spawners/blood_often,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dq" = (
@@ -1460,13 +1462,12 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dr" = (
-/obj/machinery/camera{
-	c_tag = "Mining Telecommunications Hallway";
-	network = list("Mining Outpost")
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
+	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
 "ds" = (
@@ -1482,11 +1483,7 @@
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
 "dt" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
@@ -1617,10 +1614,10 @@
 	},
 /area/mine/living_quarters)
 "dH" = (
-/obj/effect/spawner/random_spawners/blood_often,
-/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/area/mine/production)
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -1643,19 +1640,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dK" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "custom placement";
-	pixel_x = -23
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar West";
-	network = list("Mining Outpost");
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dL" = (
 /obj/structure/cable{
@@ -1840,8 +1827,14 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "ei" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway West";
+	network = list("Mining Outpost");
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "ej" = (
 /obj/structure/cable{
@@ -1852,16 +1845,18 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "ek" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "el" = (
@@ -1927,16 +1922,19 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "er" = (
-/obj/item/toy/plushie/deer,
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "es" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/structure/closet/walllocker/emerglocker/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "et" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1970,14 +1968,25 @@
 	},
 /area/mine/eva)
 "ex" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_y = -5
 	},
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "ey" = (
-/obj/effect/spawner/random_spawners/fungus_probably,
-/turf/simulated/wall,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "ez" = (
 /obj/machinery/door/airlock/maintenance,
@@ -2174,20 +2183,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
@@ -2321,11 +2325,9 @@
 	},
 /area/mine/living_quarters)
 "fg" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/camera{
-	c_tag = "Mining Disposals";
-	network = list("Mining Outpost");
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
@@ -2337,19 +2339,22 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fk" = (
 /obj/structure/table,
@@ -2406,19 +2411,22 @@
 	},
 /area/mine/living_quarters)
 "fp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fr" = (
 /obj/structure/chair/stool/bar{
@@ -2460,19 +2468,17 @@
 	},
 /area/mine/living_quarters)
 "fw" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "yellowsiding";
+	dir = 4
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "fx" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
@@ -2480,13 +2486,8 @@
 	},
 /area/mine/living_quarters)
 "fy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fz" = (
@@ -2542,19 +2543,31 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mine/production)
-"fH" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"fH" = (
+/obj/machinery/alarm{
+	dir = 4;
+	name = "custom placement";
+	pixel_x = -23
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Bar West";
+	network = list("Mining Outpost");
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "fI" = (
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fJ" = (
@@ -2565,14 +2578,10 @@
 /turf/simulated/floor/plating,
 /area/mine/production)
 "fK" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fL" = (
 /obj/structure/table,
@@ -2625,16 +2634,19 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/structure/table,
+/obj/item/stock_parts/cell{
+	pixel_y = -2
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/stock_parts/cell{
+	pixel_x = -6;
+	pixel_y = 5
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
+/obj/item/crowbar,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
 "fV" = (
 /turf/simulated/wall/indestructible/boss/see_through,
 /area/lavaland/surface/outdoors)
@@ -2647,8 +2659,10 @@
 /turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors)
 "fY" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fZ" = (
@@ -2659,22 +2673,34 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ga" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_y = -5
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "gb" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gc" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
 "gd" = (
 /obj/machinery/conveyor/east{
 	id = "garbage";
@@ -2773,10 +2799,9 @@
 /area/lavaland/surface/outdoors)
 "gl" = (
 /obj/structure/grille/broken,
-/obj/item/stack/rods{
-	amount = 4
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gm" = (
@@ -2803,22 +2828,17 @@
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/closet/walllocker/emerglocker/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "gr" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -2846,11 +2866,17 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gt" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "gu" = (
 /obj/machinery/door/airlock/external{
@@ -3040,13 +3066,13 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gZ" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway West";
-	network = list("Mining Outpost");
+/obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "hf" = (
@@ -3527,16 +3553,11 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ld" = (
-/obj/machinery/camera{
-	c_tag = "Mining Production Hallway";
-	network = list("Mining Outpost");
-	dir = 5
+/obj/item/stack/rods{
+	amount = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
-	},
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "le" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -4349,14 +4370,15 @@
 	},
 /area/mine/laborcamp)
 "rA" = (
-/obj/structure/extinguisher_cabinet{
+/obj/machinery/firealarm{
+	dir = 1;
 	name = "south bump";
-	pixel_y = -30
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "rM" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/mineral/titanium,
@@ -4371,9 +4393,14 @@
 	},
 /area/mine/laborcamp)
 "rV" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/turf/simulated/floor/plating,
+/obj/machinery/camera{
+	c_tag = "Mining Telecommunications Hallway";
+	network = list("Mining Outpost")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/living_quarters)
 "sr" = (
 /obj/structure/table,
@@ -4455,19 +4482,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"tk" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/mine/living_quarters)
 "to" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4478,9 +4492,23 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "tx" = (
-/obj/structure/chair/office{
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/deck/cards,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -4512,17 +4540,19 @@
 	},
 /area/mine/laborcamp)
 "tK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
+	icon_state = "grimy"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "tT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -4570,7 +4600,11 @@
 /area/mine/laborcamp)
 "un" = (
 /obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Mining Disposals";
+	network = list("Mining Outpost");
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "uL" = (
@@ -4666,6 +4700,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
+"wk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
 "wt" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -4674,6 +4717,12 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"wL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "wP" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -4700,13 +4749,20 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "xb" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
+/obj/machinery/camera{
+	c_tag = "Mining Infirmary";
+	network = list("Mining Outpost");
+	dir = 10
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
 "xg" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -4786,7 +4842,9 @@
 	},
 /area/mine/laborcamp)
 "yg" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/chair/office{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -4843,11 +4901,10 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "zC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = 8
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
@@ -4878,26 +4935,8 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Az" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/item/instrument/guitar,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "AB" = (
 /obj/structure/grille,
@@ -4923,8 +4962,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/mine/maintenance)
 "Bq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Bx" = (
@@ -4948,14 +4991,17 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "BD" = (
-/obj/machinery/light{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "BI" = (
 /obj/structure/ore_box,
@@ -4963,11 +5009,8 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "BT" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "BX" = (
@@ -5107,7 +5150,7 @@
 	},
 /area/mine/laborcamp)
 "EG" = (
-/obj/item/instrument/guitar,
+/obj/structure/closet/cardboard,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "EQ" = (
@@ -5341,10 +5384,7 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Jh" = (
-/obj/structure/grille/broken,
-/obj/item/shard{
-	icon_state = "medium"
-	},
+/obj/structure/closet/crate/internals,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Jl" = (
@@ -5355,9 +5395,7 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "JB" = (
-/obj/item/stack/rods{
-	amount = 4
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "JM" = (
@@ -5608,8 +5646,14 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "MM" = (
-/obj/structure/closet/cardboard,
-/turf/simulated/floor/plating,
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "Ne" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5621,10 +5665,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Nf" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/item/shard{
+	icon_state = "medium"
 	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Ni" = (
 /obj/effect/spawner/window/reinforced,
@@ -5711,14 +5755,15 @@
 	},
 /area/mine/laborcamp)
 "On" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway East";
-	network = list("Mining Outpost");
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "Oq" = (
 /obj/machinery/door/airlock{
@@ -5791,28 +5836,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "PX" = (
 /turf/simulated/wall,
 /area/mine/laborcamp/security)
 "Qq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "QE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5832,23 +5867,8 @@
 	},
 /area/mine/laborcamp)
 "QH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar East";
-	network = list("Mining Outpost");
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "Rd" = (
 /obj/structure/rack,
@@ -5996,21 +6016,13 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "TN" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway East";
+	network = list("Mining Outpost");
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
 "Uh" = (
@@ -6090,14 +6102,16 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "VD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/camera{
+	c_tag = "Mining Production Hallway";
+	network = list("Mining Outpost");
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "yellowsiding";
+	dir = 8
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "VJ" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -6151,15 +6165,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Ww" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "yellowsiding";
+	dir = 4
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "Wx" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -6198,20 +6212,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 6
-	},
-/area/mine/production)
-"Xw" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell{
-	pixel_y = -2
-	},
-/obj/item/stock_parts/cell{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/crowbar,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
 	},
 /area/mine/production)
 "XE" = (
@@ -13228,7 +13228,7 @@ ab
 cQ
 Bp
 lJ
-xb
+gq
 cQ
 cR
 Jl
@@ -13489,7 +13489,7 @@ az
 cQ
 sL
 yR
-ex
+dt
 cM
 ab
 aj
@@ -14001,7 +14001,7 @@ cQ
 cQ
 cQ
 cQ
-dr
+rV
 pb
 fs
 cM
@@ -14517,7 +14517,7 @@ dX
 cM
 eS
 Mb
-dt
+bD
 cM
 ab
 ab
@@ -15026,16 +15026,16 @@ ab
 cM
 fz
 dC
-dK
+fH
 fc
 cT
 sL
-bV
+ek
 fo
 dQ
 gh
 Uz
-tk
+gt
 cM
 ab
 aj
@@ -15284,10 +15284,10 @@ cM
 eb
 fz
 fz
-tx
+yg
 fz
 Eg
-ek
+BD
 ff
 dQ
 fL
@@ -15544,12 +15544,12 @@ bS
 fk
 xg
 sL
-eR
-fU
-TN
+fj
+On
+df
 EQ
-fp
-bU
+bi
+xb
 cR
 ab
 aj
@@ -16312,10 +16312,10 @@ cM
 fx
 fz
 bS
-Az
+tx
 xg
 sL
-bV
+ek
 fA
 cM
 cM
@@ -16568,18 +16568,18 @@ cM
 cM
 dF
 dF
-Nf
-fw
+wL
+ey
 fz
 sL
-bV
-rA
+ek
+dr
 cM
-MM
+EG
 cV
-ei
+JB
 gb
-dH
+fy
 cM
 aj
 aj
@@ -16829,14 +16829,14 @@ fr
 ec
 fz
 sL
-PQ
+fp
 fo
 cM
 cV
 eX
 eX
-bC
-EG
+bU
+Az
 cM
 aj
 aj
@@ -17079,21 +17079,21 @@ aD
 aj
 aj
 cM
-BD
-VD
+gZ
+wk
 XE
 fr
 ec
 fz
 sL
-PQ
-gZ
+fp
+ei
 cM
-dp
+gp
 cV
 cM
 cM
-ey
+QH
 cM
 aj
 aj
@@ -17337,17 +17337,17 @@ aj
 ab
 cM
 db
-gq
+fG
 dR
 fr
 ec
 fz
 Eg
-bG
-gp
+eR
+es
 cM
 eX
-JB
+ld
 cM
 Zf
 Zf
@@ -17594,17 +17594,17 @@ aj
 ai
 cM
 dc
-gq
+fG
 WO
 Te
 vq
 Kb
 eT
 El
-Ww
+MM
 cM
 gb
-Jh
+gl
 cM
 dq
 bo
@@ -17851,11 +17851,11 @@ aj
 aj
 cM
 de
-gq
+fG
 dR
-fj
-yg
-yg
+ga
+er
+er
 vZ
 oN
 fC
@@ -18108,16 +18108,16 @@ aj
 ai
 cM
 KW
-dd
+tK
 Kr
-QH
-fK
+bC
+dd
 ev
 bx
-Qq
+PQ
 fA
 cM
-zC
+Bq
 gn
 cM
 eL
@@ -18371,10 +18371,10 @@ cM
 cM
 cM
 eU
-Qq
+PQ
 fo
 cM
-zC
+Bq
 TC
 cP
 Nk
@@ -18628,10 +18628,10 @@ Vu
 Ae
 cM
 dz
-Qq
+PQ
 fA
 cM
-zC
+Bq
 AB
 cM
 px
@@ -18888,8 +18888,8 @@ Ma
 em
 fs
 cM
-zC
-bQ
+Bq
+fI
 cM
 Ms
 cV
@@ -19145,8 +19145,8 @@ sL
 ge
 fA
 cM
-fy
-rV
+bH
+BT
 cM
 ee
 fO
@@ -19400,10 +19400,10 @@ dS
 bq
 sL
 ge
-rA
+dr
 cM
 Ag
-bH
+fK
 cM
 cM
 cM
@@ -19659,12 +19659,12 @@ en
 fm
 PF
 cM
-zC
+Bq
 gb
 cM
-JB
-bi
-fg
+ld
+zC
+un
 zy
 cD
 xM
@@ -19914,14 +19914,14 @@ co
 bq
 sL
 bE
-On
+TN
 cM
-zC
+Bq
 cV
-ey
+QH
 yl
 cV
-un
+bG
 dh
 VS
 xM
@@ -20174,9 +20174,9 @@ bE
 fA
 cM
 wT
-fH
-es
-BT
+fg
+dp
+Qq
 aY
 DE
 dE
@@ -20678,10 +20678,10 @@ dO
 Nj
 eB
 dD
-ld
+VD
 xB
 eB
-bP
+gc
 eB
 cN
 eh
@@ -20691,10 +20691,10 @@ cV
 eX
 cV
 AB
-Bq
-ga
+dK
+ex
 cV
-bD
+fY
 cV
 gi
 eX
@@ -20942,19 +20942,19 @@ eA
 eA
 eK
 Lr
-df
+rA
 bq
 px
 cV
 eX
 cV
 cV
-ey
-fY
+QH
+cZ
 eg
 cV
-gt
-fI
+bV
+Jh
 cR
 aj
 aj
@@ -21191,8 +21191,8 @@ cn
 ct
 ed
 eJ
-tK
-cZ
+fw
+Ww
 JM
 ef
 ef
@@ -21458,11 +21458,11 @@ cH
 fb
 dV
 bq
-er
+bP
 eX
 gb
 cV
-gl
+bQ
 cM
 ab
 ab
@@ -21717,7 +21717,7 @@ eZ
 dn
 eX
 cV
-gc
+Nf
 cV
 cV
 cM
@@ -22741,8 +22741,8 @@ ej
 eG
 BX
 eW
-Xw
-fG
+fU
+dH
 ai
 ab
 aj
@@ -23505,10 +23505,10 @@ bK
 ck
 cr
 bf
-ab
-ab
-ab
-ab
+ai
+ai
+ai
+ai
 ab
 ab
 ab
@@ -23762,9 +23762,9 @@ bW
 cq
 ew
 bf
-ab
-ab
-ab
+ai
+ai
+ai
 ab
 ab
 ab
@@ -24019,7 +24019,7 @@ bg
 dY
 bg
 bf
-ab
+ai
 ab
 ab
 ab
@@ -24280,7 +24280,7 @@ ab
 ab
 ab
 ab
-ab
+aj
 ab
 ab
 ab
@@ -24536,10 +24536,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+aj
+aj
+aj
+aj
 ab
 ab
 aj
@@ -24789,14 +24789,14 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
 aj
 aj
-ab
-ab
-ab
-ab
-ab
-ab
+aj
+aj
+aj
 ab
 ab
 ab
@@ -25046,8 +25046,8 @@ ab
 ab
 ab
 ab
-aj
-aj
+ab
+ab
 aj
 aj
 aj
@@ -25302,9 +25302,9 @@ ab
 ab
 ab
 ab
-aj
-aj
-aj
+ab
+ab
+ab
 aj
 aj
 aj
@@ -25558,9 +25558,9 @@ ab
 ab
 ab
 ab
-aj
-aj
-aj
+ab
+ab
+ab
 aj
 aj
 aj
@@ -25815,10 +25815,10 @@ ab
 ab
 ab
 ab
-aj
-aj
-aj
-aj
+ab
+ab
+ab
+ab
 aj
 aj
 aj

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -218,13 +218,28 @@
 	},
 /area/mine/laborcamp)
 "aI" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/camera{
+	c_tag = "Mining EVA";
+	dir = 9;
+	network = list("Mining Outpost")
 	},
-/obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel,
+/obj/machinery/light_switch{
+	name = "custom placement";
+	pixel_x = 27
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 1;
+	name = "Mning EVA APC";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
 /area/mine/eva)
 "aJ" = (
 /obj/machinery/light/small{
@@ -265,13 +280,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "aN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/production)
 "aP" = (
 /obj/structure/table,
@@ -337,20 +349,16 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "aY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "miningdorm1";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 4;
+	name = "east bump";
 	pixel_x = 24;
-	specialfunctions = 4
+	shock_proof = 1
 	},
-/turf/simulated/floor/carpet,
+/obj/structure/cable,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "aZ" = (
 /obj/machinery/light/small{
@@ -420,20 +428,12 @@
 	},
 /area/mine/laborcamp/security)
 "bi" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "miningdorm2";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bj" = (
 /obj/machinery/status_display{
@@ -482,86 +482,76 @@
 	},
 /area/mine/laborcamp)
 "bo" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
 	},
-/obj/machinery/door_control{
-	id = "miningbathroom";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/plasteel/freezer,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bp" = (
-/obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "purple"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/area/mine/eva)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "bq" = (
 /turf/simulated/wall,
 /area/mine/production)
 "br" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "miningdorm3";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/carpet,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bt" = (
-/obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/mine/eva)
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "bu" = (
-/obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "purple"
-	},
-/area/mine/eva)
-"bv" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/eva)
-"bw" = (
-/obj/machinery/alarm{
-	name = "custom placement";
-	pixel_y = 23
+/area/lavaland/surface/outdoors)
+"bv" = (
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/machinery/computer/shuttle/mining{
-	req_access = null
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purple"
-	},
-/area/mine/production)
-"bx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "yellowsiding";
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	name = "custom placement";
-	pixel_y = -25
+/area/mine/production)
+"bw" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
+"bx" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/living_quarters)
 "by" = (
 /obj/structure/cable{
@@ -609,79 +599,62 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "bC" = (
-/obj/structure/closet/crate,
-/obj/item/dice/d4,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/mine/production)
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bD" = (
-/obj/machinery/camera{
-	c_tag = "EVA";
-	dir = 4;
-	network = list("Mining Outpost")
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	name = "custom placement";
-	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/mine/eva)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bE" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/mine/eva)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "bF" = (
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/mine/eva)
 "bG" = (
-/obj/machinery/light_switch{
-	name = "custom placement";
-	pixel_x = 27
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/area/mine/eva)
-"bH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
-/area/mine/eva)
+/area/mine/living_quarters)
+"bH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bI" = (
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plasteel{
-	icon_state = "purplecorner"
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
 	},
-/area/mine/eva)
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Disposal Exit";
+	name = "Disposal Exit Vent"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -715,6 +688,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "bM" = (
@@ -760,70 +734,84 @@
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
 "bP" = (
-/obj/item/radio/beacon,
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "yellowsiding";
+	dir = 8
 	},
 /area/mine/production)
 "bQ" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"bS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_access_txt = "54"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
-"bT" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "purplecorner"
-	},
-/area/mine/production)
-"bU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
-"bV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
-/area/mine/eva)
+/area/mine/production)
+"bS" = (
+/obj/structure/chair/office,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"bT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/mine/production)
+"bU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Infirmary";
+	network = list("Mining Outpost");
+	dir = 10
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"bV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "bW" = (
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
@@ -838,19 +826,10 @@
 	},
 /area/mine/eva)
 "bX" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "mining";
-	name = "interior access button";
-	pixel_x = 25;
-	pixel_y = 25;
-	req_access_txt = null
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
+/turf/simulated/floor/plasteel,
 /area/mine/eva)
 "bY" = (
 /turf/simulated/floor/plasteel,
@@ -1001,40 +980,40 @@
 	},
 /area/mine/eva)
 "cl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"cm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"cn" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	icon_state = "brown";
+	dir = 1
+	},
+/area/mine/eva)
+"cm" = (
+/obj/machinery/suit_storage_unit/lavaland,
+/turf/simulated/floor/plasteel{
+	dir = 9;
 	icon_state = "brown"
+	},
+/area/mine/eva)
+"cn" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 5
 	},
 /area/mine/production)
 "co" = (
+/obj/machinery/light,
 /obj/machinery/power/apc{
-	name = "Mining EVA APC";
-	pixel_x = 1;
-	pixel_y = -23
+	name = "south bump";
+	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/machinery/suit_storage_unit/lavaland,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
-/area/mine/eva)
+/area/mine/production)
 "cp" = (
 /obj/machinery/suit_storage_unit/lavaland,
 /turf/simulated/floor/plasteel,
@@ -1053,21 +1032,16 @@
 	},
 /area/mine/eva)
 "cs" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/mineral/equipment_vendor,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"ct" = (
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/mine/eva)
-"ct" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "yellowsiding";
+	dir = 4
 	},
 /area/mine/production)
 "cu" = (
@@ -1079,28 +1053,31 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "cw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Shuttle Docking Foyer North";
-	dir = 8;
-	network = list("Mining Outpost")
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "cx" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station EVA";
+	req_access_txt = "54"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/mine/production)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "cy" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/plasteel,
@@ -1140,118 +1117,123 @@
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
 "cD" = (
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
+/obj/machinery/conveyor/east{
+	id = "garbage"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"cE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"cF" = (
-/obj/structure/extinguisher_cabinet{
-	name = "custom placement";
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"cG" = (
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/mine/laborcamp/security)
-"cH" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Mining Station Starboard Wing APC";
-	pixel_x = -27;
-	pixel_y = 2
-	},
+/area/mine/living_quarters)
+"cE" = (
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
 	},
+/area/mine/eva)
+"cF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"cG" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/mine/laborcamp/security)
+"cH" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Mech Bay Area";
+	req_access_txt = "48"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/suit_storage_unit/lavaland,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purplecorner"
+	icon_state = "brown"
 	},
-/area/mine/production)
+/area/mine/eva)
 "cJ" = (
-/obj/machinery/door/airlock{
-	name = "Closet"
+/obj/structure/table,
+/obj/item/dice/d4,
+/obj/item/toy/carpplushie{
+	pixel_x = 10;
+	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
-/area/mine/production)
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "cK" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 7;
+	pixel_x = 6
 	},
-/turf/simulated/floor/plating,
-/area/mine/production)
+/obj/item/reagent_containers/food/snacks/tastybread{
+	pixel_x = -8
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "cL" = (
-/obj/machinery/space_heater,
-/obj/item/gps/ruin{
-	gpstag = "BASE0";
-	pixel_y = 32
+/obj/structure/dispenser/oxygen,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/mine/production)
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "cM" = (
 /turf/simulated/wall,
 /area/mine/living_quarters)
 "cN" = (
-/obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "brown"
+	icon_state = "yellowcornersiding";
+	dir = 1
 	},
 /area/mine/production)
 "cO" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
-/obj/machinery/firealarm{
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"cP" = (
-/obj/structure/closet/crate,
 /obj/machinery/alarm{
+	dir = 1;
 	name = "custom placement";
-	pixel_y = 23
+	pixel_y = -22
 	},
-/obj/effect/turf_decal/bot,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/mine/eva)
+"cP" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "cQ" = (
 /turf/simulated/wall/r_wall,
 /area/mine/maintenance)
@@ -1260,32 +1242,18 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "cS" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/item/radio/beacon,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "cT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/crate/secure/loot,
-/obj/structure/sign/electricshock{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "cU" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "cV" = (
@@ -1296,81 +1264,94 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "cX" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel,
-/area/mine/production)
+/area/mine/living_quarters)
 "cY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/suit_storage_unit/lavaland,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "purple"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/area/mine/eva)
 "cZ" = (
-/obj/effect/turf_decal/bot,
-/turf/simulated/floor/plasteel,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
 /area/mine/production)
 "da" = (
-/obj/machinery/mineral/mint{
-	input_dir = 4
+/obj/structure/closet/emcloset,
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/mine/eva)
 "db" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	name = "custom placement";
-	pixel_y = 23
-	},
-/obj/machinery/iv_drip,
-/turf/simulated/floor/plasteel/white{
-	dir = 9;
-	icon_state = "whiteblue"
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "dc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel/white{
-	dir = 1;
-	icon_state = "whiteblue"
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "dd" = (
-/obj/structure/extinguisher_cabinet{
-	name = "custom placement";
-	pixel_x = -5;
-	pixel_y = 30
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/table,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
 "de" = (
-/turf/simulated/floor/plasteel/white{
-	dir = 1;
-	icon_state = "whiteblue"
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "df" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/firealarm{
-	name = "north bump";
-	pixel_y = 24
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel/white{
-	dir = 5;
-	icon_state = "whiteblue"
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "dg" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -1379,185 +1360,66 @@
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
 "dh" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/conveyor_switch/oneway{
+	id = "garbage";
+	name = "disposal coveyor"
 	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"di" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"dj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/maintenance)
+"dk" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/mining)
+"dl" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/production)
+"dm" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Communications APC";
 	pixel_x = 1;
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance)
-"di" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/tcomms/relay/mining,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance)
-"dj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance)
-"dk" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
-"dl" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
-	},
-/area/mine/production)
-"dm" = (
-/obj/effect/turf_decal/loading_area,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dn" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"do" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"dp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"dq" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"dr" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"ds" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dt" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/simulated/floor/plasteel/white{
-	dir = 4;
-	icon_state = "whiteblue"
-	},
-/area/mine/living_quarters)
-"du" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
-/area/mine/production)
-"dv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	name = "custom placement";
-	pixel_x = 30;
-	pixel_y = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Shuttle Docking Foyer South";
-	dir = 8;
-	network = list("Mining Outpost")
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"dw" = (
-/obj/structure/closet/crate{
-	opened = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dx" = (
-/obj/machinery/light_switch{
-	name = "custom placement";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
-"dy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
-	},
+"dn" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
 /area/mine/production)
-"dz" = (
-/obj/machinery/camera{
-	c_tag = "Communications Relay";
-	dir = 8;
-	network = list("Mining Outpost")
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
-"dA" = (
-/obj/machinery/camera{
-	c_tag = "Processing Area Room";
-	dir = 8;
-	network = list("Mining Outpost")
-	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"dB" = (
+"do" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/iv_bag/blood,
 /obj/item/reagent_containers/iv_bag/blood{
@@ -1581,62 +1443,182 @@
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
-/obj/machinery/camera{
-	c_tag = "Sleeper Room";
-	dir = 1;
-	network = list("Mining Outpost")
-	},
 /turf/simulated/floor/plasteel/white{
 	dir = 8;
 	icon_state = "whiteblue"
 	},
 /area/mine/living_quarters)
-"dC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"dp" = (
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"dq" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"dD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel/white,
-/area/mine/living_quarters)
-"dE" = (
-/obj/machinery/mineral/unloading_machine{
-	dir = 1;
-	icon_state = "unloader-corner";
-	input_dir = 1;
-	output_dir = 2
+"dr" = (
+/obj/machinery/camera{
+	c_tag = "Mining Telecommunications Hallway";
+	network = list("Mining Outpost")
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
+"ds" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
+"dt" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
+"du" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dv" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dw" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"dy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/mine/production)
-"dF" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"dz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/closet/walllocker/emerglocker/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/living_quarters)
-"dG" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
+"dA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"dH" = (
-/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/binary/pump/on,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dC" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"dD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dE" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"dF" = (
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"dG" = (
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"dH" = (
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dI" = (
@@ -1646,110 +1628,120 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dJ" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "mining_mechbay";
+	name = "Mining Mech Bay"
+	},
+/obj/machinery/door_control{
+	id = "mining_mechbay";
+	name = "Mining Mech Bay Door Control";
+	pixel_x = -6;
+	pixel_y = 24;
+	req_access_txt = "48"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dK" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "purplecorner"
-	},
-/area/mine/production)
-"dL" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/mine/production)
-"dM" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dN" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining_internal";
-	name = "mining conveyor"
-	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/alarm{
 	dir = 4;
-	icon_state = "purple"
+	name = "custom placement";
+	pixel_x = -23
 	},
-/area/mine/production)
-"dO" = (
-/obj/machinery/conveyor{
-	id = "mining_internal"
+/obj/machinery/camera{
+	c_tag = "Mining Bar West";
+	network = list("Mining Outpost");
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plating,
-/area/mine/production)
-"dP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Station Communications";
-	req_access_txt = "48"
-	},
+/area/mine/living_quarters)
+"dL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/mine/maintenance)
+/area/mine/production)
+"dM" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
+"dN" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "mining";
+	name = "interior access button";
+	pixel_x = 25;
+	pixel_y = 25;
+	req_access_txt = null
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"dO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
+"dP" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "dQ" = (
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dR" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/white,
 /area/mine/living_quarters)
 "dS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Station Maintenance";
-	req_access_txt = "48"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "dT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purplecorner"
-	},
-/area/mine/living_quarters)
-"dU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dU" = (
+/obj/structure/table,
+/obj/item/toy/russian_revolver,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dV" = (
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/mine/production)
 "dW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dX" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"dX" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dY" = (
 /obj/machinery/door/airlock/external{
@@ -1765,195 +1757,210 @@
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "ea" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purplecorner"
+	icon_state = "yellowsiding"
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "eb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "ec" = (
-/obj/machinery/camera{
-	c_tag = "Crew Area Hallway East";
-	network = list("Mining Outpost")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "ed" = (
-/obj/machinery/camera{
-	c_tag = "Crew Area Hallway West";
-	network = list("Mining Outpost")
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"ee" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "purplecorner"
-	},
-/area/mine/living_quarters)
-"ef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/production)
-"eg" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Mining Station Port Wing APC";
-	pixel_x = 1;
-	pixel_y = 25
+"ee" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"eh" = (
-/obj/structure/extinguisher_cabinet{
-	name = "custom placement";
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"ei" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"ej" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"ek" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"ef" = (
+/obj/effect/turf_decal/caution/white{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"el" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Processing Area";
-	req_access_txt = "48"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "yellowsiding";
 	dir = 4
 	},
+/area/mine/production)
+"eg" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"eh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"ei" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"ej" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"ek" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"el" = (
+/obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "em" = (
-/obj/machinery/mineral/processing_unit{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/mine/production)
-"en" = (
-/obj/machinery/mineral/processing_unit_console,
-/turf/simulated/wall,
-/area/mine/production)
-"eo" = (
-/obj/machinery/suit_storage_unit/lavaland,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purplecorner"
-	},
-/area/mine/eva)
-"ep" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
-"eq" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+"en" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
+"eo" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"ep" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"eq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "er" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
+/obj/item/toy/plushie/deer,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "es" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "et" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"eu" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"ev" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"eu" = (
+/obj/structure/table,
+/obj/item/weldingtool{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
+"ev" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "ew" = (
 /obj/structure/ore_box,
@@ -1963,257 +1970,284 @@
 	},
 /area/mine/eva)
 "ex" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station Bridge";
-	req_access_txt = "48"
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ey" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "ez" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
-	},
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "eA" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station Bridge";
-	req_access_txt = "48"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"eB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"eC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"eD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"eE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"eF" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Processing Area";
-	req_access_txt = "48"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"eG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"eH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"eI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "purplecorner"
-	},
-/area/mine/production)
-"eJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/ore_box,
-/turf/simulated/floor/plasteel{
-	icon_state = "brown"
-	},
-/area/mine/production)
-"eK" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "purple"
-	},
-/area/mine/production)
-"eL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "purplecorner"
-	},
-/area/mine/living_quarters)
-"eM" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"eN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"eO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "brown"
-	},
-/area/mine/living_quarters)
-"eP" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
-"eQ" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Station Storage";
-	req_access_txt = "48"
+"eB" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/area/mine/production)
+"eC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Mech Bay";
+	network = list("Mining Outpost");
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 9
+	},
+/area/mine/production)
+"eD" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
+"eE" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/production)
+"eF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/production)
+"eG" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/production)
+"eH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/production)
+"eI" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 5
+	},
+/area/mine/production)
+"eJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
+"eK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"eL" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"eM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"eN" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
+"eO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
+"eP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
+"eQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eR" = (
-/obj/machinery/door/airlock/glass{
-	name = "Break Room"
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "yellowsiding";
+	dir = 1
 	},
 /area/mine/living_quarters)
 "eT" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"eU" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purplecorner"
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
+"eU" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
 	},
 /area/mine/living_quarters)
 "eV" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purplecorner"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_y = 6
+	},
+/obj/item/wrench,
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "eW" = (
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "eX" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
-	},
-/obj/structure/plasticflaps,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/mine/production)
+/area/mine/living_quarters)
 "eY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2224,193 +2258,219 @@
 /area/mine/laborcamp)
 "eZ" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
+	icon_state = "yellowsiding";
+	dir = 10
 	},
 /area/mine/production)
 "fa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "fb" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "custom placement";
-	pixel_y = -22
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Mech Bay Area";
+	req_access_txt = "48"
 	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel{
-	icon_state = "purple"
-	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "fc" = (
-/obj/machinery/alarm{
-	name = "custom placement";
-	pixel_y = 23
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "fd" = (
-/obj/machinery/light,
-/obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable,
-/turf/simulated/floor/plasteel{
-	icon_state = "brown"
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/mine/production)
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "fe" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/alarm{
-	name = "custom placement";
-	pixel_y = 23
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "ff" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "fg" = (
-/obj/machinery/door/airlock{
-	id_tag = "miningdorm1";
-	name = "Room 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/camera{
+	c_tag = "Mining Disposals";
+	network = list("Mining Outpost");
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fh" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/mine/production)
 "fi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fj" = (
-/obj/machinery/computer/mech_bay_power_console{
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/chair/stool/bar{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "brown"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/mine/production)
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "fk" = (
-/turf/simulated/floor/plasteel,
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8
+	},
+/obj/item/dice/d8,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "fl" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
 /area/mine/production)
 "fm" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/mine/production)
-"fn" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "mining_internal"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/mine/production)
-"fo" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/mine/living_quarters)
-"fp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
-"fr" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/mine/living_quarters)
-"fs" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	name = "custom placement";
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purplecorner"
-	},
-/area/mine/living_quarters)
-"ft" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/mine/living_quarters)
-"fu" = (
-/obj/machinery/alarm{
-	name = "custom placement";
-	pixel_y = 23
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
-	},
-/area/mine/living_quarters)
-"fv" = (
-/obj/machinery/camera{
-	c_tag = "Storage";
-	network = list("Mining Outpost")
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/firealarm{
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/mine/living_quarters)
-"fw" = (
+"fn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"fo" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
+"fp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "brown"
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"fr" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"fs" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
+"ft" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"fu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
+"fv" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
+"fw" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "fx" = (
@@ -2420,10 +2480,14 @@
 	},
 /area/mine/living_quarters)
 "fy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fz" = (
 /turf/simulated/floor/plasteel{
@@ -2431,11 +2495,8 @@
 	},
 /area/mine/living_quarters)
 "fA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
 "fB" = (
@@ -2443,13 +2504,15 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fC" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
 "fD" = (
@@ -2462,122 +2525,86 @@
 	},
 /area/mine/living_quarters)
 "fE" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
+/obj/machinery/computer/shuttle/mining{
+	dir = 8
 	},
-/area/mine/living_quarters)
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "fF" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
-	},
-/area/mine/living_quarters)
-"fG" = (
-/obj/machinery/camera{
-	c_tag = "Dormitories";
-	dir = 4;
-	network = list("Mining Outpost")
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
-	},
-/area/mine/living_quarters)
-"fH" = (
-/obj/machinery/door/airlock{
-	id_tag = "miningdorm2";
-	name = "Room 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"fI" = (
-/obj/structure/chair,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
-"fJ" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	req_access_txt = "48"
-	},
-/obj/docking_port/mobile{
+/obj/structure/disposalpipe/segment{
 	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "mining";
-	name = "mining shuttle";
-	rebuildable = 1;
-	width = 7
-	},
-/obj/structure/fans/tiny,
-/obj/docking_port/stationary{
-	area_type = /area/lavaland/surface/outdoors;
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "mining_away";
-	name = "lavaland mine";
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
-	width = 7
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/mining)
+/area/mine/living_quarters)
+"fG" = (
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/mine/production)
+"fH" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"fI" = (
+/obj/structure/closet/crate/internals,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"fJ" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/production)
 "fK" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "fL" = (
-/obj/structure/closet/secure_closet/miner,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "brown"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "fN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /obj/machinery/light{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fO" = (
-/obj/machinery/door/airlock{
-	id_tag = "miningdorm3";
-	name = "Room 3"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fP" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "fQ" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -2598,10 +2625,15 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fU" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel{
-	icon_state = "purple"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fV" = (
 /turf/simulated/wall/indestructible/boss/see_through,
@@ -2612,92 +2644,72 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "fX" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/mine/living_quarters)
+/turf/simulated/floor/plating,
+/area/lavaland/surface/outdoors)
 "fY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fZ" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ga" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_y = -5
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "gb" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/structure/girder,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gc" = (
-/obj/machinery/door/window/southleft,
-/obj/machinery/shower{
-	pixel_y = 22
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/curtain/open/shower,
-/turf/simulated/floor/plasteel/freezer,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"ge" = (
-/obj/machinery/door/window/southright,
-/obj/machinery/shower{
-	pixel_y = 22
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"ge" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/curtain/open/shower,
-/turf/simulated/floor/plasteel/freezer,
-/area/mine/living_quarters)
-"gf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"gf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gg" = (
 /obj/structure/table,
@@ -2707,28 +2719,33 @@
 	},
 /area/mine/living_quarters)
 "gh" = (
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "gi" = (
-/obj/machinery/camera{
-	c_tag = "Crew Area";
-	dir = 1;
-	network = list("Mining Outpost")
+/obj/machinery/door_control{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	pixel_x = -25;
+	pixel_y = 4;
+	req_access_txt = "12"
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
+/obj/machinery/driver_button{
+	id_tag = "trash";
+	pixel_x = -26;
+	pixel_y = -6
 	},
-/obj/machinery/light,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/chair/stool{
+	dir = 8
 	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gj" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -2755,52 +2772,51 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "gl" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "custom placement";
-	pixel_y = -22
+/obj/structure/grille/broken,
+/obj/item/stack/rods{
+	amount = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gm" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gn" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "go" = (
 /obj/structure/stone_tile/block,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gp" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/closet/walllocker/emerglocker/south,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
 "gq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "gr" = (
@@ -2830,13 +2846,11 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplecorner"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gu" = (
 /obj/machinery/door/airlock/external{
@@ -2896,9 +2910,13 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/box,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/mine/production)
 "gB" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -2967,34 +2985,35 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gI" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/baseturf_helper/lava_land/surface,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance)
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "gJ" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4;
-	name = "scrubber outlet"
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"gL" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/living_quarters)
-"gL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/baseturf_helper/lava_land/surface,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gM" = (
@@ -3020,6 +3039,16 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"gZ" = (
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway West";
+	network = list("Mining Outpost");
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
 "hf" = (
 /obj/machinery/flasher_button{
 	id = "gulagshuttleflasher";
@@ -3074,17 +3103,23 @@
 	},
 /area/mine/laborcamp)
 "hz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/mine/living_quarters)
+/area/mine/production)
 "hA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"hD" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
 "hH" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -3137,6 +3172,15 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"ik" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "ir" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 5
@@ -3397,6 +3441,15 @@
 /obj/structure/stone_tile,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"kw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ky" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3473,6 +3526,17 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ld" = (
+/obj/machinery/camera{
+	c_tag = "Mining Production Hallway";
+	network = list("Mining Outpost");
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
 "le" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3624,6 +3688,17 @@
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"lJ" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/mine/maintenance)
 "lO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -4074,6 +4149,29 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"nH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"nO" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/mining)
+"nS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
 "nT" = (
 /obj/machinery/mineral/stacking_machine/laborstacker{
 	input_dir = 2;
@@ -4081,15 +4179,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/siberia)
-"on" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"nZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"on" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
 "oA" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/atmospherics/unary/tank/air{
@@ -4100,6 +4203,31 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"oG" = (
+/obj/item/gps/ruin{
+	gpstag = "BASE0";
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"oN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-y"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "oR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dispenser/oxygen,
@@ -4109,7 +4237,40 @@
 	},
 /area/mine/laborcamp)
 "pa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	req_access_txt = "48"
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile{
+	dwidth = 3;
+	height = 5;
+	id = "mining";
+	name = "mining shuttle";
+	rebuildable = 1;
+	width = 7
+	},
+/obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
+	dwidth = 3;
+	height = 5;
+	id = "mining_away";
+	name = "lavaland mine";
+	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
+	width = 7
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/mining)
+"pb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "pq" = (
@@ -4122,6 +4283,11 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
+"px" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "qw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -4182,6 +4348,15 @@
 	icon_state = "wood-broken"
 	},
 /area/mine/laborcamp)
+"rA" = (
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
 "rM" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/mineral/titanium,
@@ -4196,22 +4371,35 @@
 	},
 /area/mine/laborcamp)
 "rV" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/rack,
+/obj/item/wrench,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"sr" = (
+/obj/structure/table,
+/obj/item/dice/d4,
+/obj/item/toy/figure/crew/miner,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/mine/production)
 "sF" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
 "sL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"sM" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "sO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/security{
@@ -4248,6 +4436,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"sZ" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "tb" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -4256,6 +4455,36 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"tk" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"to" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate/secure/loot,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"tx" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "ty" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4272,13 +4501,9 @@
 	},
 /area/mine/laborcamp)
 "tI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "tJ" = (
 /obj/machinery/light/small,
@@ -4287,8 +4512,16 @@
 	},
 /area/mine/laborcamp)
 "tK" = (
-/obj/structure/ore_box,
-/turf/simulated/floor/plasteel,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
 /area/mine/production)
 "tT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4301,6 +4534,18 @@
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
 /area/mine/laborcamp)
+"uc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "uf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4323,6 +4568,11 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"un" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "uL" = (
 /obj/machinery/flasher{
 	id = "labor"
@@ -4330,6 +4580,10 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
+"uQ" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/mine/production)
 "vk" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Labor Shuttle Airlock";
@@ -4338,8 +4592,20 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "vq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "vw" = (
 /obj/structure/table,
@@ -4364,11 +4630,30 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp)
-"vZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"vN" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel,
+/area/mine/production)
+"vR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"vZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/living_quarters)
 "wg" = (
 /obj/machinery/mineral/equipment_vendor/labor,
@@ -4397,14 +4682,55 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/siberia)
+"wT" = (
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "wY" = (
 /obj/item/clothing/mask/gas/clown_hat,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"xb" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
+"xg" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"xj" = (
+/obj/machinery/suit_storage_unit/lavaland,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/mine/eva)
 "xo" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/floor/plating/airless,
-/area/shuttle/mining)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/mine/eva)
 "xx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4416,10 +4742,24 @@
 	},
 /area/mine/laborcamp)
 "xA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "mining_mechbay";
+	name = "Mining Mech Bay"
 	},
 /turf/simulated/floor/plasteel,
+/area/mine/production)
+"xB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
 /area/mine/production)
 "xC" = (
 /turf/simulated/wall/mineral/titanium,
@@ -4433,12 +4773,11 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp/security)
 "xM" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "xR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -4446,6 +4785,18 @@
 	icon_state = "browncorner"
 	},
 /area/mine/laborcamp)
+"yg" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"yl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ym" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4480,40 +4831,158 @@
 	},
 /area/mine/laborcamp)
 "zu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
-"AB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"zy" = (
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	stack_amt = 10
 	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"Bg" = (
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
-"BD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"BT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"zC" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"Aa" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Ae" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Ag" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Az" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/deck/cards,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"AB" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"AE" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"Bg" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
+"Bp" = (
+/obj/machinery/tcomms/relay/mining,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/maintenance)
+"Bq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Bx" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"BD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"BI" = (
+/obj/structure/ore_box,
+/obj/machinery/light/small,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
+"BT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"BX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/toy/figure/mech/ripley{
+	pixel_y = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "BY" = (
 /obj/machinery/computer/shuttle/labor,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -4569,6 +5038,27 @@
 	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
+"Du" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"DE" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"DF" = (
+/obj/machinery/iv_drip,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
 "DX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4577,19 +5067,34 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Eg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/living_quarters)
 "Ej" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "El" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "Eq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4602,27 +5107,61 @@
 	},
 /area/mine/laborcamp)
 "EG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/instrument/guitar,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"EQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"Fe" = (
-/obj/structure/sink{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
 	dir = 8;
-	pixel_x = -12
+	icon_state = "barber"
 	},
-/obj/structure/mirror{
-	pixel_x = -28
+/area/mine/living_quarters)
+"EU" = (
+/obj/machinery/camera{
+	c_tag = "Communications Relay";
+	dir = 8;
+	network = list("Mining Outpost")
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
+"Fe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/mine/living_quarters)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
 "Fp" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -4631,6 +5170,40 @@
 	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
+"Fr" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "brown"
+	},
+/area/mine/production)
+"FB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
+"FF" = (
+/obj/machinery/light/small,
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"FI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "FO" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -4665,6 +5238,13 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/mine/laborcamp)
+"Gr" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "GD" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
 /turf/simulated/wall,
@@ -4674,6 +5254,16 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"GH" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/mine/eva)
 "Hi" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
@@ -4725,34 +5315,38 @@
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "Iv" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/maintenance)
+"IJ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"IK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
-"IK" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel/freezer,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "IZ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/mining)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Jh" = (
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Jl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4760,6 +5354,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"JB" = (
+/obj/item/stack/rods{
+	amount = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"JM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
 "JP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -4783,33 +5396,51 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"JT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "JV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/sustenance,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "JX" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/mine/living_quarters)
 "JZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Kb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"Kh" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
+/area/mine/eva)
 "Kl" = (
 /obj/structure/table,
 /obj/item/trash/plate,
@@ -4818,6 +5449,21 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp)
+"Kr" = (
+/obj/machinery/door/window{
+	dir = 2;
+	name = "Mining Bar"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
 "KE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
@@ -4829,6 +5475,38 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
+"KW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"Lr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "Lz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4837,12 +5515,12 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp/security)
 "LO" = (
-/obj/effect/spawner/window,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/mine/eva)
+/area/mine/production)
 "LQ" = (
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4859,6 +5537,57 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"Ma" = (
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
+"Mb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"Mf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"Ms" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ME" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -4871,6 +5600,17 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"MJ" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"MM" = (
+/obj/structure/closet/cardboard,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Ne" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4880,6 +5620,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"Nf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "Ni" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4888,13 +5634,22 @@
 /turf/simulated/floor/plating,
 /area/mine/laborcamp/security)
 "Nj" = (
-/obj/machinery/door/airlock{
-	name = "Restroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/freezer,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
+"Nk" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ND" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4919,9 +5674,25 @@
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
 "NP" = (
-/obj/machinery/computer/shuttle/mining,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/obj/machinery/door/airlock/mining{
+	name = "Mining Station Storage";
+	req_access_txt = "48"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "NW" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -4939,19 +5710,110 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"On" = (
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway East";
+	network = list("Mining Outpost");
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
+"Oq" = (
+/obj/machinery/door/airlock{
+	name = "Mining Bar Storage"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Ow" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
+	},
+/area/mine/production)
 "OF" = (
 /obj/item/card/id/prisoner/random,
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"PQ" = (
-/obj/effect/spawner/window,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"Pb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Mining EVA";
+	network = list("Mining Outpost")
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"Pp" = (
+/obj/machinery/space_heater,
 /turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Pq" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"PF" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
+"PQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "PX" = (
 /turf/simulated/wall,
 /area/mine/laborcamp/security)
+"Qq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "QE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -4969,6 +5831,25 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"QH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Bar East";
+	network = list("Mining Outpost");
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "Rd" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -4993,6 +5874,15 @@
 /obj/structure/table,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
+"RX" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id_tag = "trash";
+	name = "disposal bay door";
+	protected = 0
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Ss" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -5009,6 +5899,34 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"Te" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"Tg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "Tj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -5033,11 +5951,15 @@
 	},
 /area/mine/laborcamp)
 "Tn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel/freezer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "Ts" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5049,20 +5971,62 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"Tv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/weldingtool{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/clothing/head/welding,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"TC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "TN" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/wall/r_wall,
-/area/mine/maintenance)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
 "Uh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"Uv" = (
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "Uy" = (
@@ -5071,18 +6035,28 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
-"UQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"Uz" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"UQ" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Vt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -5093,11 +6067,9 @@
 	},
 /area/mine/laborcamp)
 "Vu" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Vv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5118,11 +6090,14 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "VD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
 "VJ" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -5132,6 +6107,12 @@
 	icon_state = "darkredcorners"
 	},
 /area/mine/laborcamp/security)
+"VL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "VN" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -5146,12 +6127,23 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"Wo" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+"VS" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "garbage"
 	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Wo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Wt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5159,9 +6151,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Ww" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
 "Wx" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -5181,11 +6179,11 @@
 	},
 /area/mine/laborcamp)
 "WO" = (
-/obj/effect/spawner/window,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Xd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -5195,6 +6193,60 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"Xi" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 6
+	},
+/area/mine/production)
+"Xw" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell{
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/crowbar,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
+"XE" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"XI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Station Communications";
+	req_access_txt = "48"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/mine/maintenance)
+"YE" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "YJ" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Storage"
@@ -5223,15 +6275,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
-"Zf" = (
-/obj/machinery/door/airlock{
-	id_tag = "miningbathroom";
-	name = "Restroom"
+"Zd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"Zf" = (
+/obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/freezer,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Zh" = (
+/obj/machinery/mass_driver{
+	id_tag = "trash"
+	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Zk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5241,6 +6301,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"ZK" = (
+/obj/machinery/computer/shuttle/mining{
+	req_access = null
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 9
+	},
+/area/mine/production)
 "ZZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10872,7 +11941,7 @@ cG
 aj
 aj
 aj
-aj
+ab
 ai
 ab
 ab
@@ -11128,12 +12197,12 @@ ci
 cG
 aj
 aj
-aj
-aj
-aj
 ab
 ab
-aj
+ab
+ab
+ab
+ab
 aj
 aj
 aj
@@ -11384,15 +12453,15 @@ cd
 VJ
 cG
 aj
-aj
-aj
-aj
+ab
+cQ
+cQ
+cQ
+cQ
+cQ
 ab
 ab
-aj
-aj
-aj
-aj
+ab
 aj
 aj
 aj
@@ -11641,16 +12710,16 @@ aq
 aq
 aq
 aj
-aj
-aj
+ab
+cQ
+dm
+JT
+az
+cQ
+ab
+gJ
 ab
 ab
-ab
-aj
-aj
-aj
-aj
-aj
 aj
 aj
 aj
@@ -11898,19 +12967,19 @@ ce
 cz
 aq
 aj
+ab
+cQ
+Iv
+ik
+az
+cQ
+fX
+gK
+fX
+ab
 aj
 aj
-ab
-ab
-ab
-gJ
-ab
-ab
 aj
-aj
-aj
-ai
-ai
 aj
 aj
 aj
@@ -12155,21 +13224,21 @@ ch
 cA
 tZ
 aj
+ab
+cQ
+Bp
+lJ
+xb
+cQ
+cR
+Jl
+cR
+cM
+ab
 aj
-ab
-ad
-ai
-fB
-gK
-fB
-ai
-ab
-ab
-ab
-ad
-ai
-ai
-ai
+aj
+aj
+aj
 aj
 aj
 aj
@@ -12412,20 +13481,20 @@ cg
 cA
 tZ
 aj
+ab
 cQ
+dj
+ds
+az
 cQ
-cQ
-cQ
-cR
-Jl
-cR
+sL
+yR
+ex
 cM
-cR
-cR
-cR
-cM
-ai
-ai
+ab
+aj
+aj
+aj
 aj
 aj
 aj
@@ -12669,19 +13738,19 @@ cB
 cC
 aq
 aj
+aj
 cQ
-az
-az
-cQ
-fk
-yR
-fk
-cM
+dg
+EU
+FB
+XI
+bt
+cX
 fo
-fE
-fL
 cM
 ab
+aj
+aj
 aj
 aj
 aj
@@ -12926,19 +13995,19 @@ qT
 qT
 qT
 aj
-cQ
-dh
-dk
-TN
-dT
-ep
-eL
 cM
+cQ
+cQ
+cQ
+cQ
+cQ
+dr
+pb
 fs
-fk
-fU
-cR
+cM
 ab
+aj
+aj
 aj
 aj
 aj
@@ -13183,19 +14252,19 @@ aj
 aj
 aj
 aj
-cQ
+cM
 di
 gI
 dP
 dU
-eq
+cM
 eO
 eQ
-ft
-fp
-fP
-cR
+ff
+cM
 ab
+aj
+aj
 aj
 aj
 aj
@@ -13438,23 +14507,23 @@ aj
 aj
 aj
 aj
-ab
-ad
-cQ
-dj
-dx
-cQ
-dX
-er
-eS
+aj
+aj
 cM
-fu
-fk
-fU
-cR
+cV
+dx
+cV
+dX
+cM
+eS
+Mb
+dt
+cM
 ab
-ai
-ai
+ab
+ab
+aj
+aj
 aj
 aj
 aj
@@ -13695,25 +14764,25 @@ aj
 aj
 aj
 aj
+aj
 ab
-ai
-cQ
-dg
-dz
-cQ
-ed
-Kb
-eM
-El
-fv
-fF
-fX
 cM
-ai
-ad
-ai
-ai
-ab
+Oq
+cM
+cM
+cM
+cM
+eN
+gL
+fv
+cM
+cM
+cM
+cM
+cM
+aj
+aj
+aj
 aj
 aj
 aj
@@ -13954,25 +15023,25 @@ aj
 aj
 ab
 ab
-cQ
-cQ
-cQ
-cQ
+cM
+fz
+dC
+dK
 fc
-er
-vZ
-cM
-cM
-cM
-cM
-cM
-cM
-cM
-cM
-cM
+cT
+sL
+bV
+fo
+dQ
+gh
+Uz
+tk
 cM
 ab
-ab
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -14212,23 +15281,23 @@ aj
 aj
 ab
 cM
-db
-dB
-cM
-fk
-EG
-on
-cM
+eb
+fz
+fz
+tx
+fz
+Eg
+ek
+ff
+dQ
+fL
 fe
-fr
-cM
-fe
-fr
-cM
-fe
-fr
-cM
+Pq
+cR
 ab
+aj
+aj
+aj
 aj
 aj
 aj
@@ -14468,23 +15537,23 @@ aj
 aj
 aj
 ab
+cM
+fD
+fz
+bS
+fk
+xg
+sL
+eR
+fU
+TN
+EQ
+fp
+bU
 cR
-dc
-dC
-WO
-dT
-Kb
-Eg
-cM
-ff
-aY
-cM
-ff
-bi
-cM
-ff
-br
-cM
+ab
+aj
+aj
 aj
 aj
 aj
@@ -14725,23 +15794,23 @@ aj
 aj
 aj
 ab
-cR
-de
-dD
-dR
+cM
+fN
+fz
+AE
 ft
-es
-vZ
-cM
-fg
-BD
-cM
-fH
-BD
-cM
-fO
-BD
-cM
+fz
+sL
+Tg
+fA
+dQ
+fP
+nS
+DF
+cR
+ai
+ai
+aj
 aj
 aj
 aj
@@ -14981,24 +16050,24 @@ aD
 aj
 aj
 ai
-ad
+ai
 cM
-df
-dt
-dQ
-dX
-er
+gg
+fz
+fz
+Tn
+fz
 sL
+eq
+fA
+dQ
+dW
 fa
-fw
-fG
-fa
-fw
-gp
-gq
-fw
-gt
-cR
+do
+cM
+ai
+ai
+ai
 aj
 aj
 aj
@@ -15238,25 +16307,25 @@ an
 aj
 aj
 ai
+ai
+cM
+fx
+fz
+bS
+Az
+xg
+sL
+bV
+fA
 cM
 cM
 cM
 cM
 cM
-eg
-et
-eN
-gL
-fi
-pa
-pa
-fi
-fN
-Ej
-gA
-fp
-cR
-ab
+cM
+cM
+aj
+aj
 aj
 aj
 aj
@@ -15496,27 +16565,27 @@ aD
 aj
 aj
 cM
-cS
-do
+cM
 dF
+dF
+Nf
+fw
+fz
+sL
+bV
+rA
 cM
-eh
-EG
-on
+MM
+cV
+ei
+gb
+dH
 cM
-cM
-dQ
-dQ
-cM
-cM
-BD
-Nj
-cM
-cM
-ai
-ab
-ab
-ab
+aj
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -15753,30 +16822,30 @@ aD
 aj
 aj
 cM
-cT
-cV
+dR
+dR
 dG
-cM
-ea
-er
-rV
-cM
-fx
+fr
+ec
 fz
-fY
-gh
+sL
+PQ
+fo
 cM
-gc
-hz
+cV
+eX
+eX
+bC
+EG
 cM
-ai
-ad
-ai
-ai
-ab
-ab
-ab
-ab
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -16010,28 +17079,28 @@ aD
 aj
 aj
 cM
-cU
-dp
-dH
-dS
-eb
-eu
-Ej
-PQ
-fy
-fy
-fZ
+BD
+VD
+XE
+fr
+ec
 fz
+sL
+PQ
+gZ
 cM
-ge
-Tn
+dp
+cV
 cM
-ab
-ai
-ai
-ab
-ab
-ab
+cM
+ey
+cM
+aj
+aj
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -16267,23 +17336,23 @@ aD
 aj
 ab
 cM
-cV
-dq
-dI
-cM
+db
+gq
+dR
+fr
 ec
-ev
-vZ
-eR
 fz
-fI
-ga
-gi
+Eg
+bG
+gp
 cM
-BD
+eX
+JB
+cM
+Zf
 Zf
 cM
-aj
+ab
 aj
 aj
 aj
@@ -16522,30 +17591,30 @@ aD
 aD
 aj
 aj
-ab
+ai
 cM
-cW
-dr
-dr
-cM
+dc
+gq
+WO
+Te
 vq
 Kb
 eT
-WO
-fA
-fA
-gb
-gl
+El
+Ww
 cM
-Fe
+gb
+Jh
+cM
+dq
 bo
 cM
+ai
 aj
 aj
 aj
 aj
-ab
-ab
+aj
 aj
 aj
 aj
@@ -16781,28 +17850,28 @@ aj
 aj
 aj
 cM
-cM
-cM
-cM
-cM
-fk
-er
+de
+gq
+dR
+fj
+yg
+yg
 vZ
-cM
+oN
 fC
-fz
+sZ
 gf
 gm
 cM
 IK
-tI
+eX
 cM
-aj
-aj
-aj
-aj
-aj
+cM
 ab
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -17036,24 +18105,26 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-ab
-ab
-cR
-fk
+ai
+cM
+KW
+dd
+Kr
+QH
+fK
 ev
 bx
+Qq
+fA
 cM
-fD
-fK
-gg
+zC
 gn
 cM
+eL
+dI
+cW
 cM
-cM
-cM
+ai
 aj
 aj
 aj
@@ -17061,8 +18132,6 @@ aj
 aj
 aj
 aj
-aj
-ab
 aj
 aj
 aj
@@ -17290,37 +18359,37 @@ aj
 aj
 aj
 aj
-ab
 aj
-aj
-aj
-aj
-aj
-aj
-ab
-cR
-ee
-ey
+ai
+cM
+cM
+cM
+fi
+cM
+cM
+cM
+cM
+cM
 eU
+Qq
+fo
 cM
-cR
-cR
-cR
-cR
+zC
+TC
+cP
+Nk
+Du
+kw
 cM
 ai
-ai
-ai
-aj
-ab
 aj
 aj
-ab
-ab
 aj
-ab
-ab
-ab
+aj
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -17547,39 +18616,39 @@ aj
 aj
 aj
 aj
-ab
 aj
-ab
-aj
-aj
-aj
-aj
-aj
-cR
-cR
-ex
-cR
-cR
-ab
-ab
-ab
-ab
+cM
+cM
+br
+Aa
+eX
+cV
+cV
+Vu
+Ae
+cM
+dz
+Qq
+fA
+cM
+zC
+AB
+cM
+px
+eX
+nZ
+cM
 ai
 ai
-ai
-ab
 aj
 aj
 aj
 aj
-ab
-ab
-ab
-ai
-ad
-ad
-ab
-ab
+aj
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -17796,48 +18865,48 @@ aj
 ai
 ai
 ai
+ai
 aj
 aj
 aj
 aj
 aj
 aj
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aj
 aj
-aj
-aj
-cR
+cM
+cV
+fZ
+eo
+Gr
+tI
+eo
+cU
+eo
 ez
-cR
-ab
-ab
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-ab
-ad
-ad
-ad
-ad
+Ma
+em
+fs
+cM
+zC
+bQ
+cM
+Ms
+cV
+to
+cM
 ad
 ai
 ai
+ab
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -18052,50 +19121,50 @@ ai
 ai
 am
 ai
+ai
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+cM
+gb
+Ej
+uQ
+bq
+bq
+bq
+bq
+bq
+bq
+sL
+ge
+fA
+cM
+fy
+rV
+cM
+ee
+fO
+YE
+cM
+cM
+cM
+cM
 ab
 aj
 aj
 aj
 aj
 aj
-ab
-xC
-xC
-tb
-xC
-tb
-xC
-xC
-ab
-aj
-aj
-aj
-cR
-BT
-cR
-ab
 aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-ab
-aj
-ab
-ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ab
 aj
 aj
 "}
@@ -18308,51 +19377,51 @@ am
 am
 am
 ai
-ab
+ai
 aj
 aj
 aj
 aj
 aj
-ab
-ab
-xC
-Rs
-Cf
+aj
+aj
+aj
+aj
+aj
 JX
-Vu
-CF
-xC
+eX
+et
+bq
+Fr
+Ow
+dS
+Uv
+dS
+bq
+sL
+ge
+rA
+cM
+Ag
+bH
+cM
+cM
+cM
+cM
+cM
+UQ
+Wo
+cM
 ab
 aj
 aj
 aj
-cR
-BT
-cR
-ab
 aj
 aj
 aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-ab
-ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ab
 aj
 aj
 "}
@@ -18565,29 +19634,42 @@ am
 am
 am
 ai
-ab
+ai
 aj
 aj
 ab
 ab
+ab
+aj
 aj
 ab
-ab
-tb
-NP
-Wo
-rM
+aj
+aj
+cM
 Vu
 IZ
-xo
+bq
+bT
+VL
+eW
+vR
+uc
+bq
+en
+fm
+PF
+cM
+zC
+gb
+cM
+JB
+bi
+fg
+zy
+cD
+xM
+cM
 ab
-ab
-aj
-aj
-cR
-BT
-cR
-ab
 aj
 aj
 aj
@@ -18597,19 +19679,6 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ab
 aj
 aj
 "}
@@ -18822,29 +19891,44 @@ am
 am
 am
 ai
-ab
-aj
-ab
-ab
-aj
 aj
 aj
 ab
-xC
-Iv
-Cf
-Cf
-Vu
+ab
+ab
+ab
+ab
+ab
+aj
+aj
+ab
+cM
+Pp
 xM
-xC
-ab
-ab
+bq
+Pb
+bp
+dA
+dB
+co
+bq
+sL
+bE
+On
+cM
+zC
+cV
+ey
+yl
+cV
+un
+dh
+VS
+xM
+cM
+cM
+cM
 aj
-ab
-bN
-UQ
-bN
-ab
 aj
 aj
 aj
@@ -18852,21 +19936,6 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-ab
-ab
-ad
-ad
-ai
-ad
-ab
-ab
 aj
 aj
 "}
@@ -19078,50 +20147,50 @@ am
 am
 am
 am
-ai
-aj
-aj
-aj
-aj
 aj
 aj
 aj
 ab
 xC
 xC
-tb
-fJ
-tb
+nO
 xC
 xC
 ab
 aj
-aj
 ab
-bN
-UQ
-bN
-ab
+bq
+oG
+et
+bq
+eM
+MJ
+cs
+gA
+sr
+bq
+sL
+bE
+fA
+cM
+wT
+fH
+es
+BT
+aY
+DE
+dE
+gd
+fF
+bI
+Zh
+RX
 aj
 aj
 aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-ab
-ab
-ab
-ab
-ab
 aj
 aj
 aj
@@ -19335,49 +20404,49 @@ am
 am
 am
 am
-am
-ai
-aj
-ab
-aj
-aj
 aj
 aj
 aj
 ab
-ab
-bJ
-gv
-bN
-ab
-ab
-aj
-aj
-aj
-ab
-bN
-UQ
-bN
-ab
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+xC
+CF
+dk
+BI
+xC
 ab
 ab
-ab
+bq
+bq
+bq
+fJ
+bq
+NP
+bq
+bq
+bq
+bq
+bq
+dl
+ep
+hD
+bq
+eX
+cV
+cM
+cM
+cM
+cM
+cV
+cM
+cR
+cM
+cR
+cM
+aj
+aj
+aj
+aj
+aj
 aj
 aj
 aj
@@ -19592,49 +20661,49 @@ am
 am
 am
 am
-am
-ai
-ab
-ab
-aj
-aj
-aj
-aj
 aj
 aj
 ab
+ab
+tb
+fu
+fu
+fu
+tb
 bN
-eW
 bN
-ab
-aj
-aj
-aj
-aj
-ab
 bN
+ZK
+dO
+Nj
 eB
-bN
+dD
+ld
+xB
+eB
+bP
+eB
+cN
+eh
+on
+bq
+cV
+eX
+cV
+AB
+Bq
+ga
+cV
+bD
+cV
+gi
+eX
+cR
 ab
-ab
 aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-ab
 aj
 aj
 aj
@@ -19849,49 +20918,49 @@ am
 am
 am
 am
-am
-am
-ai
+aj
+aj
 ab
-aj
-aj
-aj
-aj
-aj
-aj
-bN
-bN
+ab
+xC
+bw
+rM
+Cf
+pa
+gv
+eW
 gw
-bN
-bN
-ab
-aj
-aj
-ab
-bN
-bN
+aN
+cS
+Mf
+dT
+Bx
+nH
+FI
 eA
-bN
-bN
-ab
-ab
+eA
+eA
+eK
+Lr
+df
+bq
+px
+cV
+eX
+cV
+cV
+ey
+fY
+eg
+cV
+gt
+fI
+cR
 aj
 aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-ab
 aj
 aj
 aj
@@ -20106,44 +21175,44 @@ am
 am
 am
 am
-am
-am
-am
-ai
-ai
-ai
 aj
-aj
-aj
-bq
+ab
+ab
+ab
+tb
+Cf
+sM
+Cf
+tb
+bJ
 bN
-bP
+bN
 cn
 ct
-bN
-bq
-bq
-bq
-bq
-bN
+ed
+eJ
+tK
+cZ
+JM
+ef
 ef
 eD
-ct
-bN
+Fe
+dM
+Xi
 bq
-ab
-ab
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+cM
+cM
+cM
+cV
+FF
+cM
+cM
+cM
+cR
+cM
+cM
+cM
 aj
 aj
 aj
@@ -20363,31 +21432,41 @@ am
 am
 am
 am
-am
-am
-am
-am
-ai
-aj
 aj
 aj
 ab
-bq
-bw
-eW
-cl
-eW
+ab
+xC
+Rs
+fE
+fd
+xC
+ab
+aj
+bf
+bf
+bF
 cx
-cD
-cH
-cn
-du
+bF
+bf
+bf
+bq
 dJ
 xA
-aN
-eW
+dV
+cH
 fb
+dV
 bq
+er
+eX
+gb
+cV
+gl
+cM
+ab
+ab
+ab
 ab
 aj
 aj
@@ -20396,16 +21475,6 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-ab
 aj
 aj
 aj
@@ -20620,40 +21689,40 @@ am
 am
 am
 am
-am
-am
-am
-ai
-aj
 aj
 aj
 aj
 ab
-bN
-bC
-bQ
+xC
+xC
+tb
+xC
+xC
+ab
+aj
+bf
 cm
 cE
 Uh
-cE
+ck
 cY
-cE
-Uh
-cE
-Uh
+bf
+zu
+eW
+eW
 eC
 eP
-fd
-bq
+eB
+eZ
+dn
+eX
+cV
+gc
+cV
+cV
+cM
 ab
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ab
 aj
 aj
 aj
@@ -20878,38 +21947,38 @@ am
 am
 am
 am
-am
-ai
-aj
-aj
 aj
 aj
 ab
 ab
-bN
-bT
-bR
-cI
+ab
+ab
+ab
+ab
+aj
+aj
+bf
+xj
 cw
 dy
 cF
 cI
-VD
+bf
 zu
-VD
-gd
-eH
 eW
-fh
-bN
+eW
+eH
+bR
+eW
+hz
+bq
+cM
+cM
+cM
+cM
+cM
+cM
 ab
-aj
-aj
-aj
-aj
-aj
-aj
-aj
 aj
 aj
 aj
@@ -21135,38 +22204,38 @@ am
 am
 am
 am
-am
-ai
 aj
 aj
-ai
 ab
+ab
+aj
+ab
+aj
+aj
+aj
+aj
 bf
-bf
-bf
-LO
-bS
-bF
-bf
+cp
+fn
 cJ
-bq
-cN
-dl
+bX
+cp
+bf
 dv
-dK
-ei
+eW
+eW
 eE
 eV
-fj
+eW
+ea
 bN
+ad
+ai
+ai
+aj
 ab
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ab
+ab
 aj
 aj
 aj
@@ -21393,32 +22462,32 @@ am
 am
 am
 am
-am
-ai
-ai
-ai
-ab
-bf
-bp
-bD
-bE
-cs
-co
-bf
-cK
-bq
-bq
-bN
-bq
-dV
-el
-eF
-dV
-bq
-bq
+aj
+aj
+aj
+aj
+aj
 ab
 ab
 aj
+aj
+bf
+cp
+Kh
+cK
+IJ
+cp
+bf
+du
+fh
+el
+eF
+Tv
+eW
+eu
+bN
+ai
+ai
 aj
 aj
 aj
@@ -21650,32 +22719,32 @@ am
 am
 am
 am
-am
-am
-ai
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 ab
-ab
-bg
-bt
-bY
-Ww
-bU
-cp
 bf
+cl
+Zd
 cL
-bq
+bY
 da
-dm
+bf
 dw
 dL
 ej
 eG
-ct
-tK
-bN
+BX
+eW
+Xw
+fG
+ai
 ab
-ab
-aj
 aj
 aj
 aj
@@ -21911,26 +22980,26 @@ am
 ai
 aj
 aj
+aj
+aj
+aj
 ab
-bg
-bt
-bY
-bH
-bV
-aI
+ab
 bf
-bq
-bq
+aI
+GH
+dN
+xo
 cO
-eW
-eW
-eW
-xA
+bf
+vN
+fh
+el
 eI
-eZ
+bv
 fl
+LO
 bq
-ab
 ab
 aj
 aj
@@ -22168,26 +23237,26 @@ am
 ai
 aj
 aj
+aj
+aj
+ab
+ab
 ab
 bf
-bu
-bG
-bI
-bX
-eo
 bf
-ad
+bg
+cj
+bg
+bf
+bf
 bq
-cP
-eW
-dM
-dW
-AB
-eJ
 bq
-eX
 bq
-ab
+bN
+bq
+bq
+bq
+bq
 ab
 aj
 aj
@@ -22426,24 +23495,24 @@ ai
 aj
 aj
 ab
+ab
+ab
+ab
+ab
+ab
 bf
+bK
+ck
+cr
 bf
-bf
-bg
-cj
-bg
-bf
-ai
-bq
-dd
-eW
-dA
-dN
-ek
-eK
-dV
-fm
-bq
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 aj
@@ -22682,27 +23751,27 @@ am
 ai
 aj
 aj
+aj
+ab
+ab
 ab
 ab
 ab
 bf
-bK
-ck
-cr
+bW
+cq
+ew
 bf
-ai
-bq
-cX
-dn
-bq
-dV
-en
-dV
-dV
-fm
-bq
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
 aj
 aj
 aj
@@ -22940,24 +24009,22 @@ ai
 ai
 aj
 aj
+aj
+ab
+ab
 ab
 ab
 bf
-bW
-cq
-ew
+bg
+dY
+bg
 bf
-ai
-bq
-cZ
-ds
-dE
-dO
-em
-dO
-dO
-fn
-bq
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -22969,7 +24036,9 @@ aj
 aj
 aj
 aj
-ab
+aj
+aj
+aj
 aj
 aj
 aj
@@ -23197,27 +24266,27 @@ ab
 ai
 ai
 aj
+ab
+ab
+ab
+ab
+ab
+bu
+ab
+gH
+bu
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aj
-ab
-bf
-bg
-dY
-bg
-bf
-ai
-bq
-bq
-bq
-bq
-bq
-bq
-bq
-bq
-bq
-bq
-ab
-ab
-ab
+aj
 aj
 aj
 aj
@@ -23456,25 +24525,25 @@ ab
 ab
 ab
 ab
-bv
 ab
-gH
 ab
-bv
-ai
-ai
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 aj
 aj
-aj
-aj
-ab
-ab
-ab
-ab
-ab
-ab
 aj
 aj
 ab
@@ -23722,16 +24791,16 @@ ab
 ab
 aj
 aj
-aj
-aj
-aj
-aj
-aj
 ab
 ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+aj
 aj
 aj
 aj

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -540,14 +540,13 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
 "bx" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/machinery/door/poddoor{
+	id_tag = "trash";
+	name = "disposal bay door";
+	protected = 0
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
-	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "by" = (
 /obj/structure/cable{
@@ -646,13 +645,19 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "bI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor/east{
-	id = "garbage"
+/obj/machinery/driver_button{
+	id_tag = "trash";
+	pixel_x = 26;
+	pixel_y = -6
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door_control{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	pixel_x = 25;
+	pixel_y = 4;
+	req_access_txt = "12"
 	},
+/obj/structure/chair/stool,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bJ" = (
@@ -738,6 +743,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -1520,9 +1526,6 @@
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "dz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
@@ -1602,6 +1605,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
+/area/mine/living_quarters)
+"dH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -1758,10 +1768,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1941,7 +1947,9 @@
 /area/mine/production)
 "ev" = (
 /obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -2065,12 +2073,12 @@
 	},
 /area/mine/production)
 "eJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
+/obj/machinery/conveyor/east{
+	id = "garbage"
 	},
-/area/mine/production)
+/obj/machinery/recycler,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "eK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -2200,9 +2208,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 1
@@ -2318,6 +2323,9 @@
 /area/mine/production)
 "fi" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fj" = (
@@ -2435,11 +2443,14 @@
 	},
 /area/mine/living_quarters)
 "fy" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
@@ -2487,11 +2498,17 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
-"fG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+"fF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/east{
+	id = "garbage"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"fG" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -2506,6 +2523,7 @@
 	name = "east bump";
 	pixel_x = 28
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -2683,14 +2701,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/mine/living_quarters)
-"gd" = (
-/obj/machinery/conveyor/east{
-	id = "garbage";
-	dir = 2
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ge" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4663,14 +4673,12 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "vZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
-	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "wg" = (
 /obj/machinery/mineral/equipment_vendor/labor,
@@ -4798,12 +4806,6 @@
 	icon_state = "browncorner"
 	},
 /area/mine/laborcamp)
-"yg" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
 "yl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4852,18 +4854,7 @@
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
-"zy" = (
-/obj/machinery/conveyor/east{
-	id = "garbage"
-	},
-/obj/machinery/recycler,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "zC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/chair/stool/bar{
 	dir = 1
 	},
@@ -4950,15 +4941,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -4983,9 +4974,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -5069,10 +5060,8 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "DE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "DF" = (
@@ -5283,7 +5272,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "GD" = (
@@ -5509,12 +5498,12 @@
 	dir = 2;
 	name = "Mining Bar"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -5543,6 +5532,10 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -5593,7 +5586,7 @@
 	},
 /area/mine/laborcamp)
 "Ma" = (
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 1
@@ -5622,14 +5615,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -5929,11 +5922,6 @@
 /obj/structure/table,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
-"RX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "Ss" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -6087,19 +6075,10 @@
 	},
 /area/mine/living_quarters)
 "UQ" = (
-/obj/machinery/driver_button{
-	id_tag = "trash";
-	pixel_x = 26;
-	pixel_y = -6
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door_control{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	pixel_x = 25;
-	pixel_y = 4;
-	req_access_txt = "12"
-	},
-/obj/structure/chair/stool,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Vt" = (
@@ -6168,12 +6147,10 @@
 	},
 /area/mine/laborcamp)
 "VS" = (
-/obj/machinery/door/poddoor{
-	id_tag = "trash";
-	name = "disposal bay door";
-	protected = 0
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "VT" = (
@@ -17882,9 +17859,9 @@ de
 fI
 dR
 zC
-yg
-yg
-vZ
+fz
+fz
+sL
 oN
 fC
 sZ
@@ -18141,7 +18118,7 @@ Kr
 fG
 bP
 ev
-bx
+sL
 bi
 fA
 cM
@@ -18649,7 +18626,7 @@ cM
 cM
 br
 Aa
-eX
+et
 cV
 cV
 Vu
@@ -19950,7 +19927,7 @@ bQ
 yl
 eo
 eo
-DE
+VS
 eX
 eX
 cM
@@ -20464,10 +20441,10 @@ cM
 cM
 cM
 cM
-bI
+fF
 fw
 dh
-UQ
+bI
 cV
 cR
 aj
@@ -20721,11 +20698,11 @@ cV
 AB
 VT
 cM
-zy
+eJ
 eX
 cR
 cM
-RX
+DE
 cM
 aj
 aj
@@ -20980,10 +20957,10 @@ cV
 VD
 Jh
 eg
-gd
+vZ
 gq
 Zh
-VS
+bx
 aj
 aj
 aj
@@ -21218,7 +21195,7 @@ bN
 cn
 ct
 ed
-eJ
+dM
 fy
 bU
 JM
@@ -21230,7 +21207,7 @@ dM
 Xi
 bq
 cM
-cM
+dH
 cM
 cV
 FF
@@ -21744,7 +21721,7 @@ eB
 eZ
 dn
 eX
-cV
+UQ
 fw
 cV
 cV

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1604,11 +1604,6 @@
 	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
-"dH" = (
-/obj/effect/spawner/window/reinforced,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mine/production)
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -22789,7 +22784,7 @@ eG
 BX
 eW
 ld
-dH
+bN
 ai
 ab
 aj

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -349,7 +349,6 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "aY" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	cell_type = 25000;
 	dir = 4;
@@ -595,11 +594,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"bC" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "bD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -652,13 +646,12 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "bI" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor/east{
-	id = "garbage";
-	dir = 2
+	id = "garbage"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Disposal Exit";
-	name = "Disposal Exit Vent"
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
@@ -1116,12 +1109,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
-"cD" = (
-/obj/machinery/conveyor/east{
-	id = "garbage"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "cE" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1455,11 +1442,14 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dr" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ds" = (
@@ -1584,8 +1574,18 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/west,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dF" = (
@@ -1795,6 +1795,10 @@
 "eg" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
@@ -2483,17 +2487,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
-"fF" = (
-/obj/machinery/conveyor/east{
-	id = "garbage";
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "fG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -2694,9 +2687,9 @@
 "gd" = (
 /obj/machinery/conveyor/east{
 	id = "garbage";
-	dir = 6
+	dir = 2
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ge" = (
@@ -2744,24 +2737,6 @@
 	dir = 8;
 	icon_state = "barber"
 	},
-/area/mine/living_quarters)
-"gi" = (
-/obj/machinery/door_control{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	pixel_x = -25;
-	pixel_y = 4;
-	req_access_txt = "12"
-	},
-/obj/machinery/driver_button{
-	id_tag = "trash";
-	pixel_x = -26;
-	pixel_y = -6
-	},
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gj" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -2825,10 +2800,18 @@
 	},
 /area/mine/living_quarters)
 "gq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Disposal Exit";
+	name = "Disposal Exit Vent";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gr" = (
@@ -4514,13 +4497,6 @@
 /obj/structure/closet/crate/secure/loot,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"tx" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "ty" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4607,7 +4583,6 @@
 	},
 /area/mine/laborcamp)
 "un" = (
-/obj/effect/decal/warning_stripes/south,
 /obj/machinery/camera{
 	c_tag = "Mining Disposals";
 	network = list("Mining Outpost");
@@ -4833,6 +4808,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ym" = (
@@ -4874,10 +4853,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "zy" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
+/obj/machinery/conveyor/east{
+	id = "garbage"
 	},
+/obj/machinery/recycler,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "zC" = (
@@ -5090,8 +5069,10 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "DE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "DF" = (
@@ -5411,7 +5392,10 @@
 /area/mine/living_quarters)
 "Jh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Jl" = (
@@ -5946,12 +5930,8 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "RX" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id_tag = "trash";
-	name = "disposal bay door";
-	protected = 0
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Ss" = (
@@ -6107,11 +6087,19 @@
 	},
 /area/mine/living_quarters)
 "UQ" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/machinery/driver_button{
+	id_tag = "trash";
+	pixel_x = 26;
+	pixel_y = -6
 	},
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/door_control{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	pixel_x = 25;
+	pixel_y = 4;
+	req_access_txt = "12"
+	},
+/obj/structure/chair/stool,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Vt" = (
@@ -6180,10 +6168,12 @@
 	},
 /area/mine/laborcamp)
 "VS" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor/east{
-	id = "garbage"
+/obj/machinery/door/poddoor{
+	id_tag = "trash";
+	name = "disposal bay door";
+	protected = 0
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "VT" = (
@@ -6192,13 +6182,10 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Wo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Wt" = (
@@ -19450,7 +19437,7 @@ cM
 cM
 cM
 cM
-UQ
+xb
 Wo
 cM
 ab
@@ -19702,13 +19689,13 @@ PF
 cM
 fp
 gb
-cM
+VD
 QH
 Ww
 un
-zy
-cD
-xM
+eX
+eX
+cV
 cM
 ab
 aj
@@ -19959,13 +19946,13 @@ On
 cM
 fp
 cV
-VD
+bQ
 yl
-cV
-bC
-dh
-VS
-xM
+eo
+eo
+DE
+eX
+eX
 cM
 cM
 cM
@@ -20219,13 +20206,13 @@ bG
 df
 dr
 aY
-DE
+cM
 dE
-gd
-fF
-bI
-Zh
-RX
+eX
+QH
+cV
+px
+cR
 aj
 aj
 aj
@@ -20477,12 +20464,12 @@ cM
 cM
 cM
 cM
+bI
+fw
+dh
+UQ
 cV
-cM
 cR
-cM
-cR
-cM
 aj
 aj
 aj
@@ -20733,14 +20720,14 @@ eX
 cV
 AB
 VT
-bQ
-cV
-tx
-cV
-gi
+cM
+zy
 eX
 cR
-ab
+cM
+RX
+cM
+aj
 aj
 aj
 aj
@@ -20993,10 +20980,10 @@ cV
 VD
 Jh
 eg
-cV
+gd
 gq
-xb
-cR
+Zh
+VS
 aj
 aj
 aj

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -428,14 +428,19 @@
 	},
 /area/mine/laborcamp/security)
 "bi" = (
-/obj/machinery/camera{
-	c_tag = "Mining Telecommunications Hallway";
-	network = list("Mining Outpost")
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "bj" = (
 /obj/machinery/status_display{
@@ -526,10 +531,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/item/toy/plushie/deer,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bw" = (
@@ -594,15 +596,19 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "bC" = (
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -621,33 +627,29 @@
 /turf/simulated/floor/plating,
 /area/mine/eva)
 "bG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"bH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"bH" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "bI" = (
 /obj/machinery/conveyor/east{
@@ -739,17 +741,21 @@
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
 "bP" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "bQ" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_y = -5
 	},
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "bR" = (
 /obj/structure/cable{
@@ -786,15 +792,23 @@
 	},
 /area/mine/production)
 "bU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
 "bV" = (
-/obj/effect/spawner/random_spawners/grille_often,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "bW" = (
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
@@ -966,6 +980,10 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown";
@@ -1266,12 +1284,14 @@
 	},
 /area/mine/eva)
 "cZ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway West";
+	network = list("Mining Outpost");
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "da" = (
 /obj/structure/closet/emcloset,
@@ -1301,12 +1321,14 @@
 	},
 /area/mine/living_quarters)
 "dd" = (
-/obj/structure/grille/broken,
-/obj/item/stack/rods{
-	amount = 4
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "de" = (
 /obj/structure/table/reinforced,
@@ -1318,15 +1340,13 @@
 	},
 /area/mine/living_quarters)
 "df" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "dg" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -1424,8 +1444,8 @@
 	},
 /area/mine/living_quarters)
 "dp" = (
-/obj/structure/rack,
-/obj/item/wrench,
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dq" = (
@@ -1436,11 +1456,13 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dr" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/mine/production)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1454,17 +1476,9 @@
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
 "dt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
-	},
-/area/mine/production)
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "du" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -1591,11 +1605,10 @@
 	},
 /area/mine/living_quarters)
 "dH" = (
-/obj/item/stack/rods{
-	amount = 4
-	},
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/area/mine/production)
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -1618,14 +1631,8 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/item/instrument/guitar,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dL" = (
 /obj/structure/cable{
@@ -1810,9 +1817,18 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "ei" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "ej" = (
 /obj/structure/cable{
@@ -1898,17 +1914,14 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "er" = (
-/obj/effect/spawner/random_spawners/blood_often,
-/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "es" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/closet/walllocker/emerglocker/south,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "et" = (
@@ -1943,18 +1956,19 @@
 	},
 /area/mine/eva)
 "ex" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
+/obj/structure/rack,
+/obj/item/wrench,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ey" = (
-/obj/structure/closet/crate/internals,
-/turf/simulated/floor/plating,
+/obj/machinery/camera{
+	c_tag = "Mining Telecommunications Hallway";
+	network = list("Mining Outpost")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/living_quarters)
 "ez" = (
 /obj/machinery/door/airlock/maintenance,
@@ -2229,17 +2243,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "eZ" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
-	dir = 4
+	dir = 10
 	},
 /area/mine/production)
 "fa" = (
@@ -2301,22 +2307,13 @@
 	},
 /area/mine/living_quarters)
 "fg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fh" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
@@ -2326,9 +2323,15 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fj" = (
-/obj/structure/closet/cardboard,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
 "fk" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -2374,19 +2377,13 @@
 	},
 /area/mine/living_quarters)
 "fp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fr" = (
 /obj/structure/chair/stool/bar{
@@ -2428,8 +2425,9 @@
 	},
 /area/mine/living_quarters)
 "fw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/item/shard{
+	icon_state = "medium"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fx" = (
@@ -2439,15 +2437,17 @@
 	},
 /area/mine/living_quarters)
 "fy" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/area/mine/production)
 "fz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -2501,28 +2501,52 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fG" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"fH" = (
-/obj/machinery/firealarm{
-	dir = 4;
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Bar East";
+	network = list("Mining Outpost");
+	dir = 8
+	},
+/obj/item/radio/intercom{
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"fH" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8
+	},
+/obj/item/dice/d8,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "fI" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "fJ" = (
@@ -2533,8 +2557,15 @@
 /turf/simulated/floor/plating,
 /area/mine/production)
 "fK" = (
-/obj/effect/spawner/random_spawners/blood_often,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fL" = (
 /obj/structure/table,
@@ -2587,13 +2618,13 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fU" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway West";
-	network = list("Mining Outpost");
+/obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "fV" = (
@@ -2608,18 +2639,18 @@
 /turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors)
 "fY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/chair/stool/bar{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "Mining Infirmary";
+	network = list("Mining Outpost");
+	dir = 10
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "fZ" = (
@@ -2630,24 +2661,41 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ga" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "gb" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 4;
+	name = "custom placement";
+	pixel_x = -23
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "Mining Bar West";
+	network = list("Mining Outpost");
+	dir = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "gd" = (
 /obj/machinery/conveyor/east{
@@ -2747,9 +2795,10 @@
 /area/lavaland/surface/outdoors)
 "gl" = (
 /obj/structure/grille/broken,
-/obj/item/shard{
-	icon_state = "medium"
+/obj/item/stack/rods{
+	amount = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gm" = (
@@ -2776,16 +2825,16 @@
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gp" = (
-/obj/structure/extinguisher_cabinet{
-	name = "south bump";
-	pixel_y = -30
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
 "gq" = (
-/obj/item/toy/plushie/deer,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gr" = (
@@ -2815,22 +2864,19 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gt" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/dice/d8,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gu" = (
 /obj/machinery/door/airlock/external{
@@ -2981,7 +3027,6 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gL" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -2994,6 +3039,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gM" = (
@@ -3020,13 +3066,12 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gZ" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway East";
-	network = list("Mining Outpost");
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "hf" = (
@@ -3084,6 +3129,10 @@
 /area/mine/laborcamp)
 "hz" = (
 /obj/structure/closet/firecloset,
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
@@ -3130,6 +3179,13 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"hW" = (
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -3507,9 +3563,19 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ld" = (
-/obj/effect/spawner/random_spawners/fungus_probably,
-/turf/simulated/wall,
-/area/mine/living_quarters)
+/obj/structure/table,
+/obj/item/stock_parts/cell{
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/crowbar,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
 "le" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3752,6 +3818,22 @@
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"me" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "mj" = (
 /obj/item/clothing/under/color/orange,
 /obj/effect/decal/cleanable/ash,
@@ -4322,23 +4404,16 @@
 	},
 /area/mine/laborcamp)
 "rA" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
+/obj/machinery/camera{
+	c_tag = "Mining Production Hallway";
+	network = list("Mining Outpost");
+	dir = 5
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding";
+	dir = 8
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "rM" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/mineral/titanium,
@@ -4353,19 +4428,8 @@
 	},
 /area/mine/laborcamp)
 "rV" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "custom placement";
-	pixel_x = -23
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar West";
-	network = list("Mining Outpost");
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/structure/closet/cardboard,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "sr" = (
 /obj/structure/table,
@@ -4457,11 +4521,10 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "tx" = (
-/obj/structure/table,
-/obj/item/screwdriver{
-	pixel_x = 3;
-	pixel_y = 8
+/obj/item/shard{
+	icon_state = "medium"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ty" = (
@@ -4491,13 +4554,17 @@
 	},
 /area/mine/laborcamp)
 "tK" = (
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
-	dir = 8
+	dir = 4
 	},
 /area/mine/production)
 "tT" = (
@@ -4681,7 +4748,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "xb" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/closet/crate/internals,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "xg" = (
@@ -4820,22 +4887,19 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "zC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "Aa" = (
 /obj/machinery/light/small{
@@ -4864,17 +4928,16 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Az" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "AB" = (
@@ -4893,17 +4956,6 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"AN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
 "Bg" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
@@ -4912,13 +4964,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/mine/maintenance)
 "Bq" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Bx" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4940,35 +4990,33 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "BD" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
+	icon_state = "yellowsiding"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "BI" = (
 /obj/structure/ore_box,
 /obj/machinery/light/small,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "BT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "BX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5107,8 +5155,26 @@
 	},
 /area/mine/laborcamp)
 "EG" = (
-/obj/item/instrument/guitar,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/deck/cards,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "EQ" = (
 /obj/structure/disposalpipe/segment{
@@ -5264,6 +5330,15 @@
 	icon_state = "brown"
 	},
 /area/mine/eva)
+"GI" = (
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
 "Hi" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
@@ -5276,15 +5351,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"Hx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
 "HA" = (
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/plasteel{
@@ -5350,26 +5416,9 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Jh" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Jl" = (
 /obj/effect/spawner/window/reinforced,
@@ -5379,18 +5428,15 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "JB" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
 /obj/machinery/firealarm{
 	dir = 1;
 	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding"
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "JM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -5639,20 +5685,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "MM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
 	},
-/obj/machinery/camera{
-	c_tag = "Mining Infirmary";
-	network = list("Mining Outpost");
-	dir = 10
-	},
-/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding";
+	dir = 8
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "Ne" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5663,12 +5704,8 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Nf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Ni" = (
 /obj/effect/spawner/window/reinforced,
@@ -5755,10 +5792,14 @@
 	},
 /area/mine/laborcamp)
 "On" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway East";
+	network = list("Mining Outpost");
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "Oq" = (
 /obj/machinery/door/airlock{
@@ -5778,6 +5819,21 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"OP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
 "Pb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -5831,31 +5887,22 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "PX" = (
 /turf/simulated/wall,
 /area/mine/laborcamp/security)
 "Qq" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell{
-	pixel_y = -2
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/item/stock_parts/cell{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/crowbar,
+/obj/structure/closet/walllocker/emerglocker/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
-/area/mine/production)
-"QD" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_y = -5
-	},
-/turf/simulated/wall,
 /area/mine/living_quarters)
 "QE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5875,23 +5922,10 @@
 	},
 /area/mine/laborcamp)
 "QH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/item/stack/rods{
+	amount = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar East";
-	network = list("Mining Outpost");
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Rd" = (
 /obj/structure/rack,
@@ -6039,11 +6073,7 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "TN" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/blood_often,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Uh" = (
@@ -6123,16 +6153,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "VD" = (
-/obj/machinery/camera{
-	c_tag = "Mining Production Hallway";
-	network = list("Mining Outpost");
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
-	},
-/area/mine/production)
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/mine/living_quarters)
 "VJ" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -6169,6 +6192,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"VT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Wo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -6186,10 +6214,13 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Ww" = (
-/obj/effect/spawner/window/reinforced,
-/obj/effect/spawner/window/reinforced,
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = 8
+	},
 /turf/simulated/floor/plating,
-/area/mine/production)
+/area/mine/living_quarters)
 "Wx" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -13244,7 +13275,7 @@ ab
 cQ
 Bp
 lJ
-Bq
+bV
 cQ
 cR
 Jl
@@ -13505,7 +13536,7 @@ az
 cQ
 sL
 yR
-bQ
+gp
 cM
 ab
 aj
@@ -14017,7 +14048,7 @@ cQ
 cQ
 cQ
 cQ
-bi
+ey
 pb
 fs
 cM
@@ -14533,7 +14564,7 @@ dX
 cM
 eS
 Mb
-ex
+BD
 cM
 ab
 ab
@@ -14789,7 +14820,7 @@ cM
 cM
 cM
 eN
-gL
+me
 fv
 cM
 cM
@@ -15042,16 +15073,16 @@ ab
 cM
 fz
 dC
-rV
+gc
 fc
 cT
 sL
-bG
+gt
 fo
 dQ
 gh
 Uz
-JB
+Az
 cM
 ab
 aj
@@ -15557,15 +15588,15 @@ cM
 fD
 fz
 bS
-gt
+fH
 xg
 sL
-zC
-AN
-rA
+bH
+fK
+ga
 EQ
-fp
-MM
+OP
+fY
 cR
 ab
 aj
@@ -16328,11 +16359,11 @@ cM
 fx
 fz
 bS
-Jh
+EG
 xg
 sL
-BT
-fA
+gL
+GI
 cM
 cM
 cM
@@ -16584,18 +16615,18 @@ cM
 cM
 dF
 dF
-bD
-bH
+es
+ei
 fz
 sL
-bG
-gp
+gt
+fg
 cM
-fj
+rV
 cV
-xb
+dt
 gb
-er
+dp
 cM
 aj
 aj
@@ -16845,14 +16876,14 @@ fr
 ec
 fz
 sL
-fg
+PQ
 fo
 cM
 cV
 eX
 eX
-bV
-EG
+Nf
+dK
 cM
 aj
 aj
@@ -17095,21 +17126,21 @@ aD
 aj
 aj
 cM
-dK
-Hx
+fU
+gZ
 XE
 fr
 ec
 fz
 sL
-fg
-fU
+PQ
+cZ
 cM
-fK
+TN
 cV
 cM
 cM
-ld
+VD
 cM
 aj
 aj
@@ -17353,17 +17384,17 @@ aj
 ab
 cM
 db
-Nf
+fI
 dR
 fr
 ec
 fz
 Eg
 eR
-es
+Qq
 cM
 eX
-dH
+QH
 cM
 Zf
 Zf
@@ -17610,17 +17641,17 @@ aj
 ai
 cM
 dc
-Nf
+fI
 WO
 Te
 vq
 Kb
 eT
 El
-fI
+dd
 cM
 gb
-gl
+hW
 cM
 dq
 bo
@@ -17867,9 +17898,9 @@ aj
 aj
 cM
 de
-Nf
+fI
 dR
-fY
+zC
 yg
 yg
 vZ
@@ -18124,16 +18155,16 @@ aj
 ai
 cM
 KW
-Az
+BT
 Kr
-QH
-fH
+fG
+bP
 ev
 bx
-PQ
+bi
 fA
 cM
-gc
+fp
 gn
 cM
 eL
@@ -18387,10 +18418,10 @@ cM
 cM
 cM
 eU
-PQ
+bi
 fo
 cM
-gc
+fp
 TC
 cP
 Nk
@@ -18644,10 +18675,10 @@ Vu
 Ae
 cM
 dz
-PQ
+bi
 fA
 cM
-gc
+fp
 AB
 cM
 px
@@ -18904,8 +18935,8 @@ Ma
 em
 fs
 cM
-gc
-ei
+fp
+er
 cM
 Ms
 cV
@@ -19161,8 +19192,8 @@ sL
 ge
 fA
 cM
-fy
-dp
+bD
+ex
 cM
 ee
 fO
@@ -19416,10 +19447,10 @@ dS
 bq
 sL
 ge
-gp
+fg
 cM
 Ag
-bU
+Bq
 cM
 cM
 cM
@@ -19675,11 +19706,11 @@ en
 fm
 PF
 cM
-gc
+fp
 gb
 cM
-dH
-tx
+QH
+Ww
 un
 zy
 cD
@@ -19930,14 +19961,14 @@ co
 bq
 sL
 bE
-gZ
+On
 cM
-gc
+fp
 cV
-ld
+VD
 yl
 cV
-fG
+bC
 dh
 VS
 xM
@@ -20190,9 +20221,9 @@ bE
 fA
 cM
 wT
-bv
-cZ
-TN
+bG
+df
+dr
 aY
 DE
 dE
@@ -20694,11 +20725,11 @@ dO
 Nj
 eB
 dD
-VD
+rA
 xB
 eB
-tK
-eB
+MM
+fj
 cN
 eh
 on
@@ -20707,10 +20738,10 @@ cV
 eX
 cV
 AB
-fw
-QD
+VT
+bQ
 cV
-ga
+tx
 cV
 gi
 eX
@@ -20958,19 +20989,19 @@ eA
 eA
 eK
 Lr
-df
+JB
 bq
 px
 cV
 eX
 cV
 cV
-ld
-bC
+VD
+Jh
 eg
 cV
-bP
-ey
+gq
+xb
 cR
 aj
 aj
@@ -21207,8 +21238,8 @@ cn
 ct
 ed
 eJ
-dt
-BD
+fy
+bU
 JM
 ef
 ef
@@ -21474,11 +21505,11 @@ cH
 fb
 dV
 bq
-gq
+bv
 eX
 gb
 cV
-dd
+gl
 cM
 ab
 ab
@@ -21729,11 +21760,11 @@ eW
 eC
 eP
 eB
-dr
+eZ
 dn
 eX
 cV
-On
+fw
 cV
 cV
 cM
@@ -22757,8 +22788,8 @@ ej
 eG
 BX
 eW
-Qq
-Ww
+ld
+dH
 ai
 ab
 aj
@@ -23012,7 +23043,7 @@ vN
 fh
 el
 eI
-eZ
+tK
 fl
 LO
 bq

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -280,10 +280,8 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "aN" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "aP" = (
 /obj/structure/table,
@@ -349,15 +347,22 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "aY" = (
-/obj/machinery/power/apc{
-	cell_type = 25000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	shock_proof = 1
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
 	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "aZ" = (
 /obj/machinery/light/small{
@@ -427,19 +432,19 @@
 	},
 /area/mine/laborcamp/security)
 "bi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Mining Infirmary";
+	network = list("Mining Outpost");
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "bj" = (
 /obj/machinery/status_display{
@@ -494,59 +499,72 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bq" = (
 /turf/simulated/wall,
 /area/mine/production)
 "br" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"bu" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 6
+	},
+/area/mine/production)
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
-"bu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"bv" = (
-/obj/item/toy/plushie/deer,
+"bw" = (
+/obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"bw" = (
-/obj/machinery/light/small{
+"bx" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
-"bx" = (
-/obj/machinery/door/poddoor{
-	id_tag = "trash";
-	name = "disposal bay door";
-	protected = 0
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "by" = (
 /obj/structure/cable{
@@ -593,72 +611,61 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"bD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"bE" = (
+"bC" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/maintenance)
+"bD" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/mine/production)
+"bE" = (
+/obj/item/toy/plushie/deer,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bF" = (
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/mine/eva)
 "bG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10;
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
+/area/mine/production)
 "bI" = (
-/obj/machinery/driver_button{
-	id_tag = "trash";
-	pixel_x = 26;
-	pixel_y = -6
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/door_control{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	pixel_x = 25;
-	pixel_y = 4;
-	req_access_txt = "12"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
 	},
-/obj/structure/chair/stool,
-/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bJ" = (
 /obj/effect/spawner/window/reinforced,
@@ -738,75 +745,66 @@
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
 "bP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/camera{
+	c_tag = "Communications Relay";
+	dir = 8;
+	network = list("Mining Outpost")
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
+"bQ" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"bR" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"bQ" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_y = -5
+"bS" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
 	},
-/turf/simulated/wall,
-/area/mine/living_quarters)
-"bR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/area/mine/production)
+"bT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/mine/production)
-"bS" = (
-/obj/structure/chair/office,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
-"bT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/firealarm{
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purple"
-	},
-/area/mine/production)
+/area/mine/eva)
 "bU" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"bV" = (
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 9;
+	icon_state = "brown"
 	},
 /area/mine/production)
-"bV" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
 "bW" = (
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
@@ -821,11 +819,12 @@
 	},
 /area/mine/eva)
 "bX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
+/area/mine/production)
 "bY" = (
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
@@ -975,19 +974,14 @@
 	},
 /area/mine/eva)
 "cl" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "brown";
-	dir = 1
+	dir = 8;
+	icon_state = "barber"
 	},
-/area/mine/eva)
+/area/mine/living_quarters)
 "cm" = (
 /obj/machinery/suit_storage_unit/lavaland,
 /turf/simulated/floor/plasteel{
@@ -1003,15 +997,14 @@
 	},
 /area/mine/production)
 "co" = (
-/obj/machinery/light,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable,
-/turf/simulated/floor/plasteel{
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cp" = (
 /obj/machinery/suit_storage_unit/lavaland,
@@ -1031,17 +1024,21 @@
 	},
 /area/mine/eva)
 "cs" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ct" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/structure/table,
+/obj/item/toy/figure/mech/ripley{
+	pixel_y = 9
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "cu" = (
 /obj/item/pickaxe,
@@ -1102,7 +1099,6 @@
 /area/mine/laborcamp)
 "cB" = (
 /obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
 "cC" = (
@@ -1115,6 +1111,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
+"cD" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "cE" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1135,19 +1138,12 @@
 /turf/simulated/floor/plating,
 /area/mine/laborcamp/security)
 "cH" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Mech Bay Area";
-	req_access_txt = "48"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -1190,21 +1186,14 @@
 /turf/simulated/wall,
 /area/mine/living_quarters)
 "cN" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowcornersiding";
-	dir = 1
+/obj/item/gps/ruin{
+	gpstag = "BASE0";
+	pixel_y = 32
 	},
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "cO" = (
 /obj/structure/table,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
 	pixel_y = -1
@@ -1220,13 +1209,18 @@
 	},
 /area/mine/eva)
 "cP" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "brown";
+	dir = 1
+	},
+/area/mine/eva)
 "cQ" = (
 /turf/simulated/wall/r_wall,
 /area/mine/maintenance)
@@ -1235,19 +1229,27 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "cS" = (
-/obj/item/radio/beacon,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/production)
 "cT" = (
-/obj/machinery/vending/cigarette,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "cU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/mine/living_quarters)
 "cV" = (
 /turf/simulated/floor/plating,
@@ -1257,16 +1259,9 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "cX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "cY" = (
 /obj/machinery/suit_storage_unit/lavaland,
@@ -1276,15 +1271,11 @@
 	},
 /area/mine/eva)
 "cZ" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway West";
-	network = list("Mining Outpost");
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowcornersiding";
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/living_quarters)
+/area/mine/production)
 "da" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light,
@@ -1298,46 +1289,59 @@
 	},
 /area/mine/eva)
 "db" = (
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "dc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/beer{
-	pixel_y = 8
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
-"dd" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/living_quarters)
-"de" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/soda{
-	pixel_y = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
-"df" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"dd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"de" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"df" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/mine/living_quarters)
 "dg" = (
 /obj/machinery/alarm{
@@ -1347,12 +1351,13 @@
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
 "dh" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "garbage";
-	name = "disposal coveyor"
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "di" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -1371,116 +1376,125 @@
 /turf/simulated/floor/plasteel/dark,
 /area/mine/maintenance)
 "dk" = (
-/obj/structure/shuttle/engine/heater{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"dl" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-y"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/mining)
-"dl" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/area/mine/production)
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "dm" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Mining Communications APC";
-	pixel_x = 1;
-	pixel_y = 25
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/box,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
-"dn" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
 /area/mine/production)
-"do" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/iv_bag/blood,
-/obj/item/reagent_containers/iv_bag/blood{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/iv_bag/blood/AMinus,
-/obj/item/reagent_containers/iv_bag/blood/BMinus{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/iv_bag/blood/BPlus{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/iv_bag/blood/OMinus,
-/obj/item/reagent_containers/iv_bag/blood/OPlus{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/turf/simulated/floor/plasteel/white{
-	dir = 8;
-	icon_state = "whiteblue"
-	},
-/area/mine/living_quarters)
-"dp" = (
-/obj/effect/spawner/random_spawners/blood_often,
-/obj/effect/spawner/random_spawners/cobweb_left_frequent,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"dq" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"dr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"ds" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+"dn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
-"dt" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/item/weldingtool{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/clothing/head/welding,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"do" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/mine/living_quarters)
-"du" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
+"dq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"dr" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"ds" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Mining EVA";
+	network = list("Mining Outpost")
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"dt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"du" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -1526,71 +1540,61 @@
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "dz" = (
-/obj/structure/closet/walllocker/emerglocker/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
-	},
-/area/mine/living_quarters)
-"dA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dC" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
-"dD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dE" = (
-/obj/structure/disposaloutlet{
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	layer = 2.9
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/area/mine/production)
+"dA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"dB" = (
+/obj/machinery/suit_storage_unit/lavaland,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/mine/eva)
+"dC" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
+"dD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"dE" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 10
+	},
+/area/mine/production)
 "dF" = (
 /obj/structure/chair/stool/bar{
 	dir = 4
@@ -1607,11 +1611,12 @@
 	},
 /area/mine/living_quarters)
 "dH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/wall,
 /area/mine/living_quarters)
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -1635,7 +1640,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dK" = (
-/obj/item/instrument/guitar,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dL" = (
@@ -1645,32 +1653,34 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dM" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/area/mine/production)
-"dN" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "mining";
-	name = "interior access button";
-	pixel_x = 25;
-	pixel_y = 25;
-	req_access_txt = null
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/mine/eva)
-"dO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
-	},
 /area/mine/production)
+"dN" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"dO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "dP" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/blood,
@@ -1681,25 +1691,37 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dR" = (
-/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "dS" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"dT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/stool/bar{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"dT" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8
+	},
+/obj/item/dice/d8,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "dU" = (
 /obj/structure/table,
 /obj/item/toy/russian_revolver,
@@ -1710,19 +1732,19 @@
 /turf/simulated/floor/plating,
 /area/mine/production)
 "dW" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dX" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "dY" = (
 /obj/machinery/door/airlock/external{
@@ -1738,19 +1760,23 @@
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "ea" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"eb" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "yellowsiding";
+	dir = 4
 	},
 /area/mine/production)
-"eb" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
 "ec" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1763,31 +1789,25 @@
 	},
 /area/mine/living_quarters)
 "ed" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/mine/production)
-"ee" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"ee" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
 "ef" = (
 /obj/effect/turf_decal/caution/white{
 	dir = 8
@@ -1799,28 +1819,28 @@
 	},
 /area/mine/production)
 "eg" = (
-/obj/machinery/light/small{
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/conveyor/east{
-	id = "garbage";
-	dir = 2
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8;
+	pixel_y = 7
 	},
-/turf/simulated/floor/plating,
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/deck/cards,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "eh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"ei" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
@@ -1834,6 +1854,12 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"ei" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ej" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1843,108 +1869,96 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "ek" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "el" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "em" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/crate/secure/loot,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "en" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
-	},
-/area/mine/living_quarters)
-"eo" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"ep" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/mine/production)
-"eq" = (
+/area/mine/living_quarters)
+"eo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"ep" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
-"er" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"es" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+"eq" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"et" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"er" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
+/area/mine/living_quarters)
+"es" = (
+/obj/structure/closet/cardboard,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"et" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "eu" = (
-/obj/structure/table,
-/obj/item/weldingtool{
-	pixel_y = 7;
-	pixel_x = 6
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "ev" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -1962,20 +1976,28 @@
 	},
 /area/mine/eva)
 "ex" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"ey" = (
-/obj/machinery/camera{
-	c_tag = "Mining Telecommunications Hallway";
-	network = list("Mining Outpost")
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"ey" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "ez" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
@@ -1992,6 +2014,10 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "eB" = (
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 8
@@ -2073,63 +2099,39 @@
 	},
 /area/mine/production)
 "eJ" = (
-/obj/machinery/conveyor/east{
-	id = "garbage"
-	},
-/obj/machinery/recycler,
+/obj/machinery/light/small,
+/obj/effect/spawner/random_spawners/blood_often,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "eK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"eL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10;
-	initialize_directions = 10
-	},
-/obj/machinery/meter,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"eL" = (
+/obj/machinery/camera{
+	c_tag = "Mining Telecommunications Hallway";
+	network = list("Mining Outpost")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
 "eM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"eN" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 1
 	},
 /area/mine/living_quarters)
+"eN" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/production)
 "eO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -2234,9 +2236,14 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "eX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
 "eY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2246,16 +2253,23 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "eZ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
-	dir = 10
+	dir = 4
 	},
 /area/mine/production)
 "fa" = (
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2283,25 +2297,12 @@
 	},
 /area/mine/living_quarters)
 "fd" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
-"fe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding";
+	dir = 8
 	},
-/area/mine/living_quarters)
-"ff" = (
+/area/mine/production)
+"fe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -2309,11 +2310,22 @@
 	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
-"fg" = (
-/obj/structure/extinguisher_cabinet{
-	name = "south bump";
-	pixel_y = -30
+"ff" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"fg" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
@@ -2322,29 +2334,27 @@
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/mine/production)
 "fi" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "fj" = (
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
-	},
+/obj/machinery/mineral/equipment_vendor,
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "fk" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fl" = (
 /obj/machinery/alarm{
@@ -2358,24 +2368,25 @@
 	},
 /area/mine/production)
 "fm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "fo" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -2383,20 +2394,22 @@
 	},
 /area/mine/living_quarters)
 "fp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "fr" = (
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "fs" = (
@@ -2419,11 +2432,15 @@
 	},
 /area/mine/living_quarters)
 "fu" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
 "fv" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -2431,10 +2448,15 @@
 	},
 /area/mine/living_quarters)
 "fw" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "fx" = (
 /obj/machinery/vending/snack,
@@ -2443,26 +2465,26 @@
 	},
 /area/mine/living_quarters)
 "fy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway West";
+	network = list("Mining Outpost");
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
+	icon_state = "yellowsiding"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "fz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "fA" = (
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
@@ -2493,117 +2515,119 @@
 	},
 /area/mine/living_quarters)
 "fE" = (
-/obj/machinery/computer/shuttle/mining{
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
+"fF" = (
+/obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
-"fF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor/east{
-	id = "garbage"
-	},
-/obj/machinery/light/small{
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/mining)
 "fG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar East";
-	network = list("Mining Outpost");
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "fH" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8
-	},
-/obj/item/dice/d8,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "fI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
-"fJ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment{
+	icon_state = "yellowsiding";
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/area/mine/production)
+"fJ" = (
+/obj/structure/table,
+/obj/item/dice/d4,
+/obj/item/toy/figure/crew/miner,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "brown"
+	},
 /area/mine/production)
 "fK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fL" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/mine/living_quarters)
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "fN" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fO" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Mining Communications APC";
+	pixel_x = 1;
+	pixel_y = 25
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/area/mine/living_quarters)
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "fQ" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored/danger)
@@ -2623,86 +2647,9 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
-"fV" = (
-/turf/simulated/wall/indestructible/boss/see_through,
-/area/lavaland/surface/outdoors)
-"fW" = (
-/obj/structure/necropolis_gate/locked,
-/obj/structure/stone_tile/slab,
-/turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
-"fX" = (
-/turf/simulated/floor/plating,
-/area/lavaland/surface/outdoors)
-"fY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Infirmary";
-	network = list("Mining Outpost");
-	dir = 10
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/mine/living_quarters)
-"fZ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"ga" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/mine/living_quarters)
-"gb" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"gc" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "custom placement";
-	pixel_x = -23
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar West";
-	network = list("Mining Outpost");
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
-"ge" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2713,6 +2660,65 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"fV" = (
+/turf/simulated/wall/indestructible/boss/see_through,
+/area/lavaland/surface/outdoors)
+"fW" = (
+/obj/structure/necropolis_gate/locked,
+/obj/structure/stone_tile/slab,
+/turf/simulated/floor/indestructible/boss,
+/area/lavaland/surface/outdoors)
+"fX" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"fY" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
+"fZ" = (
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"ga" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"gb" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"gc" = (
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"gd" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Station Communications";
+	req_access_txt = "48"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/mine/maintenance)
+"ge" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2738,15 +2744,20 @@
 	},
 /area/mine/living_quarters)
 "gh" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/closet/firecloset,
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding"
 	},
+/area/mine/production)
+"gi" = (
+/obj/item/stack/rods{
+	amount = 4
+	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gj" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -2774,10 +2785,9 @@
 /area/lavaland/surface/outdoors)
 "gl" = (
 /obj/structure/grille/broken,
-/obj/item/stack/rods{
-	amount = 4
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gm" = (
@@ -2804,25 +2814,48 @@
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gp" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/iv_bag/blood,
+/obj/item/reagent_containers/iv_bag/blood{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/iv_bag/blood/AMinus,
+/obj/item/reagent_containers/iv_bag/blood/BMinus{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/iv_bag/blood/BPlus{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/iv_bag/blood/OMinus,
+/obj/item/reagent_containers/iv_bag/blood/OPlus{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/turf/simulated/floor/plasteel/white{
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/mine/living_quarters)
 "gq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor/east{
-	id = "garbage";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Disposal Exit";
-	name = "Disposal Exit Vent";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gr" = (
 /obj/structure/stone_tile{
@@ -2851,20 +2884,11 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "gu" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_away";
@@ -2923,11 +2947,8 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gA" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
+	icon_state = "yellowsiding"
 	},
 /area/mine/production)
 "gB" = (
@@ -3002,17 +3023,38 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gJ" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4
+/obj/structure/grille/broken,
+/obj/item/stack/rods{
+	amount = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	req_access_txt = "48"
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile{
+	dwidth = 3;
+	height = 5;
+	id = "mining";
+	name = "mining shuttle";
+	rebuildable = 1;
+	width = 7
+	},
+/obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
+	dwidth = 3;
+	height = 5;
+	id = "mining_away";
+	name = "lavaland mine";
+	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
+	width = 7
 	},
 /turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/area/shuttle/mining)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -3052,14 +3094,20 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"gZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+"hd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Disposal Exit";
+	name = "Disposal Exit Vent";
+	opacity = 0
 	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "hf" = (
 /obj/machinery/flasher_button{
@@ -3095,6 +3143,16 @@
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"hu" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
 "hv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3115,27 +3173,15 @@
 	},
 /area/mine/laborcamp)
 "hz" = (
-/obj/structure/closet/firecloset,
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/production)
+/obj/item/instrument/guitar,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "hA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"hD" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/production)
 "hH" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -3156,6 +3202,15 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"hM" = (
+/obj/machinery/door/poddoor{
+	id_tag = "trash";
+	name = "disposal bay door";
+	protected = 0
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "hQ" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_away";
@@ -3166,13 +3221,6 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"hW" = (
-/obj/structure/grille/broken,
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "ic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -3195,15 +3243,6 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"ik" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
 "ir" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 5
@@ -3271,6 +3310,13 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"iZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "ja" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -3283,6 +3329,16 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"jd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "jf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/arrows,
@@ -3464,15 +3520,6 @@
 /obj/structure/stone_tile,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "ky" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3549,20 +3596,6 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ld" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell{
-	pixel_y = -2
-	},
-/obj/item/stock_parts/cell{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/crowbar,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/production)
 "le" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3714,23 +3747,12 @@
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"lJ" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance)
 "lO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "lP" = (
@@ -3805,22 +3827,6 @@
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"me" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
 "mj" = (
 /obj/item/clothing/under/color/orange,
 /obj/effect/decal/cleanable/ash,
@@ -4141,6 +4147,13 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"na" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "nb" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -4191,27 +4204,36 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"nH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"nF" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"nO" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/mining)
-"nS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"nL" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
+"nO" = (
+/obj/machinery/alarm{
+	dir = 4;
+	name = "custom placement";
+	pixel_x = -23
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Bar West";
+	network = list("Mining Outpost");
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "nT" = (
@@ -4221,19 +4243,50 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/siberia)
-"nZ" = (
+"oa" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"om" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
+	},
+/area/mine/production)
+"on" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
+"or" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"on" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/production)
 "oA" = (
 /obj/effect/decal/cleanable/cobweb2,
@@ -4245,30 +4298,25 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"oG" = (
-/obj/item/gps/ruin{
-	gpstag = "BASE0";
-	pixel_y = 32
+"oK" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "garbage";
+	name = "disposal coveyor"
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"oN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y"
+"oO" = (
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "oR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4279,42 +4327,22 @@
 	},
 /area/mine/laborcamp)
 "pa" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Mech Bay Area";
 	req_access_txt = "48"
 	},
-/obj/structure/fans/tiny,
-/obj/docking_port/mobile{
-	dwidth = 3;
-	height = 5;
-	id = "mining";
-	name = "mining shuttle";
-	rebuildable = 1;
-	width = 7
-	},
-/obj/docking_port/stationary{
-	area_type = /area/lavaland/surface/outdoors;
-	dwidth = 3;
-	height = 5;
-	id = "mining_away";
-	name = "lavaland mine";
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
-	width = 7
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/mining)
-"pb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
+/area/mine/production)
 "pq" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
@@ -4325,10 +4353,50 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
-"px" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+"pF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"pI" = (
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"pO" = (
+/obj/machinery/door/airlock{
+	name = "Mining Bar Storage"
+	},
 /turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"qe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "qw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4364,6 +4432,26 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/mine/laborcamp)
+"rb" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-y"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "rj" = (
 /obj/structure/chair{
 	dir = 8
@@ -4390,17 +4478,23 @@
 	icon_state = "wood-broken"
 	},
 /area/mine/laborcamp)
-"rA" = (
-/obj/machinery/camera{
-	c_tag = "Mining Production Hallway";
-	network = list("Mining Outpost");
-	dir = 5
+"rv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"rJ" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/mine/production)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "rM" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/mineral/titanium,
@@ -4414,35 +4508,50 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"rV" = (
-/obj/structure/closet/cardboard,
+"rU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"sr" = (
-/obj/structure/table,
-/obj/item/dice/d4,
-/obj/item/toy/figure/crew/miner,
+"rV" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"sj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "brown"
+	icon_state = "yellowsiding";
+	dir = 4
 	},
 /area/mine/production)
+"sx" = (
+/obj/structure/ore_box,
+/obj/machinery/light/small,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "sF" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
 "sL" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"sM" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
 "sO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/security{
@@ -4479,17 +4588,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"sZ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "tb" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -4498,14 +4596,23 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"to" = (
+"tm" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/closet/crate/secure/loot,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"tn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/mine/living_quarters)
 "ty" = (
 /obj/structure/lattice/catwalk,
@@ -4522,11 +4629,26 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"tI" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment,
+"tD" = (
+/obj/machinery/camera{
+	c_tag = "Mining Disposals";
+	network = list("Mining Outpost");
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"tI" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "mining";
+	name = "interior access button";
+	pixel_x = 25;
+	pixel_y = 25;
+	req_access_txt = null
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "tJ" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -4534,19 +4656,30 @@
 	},
 /area/mine/laborcamp)
 "tK" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/area/mine/production)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"tL" = (
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24;
+	shock_proof = 1
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"tM" = (
+/obj/structure/closet/crate/internals,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "tT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -4558,18 +4691,6 @@
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
 /area/mine/laborcamp)
-"uc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
 "uf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4592,12 +4713,15 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"un" = (
-/obj/machinery/camera{
-	c_tag = "Mining Disposals";
-	network = list("Mining Outpost");
-	dir = 4
+"up" = (
+/obj/machinery/tcomms/relay/mining,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/maintenance)
+"uu" = (
+/obj/machinery/conveyor/east{
+	id = "garbage"
 	},
+/obj/machinery/recycler,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "uL" = (
@@ -4607,10 +4731,15 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
-"uQ" = (
-/obj/effect/spawner/random_spawners/fungus_maybe,
-/turf/simulated/wall,
-/area/mine/production)
+"uT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "vk" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Labor Shuttle Airlock";
@@ -4657,28 +4786,21 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp)
-"vN" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
+"vS" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"vR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"vZ" = (
-/obj/machinery/conveyor/east{
-	id = "garbage";
-	dir = 2
-	},
-/obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"vZ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
 /area/mine/living_quarters)
 "wg" = (
 /obj/machinery/mineral/equipment_vendor/labor,
@@ -4691,6 +4813,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
+"wj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/mine/production)
 "wt" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -4707,51 +4840,51 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/siberia)
-"wT" = (
-/obj/structure/grille/broken,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "wY" = (
 /obj/item/clothing/mask/gas/clown_hat,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"xb" = (
-/obj/structure/closet/crate/internals,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"xg" = (
-/obj/structure/chair/office{
+"xd" = (
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway East";
+	network = list("Mining Outpost");
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
-"xj" = (
-/obj/machinery/suit_storage_unit/lavaland,
-/obj/machinery/light{
-	dir = 1
+"xl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purple"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/mine/eva)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "xo" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/area/mine/eva)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "xx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4769,18 +4902,6 @@
 	name = "Mining Mech Bay"
 	},
 /turf/simulated/floor/plasteel,
-/area/mine/production)
-"xB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
-	},
 /area/mine/production)
 "xC" = (
 /turf/simulated/wall/mineral/titanium,
@@ -4806,13 +4927,11 @@
 	icon_state = "browncorner"
 	},
 /area/mine/laborcamp)
-"yl" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+"xY" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard{
+	icon_state = "medium"
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
@@ -4824,6 +4943,19 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp)
+"yB" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_y = -5
+	},
+/turf/simulated/wall,
+/area/mine/living_quarters)
+"yO" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/mining)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4854,34 +4986,64 @@
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
-"zC" = (
-/obj/structure/chair/stool/bar{
-	dir = 1
+"zI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
-"Aa" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"Ae" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shard{
-	icon_state = "medium"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"Ag" = (
-/obj/machinery/light/small{
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"AB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"AV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"AZ" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell{
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/crowbar,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
+"Bg" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
+"Bq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4889,112 +5051,35 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"Az" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"BB" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
 	},
+/area/mine/living_quarters)
+"BD" = (
+/obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
 	},
 /area/mine/living_quarters)
-"AB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"AE" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
-"Bg" = (
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
-"Bp" = (
-/obj/machinery/tcomms/relay/mining,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance)
-"Bq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"Bx" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+"BS" = (
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-y"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"BD" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/living_quarters)
-"BI" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
-"BT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
-"BX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/table,
-/obj/item/toy/figure/mech/ripley{
-	pixel_y = 9
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"BT" = (
+/obj/machinery/mass_driver{
+	id_tag = "trash"
 	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "BY" = (
 /obj/machinery/computer/shuttle/labor,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -5017,6 +5102,15 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
+"CQ" = (
+/obj/machinery/computer/shuttle/mining{
+	req_access = null
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 9
+	},
+/area/mine/production)
 "CT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5028,6 +5122,12 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"CU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "Dd" = (
 /obj/structure/toilet,
 /obj/effect/decal/cleanable/vomit,
@@ -5050,25 +5150,18 @@
 	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
-"Du" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
+"Dk" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"DE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"DF" = (
-/obj/machinery/iv_drip,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
 "DX" = (
@@ -5078,33 +5171,59 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"Eg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
+"Ee" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/east{
+	id = "garbage"
 	},
-/area/mine/living_quarters)
-"Ej" = (
-/obj/effect/spawner/random_spawners/blood_often,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"El" = (
+"Eg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"Ej" = (
+/obj/machinery/door/window{
+	dir = 2;
+	name = "Mining Bar"
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
+"El" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
@@ -5119,79 +5238,28 @@
 	},
 /area/mine/laborcamp)
 "EG" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/conveyor/east{
+	id = "garbage";
+	dir = 2
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8;
-	pixel_y = 7
+/obj/structure/plasticflaps,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Fe" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Fh" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/deck/cards,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"EQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/mine/living_quarters)
-"EU" = (
-/obj/machinery/camera{
-	c_tag = "Communications Relay";
-	dir = 8;
-	network = list("Mining Outpost")
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
-"Fe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
-	},
-/area/mine/production)
 "Fp" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -5200,40 +5268,6 @@
 	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
-"Fr" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/mine/production)
-"FB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
-"FF" = (
-/obj/machinery/light/small,
-/obj/effect/spawner/random_spawners/blood_often,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"FI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
 "FO" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -5268,11 +5302,10 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/mine/laborcamp)
-"Gr" = (
-/obj/item/shard{
-	icon_state = "medium"
+"Gw" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "GD" = (
@@ -5284,25 +5317,15 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"GH" = (
-/obj/effect/baseturf_helper/lava_land/surface,
+"Hg" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/eva)
-"GI" = (
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/living_quarters)
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "Hi" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
@@ -5315,6 +5338,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"Hk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "HA" = (
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/plasteel{
@@ -5343,6 +5382,12 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"HV" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/mine/eva)
 "Ia" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5353,16 +5398,43 @@
 /obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
+"Ir" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Iv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance)
-"IJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
+"IH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel,
-/area/mine/eva)
+/area/mine/production)
+"IJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "IK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -5379,14 +5451,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"Jh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor/east{
-	id = "garbage";
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "Jl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5394,29 +5458,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"JB" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/production)
-"JM" = (
+"Jp" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"JG" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
-	},
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "JP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -5434,23 +5485,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/portable/canister/oxygen,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"JT" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
 "JV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/sustenance,
@@ -5476,15 +5516,6 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"Kh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
 "Kl" = (
 /obj/structure/table,
 /obj/item/trash/plate,
@@ -5493,25 +5524,46 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp)
-"Kr" = (
-/obj/machinery/door/window{
-	dir = 2;
-	name = "Mining Bar"
-	},
+"Ky" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"KA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "KE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"KJ" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"KN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "KR" = (
 /obj/machinery/mineral/labor_claim_console{
 	machinedir = 1;
@@ -5520,38 +5572,32 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
 "KW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	cell_type = 25000;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer{
+	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
-"Lr" = (
+"KY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/closet/walllocker/emerglocker/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/living_quarters)
+"Lm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -5563,12 +5609,25 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp/security)
 "LO" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 6
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/mine/production)
+/obj/machinery/camera{
+	c_tag = "Mining Bar East";
+	network = list("Mining Outpost");
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
 "LQ" = (
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5585,14 +5644,7 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"Ma" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
-	},
-/area/mine/living_quarters)
-"Mb" = (
+"LT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -5602,40 +5654,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
-"Mf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
-"Ms" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "ME" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -5648,14 +5668,11 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"MJ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
+"MQ" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
 /area/mine/production)
-"MM" = (
+"Nb" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
 	pixel_x = -27
@@ -5674,10 +5691,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"Nf" = (
-/obj/effect/spawner/random_spawners/grille_often,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "Ni" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5686,21 +5699,8 @@
 /turf/simulated/floor/plating,
 /area/mine/laborcamp/security)
 "Nj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
-	},
-/area/mine/production)
-"Nk" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ND" = (
@@ -5726,25 +5726,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
 "NP" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Station Storage";
-	req_access_txt = "48"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "NW" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -5762,89 +5748,62 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"On" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway East";
-	network = list("Mining Outpost");
-	dir = 1
-	},
+"Or" = (
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "yellowsiding";
+	dir = 6
 	},
-/area/mine/living_quarters)
-"Oq" = (
-/obj/machinery/door/airlock{
-	name = "Mining Bar Storage"
+/area/mine/production)
+"Ou" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"Ow" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
-/area/mine/production)
 "OF" = (
 /obj/item/card/id/prisoner/random,
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"OP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"Pf" = (
+/obj/machinery/camera{
+	c_tag = "Mining Production Hallway";
+	network = list("Mining Outpost");
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 8
 	},
+/area/mine/production)
+"Pj" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"Px" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
+"PJ" = (
+/obj/effect/baseturf_helper/lava_land/surface,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	dir = 4;
+	icon_state = "brown"
 	},
-/area/mine/living_quarters)
-"Pb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/camera{
-	c_tag = "Mining EVA";
-	network = list("Mining Outpost")
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
-"Pp" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"Pq" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/mine/living_quarters)
-"PF" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
-/area/mine/living_quarters)
+/area/mine/eva)
 "PQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5866,14 +5825,21 @@
 "PX" = (
 /turf/simulated/wall,
 /area/mine/laborcamp/security)
-"Qq" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+"Qm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/closet/walllocker/emerglocker/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "QE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5892,9 +5858,14 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"QH" = (
-/obj/item/stack/rods{
-	amount = 4
+"QI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
@@ -5918,10 +5889,44 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"Rf" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/mine/living_quarters)
+"Rk" = (
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "Rs" = (
 /obj/structure/table,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
+"Sm" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
+"Sr" = (
+/obj/structure/closet/walllocker/emerglocker/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 1
+	},
+/area/mine/living_quarters)
 "Ss" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -5938,33 +5943,12 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"Te" = (
-/obj/structure/chair/stool/bar{
+"SB" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
-"Tg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "Tj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5990,15 +5974,8 @@
 	},
 /area/mine/laborcamp)
 "Tn" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "Ts" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6010,32 +5987,40 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"Tv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"Tw" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
+"TF" = (
+/obj/structure/table,
+/obj/machinery/light/small{
 	dir = 4
 	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
+"TM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/table,
-/obj/item/weldingtool{
-	pixel_y = 7;
-	pixel_x = 6
-	},
-/obj/item/clothing/head/welding,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
-"TC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
 "TN" = (
-/obj/effect/spawner/random_spawners/blood_often,
+/obj/structure/rack,
+/obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Uh" = (
@@ -6050,37 +6035,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
-"Uv" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel,
-/area/mine/production)
 "Uy" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
-"Uz" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/mine/living_quarters)
 "UQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/light,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/mine/production)
+"UX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/maintenance)
 "Vt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -6091,7 +6066,7 @@
 	},
 /area/mine/laborcamp)
 "Vu" = (
-/obj/effect/spawner/random_spawners/oil_maybe,
+/obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Vv" = (
@@ -6114,9 +6089,16 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "VD" = (
-/obj/effect/spawner/random_spawners/fungus_probably,
-/turf/simulated/wall,
-/area/mine/living_quarters)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "VJ" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -6126,12 +6108,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/mine/laborcamp/security)
-"VL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/production)
 "VN" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -6146,23 +6122,22 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"VS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+"Wg" = (
+/obj/structure/table,
+/obj/item/weldingtool{
+	pixel_y = 7;
+	pixel_x = 6
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"VT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
 "Wo" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Wt" = (
@@ -6172,11 +6147,19 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Ww" = (
-/obj/structure/table,
-/obj/item/screwdriver{
-	pixel_x = 3;
-	pixel_y = 8
+/obj/machinery/driver_button{
+	id_tag = "trash";
+	pixel_x = 26;
+	pixel_y = -6
 	},
+/obj/machinery/door_control{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	pixel_x = 25;
+	pixel_y = 4;
+	req_access_txt = "12"
+	},
+/obj/structure/chair/stool,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Wx" = (
@@ -6198,10 +6181,41 @@
 	},
 /area/mine/laborcamp)
 "WO" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag,
+/obj/structure/chair/office,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "bar"
+	},
+/area/mine/living_quarters)
+"WU" = (
+/obj/machinery/door/airlock/mining{
+	name = "Mining Station Storage";
+	req_access_txt = "48"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/production)
+"WY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "Xd" = (
@@ -6212,46 +6226,19 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"Xi" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 6
-	},
-/area/mine/production)
-"XE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches,
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
-"XI" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Station Communications";
-	req_access_txt = "48"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/mine/maintenance)
-"YE" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+"Xu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"Yu" = (
+/turf/simulated/floor/plating,
+/area/lavaland/surface/outdoors)
+"Yx" = (
+/obj/item/radio/beacon,
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "YJ" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Storage"
@@ -6280,24 +6267,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
-"Zd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/eva)
 "Zf" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
-"Zh" = (
-/obj/machinery/mass_driver{
-	id_tag = "trash"
+"Zj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/turf/simulated/floor/plasteel,
+/area/mine/production)
 "Zk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6306,15 +6290,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"ZK" = (
-/obj/machinery/computer/shuttle/mining{
-	req_access = null
+"Zn" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 9
+	dir = 8;
+	icon_state = "barber"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "ZZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12717,12 +12705,12 @@ aq
 aj
 ab
 cQ
-dm
-JT
+fP
+VD
 az
 cQ
 ab
-gJ
+Pj
 ab
 ab
 aj
@@ -12974,13 +12962,13 @@ aq
 aj
 ab
 cQ
-Iv
-ik
+UX
+fn
 az
 cQ
-fX
-gK
-fX
+Yu
+Xu
+Yu
 ab
 aj
 aj
@@ -13231,9 +13219,9 @@ tZ
 aj
 ab
 cQ
-Bp
-lJ
-bV
+up
+bC
+dh
 cQ
 cR
 Jl
@@ -13489,12 +13477,12 @@ aj
 ab
 cQ
 dj
-ds
+xl
 az
 cQ
-sL
+vZ
 yR
-gp
+BB
 cM
 ab
 aj
@@ -13746,11 +13734,11 @@ aj
 aj
 cQ
 dg
-EU
-FB
-XI
-bt
-cX
+bP
+fL
+gd
+fk
+ea
 fo
 cM
 ab
@@ -14006,8 +13994,8 @@ cQ
 cQ
 cQ
 cQ
-ey
-pb
+eL
+dD
 fs
 cM
 ab
@@ -14265,7 +14253,7 @@ dU
 cM
 eO
 eQ
-ff
+fe
 cM
 ab
 aj
@@ -14518,11 +14506,11 @@ cM
 cV
 dx
 cV
-dX
+ge
 cM
 eS
-Mb
-BD
+Hk
+fu
 cM
 ab
 ab
@@ -14772,13 +14760,13 @@ aj
 aj
 ab
 cM
-Oq
+pO
 cM
 cM
 cM
 cM
-eN
-me
+eM
+El
 fv
 cM
 cM
@@ -15030,17 +15018,17 @@ ab
 ab
 cM
 fz
-dC
-gc
+Fh
+nO
 fc
-cT
-sL
-gt
+er
+vZ
+Eg
 fo
 dQ
-gh
-Uz
-Az
+bI
+Rf
+Zn
 cM
 ab
 aj
@@ -15286,18 +15274,18 @@ aj
 aj
 ab
 cM
-eb
+db
 fz
 fz
-fk
+fG
 fz
-Eg
-ek
-ff
-dQ
-fL
+on
+KN
 fe
-Pq
+dQ
+KJ
+WY
+fr
 cR
 ab
 aj
@@ -15545,16 +15533,16 @@ ab
 cM
 fD
 fz
-bS
-fH
-xg
-sL
-bH
-fK
-ga
-EQ
-OP
-fY
+WO
+dT
+et
+vZ
+ex
+ed
+aY
+AV
+ff
+bi
 cR
 ab
 aj
@@ -15800,18 +15788,18 @@ aj
 aj
 ab
 cM
-fN
+de
 fz
-AE
+dR
 ft
 fz
-sL
-Tg
-fA
+vZ
+ep
+fg
 dQ
-fP
-nS
-DF
+cl
+fH
+BD
 cR
 ai
 ai
@@ -16060,15 +16048,15 @@ cM
 gg
 fz
 fz
-Tn
+dX
 fz
-sL
-eq
-fA
+vZ
+gq
+fg
 dQ
-dW
 fa
-do
+fw
+gp
 cM
 ai
 ai
@@ -16316,12 +16304,12 @@ ai
 cM
 fx
 fz
-bS
-EG
-xg
-sL
+WO
+eg
+et
+vZ
 gL
-GI
+fi
 cM
 cM
 cM
@@ -16573,18 +16561,18 @@ cM
 cM
 dF
 dF
-es
-ei
+bR
+eh
 fz
-sL
-gt
-fg
+vZ
+Eg
+eu
 cM
-rV
+es
 cV
-dt
+cs
 gb
-dp
+Nj
 cM
 aj
 aj
@@ -16827,21 +16815,21 @@ aD
 aj
 aj
 cM
-dR
-dR
+cT
+cT
 dG
-fr
+dS
 ec
 fz
-sL
+vZ
 PQ
 fo
 cM
 cV
-eX
-eX
-Nf
-dK
+ga
+ga
+gc
+hz
 cM
 aj
 aj
@@ -17084,21 +17072,21 @@ aD
 aj
 aj
 cM
-fU
-gZ
-XE
-fr
+cU
+dp
+dH
+dS
 ec
 fz
-sL
+vZ
 PQ
-cZ
+fy
 cM
-TN
+fZ
 cV
 cM
 cM
-VD
+Tn
 cM
 aj
 aj
@@ -17341,18 +17329,18 @@ aD
 aj
 ab
 cM
-db
-fI
-dR
-fr
+pI
+dq
+cT
+dS
 ec
 fz
-Eg
+on
 eR
-Qq
+KY
 cM
-eX
-QH
+ga
+gi
 cM
 Zf
 Zf
@@ -17598,20 +17586,20 @@ aj
 aj
 ai
 cM
-dc
-fI
-WO
-Te
+KW
+dq
+dr
+eq
 vq
 Kb
 eT
-El
-dd
+qe
+fA
 cM
 gb
-hW
+gl
 cM
-dq
+Fe
 bo
 cM
 ai
@@ -17855,21 +17843,21 @@ aj
 aj
 aj
 cM
-de
-fI
-dR
-zC
+tn
+dq
+cT
+nF
 fz
 fz
-sL
-oN
+vZ
+dl
 fC
-sZ
+bU
 gf
 gm
 cM
 IK
-eX
+ga
 cM
 cM
 ab
@@ -18112,20 +18100,20 @@ aj
 aj
 ai
 cM
-KW
-BT
-Kr
-fG
-bP
+df
+Dk
+Ej
+LO
+fm
 ev
-sL
-bi
-fA
+vZ
+fU
+fg
 cM
-fp
+br
 gn
 cM
-eL
+bG
 dI
 cW
 cM
@@ -18369,22 +18357,22 @@ ai
 cM
 cM
 cM
-fi
+fX
 cM
 cM
 cM
 cM
 cM
 eU
-bi
+fU
 fo
 cM
-fp
-TC
-cP
-Nk
-Du
-kw
+br
+fK
+Ky
+dc
+uT
+oa
 cM
 ai
 aj
@@ -18624,24 +18612,24 @@ aj
 aj
 cM
 cM
+bQ
+Gw
+dA
+cV
+cV
+bw
+xY
+cM
+Sr
+fU
+fg
+cM
 br
-Aa
-et
-cV
-cV
-Vu
-Ae
+fO
 cM
-dz
-bi
-fA
-cM
-fp
-AB
-cM
-px
-eX
-nZ
+eK
+ga
+BS
 cM
 ai
 ai
@@ -18881,24 +18869,24 @@ aj
 aj
 cM
 cV
-fZ
-eo
-Gr
-tI
-eo
-cU
-eo
+rv
+dW
+ek
+rV
+dW
+JG
+dW
 ez
-Ma
-em
+SB
+Qm
 fs
 cM
-fp
-er
+br
+cX
 cM
-Ms
+vS
 cV
-to
+em
 cM
 ad
 ai
@@ -19138,24 +19126,24 @@ aj
 aj
 cM
 gb
-Ej
-uQ
+Rk
+MQ
 bq
 bq
 bq
 bq
 bq
 bq
-sL
-ge
-fA
+vZ
+bv
+fg
 cM
-bD
-ex
+tK
+TN
 cM
-ee
-fO
-YE
+Ir
+Jp
+dN
 cM
 cM
 cM
@@ -19394,28 +19382,28 @@ aj
 aj
 aj
 JX
-eX
-et
+ga
+dA
 bq
-Fr
-Ow
-dS
-Uv
-dS
+bV
+bX
+ey
+aN
+ey
 bq
-sL
-ge
-fg
+vZ
+bv
+eu
 cM
-Ag
-Bq
-cM
-cM
+rU
+ei
 cM
 cM
 cM
-xb
-Wo
+cM
+cM
+tM
+dK
 cM
 ab
 aj
@@ -19651,27 +19639,27 @@ ab
 aj
 aj
 cM
-Vu
+bw
 IZ
 bq
-bT
-VL
+wj
+do
 eW
-vR
-uc
+AB
+IH
 bq
+hu
 en
-fm
-PF
+bx
 cM
-fp
+br
 gb
-VD
-QH
-Ww
-un
-eX
-eX
+Tn
+gi
+Wo
+tD
+ga
+ga
 cV
 cM
 ab
@@ -19908,28 +19896,28 @@ aj
 aj
 ab
 cM
-Pp
+Vu
 xM
 bq
-Pb
-bp
-dA
-dB
+ds
+dM
 co
-bq
-sL
-bE
-On
-cM
 fp
+UQ
+bq
+vZ
+dt
+xd
+cM
+br
 cV
-bQ
-yl
-eo
-eo
-VS
-eX
-eX
+yB
+rJ
+dW
+dW
+na
+ga
+ga
 cM
 cM
 cM
@@ -20158,37 +20146,37 @@ aj
 ab
 xC
 xC
-nO
+yO
 xC
 xC
 ab
 aj
 ab
 bq
-oG
-et
+cN
+dA
 bq
-eM
-MJ
-cs
-gA
-sr
+pF
+cD
+fj
+dm
+fJ
 bq
-sL
-bE
-fA
+vZ
+dt
+fg
 cM
-wT
-bG
-df
-dr
-aY
+oO
+dO
+Ou
+QI
+tL
 cM
-dE
-eX
-QH
+fN
+ga
+gi
 cV
-px
+eK
 cR
 aj
 aj
@@ -20415,36 +20403,36 @@ aj
 ab
 xC
 CF
-dk
-BI
+fF
+sx
 xC
 ab
 ab
 bq
 bq
 bq
-fJ
+eN
 bq
-NP
-bq
-bq
+WU
 bq
 bq
 bq
-dl
-ep
-hD
 bq
-eX
+bq
+cS
+du
+dC
+bq
+ga
 cV
 cM
 cM
 cM
 cM
-fF
-fw
-dh
-bI
+Ee
+bp
+oK
+Ww
 cV
 cR
 aj
@@ -20671,38 +20659,38 @@ aj
 ab
 ab
 tb
-fu
-fu
-fu
+nL
+nL
+nL
 tb
 bN
 bN
 bN
-ZK
-dO
-Nj
+CQ
+ee
+eX
+fd
+Bq
+Pf
+om
+fd
+Nb
 eB
-dD
-rA
-xB
-eB
-MM
-fj
-cN
-eh
-on
+cZ
+LT
+gA
 bq
 cV
-eX
+ga
 cV
-AB
-VT
+fO
+IJ
 cM
-eJ
-eX
+uu
+ga
 cR
 cM
-DE
+sL
 cM
 aj
 aj
@@ -20928,39 +20916,39 @@ aj
 ab
 ab
 xC
-bw
+NP
 rM
 Cf
-pa
+gK
 gv
 eW
 gw
-aN
-cS
-Mf
-dT
-Bx
-nH
-FI
+bS
+Yx
+bt
+Zj
+rb
+dd
+zI
 eA
 eA
 eA
-eK
-Lr
-JB
+xo
+TM
+Tw
 bq
-px
+eK
 cV
-eX
+ga
 cV
 cV
-VD
-Jh
-eg
-vZ
-gq
-Zh
-bx
+Tn
+dk
+jd
+EG
+hd
+BT
+hM
 aj
 aj
 aj
@@ -21186,31 +21174,31 @@ ab
 ab
 tb
 Cf
-sM
+Sm
 Cf
 tb
 bJ
 bN
 bN
 cn
-ct
-ed
-dM
-fy
-bU
-JM
+fE
+Lm
+eb
+bH
+fI
+sj
 ef
 ef
 eD
-Fe
-dM
-Xi
+dz
+eb
+bu
 bq
 cM
-dH
+KA
 cM
 cV
-FF
+eJ
 cM
 cM
 cM
@@ -21443,8 +21431,8 @@ ab
 ab
 xC
 Rs
-fE
-fd
+Iv
+TF
 xC
 ab
 aj
@@ -21459,15 +21447,15 @@ bq
 dJ
 xA
 dV
-cH
+pa
 fb
 dV
 bq
-bv
-eX
+bE
+ga
 gb
 cV
-gl
+gJ
 cM
 ab
 ab
@@ -21717,12 +21705,12 @@ eW
 eW
 eC
 eP
-eB
-eZ
-dn
-eX
-UQ
-fw
+fd
+dE
+bD
+ga
+iZ
+bp
 cV
 cV
 cM
@@ -21963,7 +21951,7 @@ ab
 aj
 aj
 bf
-xj
+dB
 cw
 dy
 cF
@@ -21973,9 +21961,9 @@ zu
 eW
 eW
 eH
-bR
+or
 eW
-hz
+gh
 bq
 cM
 cM
@@ -22221,9 +22209,9 @@ aj
 aj
 bf
 cp
-fn
+Px
 cJ
-bX
+eo
 cp
 bf
 dv
@@ -22232,7 +22220,7 @@ eW
 eE
 eV
 eW
-ea
+fY
 bN
 ad
 ai
@@ -22478,18 +22466,18 @@ aj
 aj
 bf
 cp
-Kh
+tm
 cK
-IJ
+CU
 cp
 bf
-du
+cH
 fh
 el
 eF
-Tv
+dn
 eW
-eu
+Wg
 bN
 ai
 ai
@@ -22734,8 +22722,8 @@ aj
 aj
 ab
 bf
-cl
-Zd
+cP
+bT
 cL
 bY
 da
@@ -22744,9 +22732,9 @@ dw
 dL
 ej
 eG
-BX
+ct
 eW
-ld
+AZ
 bN
 ai
 ab
@@ -22992,18 +22980,18 @@ ab
 ab
 bf
 aI
-GH
-dN
-xo
+PJ
+tI
+HV
 cO
 bf
-vN
+Hg
 fh
 el
 eI
-tK
+eZ
 fl
-LO
+Or
 bq
 ab
 aj
@@ -24276,10 +24264,10 @@ ab
 ab
 ab
 ab
-bu
+gt
 ab
 gH
-bu
+gt
 ab
 ab
 ab

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -428,18 +428,13 @@
 	},
 /area/mine/laborcamp/security)
 "bi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/camera{
+	c_tag = "Mining Telecommunications Hallway";
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding";
+	dir = 1
 	},
 /area/mine/living_quarters)
 "bj" = (
@@ -531,19 +526,12 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bv" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
-	},
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "bw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -606,32 +594,14 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "bC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar East";
-	network = list("Mining Outpost");
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bD" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "bE" = (
@@ -651,19 +621,33 @@
 /turf/simulated/floor/plating,
 /area/mine/eva)
 "bG" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"bH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
+"bH" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "bI" = (
 /obj/machinery/conveyor/east{
@@ -755,16 +739,17 @@
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
 "bP" = (
-/obj/item/toy/plushie/deer,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"bQ" = (
-/obj/structure/grille/broken,
-/obj/item/stack/rods{
-	amount = 4
+/obj/machinery/light/small{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"bQ" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "bR" = (
 /obj/structure/cable{
@@ -801,14 +786,13 @@
 	},
 /area/mine/production)
 "bU" = (
-/obj/effect/spawner/random_spawners/grille_often,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "bW" = (
@@ -1282,8 +1266,11 @@
 	},
 /area/mine/eva)
 "cZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "da" = (
@@ -1314,14 +1301,12 @@
 	},
 /area/mine/living_quarters)
 "dd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/grille/broken,
+/obj/item/stack/rods{
+	amount = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "de" = (
 /obj/structure/table/reinforced,
@@ -1333,23 +1318,15 @@
 	},
 /area/mine/living_quarters)
 "df" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "yellowsiding"
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "dg" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -1447,11 +1424,8 @@
 	},
 /area/mine/living_quarters)
 "dp" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/rack,
+/obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dq" = (
@@ -1462,14 +1436,11 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "dr" = (
-/obj/structure/extinguisher_cabinet{
-	name = "south bump";
-	pixel_y = -30
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	icon_state = "yellowsiding";
+	dir = 10
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1483,11 +1454,17 @@
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
 "dt" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/area/mine/living_quarters)
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
+	dir = 4
+	},
+/area/mine/production)
 "du" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -1614,10 +1591,11 @@
 	},
 /area/mine/living_quarters)
 "dH" = (
-/obj/effect/spawner/window/reinforced,
-/obj/effect/spawner/window/reinforced,
+/obj/item/stack/rods{
+	amount = 4
+	},
 /turf/simulated/floor/plating,
-/area/mine/production)
+/area/mine/living_quarters)
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -1640,9 +1618,14 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "dK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/mine/living_quarters)
 "dL" = (
 /obj/structure/cable{
@@ -1827,14 +1810,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "ei" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway West";
-	network = list("Mining Outpost");
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ej" = (
 /obj/structure/cable{
@@ -1845,18 +1823,16 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "ek" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "el" = (
@@ -1922,10 +1898,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "er" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "es" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1968,25 +1943,18 @@
 	},
 /area/mine/eva)
 "ex" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_y = -5
-	},
-/turf/simulated/wall,
-/area/mine/living_quarters)
-"ey" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "yellowsiding"
 	},
+/area/mine/living_quarters)
+"ey" = (
+/obj/structure/closet/crate/internals,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ez" = (
 /obj/machinery/door/airlock/maintenance,
@@ -2261,9 +2229,17 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "eZ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
-	dir = 10
+	dir = 4
 	},
 /area/mine/production)
 "fa" = (
@@ -2325,11 +2301,22 @@
 	},
 /area/mine/living_quarters)
 "fg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fh" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
@@ -2339,37 +2326,13 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/cardboard,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fk" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8
-	},
-/obj/item/dice/d8,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -2411,22 +2374,19 @@
 	},
 /area/mine/living_quarters)
 "fp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
 	},
-/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fr" = (
 /obj/structure/chair/stool/bar{
@@ -2468,17 +2428,10 @@
 	},
 /area/mine/living_quarters)
 "fw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
-	},
-/area/mine/production)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "fx" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
@@ -2486,8 +2439,13 @@
 	},
 /area/mine/living_quarters)
 "fy" = (
-/obj/effect/spawner/random_spawners/blood_often,
-/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fz" = (
@@ -2543,32 +2501,29 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fH" = (
-/obj/machinery/alarm{
+/obj/machinery/firealarm{
 	dir = 4;
-	name = "custom placement";
-	pixel_x = -23
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Bar West";
-	network = list("Mining Outpost");
-	dir = 5
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "fI" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "fJ" = (
 /obj/machinery/door/airlock/maintenance,
@@ -2578,9 +2533,7 @@
 /turf/simulated/floor/plating,
 /area/mine/production)
 "fK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random_spawners/blood_often,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "fL" = (
@@ -2634,19 +2587,15 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fU" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell{
-	pixel_y = -2
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway West";
+	network = list("Mining Outpost");
+	dir = 1
 	},
-/obj/item/stock_parts/cell{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/crowbar,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "fV" = (
 /turf/simulated/wall/indestructible/boss/see_through,
 /area/lavaland/surface/outdoors)
@@ -2659,20 +2608,6 @@
 /turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors)
 "fY" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"fZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
-"ga" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -2687,20 +2622,33 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"fZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
+"ga" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "gb" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "gc" = (
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/mine/production)
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "gd" = (
 /obj/machinery/conveyor/east{
 	id = "garbage";
@@ -2828,17 +2776,18 @@
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gp" = (
-/obj/effect/spawner/random_spawners/blood_often,
-/turf/simulated/floor/plating,
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
 /area/mine/living_quarters)
 "gq" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/bluegrid,
-/area/mine/maintenance)
+/obj/item/toy/plushie/deer,
+/turf/simulated/floor/plating,
+/area/mine/living_quarters)
 "gr" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -2866,16 +2815,21 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gt" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 7;
+	pixel_y = 5
 	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8
+	},
+/obj/item/dice/d8,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "gu" = (
@@ -3066,13 +3020,13 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "gZ" = (
-/obj/machinery/light{
+/obj/machinery/camera{
+	c_tag = "Mining Living Hallway East";
+	network = list("Mining Outpost");
 	dir = 1
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "yellowsiding"
 	},
 /area/mine/living_quarters)
 "hf" = (
@@ -3553,10 +3507,8 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ld" = (
-/obj/item/stack/rods{
-	amount = 4
-	},
-/turf/simulated/floor/plating,
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "le" = (
 /obj/structure/stone_tile,
@@ -4370,15 +4322,23 @@
 	},
 /area/mine/laborcamp)
 "rA" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	dir = 8;
+	icon_state = "barber"
 	},
-/area/mine/production)
+/area/mine/living_quarters)
 "rM" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/mineral/titanium,
@@ -4393,13 +4353,18 @@
 	},
 /area/mine/laborcamp)
 "rV" = (
+/obj/machinery/alarm{
+	dir = 4;
+	name = "custom placement";
+	pixel_x = -23
+	},
 /obj/machinery/camera{
-	c_tag = "Mining Telecommunications Hallway";
-	network = list("Mining Outpost")
+	c_tag = "Mining Bar West";
+	network = list("Mining Outpost");
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
+	icon_state = "bar"
 	},
 /area/mine/living_quarters)
 "sr" = (
@@ -4493,25 +4458,11 @@
 /area/mine/living_quarters)
 "tx" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "ty" = (
 /obj/structure/lattice/catwalk,
@@ -4540,19 +4491,15 @@
 	},
 /area/mine/laborcamp)
 "tK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "yellowsiding";
+	dir = 8
 	},
-/area/mine/living_quarters)
+/area/mine/production)
 "tT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -4700,15 +4647,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
-"wk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/mine/living_quarters)
 "wt" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -4717,12 +4655,6 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"wL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/mine/living_quarters)
 "wP" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -4749,19 +4681,8 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "xb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Infirmary";
-	network = list("Mining Outpost");
-	dir = 10
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "xg" = (
 /obj/structure/chair/office{
@@ -4842,9 +4763,7 @@
 	},
 /area/mine/laborcamp)
 "yg" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -4901,12 +4820,22 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "zC" = (
-/obj/structure/table,
-/obj/item/screwdriver{
-	pixel_x = 3;
-	pixel_y = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "Aa" = (
 /obj/machinery/light/small{
@@ -4935,8 +4864,18 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Az" = (
-/obj/item/instrument/guitar,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/mine/living_quarters)
 "AB" = (
 /obj/structure/grille,
@@ -4954,6 +4893,17 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"AN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/living_quarters)
 "Bg" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
@@ -4962,14 +4912,13 @@
 /turf/simulated/floor/plasteel/dark,
 /area/mine/maintenance)
 "Bq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/mine/living_quarters)
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 "Bx" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4991,27 +4940,35 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "BD" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding";
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/mine/living_quarters)
+/area/mine/production)
 "BI" = (
 /obj/structure/ore_box,
 /obj/machinery/light/small,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "BT" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "BX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5150,7 +5107,7 @@
 	},
 /area/mine/laborcamp)
 "EG" = (
-/obj/structure/closet/cardboard,
+/obj/item/instrument/guitar,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "EQ" = (
@@ -5319,6 +5276,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"Hx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/mine/living_quarters)
 "HA" = (
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/plasteel{
@@ -5384,8 +5350,26 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Jh" = (
-/obj/structure/closet/crate/internals,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/deck/cards,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "Jl" = (
 /obj/effect/spawner/window/reinforced,
@@ -5395,8 +5379,17 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "JB" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/mine/living_quarters)
 "JM" = (
 /obj/structure/disposalpipe/segment,
@@ -5646,13 +5639,18 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "MM" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Mining Infirmary";
+	network = list("Mining Outpost");
+	dir = 10
+	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/mine/living_quarters)
 "Ne" = (
@@ -5665,10 +5663,12 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Nf" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/mine/living_quarters)
 "Ni" = (
 /obj/effect/spawner/window/reinforced,
@@ -5755,15 +5755,10 @@
 	},
 /area/mine/laborcamp)
 "On" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Oq" = (
 /obj/machinery/door/airlock{
@@ -5842,12 +5837,25 @@
 /turf/simulated/wall,
 /area/mine/laborcamp/security)
 "Qq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/stock_parts/cell{
+	pixel_y = -2
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/item/stock_parts/cell{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/crowbar,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowsiding"
+	},
+/area/mine/production)
+"QD" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_y = -5
+	},
+/turf/simulated/wall,
 /area/mine/living_quarters)
 "QE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5867,8 +5875,23 @@
 	},
 /area/mine/laborcamp)
 "QH" = (
-/obj/effect/spawner/random_spawners/fungus_probably,
-/turf/simulated/wall,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Bar East";
+	network = list("Mining Outpost");
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/mine/living_quarters)
 "Rd" = (
 /obj/structure/rack,
@@ -6016,14 +6039,12 @@
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "TN" = (
-/obj/machinery/camera{
-	c_tag = "Mining Living Hallway East";
-	network = list("Mining Outpost");
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/mine/living_quarters)
 "Uh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6165,14 +6186,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Ww" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 4
-	},
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/mine/production)
 "Wx" = (
 /obj/structure/table,
@@ -13228,7 +13244,7 @@ ab
 cQ
 Bp
 lJ
-gq
+Bq
 cQ
 cR
 Jl
@@ -13489,7 +13505,7 @@ az
 cQ
 sL
 yR
-dt
+bQ
 cM
 ab
 aj
@@ -14001,7 +14017,7 @@ cQ
 cQ
 cQ
 cQ
-rV
+bi
 pb
 fs
 cM
@@ -14517,7 +14533,7 @@ dX
 cM
 eS
 Mb
-bD
+ex
 cM
 ab
 ab
@@ -15026,16 +15042,16 @@ ab
 cM
 fz
 dC
-fH
+rV
 fc
 cT
 sL
-ek
+bG
 fo
 dQ
 gh
 Uz
-gt
+JB
 cM
 ab
 aj
@@ -15284,10 +15300,10 @@ cM
 eb
 fz
 fz
-yg
+fk
 fz
 Eg
-BD
+ek
 ff
 dQ
 fL
@@ -15541,15 +15557,15 @@ cM
 fD
 fz
 bS
-fk
+gt
 xg
 sL
-fj
-On
-df
+zC
+AN
+rA
 EQ
-bi
-xb
+fp
+MM
 cR
 ab
 aj
@@ -16312,10 +16328,10 @@ cM
 fx
 fz
 bS
-tx
+Jh
 xg
 sL
-ek
+BT
 fA
 cM
 cM
@@ -16568,18 +16584,18 @@ cM
 cM
 dF
 dF
-wL
-ey
+bD
+bH
 fz
 sL
-ek
-dr
+bG
+gp
 cM
-EG
+fj
 cV
-JB
+xb
 gb
-fy
+er
 cM
 aj
 aj
@@ -16829,14 +16845,14 @@ fr
 ec
 fz
 sL
-fp
+fg
 fo
 cM
 cV
 eX
 eX
-bU
-Az
+bV
+EG
 cM
 aj
 aj
@@ -17079,21 +17095,21 @@ aD
 aj
 aj
 cM
-gZ
-wk
+dK
+Hx
 XE
 fr
 ec
 fz
 sL
-fp
-ei
+fg
+fU
 cM
-gp
+fK
 cV
 cM
 cM
-QH
+ld
 cM
 aj
 aj
@@ -17337,7 +17353,7 @@ aj
 ab
 cM
 db
-fG
+Nf
 dR
 fr
 ec
@@ -17347,7 +17363,7 @@ eR
 es
 cM
 eX
-ld
+dH
 cM
 Zf
 Zf
@@ -17594,14 +17610,14 @@ aj
 ai
 cM
 dc
-fG
+Nf
 WO
 Te
 vq
 Kb
 eT
 El
-MM
+fI
 cM
 gb
 gl
@@ -17851,11 +17867,11 @@ aj
 aj
 cM
 de
-fG
+Nf
 dR
-ga
-er
-er
+fY
+yg
+yg
 vZ
 oN
 fC
@@ -18108,16 +18124,16 @@ aj
 ai
 cM
 KW
-tK
+Az
 Kr
-bC
-dd
+QH
+fH
 ev
 bx
 PQ
 fA
 cM
-Bq
+gc
 gn
 cM
 eL
@@ -18374,7 +18390,7 @@ eU
 PQ
 fo
 cM
-Bq
+gc
 TC
 cP
 Nk
@@ -18631,7 +18647,7 @@ dz
 PQ
 fA
 cM
-Bq
+gc
 AB
 cM
 px
@@ -18888,8 +18904,8 @@ Ma
 em
 fs
 cM
-Bq
-fI
+gc
+ei
 cM
 Ms
 cV
@@ -19145,8 +19161,8 @@ sL
 ge
 fA
 cM
-bH
-BT
+fy
+dp
 cM
 ee
 fO
@@ -19400,10 +19416,10 @@ dS
 bq
 sL
 ge
-dr
+gp
 cM
 Ag
-fK
+bU
 cM
 cM
 cM
@@ -19659,11 +19675,11 @@ en
 fm
 PF
 cM
-Bq
+gc
 gb
 cM
-ld
-zC
+dH
+tx
 un
 zy
 cD
@@ -19914,14 +19930,14 @@ co
 bq
 sL
 bE
-TN
+gZ
 cM
-Bq
+gc
 cV
-QH
+ld
 yl
 cV
-bG
+fG
 dh
 VS
 xM
@@ -20174,9 +20190,9 @@ bE
 fA
 cM
 wT
-fg
-dp
-Qq
+bv
+cZ
+TN
 aY
 DE
 dE
@@ -20681,7 +20697,7 @@ dD
 VD
 xB
 eB
-gc
+tK
 eB
 cN
 eh
@@ -20691,10 +20707,10 @@ cV
 eX
 cV
 AB
-dK
-ex
+fw
+QD
 cV
-fY
+ga
 cV
 gi
 eX
@@ -20942,19 +20958,19 @@ eA
 eA
 eK
 Lr
-rA
+df
 bq
 px
 cV
 eX
 cV
 cV
-QH
-cZ
+ld
+bC
 eg
 cV
-bV
-Jh
+bP
+ey
 cR
 aj
 aj
@@ -21191,8 +21207,8 @@ cn
 ct
 ed
 eJ
-fw
-Ww
+dt
+BD
 JM
 ef
 ef
@@ -21458,11 +21474,11 @@ cH
 fb
 dV
 bq
-bP
+gq
 eX
 gb
 cV
-bQ
+dd
 cM
 ab
 ab
@@ -21713,11 +21729,11 @@ eW
 eC
 eP
 eB
-eZ
+dr
 dn
 eX
 cV
-Nf
+On
 cV
 cV
 cM
@@ -22741,8 +22757,8 @@ ej
 eG
 BX
 eW
-fU
-dH
+Qq
+Ww
 ai
 ab
 aj
@@ -22996,7 +23012,7 @@ vN
 fh
 el
 eI
-bv
+eZ
 fl
 LO
 bq


### PR DESCRIPTION
This PR remap the entire mining outpost.  The old mining post
his time was already counted. A new outpost was made from scratch WITHOUT that bridge.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR remakes the miners' outpost from scratch, so with a new atmos and some new implementations. The old outpost had some flaws, so instead of just fixing those flaws, it was completely redone.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
With this new outpost, which we want to add more stuff in the future, antags can see new opportunities to do new things, and at the same time, miners can also take advantage of the new space.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/62888630/182249336-f1faa823-58ae-49d6-ae50-b12eb2797b6e.png)



## Testing
<!-- How did you test the PR, if at all? -->
It was tested at my local host server.
## Changelog
:cl:
tweak: Remap Mining Outpost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
