### PR TITLE
Allow cursed heart to be defibrillated up to three times

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -390,10 +390,13 @@
 #define COMSIG_LIVING_SHOCK_PREVENTED "living_shock_prevented"
 ///sent by stuff like stunbatons and tasers: ()
 #define COMSIG_LIVING_MINOR_SHOCK "living_minor_shock"
-///Sent from defibrillators when everything seems good and the user will be shocked: (defibber, ghost)
+///Sent from defibrillators when everything seems good and the user will be shocked: (defibber, defib_item, ghost)
 #define COMSIG_LIVING_BEFORE_DEFIB "living_pre_defib"
+	/// If returned from LIVING_BEFORE_DEFIB or LIVING_DEFIBBED, the defibrillation will fail
 	#define COMPONENT_BLOCK_DEFIB (1<<0)
-///send from defibs on ressurection: (defibber, ghost)
+	/// If returned, don't even show the "failed" message, defer to the signal handler to do that.
+	#define COMPONENT_DEFIB_OVERRIDE (1<<1)
+///send from defibs on ressurection: (defibber, defib_item, ghost)
 #define COMSIG_LIVING_DEFIBBED "living_defibbed"
 ///from base of mob/living/revive() (full_heal, admin_revive)
 #define COMSIG_LIVING_REVIVE "living_revive"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -391,7 +391,7 @@
 ///sent by stuff like stunbatons and tasers: ()
 #define COMSIG_LIVING_MINOR_SHOCK "living_minor_shock"
 ///Sent from defibrillators when everything seems good and the user will be shocked: (defibber, defib_item, ghost)
-#define COMSIG_LIVING_BEFORE_DEFIB "living_pre_defib"
+#define COMSIG_LIVING_PRE_DEFIB "living_pre_defib"
 	/// If returned from LIVING_BEFORE_DEFIB or LIVING_DEFIBBED, the defibrillation will fail
 	#define COMPONENT_BLOCK_DEFIB (1<<0)
 	/// If returned, don't even show the "failed" message, defer to the signal handler to do that.

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -390,6 +390,11 @@
 #define COMSIG_LIVING_SHOCK_PREVENTED "living_shock_prevented"
 ///sent by stuff like stunbatons and tasers: ()
 #define COMSIG_LIVING_MINOR_SHOCK "living_minor_shock"
+///Sent from defibrillators when everything seems good and the user will be shocked: (defibber, ghost)
+#define COMSIG_LIVING_BEFORE_DEFIB "living_pre_defib"
+	#define COMPONENT_BLOCK_DEFIB (1<<0)
+///send from defibs on ressurection: (defibber, ghost)
+#define COMSIG_LIVING_DEFIBBED "living_defibbed"
 ///from base of mob/living/revive() (full_heal, admin_revive)
 #define COMSIG_LIVING_REVIVE "living_revive"
 ///from base of /mob/living/regenerate_limbs(): (noheal, excluded_limbs)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -916,6 +916,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	return ..()
 
 /obj/item/organ/internal/heart/cursed/wizard
+	max_shocks_allowed = 1  // You Only Have One Shot
 	pump_delay = 60
 	heal_brute = 25
 	heal_burn = 25

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -916,7 +916,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	return ..()
 
 /obj/item/organ/internal/heart/cursed/wizard
-	max_shocks_allowed = 1  // You Only Have One Shot
+	max_shocks_allowed = 3
 	pump_delay = 60
 	heal_brute = 25
 	heal_burn = 25

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -404,7 +404,7 @@
 			var/total_burn	= 0
 			var/total_brute	= 0
 
-			var/signal_result = SEND_SIGNAL(M, COMSIG_LIVING_BEFORE_DEFIB, user, defib, ghost)
+			var/signal_result = SEND_SIGNAL(M, COMSIG_LIVING_PRE_DEFIB, user, defib, ghost)
 
 			if(do_after(user, 20 * toolspeed, target = M)) //placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 				signal_result |= SEND_SIGNAL(M, COMSIG_LIVING_DEFIBBED, user, defib, ghost)
@@ -577,7 +577,7 @@
 			var/total_burn	= 0
 			var/total_brute	= 0
 
-			var/signal_result = SEND_SIGNAL(M, COMSIG_LIVING_BEFORE_DEFIB, user, src, ghost)
+			var/signal_result = SEND_SIGNAL(M, COMSIG_LIVING_PRE_DEFIB, user, src, ghost)
 			if(do_after(user, 20 * toolspeed, target = M)) //placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 				signal_result |= SEND_SIGNAL(M, COMSIG_LIVING_DEFIBBED, user, src, ghost)
 				if(H.stat == DEAD)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -456,7 +456,7 @@
 						total_brute	+= O.brute_dam
 						total_burn	+= O.burn_dam
 					ghost = H.get_ghost(TRUE) // We have to double check whether the dead guy has entered their body during the above
-					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK) && !HAS_TRAIT(H, TRAIT_BADDNA) && H.blood_volume > BLOOD_VOLUME_SURVIVE && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)) && signal_result != COMPONENT_BLOCK_DEFIB)
+					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK) && !HAS_TRAIT(H, TRAIT_BADDNA) && H.blood_volume > BLOOD_VOLUME_SURVIVE && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)) && !(signal_result & COMPONENT_BLOCK_DEFIB))
 						tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 						tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 						H.adjustOxyLoss(tobehealed)
@@ -588,7 +588,7 @@
 					for(var/obj/item/organ/external/O in H.bodyparts)
 						total_brute	+= O.brute_dam
 						total_burn	+= O.burn_dam
-					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK) && signal_result != COMPONENT_BLOCK_DEFIB)
+					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK) && !(signal_result & COMPONENT_BLOCK_DEFIB))
 						tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 						tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 						H.adjustOxyLoss(tobehealed)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -65,7 +65,7 @@
 		. += "[icon_state]-emagged"
 	if(powered)
 		. += "[icon_state]-powered"
-	if(powered && cell) 
+	if(powered && cell)
 		var/ratio = cell.charge / cell.maxcharge
 		ratio = CEILING(ratio*4, 1) * 25
 		. += "[icon_state]-charge[ratio]"
@@ -404,6 +404,8 @@
 			var/total_burn	= 0
 			var/total_brute	= 0
 
+			var/signal_result = SEND_SIGNAL(M, COMSIG_LIVING_BEFORE_DEFIB, user, ghost)
+
 			if(do_after(user, 20 * toolspeed, target = M)) //placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 				for(var/obj/item/carried_item in H.contents)
 					if(istype(carried_item, /obj/item/clothing/suit/space))
@@ -450,7 +452,7 @@
 						total_brute	+= O.brute_dam
 						total_burn	+= O.burn_dam
 					ghost = H.get_ghost(TRUE) // We have to double check whether the dead guy has entered their body during the above
-					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK) && !HAS_TRAIT(H, TRAIT_BADDNA) && H.blood_volume > BLOOD_VOLUME_SURVIVE && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
+					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !HAS_TRAIT(H, TRAIT_HUSK) && !HAS_TRAIT(H, TRAIT_BADDNA) && H.blood_volume > BLOOD_VOLUME_SURVIVE && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)) && signal_result != COMPONENT_BLOCK_DEFIB)
 						tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 						tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 						H.adjustOxyLoss(tobehealed)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -157,7 +157,7 @@
 	addtimer(CALLBACK(src, .proc/on_end_grace_period), revival_grace_period)  // hide the scars to fade away the shake-up
 
 /obj/item/organ/internal/heart/cursed/proc/after_revive()
-	owner.WakeUp()
+	owner.SetSleeping(0)
 	owner.SetParalysis(0)
 
 /// Run this just before the shock is applied so we end up with enough blood to revive.

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -121,17 +121,11 @@
 	..()
 	if(owner)
 		to_chat(owner, "<span class='userdanger'>Your heart has been replaced with a cursed one, you have to pump this one manually otherwise you'll die!</span>")
-		RegisterSignal(owner, COMSIG_LIVING_BEFORE_DEFIB, .proc/on_defib)
+		RegisterSignal(owner, COMSIG_LIVING_PRE_DEFIB, .proc/just_before_revive)
 		RegisterSignal(owner, COMSIG_LIVING_DEFIBBED, .proc/on_defib_revive)
 
-/obj/item/organ/internal/heart/cursed/remove(mob/living/carbon/M, special)
-	if(owner)
-		UnregisterSignal(owner, COMSIG_LIVING_BEFORE_DEFIB)
-		UnregisterSignal(owner, COMSIG_LIVING_DEFIBBED)
-	. = ..()
-
 /obj/item/organ/internal/heart/cursed/proc/on_defib_revive(mob/living/carbon/shocked, mob/living/carbon/shocker, obj/item/defib, mob/dead/observer/ghost = null)
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER  // COMSIG_LIVING_DEFIBBED
 
 	if(!owner || !istype(owner) || owner.stat != DEAD)
 		return
@@ -161,12 +155,11 @@
 	owner.SetParalysis(0)
 
 /// Run this just before the shock is applied so we end up with enough blood to revive.
-/obj/item/organ/internal/heart/cursed/proc/on_defib(mob/living/carbon/shocked, mob/living/carbon/shocker, mob/dead/observer/ghost = null)
-	SIGNAL_HANDLER
+/obj/item/organ/internal/heart/cursed/proc/just_before_revive(mob/living/carbon/shocked, mob/living/carbon/shocker, mob/dead/observer/ghost = null)
+	SIGNAL_HANDLER  // COMSIG_LIVING_PRE_DEFIB
 
 	if(owner.stat == DEAD)
 		owner.blood_volume = BLOOD_VOLUME_OKAY
-
 
 /obj/item/organ/internal/heart/cursed/proc/on_end_grace_period()
 	in_grace_period = FALSE

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -79,6 +79,16 @@
 	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
+	// Give the user a chance to be shocked to life with the heart in, since defibs put them to sleep.
+	/// How long the shock pumps their heart for them.
+	var/revival_grace_period = 10 SECONDS
+	/// If true, the user doesn't need to pump their heart.
+	var/in_grace_period = FALSE
+	/// Times that it's been shocked.
+	var/times_shocked = 0
+	/// Max times that the shock will work before it'll just refuse.
+	var/max_shocks_allowed = 5
+
 	//How much to heal per pump, negative numbers would HURT the player
 	var/heal_brute = 0
 	var/heal_burn = 0
@@ -96,7 +106,7 @@
 		return ..()
 
 /obj/item/organ/internal/heart/cursed/on_life()
-	if(world.time > (last_pump + pump_delay))
+	if(world.time > (last_pump + pump_delay) && !in_grace_period)
 		if(ishuman(owner) && owner.client) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/H = owner
 			if(!(NO_BLOOD in H.dna.species.species_traits))
@@ -111,9 +121,53 @@
 	..()
 	if(owner)
 		to_chat(owner, "<span class='userdanger'>Your heart has been replaced with a cursed one, you have to pump this one manually otherwise you'll die!</span>")
+		RegisterSignal(owner, COMSIG_LIVING_BEFORE_DEFIB, .proc/on_defib)
+		RegisterSignal(owner, COMSIG_LIVING_DEFIBBED, .proc/on_defib_revive)
+
+/obj/item/organ/internal/heart/cursed/remove(mob/living/carbon/M, special)
+	if(owner)
+		UnregisterSignal(owner, COMSIG_LIVING_BEFORE_DEFIB)
+		UnregisterSignal(owner, COMSIG_LIVING_DEFIBBED)
+	. = ..()
+
+/obj/item/organ/internal/heart/cursed/proc/on_defib_revive(mob/living/carbon/shocked, mob/living/carbon/shocker, mob/dead/observer/ghost = null)
+	SIGNAL_HANDLER
+
+	if(!owner || !istype(owner))
+		return
+
+	if(times_shocked >= max_shocks_allowed)
+		shocker.visible_message(
+			"<span class='danger'>A ghastly electric shock permeates out from [shocked]'s chest!</span>",
+			"<span class='userdanger'>Tendrils of ghastly electricity surge from [shocked] as [shocked.p_their()] heart seems to outright refuse defibrillation!<span>",
+			"<span class='danger'>You hear a loud shock.</span>"
+		)
+		shocker.electrocute_act(5, shocked)
+		return
+
+	in_grace_period = TRUE
+	times_shocked++
+	addtimer(CALLBACK(owner, /mob/living/.proc/SetSleeping, 0), 3 SECONDS)  // let em wake up
+	addtimer(CALLBACK(src, .proc/on_end_grace_period), revival_grace_period)
+
+
+/// Run this just before the shock is applied so we end up with enough blood to revive.
+/obj/item/organ/internal/heart/cursed/proc/on_defib(mob/living/carbon/shocked, mob/living/carbon/shocker, mob/dead/observer/ghost = null)
+	SIGNAL_HANDLER
+
+	if(owner.stat == DEAD)
+		owner.blood_volume = BLOOD_VOLUME_OKAY
+
+
+/obj/item/organ/internal/heart/cursed/proc/on_end_grace_period()
+	in_grace_period = FALSE
+	if(!owner)
+		return
+	to_chat(owner, "<span class='userdanger'>The effects of the shock seem to wear off, and you feel a familiar tightness in your chest! Get pumping!</span>")
+	to_chat(owner, "<span class='warning'>It doesn't feel like your [src] enjoyed that, though, you probably won't be able to get revived too many more times!</span>")
 
 /datum/action/item_action/organ_action/cursed_heart
-	name = "pump your blood"
+	name = "Pump your heart"
 
 //You are now brea- pumping blood manually
 /datum/action/item_action/organ_action/cursed_heart/Trigger()
@@ -127,7 +181,7 @@
 
 		cursed_heart.last_pump = world.time
 		playsound(owner,'sound/effects/singlebeat.ogg',40,1)
-		to_chat(owner, "<span class = 'notice'>Your heart beats.</span>")
+		to_chat(owner, "<span class='notice'>Your heart beats.</span>")
 
 		var/mob/living/carbon/human/H = owner
 		if(istype(H))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is a different take on #18573, which simply deleted your cursed heart on death.

### Current Functionality
As it stands currently, cursed heart users are incredibly difficult to revive. The cursed heart functions by adjusting your blood level when you pump it, bringing it down below the insta-death threshold if you don't pump it as needed. 
When you get defibrillated, you get the sleeping status applied, which prevents you from manually pumping your heart, though the pump timer keeps ticking down. This means that you will almost never have enough time to get a single pump in before you instantly die again.

### *New Functionality*
When a player with a cursed heart gets defibrillated, they will be filled with enough blood to be "okay", and their heart will go into overdrive, not needing pumping for a grace period of 10 seconds. This should give them enough time to once again become conscious and start pumping their blood.
This is not the key to immortality, though; a cursed heart can only be revived this way **three times** before it will refuse to be defibrillated again, shocking whoever's trying to defibrillate them. This means you can't just have a buddy keep you alive forever like this.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I've made the argument before that this is a bit inspired by my own experiences with the cursed heart in medbay, as patients with cursed hearts tend to take a good bit of medbay's blood before a failed revive instantly deletes it all. Also, in the current state, if someone dies with a cursed heart, the only way they can be revived is by cloning or replacing their heart (which is of course limited by the 5 minute revive window). 

Instead of just deleting the heart outright, I think that this makes the experience better for the user with the cursed heart since they are no longer shocked into helplessness by the defibrillator, only to get caught in a death loop. Also, since revival requires someone else to defibrillate your dead corpse, it's not a free self-revive or anything. This also keeps a cursed heart in the game when a user dies (unlike #18573), meaning it can still be extracted and used by someone else -- with the caveat that it might not have as many revives as it originally did. 

~~Since the base cursed heart doesn't heal any damage in the first place (and it's kind of a noob trap), I think this is a fair move to make. Don't completely ruin the round of someone who picked it up off the ground. As for the wizard's heart, which heals 25 burn/brute/oxy, it only allows for a single revive. This allows wizards with apprentices a bit of flexibility; if they didn't grab a healing wand, they can still get one revive off if they're carrying around a defib. Still, this shouldn't keep the round going for too much longer, since cursed heart is enough of a handicap.~~

I've been informed that miners get the wizard heart, and so the wizard heart will be set at three revives. That should be a fair *enough* balance for an item that can heal you out of pretty much anything.



<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/182257846-496e5168-c0d7-498a-b381-3ce454941aeb.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See video
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: When being defibbed with a cursed heart, you now get a 10 second grace period before you need to start pumping manually, and you can be revived up to 3 times with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
