### PR TITLE
Some more stats logging

### DIFF
--- a/SQL/updates/42-43.sql
+++ b/SQL/updates/42-43.sql
@@ -1,0 +1,6 @@
+# Updating SQL from 42-43 ~AffectedArc07
+# Adds round ID column to deaths table
+
+ALTER TABLE `death` ADD COLUMN `death_rid` INT NULL AFTER `tod`;
+
+# You may now run tools/death_rid_assigner to assign round IDs to existing deaths

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -371,7 +371,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 42
+#define SQL_VERSION 43
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -288,8 +288,8 @@ SUBSYSTEM_DEF(blackbox)
 		lakey = L.lastattackerckey
 
 	var/datum/db_query/deathquery = SSdbcore.NewQuery({"
-		INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord, server_id)
-		VALUES (:name, :key, :job, :special, :pod, NOW(), :laname, :lakey, :gender, :bruteloss, :fireloss, :brainloss, :oxyloss, :coord, :server_id)"},
+		INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord, server_id, death_rid)
+		VALUES (:name, :key, :job, :special, :pod, NOW(), :laname, :lakey, :gender, :bruteloss, :fireloss, :brainloss, :oxyloss, :coord, :server_id, :rid)"},
 		list(
 			"name" = L.real_name,
 			"key" = L.key,
@@ -304,7 +304,8 @@ SUBSYSTEM_DEF(blackbox)
 			"brainloss" = L.getBrainLoss(),
 			"oxyloss" = L.getOxyLoss(),
 			"coord" = "[L.x], [L.y], [L.z]",
-			"server_id" = GLOB.configuration.system.instance_id
+			"server_id" = GLOB.configuration.system.instance_id,
+			"rid" = GLOB.round_id
 		)
 	)
 	deathquery.warn_execute()

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -394,7 +394,7 @@ SUBSYSTEM_DEF(jobs)
 	log_debug("Dividing Occupations took [stop_watch(watch)]s")
 	return 1
 
-/datum/controller/subsystem/jobs/proc/AssignRank(mob/living/carbon/human/H, rank, joined_late = 0)
+/datum/controller/subsystem/jobs/proc/AssignRank(mob/living/carbon/human/H, rank, joined_late = FALSE, log_to_db = TRUE)
 	if(!H)
 		return null
 	var/datum/job/job = GetJob(rank)
@@ -435,6 +435,9 @@ SUBSYSTEM_DEF(jobs)
 	if(job.important_information)
 		to_chat(H, "<center><div class='userdanger' style='width: 80%'>[job.important_information]</div></center>")
 	to_chat(H, "<center><span class='green'>----------------</span><br><br></center>")
+
+	if(log_to_db)
+		SSblackbox.record_feedback("nested tally", "manifest", 1, list(rank, (joined_late ? "latejoin" : "roundstart")))
 
 	return H
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -482,7 +482,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 						new_character.mind.add_antag_datum(/datum/antagonist/traitor)
 				//Add aliens.
 				else
-					SSjobs.AssignRank(new_character, new_character.mind.assigned_role, 0)
+					SSjobs.AssignRank(new_character, new_character.mind.assigned_role, FALSE, FALSE)
 					SSjobs.EquipRank(new_character, new_character.mind.assigned_role, 1)//Or we simply equip them.
 
 	//Announces the character on all the systems, based on the record.

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -48,6 +48,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new next_event.event_type(next_event)	// Events are added and removed from the processing queue in their New/kill procs
 
 		log_debug("Starting event '[next_event.name]' of severity [GLOB.severity_to_string[severity]].")
+		SSblackbox.record_feedback("nested tally", "events", 1, list(GLOB.severity_to_string[severity], next_event.name))
 		next_event = null						// When set to null, a random event will be selected next time
 	else
 		// If not, wait for one minute, instead of one tick, before checking again.

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -349,9 +349,9 @@ While using this makes the system rely on OnFire, it still gives options for tim
 			new mychild.loot_drop(lootbox)
 		else
 			new /obj/item/tumor_shard(lootbox)
-		SSblackbox.record_feedback("tally", "Player controlled Elite loss", 1, mychild.name)
+		SSblackbox.record_feedback("tally", "player_controlled_elite_loss", 1, mychild.name)
 	else
-		SSblackbox.record_feedback("tally", "AI controlled Elite loss", 1, mychild.name)
+		SSblackbox.record_feedback("tally", "ai_controlled_elite_loss", 1, mychild.name)
 	qdel(src)
 
 /obj/structure/elite_tumor/proc/onEliteWon()
@@ -360,7 +360,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		clear_activator(activator)
 	mychild.revive()
 	if(boosted)
-		SSblackbox.record_feedback("tally", "Player controlled Elite win", 1, mychild.name)
+		SSblackbox.record_feedback("tally", "player_controlled_elite_win", 1, mychild.name)
 		times_won++
 		mychild.maxHealth = mychild.maxHealth * 0.4
 		mychild.health = mychild.maxHealth
@@ -372,7 +372,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 				M.playsound_local(T, null, 100, FALSE, 0, FALSE, pressure_affected = FALSE, S = elite_sound)
 				M.flash_screen_color("#FF0000", 2.5 SECONDS)
 	else
-		SSblackbox.record_feedback("tally", "AI controlled Elite win", 1, mychild.name)
+		SSblackbox.record_feedback("tally", "ai_controlled_elite_win", 1, mychild.name)
 	if(times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/magic/cult_spell.ogg', 40, 0)
 		to_chat(mychild, "<span class='warning'><As the life in the activator's eyes fade, the forcefield around you dies out and you feel your power subside.\n\

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -319,7 +319,7 @@
 	SSjobs.AssignRole(src, rank, 1)
 
 	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
-	character = SSjobs.AssignRank(character, rank, 1)					//equips the human
+	character = SSjobs.AssignRank(character, rank, TRUE)					//equips the human
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -145,7 +145,7 @@ ipc_screens = [
 # Enable/disable the database on a whole
 sql_enabled = false
 # SQL version. If this is a mismatch, round start will be delayed
-sql_version = 42
+sql_version = 43
 # SQL server address. Can be an IP or DNS name
 sql_address = "127.0.0.1"
 # SQL server port

--- a/tools/death_rid_parser/death_rid_parser.py
+++ b/tools/death_rid_parser/death_rid_parser.py
@@ -1,0 +1,83 @@
+# This script will read your deaths table and assign round IDs from the round table
+
+# To run this, supply the following args in a command shell
+# Example:
+# python death_rid_parser.py 172.16.0.200 affectedarc07 (redacted) paradise_gamedb
+
+#!/usr/bin/env python3
+import mysql.connector, argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("address", help="MySQL server address (use localhost for the current computer)")
+parser.add_argument("username", help="MySQL login username")
+parser.add_argument("password", help="MySQL login password")
+parser.add_argument("database", help="Database name")
+
+args = parser.parse_args()
+db = mysql.connector.connect(host=args.address, user=args.username, passwd=args.password, db=args.database)
+cursor = db.cursor()
+print("Connected")
+
+print("Loading round timing map")
+round_times_map = []
+
+# Get all the time maps
+cursor.execute("SELECT id, initialize_datetime FROM round ORDER BY initialize_datetime ASC")
+all_rounds = cursor.fetchall()
+last_round = None
+
+
+for round in all_rounds:
+    round_obj = {}
+    round_obj["rid"] = round[0]
+    round_obj["stime"] = round[1]
+
+    if last_round:
+        last_round["etime"] = round[1]
+
+    last_round = round_obj
+    round_times_map.append(round_obj)
+
+first_logged_round = None
+print("Round times loaded, getting first round ID to get first death")
+cursor.execute("SELECT MIN(initialize_datetime) FROM round")
+first_logged_round = cursor.fetchone()[0]
+print("First logged round init time is {} | Only loading deaths since then".format(first_logged_round))
+print("This will take a while")
+
+
+print("Pulling data")
+# Now get all the deaths
+cursor.execute("SELECT id, tod FROM death WHERE tod >= %s ORDER BY tod ASC", [first_logged_round])
+all_deaths = cursor.fetchall()
+print("Found {} deaths to assign round IDs to".format(len(all_deaths)))
+
+replacement_map = {}
+round_idx = 0
+current_round = round_times_map[round_idx]
+
+
+print("Beginning iteration")
+for death in all_deaths:
+    # If the death time is after the current round
+    while death[1] > current_round["etime"]:
+        round_idx += 1
+        current_round = round_times_map[round_idx]
+
+    if (death[1] >= current_round["stime"]) and (death[1] <= current_round["etime"]):
+        replacement_map[str(death[0])] = current_round["rid"]
+    else:
+        # I tested this on prod data, it never happened
+        print("WHAT?!")
+        print(death)
+        print(current_round)
+
+print("Updating the existing death rows")
+
+for death_id in replacement_map:
+    cursor.execute("UPDATE death SET death_rid=%s WHERE id=%s", [replacement_map[death_id], death_id])
+
+cursor.close()
+print("Saving...")
+db.commit()
+print("Done!")


### PR DESCRIPTION
## What Does This PR Do
- Manifest is now logged to the blackbox (Both latejoins & roundstarts)
- Events rolled are logged to the blackbox
- Deaths now have an associated round ID
- Renamed feedback keys related to lavaland elites to keep then inline with existing keys

## Why It's Good For The Game
More stats gathering is good for future projects (hint hint)

## Testing
- Tested the import script against the prod DB
- Tested joining as jobs 
- Tested event rolls
- Ensured all data saved at the end of the round

## Changelog
:cl: AffectedArc07
add: Added more stats logging for future projects
/:cl:
