### PR TITLE
You now need to cut the cables before unscrewing the plating

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -103,7 +103,7 @@
 	if(!I.tool_use_check(user, 0))
 		return
 	if(locate(/obj/structure/cable) in src)
-		to_chat(user, "<span class='notice'>There is a cable still attached to the [src]. Remove it first!</span>")
+		to_chat(user, "<span class='notice'>There is a cable still attached to [src]. Remove it first!</span>")
 		return
 	to_chat(user, "<span class='notice'>You start [unfastened ? "fastening" : "unfastening"] [src].</span>")
 	if(!I.use_tool(src, user, 20, volume = I.tool_volume))

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -102,8 +102,10 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+	if(locate(/obj/structure/cable) in src)
+		to_chat(user, "<span class='notice'>There is a cable still attached to the [src]. Remove it first!</span>")
+		return
 	to_chat(user, "<span class='notice'>You start [unfastened ? "fastening" : "unfastening"] [src].</span>")
-	. = TRUE
 	if(!I.use_tool(src, user, 20, volume = I.tool_volume))
 		return
 	to_chat(user, "<span class='notice'>You [unfastened ? "fasten" : "unfasten"] [src].</span>")

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -99,9 +99,9 @@
 			return TRUE
 
 /turf/simulated/floor/plating/screwdriver_act(mob/user, obj/item/I)
-	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+	. = TRUE
 	if(locate(/obj/structure/cable) in src)
 		to_chat(user, "<span class='notice'>There is a cable still attached to [src]. Remove it first!</span>")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so you need to remove the power cable first before being able to unscrew the plating.
Fixes #18606

## Why It's Good For The Game
Cables no longer mysteriously vanish when removing the plating.
Prevents an exploit allowing you to remove a powered cable without having insulated gloves.

## Testing
Tested locally. New behavior works as described with both the screwdriver and electric screwdriver. No abnormalities or runtimes detected.

## Changelog
:cl: uc_guy
fix: Fixed being able to remove the plating if cables are still attached to it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
