### PR TITLE
Fixes 18704

### DIFF
--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -112,13 +112,13 @@
 		. += "newscaster_alert"
 	var/hp_percent = obj_integrity * 100 / max_integrity
 	switch(hp_percent)
-		if(75 to INFINITY)
+		if(75 to 200)
 			return
 		if(50 to 75)
 			. += "crack1"
 		if(25 to 50)
 			. += "crack2"
-		else
+		if(1 to 25)
 			. += "crack3"
 
 /obj/machinery/newscaster/power_change()


### PR DESCRIPTION
## What Does This PR Do
Fixes issue #18704, newly placed newscasters no longer have cracks.

First PR, please tell me if I screwed something up.

## Why It's Good For The Game
Icon errors bad.

## Testing
Went on test server
Placed newscaster
Newscaster nice and shiny, no cracks
Shot newscaster with various firearms
Newscaster cracks normally

## Changelog
:cl:
fix: Newscasters are no longer cracked when you place them
/:cl:
