### PR TITLE
Xeno Larva burst out of the chest, instead of gibbing

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -43,11 +43,11 @@
 				if(prob(20))
 					owner.take_organ_damage(1)
 			if(prob(4))
-				to_chat(owner, "<span class='danger'>Your stomach hurts.</span>")
+				to_chat(owner, "<span class='danger'>Your chest hurts.</span>")
 				if(prob(20))
 					owner.adjustToxLoss(1)
 		if(5)
-			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your stomach...</span>")
+			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your chest...</span>")
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/internal/body_egg/alien_embryo/egg_process()
@@ -65,7 +65,7 @@
 
 
 
-/obj/item/organ/internal/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success = 1)
+/obj/item/organ/internal/body_egg/alien_embryo/proc/AttemptGrow(burst_on_success = 1)
 	if(!owner || polling)
 		return
 	polling = 1
@@ -91,6 +91,7 @@
 		owner.overlays += overlay
 
 		spawn(6)
+			owner.overlays -= overlay
 			var/mob/living/carbon/alien/larva/new_xeno = new(owner.drop_location())
 			new_xeno.key = C.key
 			if(SSticker && SSticker.mode)
@@ -101,11 +102,13 @@
 			new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)//To get the player's attention
 			to_chat(new_xeno, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Xenomorph)</span>")
 
-			if(gib_on_success)
-				owner.gib()
-			else
+			if(burst_on_success) //If we burst naturally
+				owner.apply_damage(300, BRUTE, "chest")
+				owner.bleed(BLOOD_VOLUME_NORMAL)
+				var/obj/item/organ/external/chestorgans = owner.get_organ(ran_zone("chest"))
+				chestorgans.droplimb()
+			else //If we are discovered mid-surgery
 				owner.adjustBruteLoss(40)
-				owner.overlays -= overlay
 			qdel(src)
 
 /*----------------------------------------

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -103,10 +103,11 @@
 			to_chat(new_xeno, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Xenomorph)</span>")
 
 			if(burst_on_success) //If we burst naturally
-				owner.apply_damage(300, BRUTE, "chest")
+				owner.apply_damage(300, BRUTE, BODY_ZONE_CHEST)
 				owner.bleed(BLOOD_VOLUME_NORMAL)
-				var/obj/item/organ/external/chestorgans = owner.get_organ(ran_zone("chest"))
-				chestorgans.droplimb()
+				var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
+				chest.fracture()
+				chest.droplimb()
 			else //If we are discovered mid-surgery
 				owner.adjustBruteLoss(40)
 			qdel(src)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
 	var/stage = 0
-	var/polling = 0
+	var/polling = FALSE
 
 /obj/item/organ/internal/body_egg/alien_embryo/on_find(mob/living/finder)
 	..()
@@ -15,7 +15,7 @@
 	else
 		to_chat(finder, "It's grown quite large, and writhes slightly as you look at it.")
 		if(prob(10))
-			AttemptGrow(0)
+			AttemptGrow(burst_on_success = FALSE)
 
 /obj/item/organ/internal/body_egg/alien_embryo/prepare_eat()
 	var/obj/S = ..()
@@ -59,16 +59,16 @@
 	if(stage == 5 && prob(50))
 		for(var/datum/surgery/S in owner.surgeries)
 			if(S.location == "chest" && istype(S.get_surgery_step(), /datum/surgery_step/internal/manipulate_organs))
-				AttemptGrow(0)
+				AttemptGrow(burst_on_success = FALSE)
 				return
 		AttemptGrow()
 
 
 
-/obj/item/organ/internal/body_egg/alien_embryo/proc/AttemptGrow(burst_on_success = 1)
+/obj/item/organ/internal/body_egg/alien_embryo/proc/AttemptGrow(burst_on_success = TRUE)
 	if(!owner || polling)
 		return
-	polling = 1
+	polling = TRUE
 	spawn()
 		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as an alien?", ROLE_ALIEN, FALSE, source = /mob/living/carbon/alien/larva)
 		var/mob/C = null
@@ -84,7 +84,7 @@
 			C = owner.client
 		else
 			stage = 2 // Let's try again later.
-			polling = 0
+			polling = FALSE
 			return
 
 		var/overlay = image('icons/mob/alien.dmi', loc = owner, icon_state = "burst_lie")
@@ -99,7 +99,7 @@
 			new_xeno.mind.name = new_xeno.name
 			new_xeno.mind.assigned_role = SPECIAL_ROLE_XENOMORPH
 			new_xeno.mind.special_role = SPECIAL_ROLE_XENOMORPH
-			new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)//To get the player's attention
+			SEND_SOUND(new_xeno, sound('sound/voice/hiss5.ogg'))
 			to_chat(new_xeno, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Xenomorph)</span>")
 
 			if(burst_on_success) //If we burst naturally

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -88,10 +88,10 @@
 			return
 
 		var/overlay = image('icons/mob/alien.dmi', loc = owner, icon_state = "burst_lie")
-		owner.overlays += overlay
+		owner.add_overlay(overlay)
 
 		spawn(6)
-			owner.overlays -= overlay
+			owner.cut_overlay(overlay)
 			var/mob/living/carbon/alien/larva/new_xeno = new(owner.drop_location())
 			new_xeno.key = C.key
 			if(SSticker && SSticker.mode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Once an Alien Embryo has fully gestated, a larva will now burst out of the chest of the host instead of gibbing them. Chestbursting inflicts a hefty 300 brute damage to the chest, fractures the chest, and disembowels the chest region (heart and lungs).

This PR does **not** change anything regarding how larva clients are selected; first dchat is notified, and if there are no takers, the host is put into the larva.

Also adds a few comments to better describe Alien Embryo functions.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Massively reduces object spam (liver/eyeballs/kidney/brain/appendix/ears/leftleg/rightleg/leftarm/rightarm for every single host)
* Embryo hosts were only ever gibbed due to design considerations that don't apply to modern Paradise (see below). Updating Alien Embryo gestation to reflect how people actually treat antags is good

The idea behind this PR was floated years ago (#11111), and rejected by heads for the following reason:

>We want the xeno numbers to increase over time and not just have players waiting around forever in the hopes that they get revived

To be blunt, I don't think this is a realistic concern for Paradise in 2022. Dchat is always chomping at the bit to take self-reproducing antag roles like Terror Spiders and Swarmers, to the point that they're often claimed before the prompt icon even appears on-screen. The same was true when Xenomorphs were run as a midround event, just yesterday. IMO it's _very_ unlikely that there will ever be a case where the pop is so low that no one volunteers to become a xenomorph... and even if that does happen, the larva host is still there as a failsafe to make sure all human-gestated larvas have clients.

Xenomorphs have existed in a warped state of balance for years now, which is the reason why they were removed from rotation in #13104 and why subsequent attempts to return them to rotation (#13292 and #13796) have failed. Larva gibbing making it a massive pain to revive recovered victims is, IMO, one of the more glaring issues plaguing Xenos. If the rationale behind gibbing no longer applies to this server, then it should be removed to get Xenomorphs a little closer inline with other antags.

tl;dr if White Terrors don't need to gib to secure clients, then neither do Xenos

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Xenomorph Larva now burst out of the victim's chest, instead of gibbing them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
