### PR TITLE
Mind-transferring into a golem keeps antagonist status

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -147,6 +147,8 @@
 	if(!permanent && !uses)
 		qdel(src)
 
+	return M
+
 // Base version - place these on maps/templates.
 /obj/effect/mob_spawn/human
 	mob_type = /mob/living/carbon/human

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -168,8 +168,12 @@
 		user.visible_message("<span class='notice'>As [user] applies the potion on the golem shell, a faint light leaves them, moving to [src] and animating it!</span>",
 		"<span class='notice'>You apply the potion to [src], feeling your mind leave your body!</span>")
 		message_admins("[key_name(user)] used [I] to transfer their mind into [src]")
-		create(ckey = user.ckey, name = user.real_name)
+		var/mob/living/carbon/human/g = create() //Create the golem and prep mind transfer stuff
+		user.mind.transfer_to(g)
+		g.real_name = user.real_name
+		g.faction = user.faction
 		user.death()  //Keeps brain intact to prevent forcing redtext
+		to_chat(g, "<span class='warning'>You have become the [g.dna.species]. Your allegiances, alliances, and roles are still the same as they were prior to using [I]!</span>")
 		qdel(I)
 
 /obj/effect/mob_spawn/human/golem/servant


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Makes it so antagonist roles and objectives carry over from the original body into the newly created golem. Normal objectives, Vampires, Changelings, etc. work as expected. Cultists don't keep their powers but this is probably fine since golems don't have blood to be a blood cultist with anyway.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I'm hesitant of the balance implications and required work to keep them balanced for any future antagonist changes but it's worth seeing how it goes. At the very least it solves the issue of people unexpectedly losing their role when they become a golem.

## Testing
<!-- How did you test the PR, if at all? -->

Tested various species turning into types of golems with different antagonist roles. Worked as expected reliably.

## Changelog
:cl:
tweak: Mind-transferring into a golem lets you keep your antagonist roles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
