### PR TITLE
Fix - Undersuits grant actions to mobs properly

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -722,6 +722,7 @@ BLIND     // can't see anything
 			A.attached_unequip()
 
 /obj/item/clothing/under/equipped(mob/user, slot, initial)
+	..()
 	if(!ishuman(user))
 		return
 	if(slot == slot_w_uniform)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The undersuits weren't calling the parent `equipped` proc, and thus wouldn't grant their mobs any actions they had. This just makes it do that properly.

## Why It's Good For The Game
Fixes #18675, and possibly other undersuits with actions attached to them.

## Images of changes
![Suits](https://user-images.githubusercontent.com/80771500/182259003-a325ebda-57d8-4d6e-a76b-2db6f09b7eeb.png)

## Testing
Spawning chameleon objects. The jumpsuit stood out and would actually work if `Grant` was manually called, so something must have broke on the item pickup.

## Changelog
:cl:
fix: Chameleon jumpsuit actions can be used by mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
