### PR TITLE
Donut boxes do exist

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -53,6 +53,9 @@
 		var/icon/new_donut_icon = icon('icons/obj/food/containers.dmi', "[(I - 1)]donut[donut.donut_sprite_type]")
 		. += new_donut_icon
 
+/obj/item/storage/fancy/update_icon_state()
+	return
+
 /obj/item/storage/fancy/donut_box/populate_contents()
 	for(var/I in 1 to storage_slots)
 		new /obj/item/reagent_containers/food/snacks/donut(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes donut boxes turning invisible when you remove something from them, because flatty coded it so it changes to a non-existing icon state when you remove something. Instead of fixing the issue they just pasted the correct icon over the top of it as an overlay. I previously removed the line of code that did this because thats a crazy way of doing it, but that broke stuff.

I should have caught this in testing but my stupid ass assumed a sprite change would not cause this sort of issue.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Non-invisible objects
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://user-images.githubusercontent.com/12197162/182816348-602e1e84-3182-40b8-8983-5006048a67eb.png)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed invisible donut boxes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
