### PR TITLE
Megafauna Drop Armor Rebalance

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -567,7 +567,7 @@
 	item_state = "dragon"
 	desc = "A suit of armour fashioned from the remains of an ash drake."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/twohanded/spear)
-	armor = list(MELEE = 115, BULLET = 20, LASER = 50, ENERGY = 35, BOMB = 115, BIO = 75, RAD = 50, FIRE = INFINITY, ACID = INFINITY)
+	armor = list(MELEE = 115, BULLET = 25, LASER = 25, ENERGY = 25, BOMB = 150, BIO = 25, RAD = 25, FIRE = INFINITY, ACID = INFINITY)
 	hoodtype = /obj/item/clothing/head/hooded/drake
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
@@ -579,7 +579,7 @@
 	icon_state = "dragon"
 	item_state = "dragon"
 	desc = "The skull of a dragon."
-	armor = list(MELEE = 115, BULLET = 20, LASER = 50, ENERGY = 35, BOMB = 115, BIO = 75, RAD = 50, FIRE = INFINITY, ACID = INFINITY)
+	armor = list(MELEE = 115, BULLET = 25, LASER = 25, ENERGY = 25, BOMB = 150, BIO = 25, RAD = 25, FIRE = INFINITY, ACID = INFINITY)
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -48,11 +48,10 @@
 	desc = "Hostile Environment Cross-Kinetic Suit: A suit designed to withstand the wide variety of hazards from Lavaland. It wasn't enough for its last owner."
 	icon_state = "hostile_env"
 	item_state = "hostile_env"
-	flags = THICKMATERIAL //not spaceproof
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	slowdown = 0
-	armor = list(MELEE = 115, BULLET = 35, LASER = 5, ENERGY = 5, BOMB = 50, BIO = INFINITY, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
+	armor = list(MELEE = 120, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, BIO = INFINITY, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/melee/spellblade)
 
 
@@ -83,8 +82,7 @@
 	item_state = "hostile_env"
 	w_class = WEIGHT_CLASS_NORMAL
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	flags = THICKMATERIAL // no space protection
-	armor = list(MELEE = 115, BULLET = 35, LASER = 5, ENERGY = 5, BOMB = 50, BIO = INFINITY, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
+	armor = list(MELEE = 120, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, BIO = INFINITY, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 /obj/item/clothing/head/helmet/space/hostile_environment/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
H.E.C.K. suit has been buffed and made spaceproof. Drake armor has been nerfed. Part of #18521

Check changed files for the exact value changes. For your convenience, below is what percentage reductions the changes come out to for the damage types, rounded to the nearest integer.

Drake armor reduction:
- Melee 70% -> 60%
- Bullet 29% -> 33%
- Laser 50% -> 33%
- Energy 41% -> 33%
- Bomb 70% -> 75%
- Bio 60% -> 33%
- Rad 50% -> 33%
- Fire INFINITY (unchanged)
- Acid INFINITY (unchanged)

H.E.C.K. suit reduction:
- Melee 70% -> 71% 
- Bullet 41% (unchanged)
- Laser 9% -> 33%
- Energy 9% -> 33%
- Bomb 50% -> 75%
- Bio INFINITY (unchanged)
- Rad INFINITY (unchanged)
- Fire INFINITY (unchanged)
- Acid INFINITY (unchanged)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- With the emergence of lavaland elites melee armor actually matters, and it does not really come up on station aside from biohazards (harmbatons tickle anyway), so it is fine for it to remain high.
- Energy and laser armor does not really come up on lavaland, only in bouts against security. This should be weaker so that robust miners aren't literally unstoppable for the average officer.
- Drake armor is relatively easy to get, yet it is easily one of the best armors in the game. Its values need to be lower to match its relative ease of acquisition.
- H.E.C.K. suit is one-of-a-kind and requires killing the hardest megafauna, yet it is currently much worse than drake armor, and not even spaceproof. This armor should be a sufficient reward for killing Bubblegum, but also avoid making the obviously robust miner an absolutely unstoppable menace.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled locally. This is only a value change, nothing to test.

## Changelog
:cl:
tweak: Drake armor and H.E.C.K. suit have been rebalanced. Check the PR for numbers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
