### PR TITLE
Update golem mind-transference prompt

### DIFF
--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -149,7 +149,7 @@
 	if(!istype(I, /obj/item/slimepotion/transference))
 		return ..()
 	if(iscarbon(user) && can_transfer)
-		var/human_transfer_choice = alert("Transfer your soul to [src]? (Warning, your old body will die!)", null, "Yes", "No")
+		var/human_transfer_choice = alert("Transfer your soul to [src]? (Warning, your old body will die and you will forfeit any antagonist roles and objectives!)", null, "Yes", "No")
 		if(human_transfer_choice != "Yes")
 			return
 		if(QDELETED(src) || uses <= 0 || user.stat >= 1 || QDELETED(I))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Addresses #18467.

Updates the golem transference text to make it more clear that you're giving up your antagonist role.

As it currently exists there is no effort to maintain your antagonist role. I believe this is good for balance and likely intended considering you can get something like ventcrawl (6 TC and job locked), among others, for free.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Makes it more clear pre-transference that you will no longer be an antagonist.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://user-images.githubusercontent.com/109384402/182601430-71cf4198-a922-4f4b-b8e7-34d65b393735.png)

## Testing
<!-- How did you test the PR, if at all? -->

Transferred as antagonist humans into golems. Confirmed it still works as intended with new text.

## Changelog
:cl:
tweak: Updates golem mind-transference prompt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
