### PR TITLE
Reactive fire armor keeps you from taking heat damage again

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -351,14 +351,13 @@
 
 /obj/item/clothing/suit/armor/reactive/fire/equipped(mob/user, slot)
 	..()
-	if(slot == slot_wear_suit)
-		var/enchant_ID = UID(src)
-		ADD_TRAIT(user, TRAIT_RESISTHEAT, "[enchant_ID]")
+	if(slot != slot_wear_suit)
+		return
+	ADD_TRAIT(user, TRAIT_RESISTHEAT, "[UID()]")
 
 /obj/item/clothing/suit/armor/reactive/fire/dropped(mob/user, silent)
 	..()
-	var/enchant_ID = UID(src)
-	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, "[enchant_ID]")
+	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, "[UID()]")
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -352,11 +352,13 @@
 /obj/item/clothing/suit/armor/reactive/fire/equipped(mob/user, slot)
 	..()
 	if(slot == slot_wear_suit)
-		ADD_TRAIT(user, TRAIT_RESISTHEAT, "incendiary_armor")
+		var/enchant_ID = UID(src)
+		ADD_TRAIT(user, TRAIT_RESISTHEAT, "[enchant_ID]")
 
 /obj/item/clothing/suit/armor/reactive/fire/dropped(mob/user, silent)
 	..()
-	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, "incendiary_armor")
+	var/enchant_ID = UID(src)
+	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, "[enchant_ID]")
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -349,6 +349,15 @@
 	heat_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS | HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 
+/obj/item/clothing/suit/armor/reactive/fire/equipped(mob/user, slot)
+	..()
+	if(slot == slot_wear_suit)
+		ADD_TRAIT(user, TRAIT_RESISTHEAT, "incendiary_armor")
+
+/obj/item/clothing/suit/armor/reactive/fire/dropped(mob/user, silent)
+	..()
+	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, "incendiary_armor")
+
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Reactive incendiary armor once again protects the user from taking damage from fire, by using the heat resist trait.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The fire spewing fireproof armor setting you on fire is not great.

## Testing
<!-- How did you test the PR, if at all? -->

Spawn self, put on armor, light on fire, no damage.

Take armor off, take damage and overheat.

## Changelog
:cl:
fix:  Reactive fire armor no longer has the user take burn damage from being on fire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
