### PR TITLE
Attempts to Fix 18730, Neckgrab stuns are made much more reasonable

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -545,13 +545,14 @@ moving up or down retains their old lying angle
 		return S.duration - world.time
 	return 0
 
-/mob/living/proc/Stun(amount, ignore_canstun = FALSE) //Can't go below remaining duration
+/// Takes a time, whether it ignores stun immunity, and whether it replaces instead of adding to already-existing stuns.
+/mob/living/proc/Stun(amount, ignore_canstun = FALSE, superceding = FALSE) //Can't go below remaining duration
 	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
 	if(absorb_stun(amount, ignore_canstun))
 		return
 	var/datum/status_effect/incapacitating/stun/S = IsStunned()
-	if(S)
+	if(S && !superceding)
 		S.duration = max(world.time + amount, S.duration)
 	else if(amount > 0)
 		S = apply_status_effect(STATUS_EFFECT_STUN, amount)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -545,14 +545,13 @@ moving up or down retains their old lying angle
 		return S.duration - world.time
 	return 0
 
-/// Takes a time, whether it ignores stun immunity, and whether it replaces instead of adding to already-existing stuns.
-/mob/living/proc/Stun(amount, ignore_canstun = FALSE, superceding = FALSE) //Can't go below remaining duration
+/mob/living/proc/Stun(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
 	if(absorb_stun(amount, ignore_canstun))
 		return
 	var/datum/status_effect/incapacitating/stun/S = IsStunned()
-	if(S && !superceding)
+	if(S)
 		S.duration = max(world.time + amount, S.duration)
 	else if(amount > 0)
 		S = apply_status_effect(STATUS_EFFECT_STUN, amount)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -145,7 +145,7 @@
 	var/breathing_tube = affecting.get_organ_slot("breathing_tube")
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(3 SECONDS)
+		affecting.SetStunned(3 SECONDS)
 		if(isliving(affecting) && !breathing_tube) //It will hamper your breathing, being choked and all.
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -145,7 +145,7 @@
 	var/breathing_tube = affecting.get_organ_slot("breathing_tube")
 
 	if(state >= GRAB_NECK)
-		affecting.SetStunned(3 SECONDS)
+		affecting.Stun(3 SECONDS)
 		if(isliving(affecting) && !breathing_tube) //It will hamper your breathing, being choked and all.
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)
@@ -259,7 +259,7 @@
 			affecting.LAssailant = assailant
 		hud.icon_state = "kill"
 		hud.name = "kill"
-		affecting.Stun(20 SECONDS) //10 ticks of ensured grab
+		affecting.Stun(3 SECONDS) // Ensures the grab is able to be secured
 	else if(state < GRAB_UPGRADING)
 		assailant.visible_message("<span class='danger'>[assailant] starts to tighten [assailant.p_their()] grip on [affecting]'s neck!</span>")
 		hud.icon_state = "kill1"

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -145,7 +145,7 @@
 	var/breathing_tube = affecting.get_organ_slot("breathing_tube")
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(3 SECONDS)
+		affecting.Stun(3 SECONDS,,TRUE)
 		if(isliving(affecting) && !breathing_tube) //It will hamper your breathing, being choked and all.
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -145,7 +145,7 @@
 	var/breathing_tube = affecting.get_organ_slot("breathing_tube")
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(3 SECONDS,,TRUE)
+		affecting.Stun(3 SECONDS)
 		if(isliving(affecting) && !breathing_tube) //It will hamper your breathing, being choked and all.
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the stun proc when you get neckgrabbed from 20 seconds to 3 seconds

this was done because of 
* https://github.com/ParadiseSS13/Paradise/issues/18730

The problem is caused because being neck grabbed applies a 20 second stun so you don't have a chance to try to break it for awhile, so when you are "released" or otherwise get out early by some means, you are still stunned for whatever is left of that stun + 3 seconds. This lowers the value to a more reasonable one 


44 is also way too low a number of pull requests
## Why It's Good For The Game
A PR's intent should probably be met

## Images of changes
N/A

## Testing
I went into the game, grabbed a second account, split the screen on my wholesome big chungus epic ultrawide screen, and choked my squid and released him. 


I don't know if paradise takes non-player facing changes in the CL but if it does I'll add more to the CL. The contributing guidelines do not specify this.
## Changelog
:cl: Froststahr
fix: When you are released from a neck grab, you will no longer have an unreasonably long stun applied to you. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
