### PR TITLE
Renames the exosuit fabricator Cyborg Upgrade board (reset) to (module reset)

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -42,7 +42,7 @@
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
 			if(!suiciding)
-				msg += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>\n"
+				msg += "<span class='deadsay'>It looks like its internal subsystems are beyond repair and require replacing.</span>\n"
 			else
 				msg += "<span class='warning'>It looks like its system is corrupted beyond repair. There is no hope of recovery.</span>\n"
 	msg += "*---------*</span>"


### PR DESCRIPTION
## What Does This PR Do
As it says on the tin, renames the (reset) board to (module reset)

## Why It's Good For The Game
the boards' description already explains what the board do, this should be clearer what the module does for everyone.

better clarity, more consistency, less confusion.

## Images of changes
![1](https://user-images.githubusercontent.com/46283583/183251256-8d4018aa-2e76-4ac5-9ac5-e1c9b7951b92.PNG)
![2](https://user-images.githubusercontent.com/46283583/183251305-9c2e8482-c879-4301-a4ae-56b3cd9b062e.PNG)

## Changelog
:cl:
tweak: Renamed Cyborg Upgrade Module (Reset) to Renamed Cyborg Upgrade Module (Module Reset)
/:cl:
