### PR TITLE
Fix security camera console users never being removed from the `watchers` list when closing the UI

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -84,6 +84,7 @@
 		ui.open()
 
 /obj/machinery/computer/security/ui_close(mob/user)
+	..()
 	watchers -= user.UID()
 
 /obj/machinery/computer/security/ui_data()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -83,6 +83,9 @@
 		ui = new(user, src, ui_key, "CameraConsole", name, 870, 708, master_ui, state)
 		ui.open()
 
+/obj/machinery/computer/security/ui_close(mob/user)
+	watchers -= user.UID()
+
 /obj/machinery/computer/security/ui_data()
 	var/list/data = list()
 	data["network"] = network


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix security camera console users never being removed from the `watchers` list when closing the UI.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Images of changes
Fixes this:

![dreamseeker_4PgSc8BLwD](https://user-images.githubusercontent.com/42044220/183331556-e4911828-cc9a-455b-96c5-e0d2f5d02b42.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Opened the security camera console. VV it to see I was added to the watchers list. Closed the UI. Refreshed VV page. Saw I was removed from the watchers list.
<!-- How did you test the PR, if at all? -->

## Changelog
Backend only.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
