### PR TITLE
Adds nian cocoon admin logging

### DIFF
--- a/code/modules/mob/living/carbon/human/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species/moth.dm
@@ -191,7 +191,7 @@
 		H.adjust_nutrition(COCOON_NUTRITION_AMOUNT)
 		H.WakeUp()
 		H.forceMove(loc)
-		H.create_log(MISC_LOG, "has emerged from their cocoon, with the nutrition level of [H.nutrition][H.nutrition <= NUTRITION_LEVEL_STARVING ? ", now starving" : ""]")
+		H.create_log(MISC_LOG, "has emerged from their cocoon with the nutrition level of [H.nutrition][H.nutrition <= NUTRITION_LEVEL_STARVING ? ", now starving" : ""]")
 	return ..()
 
 /datum/status_effect/burnt_wings

--- a/code/modules/mob/living/carbon/human/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species/moth.dm
@@ -148,6 +148,7 @@
 		C.preparing_to_emerge = TRUE
 		H.apply_status_effect(STATUS_EFFECT_COCOONED)
 		H.KnockOut()
+		H.create_log(MISC_LOG, "has woven a cocoon")
 		addtimer(CALLBACK(src, .proc/emerge, C), COCOON_EMERGE_DELAY, TIMER_UNIQUE)
 	else
 		to_chat(H, "<span class='warning'>You need to hold still in order to weave a cocoon!</span>")
@@ -190,6 +191,7 @@
 		H.adjust_nutrition(COCOON_NUTRITION_AMOUNT)
 		H.WakeUp()
 		H.forceMove(loc)
+		H.create_log(MISC_LOG, "has emerged from their cocoon, with the nutrition level of [H.nutrition][H.nutrition <= NUTRITION_LEVEL_STARVING ? ", now starving" : ""]")
 	return ..()
 
 /datum/status_effect/burnt_wings


### PR DESCRIPTION
## What Does This PR Do

Adds admin logging to nians' "Cocoon" skill.

The "now starving" means their nutrition level is equal to or below `NUTRITION_LEVEL_STARVING` (currently 150), which is when your hunger bar turns red. Below that is `NUTRITION_LEVEL_HYPOGLYCEMIA` (100) when you get the medical condition.

## Why It's Good For The Game

Nian cocooning can be (apparently) used for nefarious reasons and we do not log its when and how.

## Images of changes

Edit: removed the comma between "cocoon, with"

![image](https://user-images.githubusercontent.com/33333517/182775560-1cf02047-41c7-4425-a11c-d9e023dcc82b.png)

## Testing

1. Spawned a nian.
2. Cocooned with it.
3. Set its nutrition to 330.
4. Cocooned again.

## Changelog
:cl:
add: Adds admin logging to nians' cocoon skill.
/:cl:
