### PR TITLE
Fixes kitchenspikes making upsidedown mobs [No GBP Update]

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -135,11 +135,11 @@
 	M.emote("scream")
 	M.AdjustWeakened(20 SECONDS)
 
+
 /obj/structure/kitchenspike/post_unbuckle_mob(mob/living/M)
 	M.pixel_y = M.get_standard_pixel_y_offset(0)
-	var/matrix/m180 = matrix(M.transform)
-	m180.Turn(180)
-	animate(M, transform = m180, time = 3)
+	M.set_lying_angle(0)
+	M.update_transform()
 
 /obj/structure/kitchenspike/Destroy()
 	if(has_buckled_mobs())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes a bug introduced in https://github.com/ParadiseSS13/Paradise/pull/18241

I changed the code that rotated mobs to appear upside-down in that PR so I wouldn't have to use snowflakey code. I neglected to change the code that returned these mobs to normal if and when they are removed from kitchenspikes.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
bugs bad.

## Testing
<!-- How did you test the PR, if at all? -->
Put mob on and took off a kitchen spike, before they would result upside down. Tested again after code changes, now they dont.

## Changelog
:cl:
fix: Fixed mobs being turned upside-down permanently from kitchenspikes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
