### PR TITLE
gives reactive armors internal power cells

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -13,7 +13,7 @@
 	active_power_usage = 200
 	pass_flags = PASSTABLE
 
-	var/list/allowed_devices = list(/obj/item/gun/energy, /obj/item/melee/baton, /obj/item/rcs, /obj/item/bodyanalyzer, /obj/item/handheld_chem_dispenser)
+	var/list/allowed_devices = list(/obj/item/gun/energy, /obj/item/melee/baton, /obj/item/rcs, /obj/item/bodyanalyzer, /obj/item/handheld_chem_dispenser, /obj/item/clothing/suit/armor/reactive)
 	var/recharge_coeff = 1
 
 	var/obj/item/charging = null // The item that is being charged
@@ -88,7 +88,6 @@
 		SCREWDRIVER_OPEN_PANEL_MESSAGE
 	else
 		SCREWDRIVER_CLOSE_PANEL_MESSAGE
-	
 	update_icon()
 
 /obj/machinery/recharger/wrench_act(mob/user, obj/item/I)
@@ -199,6 +198,10 @@
 	if(istype(I, /obj/item/bodyanalyzer))
 		var/obj/item/bodyanalyzer/B = I
 		return B.cell
+
+	if(istype(I, /obj/item/clothing/suit/armor/reactive))
+		var/obj/item/clothing/suit/armor/reactive/A = I
+		return A.cell
 
 	return null
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -271,6 +271,29 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	hit_reaction_chance = 50
+	/// The default cell reactive armor uses.
+	var/obj/item/stock_parts/cell/emproof/reactive/cell
+	/// The cell it will start with, used by stronger armors to have smaller cells.
+	var/cell_type = /obj/item/stock_parts/cell/emproof/reactive
+	/// Is the armor in the one second grace period, to prevent rubbershot / buckshot from draining significant cell useage.
+	var/in_grace_period = FALSE
+
+
+/obj/item/clothing/suit/armor/reactive/Initialize(mapload, ...)
+	. = ..()
+	if(cell_type)
+		cell = new cell_type(src)
+	else
+		cell = new(src)
+
+/obj/item/clothing/suit/armor/reactive/Destroy()
+	qdel(cell)
+	return ..()
+
+/obj/item/clothing/suit/armor/reactive/examine(mob/user)
+	. = ..()
+	if(cell)
+		. += "<span class='notice'>The armor is [round(cell.percent())]% charged.</span>"
 
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
 	active = !(active)
@@ -293,8 +316,21 @@
 
 /obj/item/clothing/suit/armor/reactive/emp_act(severity)
 	var/emp_power = 5 + (severity-1 ? 0 : 5)
+	if(!disabled) //We want ions to drain power, but we do not want it to drain all power in one go, or be one shot via ion scatter
+		cell.use(400 / severity)
 	disable(emp_power)
 	..()
+
+/obj/item/clothing/suit/armor/reactive/proc/use_power()
+	if(in_grace_period)
+		return
+	else
+		in_grace_period = TRUE
+		cell.use(100) // 20 blocks for most armors, 12 blocks for the "stronger" armors
+		addtimer(VARSET_CALLBACK(src, in_grace_period, FALSE), 1 SECONDS)
+
+/obj/item/clothing/suit/armor/reactive/get_cell()
+	return cell
 
 /obj/item/clothing/suit/armor/reactive/proc/disable(disable_time = 0)
 	active = FALSE
@@ -321,7 +357,7 @@
 			var/obj/item/projectile/P = hitby
 			if(istype(P, /obj/item/projectile/ion))
 				return FALSE
-			if(!P.nodamage || P.stun)
+			if(!P.nodamage || P.stun || P.weaken)
 				return TRUE
 		else
 			return TRUE
@@ -330,6 +366,7 @@
 /obj/item/clothing/suit/armor/reactive/teleport
 	name = "reactive teleport armor"
 	desc = "Someone seperated our Research Director from his own head!"
+	cell_type = /obj/item/stock_parts/cell/emproof/reactive/small
 	var/tele_range = 6
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
@@ -339,6 +376,7 @@
 		var/mob/living/carbon/human/H = owner
 		if(do_teleport(owner, owner, 6, safe_turf_pick = TRUE)) //Teleport on the same spot with a precision of 6 gets a random tile near the owner.
 			owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
+			use_power()
 			return TRUE
 		return FALSE
 	return FALSE
@@ -364,6 +402,7 @@
 		return FALSE
 	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], sending out jets of flame!</span>")
+		use_power()
 		for(var/mob/living/carbon/C in range(6, owner))
 			if(C != owner)
 				C.fire_stacks += 8
@@ -376,6 +415,7 @@
 /obj/item/clothing/suit/armor/reactive/stealth
 	name = "reactive stealth armor"
 	desc = "This armor uses an anomaly core combined with holographic projectors to make the user invisible temporarly, and make a fake image of the user."
+	cell_type = /obj/item/stock_parts/cell/emproof/reactive/small
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
@@ -387,6 +427,7 @@
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
 		owner.make_invisible()
+		use_power()
 		addtimer(CALLBACK(owner, /mob/living/.proc/reset_visibility), 4 SECONDS)
 		return TRUE
 
@@ -399,6 +440,7 @@
 		return FALSE
 	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], sending out arcs of lightning!</span>")
+		use_power()
 		for(var/mob/living/M in view(6, owner))
 			if(M == owner)
 				continue
@@ -418,12 +460,14 @@
 	var/repulse_range = 5
 	/// What the sparkles looks like
 	var/sparkle_path = /obj/effect/temp_visual/gravpush
+	cell_type = /obj/item/stock_parts/cell/emproof/reactive/small
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
 	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], converting the attack into a wave of force!</span>")
+		use_power()
 		var/list/thrown_atoms = list()
 		for(var/turf/T in range(repulse_range, owner)) //Done this way so things don't get thrown all around hilariously.
 			for(var/atom/movable/AM in T)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -284,7 +284,7 @@
 	cell = new(src)
 
 /obj/item/clothing/suit/armor/reactive/Destroy()
-	qdel(cell)
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/item/clothing/suit/armor/reactive/examine(mob/user)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -271,20 +271,17 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	hit_reaction_chance = 50
-	/// The default cell reactive armor uses.
+	/// The cell reactive armor uses.
 	var/obj/item/stock_parts/cell/emproof/reactive/cell
-	/// The cell it will start with, used by stronger armors to have smaller cells.
-	var/cell_type = /obj/item/stock_parts/cell/emproof/reactive
+	/// Cost multiplier for armor. "Stronger" armors use 200 charge, other armors use 120.
+	var/energy_cost = 120
 	/// Is the armor in the one second grace period, to prevent rubbershot / buckshot from draining significant cell useage.
 	var/in_grace_period = FALSE
 
 
 /obj/item/clothing/suit/armor/reactive/Initialize(mapload, ...)
 	. = ..()
-	if(cell_type)
-		cell = new cell_type(src)
-	else
-		cell = new(src)
+	cell = new(src)
 
 /obj/item/clothing/suit/armor/reactive/Destroy()
 	qdel(cell)
@@ -317,7 +314,7 @@
 /obj/item/clothing/suit/armor/reactive/emp_act(severity)
 	var/emp_power = 5 + (severity-1 ? 0 : 5)
 	if(!disabled) //We want ions to drain power, but we do not want it to drain all power in one go, or be one shot via ion scatter
-		cell.use(400 / severity)
+		cell.use(energy_cost * 4 / severity)
 	disable(emp_power)
 	..()
 
@@ -326,7 +323,7 @@
 		return
 	else
 		in_grace_period = TRUE
-		cell.use(100) // 20 blocks for most armors, 12 blocks for the "stronger" armors
+		cell.use(energy_cost) // 20 blocks for most armors, 12 blocks for the "stronger" armors
 		addtimer(VARSET_CALLBACK(src, in_grace_period, FALSE), 1 SECONDS)
 
 /obj/item/clothing/suit/armor/reactive/get_cell()
@@ -366,7 +363,7 @@
 /obj/item/clothing/suit/armor/reactive/teleport
 	name = "reactive teleport armor"
 	desc = "Someone seperated our Research Director from his own head!"
-	cell_type = /obj/item/stock_parts/cell/emproof/reactive/small
+	energy_cost = 200
 	var/tele_range = 6
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
@@ -415,7 +412,7 @@
 /obj/item/clothing/suit/armor/reactive/stealth
 	name = "reactive stealth armor"
 	desc = "This armor uses an anomaly core combined with holographic projectors to make the user invisible temporarly, and make a fake image of the user."
-	cell_type = /obj/item/stock_parts/cell/emproof/reactive/small
+	energy_cost = 200
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
@@ -460,7 +457,7 @@
 	var/repulse_range = 5
 	/// What the sparkles looks like
 	var/sparkle_path = /obj/effect/temp_visual/gravpush
-	cell_type = /obj/item/stock_parts/cell/emproof/reactive/small
+	energy_cost = 200
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -373,9 +373,4 @@
 /obj/item/stock_parts/cell/emproof/reactive // EMP proof so emp_act does not double dip.
 	name = "reactive armor power cell"
 	desc = "A cell used to power reactive armors."
-	maxcharge = 2000
-
-/obj/item/stock_parts/cell/emproof/reactive/small
-	name = "small reactive armor power cell"
-	desc = "A smaller cell used to power reactive armors."
-	maxcharge = 1200
+	maxcharge = 2400

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -369,3 +369,13 @@
 	desc = "A high capacity, slow charging cell for the B.S.G."
 	maxcharge = 40000
 	chargerate = 2600 // about 30 seconds to charge with a default recharger
+
+/obj/item/stock_parts/cell/emproof/reactive // EMP proof so emp_act does not double dip.
+	name = "reactive armor power cell"
+	desc = "A cell used to power reactive armors."
+	maxcharge = 2000
+
+/obj/item/stock_parts/cell/emproof/reactive/small
+	name = "small reactive armor power cell"
+	desc = "A smaller cell used to power reactive armors."
+	maxcharge = 1200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Reactive armors now have internal power cells. Fire and pyro have 2000 charge, teleport stealth and repulse 1200.
A successful block uses 100 charge. There is a 1 second grace period, so rubbershot doesn't drain insane amounts of power.
EMP's, in addition to disabling the armor as before, will drain 400 power on a strong emp, 200 otherwise.
However when an armor is disabled, EMP will not drain power from it, to keep ion from instantly draining all of it's power in 3-5 shots, has to be done over time.

Cell can not be replaced, can be charged in a recharger.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

What is effectively 50% armor (in all stats, assuming no EMP and counting the block chance like armor) in addition to other effects, is quite strong. While EMP is greatly effective against the armor, it only lasts 10 seconds, which is a window of vulnerability, but over the long run has no effect.

This PR changes it to make reactive armor need charging, and not have infinite blocks constantly. These values may be changed, we will have to see.

This means antags have to take a quick break to recharge, where they are much more vulnerable. EMP drains 4 shots in one, as well as disabling the armor, making it much more effective. However, emp not draining charge from the armor when disabled, means the armor is not fully hard countered by it, being fully drained in a few seconds.

## Testing
<!-- How did you test the PR, if at all? -->
Spawn in.
Confirm cells spawn.
Confirm cell is proper size.
Confirm blocks use charge.
Confirm emp lowers charge.
Confirm emp doesnt lower charge when disabled.
Confirm rubbershot doesn't cause insane power consumption.

## Changelog
:cl:
tweak: Reactive armor now has an internal cell. Can block 20 / 12 shots based on armor type, before needing recharging. EMP's drain 4 charges, when armor is not disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
