### PR TITLE
Renames the exosuit fabricator Cyborg Upgrade board (reset) to (module reset)

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -983,7 +983,7 @@
 //Cyborg Upgrade Modules
 
 /datum/design/borg_upgrade_reset
-	name = "Cyborg Upgrade Module (Reset)"
+	name = "Cyborg Upgrade Module (Module Reset)"
 	id = "borg_upgrade_reset"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/reset


### PR DESCRIPTION
## What Does This PR Do
As it says on the tin, renames the (reset) board to (module reset)

## Why It's Good For The Game
the boards' description already explains what the board do, this should be clearer what the module does for everyone.

better clarity, more consistency, less confusion.

## Images of changes
![1](https://user-images.githubusercontent.com/46283583/183251256-8d4018aa-2e76-4ac5-9ac5-e1c9b7951b92.PNG)
![2](https://user-images.githubusercontent.com/46283583/183251305-9c2e8482-c879-4301-a4ae-56b3cd9b062e.PNG)

## Changelog
:cl:
tweak: Renamed Cyborg Upgrade Module (Reset) to Cyborg Upgrade Module (Module Reset) in Exosuit fabricator
/:cl: