### PR TITLE
Tendril Drop Armor Rebalance

### DIFF
--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -266,14 +266,16 @@
 	desc = "Peering into the eyes of the helmet is enough to seal damnation."
 	icon_state = "hardsuit0-berserker"
 	item_color = "berserker"
-	armor = list(MELEE = 95, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = INFINITY, RAD = INFINITY, FIRE = 200, ACID = 200)
+	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	armor = list(MELEE = 60, BULLET = 20, LASER = 15, ENERGY = 15, BOMB = 75, BIO = INFINITY, RAD = 25, FIRE = 200, ACID = 200)
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/berserker
 	name = "champion's hardsuit"
 	desc = "Voices echo from the hardsuit, driving the user insane."
 	icon_state = "hardsuit-berserker"
+	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/berserker
-	armor = list(MELEE = 95, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = INFINITY, RAD = INFINITY, FIRE = 200, ACID = 200)
+	armor = list(MELEE = 60, BULLET = 20, LASER = 15, ENERGY = 15, BOMB = 75, BIO = INFINITY, RAD = 25, FIRE = 200, ACID = 200)
 	slowdown = 0
 
 // Solgov

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -64,7 +64,6 @@
 			new /obj/item/grenade/clusterbuster/inferno(src)
 		if(21)
 			new /obj/item/reagent_containers/food/drinks/bottle/holywater/hell(src)
-			new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor(src)
 		if(22)
 			new /obj/item/spellbook/oneuse/summonitem(src)
 		if(23)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Gamma ERT inquisitor's hardsuit is no longer a tendril loot drop.
Champion's hardsuit has been nerfed as such:
- Melee 66% -> 55% 
- Bullet 50% -> 29%
- Laser 50% -> 23%
- Energy 50% -> 23%
- Bomb 50% -> 60%
- Bio INFINITY (unchanged)
- Rad INFINITY -> 25%
- Fire 80% (unchanged)
- Acid 80% (unchanged)
- Additionally, it no longer confers ash storm immunity.

Part of #18521

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Tendrils are very easy to destroy for even intermediate miners, yet two different no-slowdown hardsuits can drop from it, both of which are better than megafauna armors - and some of the best armors in the game, period. This PR makes the inquisitor's hardsuit unique to Gamma ERT, and nerfs champion's hardsuit to be a little weaker than ash drake armor (post #18682 if merged). The relatively high melee armor value of champion's has not been decreased signfinicantly, as melee armor is useful on lavaland, similarly, the bomb armor has been buffed slightly.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled locally. This is only a value change, nothing to test.

## Changelog
:cl:
del: Removed inquisitor's hardsuit from the tendril loot table.
tweak: Champion's hardsuit has been nerfed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
