### PR TITLE
Fixes bones being able to break on the first hit.

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -167,6 +167,8 @@
 		brute *= brute_mod
 		burn *= burn_mod
 
+	// See if bones need to break
+	check_fracture(brute)
 	// Threshold needed to have a chance of hurting internal bits with something sharp
 #define LIMB_SHARP_THRESH_INT_DMG 5
 	// Threshold needed to have a chance of hurting internal bits
@@ -237,8 +239,6 @@
 			if(dismember_at_max_damage && body_part != UPPER_TORSO && body_part != LOWER_TORSO) // We've ensured all damage to the mob is retained, now let's drop it, if necessary.
 				droplimb(1) //Clean loss, just drop the limb and be done
 
-	// See if bones need to break
-	check_fracture(brute)
 	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Moves the bone fracture brute check before damage is applied to the limb. The original PR, #11653 intended for bones to not break on the first hit, as detailed in comments. However, as the bone break chance was done after the limb was damaged, bones could still break on the first hit, as the damage from the attack put them over threshold before calculating. How this was missed in their testing, is a very good question.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bug fixes are good.

Bones not breaking on the first hit, ending you in one way or another is good, be it organ death, a non working hand or leg, or else.

IB is not affected, as it does not use thresholds.

Even though this is a fix, this may need the balance tag, due to implications.

## Testing
<!-- How did you test the PR, if at all? -->
Shoot a bunch off skrell with bullets from a revolver. No breaks in chest.
Shoot them again, after being hits. 
Bones would often break (prob 60), but not always break.
Also tested with a force 200 katana, never broke on first hit, but the second hit would always do it.

## Changelog
:cl:
fix: Bones no longer break on the first hit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
