### PR TITLE
Xenomorph gib no longer deletes eaten mobs

### DIFF
--- a/code/modules/mob/living/carbon/alien/death.dm
+++ b/code/modules/mob/living/carbon/alien/death.dm
@@ -14,13 +14,12 @@
 
 	playsound(src.loc, 'sound/goonstation/effects/gib.ogg', 50, 1)
 
-	if(LAZYLEN(stomach_contents)) //Release eaten mobs when Beno is gibbed
-		for(var/mob/M in src)
-			LAZYREMOVE(stomach_contents, M)
-			M.forceMove(drop_location())
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				H.KnockDown(5 SECONDS)
+	for(var/mob/M in stomach_contents) //Release eaten mobs when Beno is gibbed
+		LAZYREMOVE(stomach_contents, M)
+		M.forceMove(drop_location())
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			H.KnockDown(5 SECONDS)
 
 	flick("gibbed-a", animation)
 	xgibs(loc)

--- a/code/modules/mob/living/carbon/alien/death.dm
+++ b/code/modules/mob/living/carbon/alien/death.dm
@@ -14,6 +14,14 @@
 
 	playsound(src.loc, 'sound/goonstation/effects/gib.ogg', 50, 1)
 
+	if(LAZYLEN(stomach_contents)) //Release eaten mobs when Beno is gibbed
+		for(var/mob/M in src)
+			LAZYREMOVE(stomach_contents, M)
+			M.forceMove(drop_location())
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				H.KnockDown(5 SECONDS)
+
 	flick("gibbed-a", animation)
 	xgibs(loc)
 	GLOB.dead_mob_list -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #18708

Xenomorphs now dump all eaten mobs onto the ground upon gib (i.e. butchering).
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Arbitrary mob deletion is bad, especially when the mob is still alive inside the Xenomorph.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Xenomorphs now dump out devoured mobs after being gibbed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
