### PR TITLE
Fix 18746, Dedups cable coil description

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -494,7 +494,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	max_amount = MAXCOIL
 	merge_type = /obj/item/stack/cable_coil // This is here to let its children merge between themselves
 	color = COLOR_RED
-	desc = "A coil of power cable."
 	throwforce = 10
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 2
@@ -617,7 +616,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 		else if(get_amount() == 2)
 			. += "A piece of power cable."
 		else
-			. += "There are [get_amount()] lengths of cable in the coil."
+			. += "A coil of power cables."
 
 // Items usable on a cable coil :
 //   - Wirecutters : cut them duh !

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -617,7 +617,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 		else if(get_amount() == 2)
 			. += "A piece of power cable."
 		else
-			. += "A coil of power cable. There are [get_amount()] lengths of cable in the coil."
+			. += "There are [get_amount()] lengths of cable in the coil."
 
 // Items usable on a cable coil :
 //   - Wirecutters : cut them duh !


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the duplicate description from the line that describes the amount of cables in the coil

* https://github.com/ParadiseSS13/Paradise/issues/18746
## Why It's Good For The Game
Redundant info is bad

## Images of changes
I wanted the meme of posting this 3 minutes after the issue so I'll post a pic in a sec
<img width="144" alt="image" src="https://user-images.githubusercontent.com/40812746/183460658-17a5e007-801c-4363-bd6c-081eff25ee20.png">

## Testing
Not particularly relevant due to simplicity

## Changelog
:cl:Froststahr
fix: A duplicate description on cable coils has been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
