### PR TITLE
reverts #18618, fixing the melee attack chain

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -627,7 +627,7 @@
 		else
 			if(target.stat != DEAD)
 				user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
-			if(..())
+			if(isnull(..())) // attack returns null if the attack was successful, (against humans)
 				target.KnockDown(8 SECONDS)
 		return
 	else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -473,7 +473,6 @@ emp_act
 		bonus_damage = H.physiology.melee_bonus
 
 	apply_damage(I.force + bonus_damage , I.damtype, affecting, armor, sharp = weapon_sharp, used_weapon = I)
-	. = TRUE // at this point the attack has succeeded.
 
 	var/bloody = 0
 	if(I.damtype == BRUTE && I.force && prob(25 + I.force * 2))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #18686

melee attack chain does this
```
		var/resolved = target.attackby(src, user, params)
		if(!resolved && target && !QDELETED(src))
			afterattack(target, user, 1, params) // 1: clicking something Adjacent
```
so afterattack isn't called if attackby returns TRUE. 
afterattack is important for a lot of things
![image](https://user-images.githubusercontent.com/69320440/182498602-3c90792f-f49c-40e3-8d5e-ed46e0b7357f.png)
not all of these will be affected. as not all of them are used on humans. but this is a bad bug.

melee attack chain returns null against humans, (when successful), so I used that to check for the chainsaw. kinda hacky, best I can do without a major overhaul of attack code.

## Why It's Good For The Game
bugs are bad

## Testing
spawn skrell, hit with spellblade, afterattack fires.

hit skrell with chainsaw, the knockdown proc fires.

## Changelog
:cl:
fix: item special attack effects should work properly against humans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
