### PR TITLE
Minor Mountable Frame Code Refactor

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -38,6 +38,9 @@
 #define PLASTIC_FLAPS_NORMAL 0
 #define PLASTIC_FLAPS_DETACHED 1
 
+//Mounted Frames BITMASK
+#define MOUNTED_FRAME_SIMFLOOR	1
+#define MOUNTED_FRAME_NOSPACE	2
 
 //ai core defines
 #define EMPTY_CORE 0

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -39,8 +39,8 @@
 #define PLASTIC_FLAPS_DETACHED 1
 
 //Mounted Frames BITMASK
-#define MOUNTED_FRAME_SIMFLOOR	1
-#define MOUNTED_FRAME_NOSPACE	2
+#define MOUNTED_FRAME_SIMFLOOR	(1 << 0)
+#define MOUNTED_FRAME_NOSPACE	(1 << 1)
 
 //ai core defines
 #define EMPTY_CORE 0

--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -151,9 +151,9 @@
 	desc = "A frame for a defibrillator mount."
 	icon = 'icons/obj/machines/defib_mount.dmi'
 	icon_state = "defibrillator_mount"
-	sheets_refunded = 0
-	materials = list(MAT_METAL = 300, MAT_GLASS = 100)
 	w_class = WEIGHT_CLASS_BULKY
+
+	materials = list(MAT_METAL = 300, MAT_GLASS = 100)
 
 /obj/item/mounted/frame/defib_mount/do_build(turf/on_wall, mob/user)
 	new /obj/machinery/defibrillator_mount(get_turf(src), get_dir(user, on_wall), 1)

--- a/code/game/objects/items/mountable_frames/air_alarm.dm
+++ b/code/game/objects/items/mountable_frames/air_alarm.dm
@@ -10,7 +10,7 @@ Code shamelessly copied from apc_frame
 	icon_state = "alarm_bitem"
 
 	materials = list(MAT_METAL=2000)
-	metal_sheets_refunded = 2
+	metal_sheets_refunded = 1
 	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
 
 /obj/item/mounted/frame/alarm_frame/do_build(turf/on_wall, mob/user)

--- a/code/game/objects/items/mountable_frames/air_alarm.dm
+++ b/code/game/objects/items/mountable_frames/air_alarm.dm
@@ -8,8 +8,10 @@ Code shamelessly copied from apc_frame
 	desc = "Used for building Air Alarms"
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "alarm_bitem"
+
 	materials = list(MAT_METAL=2000)
-	mount_reqs = list("simfloor", "nospace")
+	metal_sheets_refunded = 2
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
 
 /obj/item/mounted/frame/alarm_frame/do_build(turf/on_wall, mob/user)
 	new /obj/machinery/alarm(get_turf(src), get_dir(on_wall, user), 1)

--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -3,7 +3,9 @@
 	desc = "Used for repairing or building APCs"
 	icon = 'icons/obj/apc_repair.dmi'
 	icon_state = "apc_frame"
-	mount_reqs = list("simfloor", "nospace")
+
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 2
 
 /obj/item/mounted/frame/apc_frame/try_build(turf/on_wall, mob/user)
 	if(!..())

--- a/code/game/objects/items/mountable_frames/buttons_switches.dm
+++ b/code/game/objects/items/mountable_frames/buttons_switches.dm
@@ -3,8 +3,9 @@
 	desc = "Used for repairing or building mass driver buttons"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt_frame"
-	mount_reqs = list("simfloor")
-	sheets_refunded = 1
+
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR
+	metal_sheets_refunded = 1
 
 /obj/item/mounted/frame/driver_button/do_build(turf/on_wall, mob/user)
 	new /obj/machinery/driver_button(get_turf(user), get_dir(user, on_wall))
@@ -15,8 +16,9 @@
 	desc = "Used for repairing or building light switches"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light-p"
-	mount_reqs = list("simfloor", "nospace")
-	sheets_refunded = 1
+
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 1
 
 /obj/item/mounted/frame/light_switch/do_build(turf/on_wall, mob/user)
 	new /obj/machinery/light_switch(get_turf(user), get_dir(user, on_wall))

--- a/code/game/objects/items/mountable_frames/extinguisher_frame.dm
+++ b/code/game/objects/items/mountable_frames/extinguisher_frame.dm
@@ -3,7 +3,9 @@
 	desc = "Used for building extinguisher cabinet"
 	icon = 'icons/obj/closet.dmi'
 	icon_state = "extinguisher_frame"
-	mount_reqs = list("simfloor", "nospace")
+
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 2
 
 /obj/item/mounted/frame/extinguisher/do_build(turf/on_wall, mob/user)
 	new /obj/structure/extinguisher_cabinet/empty(get_turf(src), get_dir(user, on_wall))

--- a/code/game/objects/items/mountable_frames/fire_alarm.dm
+++ b/code/game/objects/items/mountable_frames/fire_alarm.dm
@@ -3,7 +3,9 @@
 	desc = "Used for building Fire Alarms"
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "firealarm_frame"
-	mount_reqs = list("simfloor", "nospace")
+
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 2
 
 /obj/item/mounted/frame/firealarm/do_build(turf/on_wall, mob/user)
 	new /obj/machinery/firealarm(get_turf(src), get_dir(user, on_wall), 1)

--- a/code/game/objects/items/mountable_frames/frames.dm
+++ b/code/game/objects/items/mountable_frames/frames.dm
@@ -2,29 +2,37 @@
 	name = "mountable frame"
 	desc = "Place it on a wall."
 	origin_tech = "materials=1;engineering=1"
-	var/sheets_refunded = 2
-	var/list/mount_reqs = list() //can contain simfloor, nospace. Used in try_build to see if conditions are needed, then met
 	toolspeed = 1
 	usesound = 'sound/items/deconstruct.ogg'
 
+	///amount of metal sheets returned upon the frame being wrenched
+	var/metal_sheets_refunded = 2
+	///amount of glass sheets returned upon the frame being wrenched
+	var/glass_sheets_refunded = 0
+	///The requirements for this frame to be placed, uses bit flags
+	var/mount_requirements = 0
+
 /obj/item/mounted/frame/attackby(obj/item/W, mob/user)
 	..()
-	if(istype(W, /obj/item/wrench) && sheets_refunded)
-		//new /obj/item/stack/sheet/metal( get_turf(src.loc), sheets_refunded )
-		var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal(get_turf(src))
-		M.amount = sheets_refunded
+	if(istype(W, /obj/item/wrench))
+		var/turf/user_turf = get_turf(user)
+		if(metal_sheets_refunded)
+			new /obj/item/stack/sheet/metal(user_turf, metal_sheets_refunded)
+		if(glass_sheets_refunded)
+			new /obj/item/stack/sheet/glass(user_turf, glass_sheets_refunded)
 		qdel(src)
 
 /obj/item/mounted/frame/try_build(turf/on_wall, mob/user)
-	if(..()) //if we pass the parent tests
-		var/turf/turf_loc = get_turf(user)
+	if(!..())
+		return
 
-		if(src.mount_reqs.Find("simfloor") && !istype(turf_loc, /turf/simulated/floor))
-			to_chat(user, "<span class='warning'>[src] cannot be placed on this spot.</span>")
+	var/turf/build_turf = get_turf(user)
+	if((mount_requirements & MOUNTED_FRAME_SIMFLOOR) && !isfloorturf(build_turf))
+		to_chat(user, "<span class='warning'>[src] cannot be placed on this spot.</span>")
+		return
+	if(mount_requirements & MOUNTED_FRAME_NOSPACE)
+		var/area/my_area = get_area(build_turf)
+		if(!istype(my_area) || !my_area.requires_power || istype(my_area, /area/space))
+			to_chat(user, "<span class='warning'>[src] cannot be placed in this area.</span>")
 			return
-		if(src.mount_reqs.Find("nospace"))
-			var/area/my_area = turf_loc.loc
-			if(!istype(my_area) || (my_area.requires_power == 0 || istype(my_area,/area/space)))
-				to_chat(user, "<span class='warning'>[src] cannot be placed in this area.</span>")
-				return
-		return 1
+	return TRUE

--- a/code/game/objects/items/mountable_frames/intercom.dm
+++ b/code/game/objects/items/mountable_frames/intercom.dm
@@ -3,7 +3,9 @@
 	desc = "Used for building intercoms"
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "intercom-frame"
-	mount_reqs = list("simfloor", "nospace")
+
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 2
 
 /obj/item/mounted/frame/intercom/do_build(turf/on_wall, mob/user)
 	new /obj/item/radio/intercom(get_turf(src), get_dir(user, on_wall), 0)

--- a/code/game/objects/items/mountable_frames/lights.dm
+++ b/code/game/objects/items/mountable_frames/lights.dm
@@ -3,8 +3,11 @@
 	desc = "Used for building lights."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-item"
+
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR
+	metal_sheets_refunded = 2
+	///specifies which type of light fixture this frame will build
 	var/fixture_type = "tube"
-	mount_reqs = list("simfloor")
 
 /obj/item/mounted/frame/light_fixture/do_build(turf/on_wall, mob/user)
 	to_chat(user, "You begin attaching [src] to \the [on_wall].")
@@ -36,4 +39,4 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "bulb-construct-item"
 	fixture_type = "bulb"
-	sheets_refunded = 1
+	metal_sheets_refunded = 1

--- a/code/game/objects/items/mountable_frames/newscaster_frame.dm
+++ b/code/game/objects/items/mountable_frames/newscaster_frame.dm
@@ -3,26 +3,11 @@
 	desc = "Used to build newscasters, just secure to the wall."
 	icon_state = "newscaster"
 	item_state = "syringe_kit"
+
 	materials = list(MAT_METAL=14000, MAT_GLASS=8000)
-	mount_reqs = list("simfloor", "nospace")
-
-/obj/item/mounted/frame/newscaster_frame/try_build(turf/on_wall, mob/user)
-	if(..())
-		var/turf/loc = get_turf(usr)
-		var/area/A = loc.loc
-		if(!istype(loc, /turf/simulated/floor))
-			to_chat(usr, "<span class='alert'>Newscaster cannot be placed on this spot.</span>")
-			return
-		if(A.requires_power == 0 || A.name == "Space")
-			to_chat(usr, "<span class='alert'>Newscaster cannot be placed in this area.</span>")
-			return
-
-		for(var/obj/machinery/newscaster/T in loc)
-			to_chat(usr, "<span class='alert'>There is another newscaster here.</span>")
-			return
-
-		return 1
-	return
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 7
+	glass_sheets_refunded = 4
 
 /obj/item/mounted/frame/newscaster_frame/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/newscaster/N = new /obj/machinery/newscaster(get_turf(src), get_dir(on_wall, user), 1)


### PR DESCRIPTION
## What Does This PR Do
Refactors mountable frames code to:
- be able to drop metal and glass sheets upon wrenching
- use bitmaps instead of string lists for mounting requirements
- to be up to modern standards
- all of that deleted code in the newscaster frame file is stuff that is already handled in parent procs (wtf)

**Moves newscaster frames to drop 7 metal and 4 glass instead of 2 metal to reflect autolathe costs**

## Why It's Good For The Game
Better code
Newscasters shouldn't just eat 5 metal and 4 glass if you want to wrench it back into base materials.
fixes #18705
## Testing

1. Loaded up test server
2. Game Panel spawned in all mountable frames
3. Deconstructed every frame with wrench
4. Attempted to place each frame on an empty (no wall items) r-wall in a powered room
5. Attempted to place each frame on an empty r-wall in space with no floor turf
6. Attempted to place each frame on an empty r-wall in space with a simulated floor turf (plating)

## Changelog
:cl:
fix: newscaster frames drop 7 metal and 4 glass instead of 2 metal to reflect autolathe costs
/:cl: