### PR TITLE
Fixed radstorm not affecting IPCs

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -44,7 +44,10 @@
 	if(HAS_TRAIT(H, TRAIT_RADIMMUNE) || resist == INFINITY)
 		return
 
-	if(prob(max(0, 100 - ARMOUR_VALUE_TO_PERCENTAGE(resist))) && !HAS_TRAIT(H, TRAIT_GENELESS))
+	if(prob(max(0, 100 - ARMOUR_VALUE_TO_PERCENTAGE(resist))))
+		L.rad_act(20)
+		if(HAS_TRAIT(H, TRAIT_GENELESS))
+			return
 		randmuti(H) // Applies bad mutation
 		if(prob(50))
 			if(prob(90))
@@ -53,8 +56,6 @@
 				randmutg(H)
 
 		domutcheck(H, MUTCHK_FORCED)
-
-		L.rad_act(20)
 
 /datum/weather/rad_storm/end()
 	if(..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As mentioned in #18501 IPCs are no longer rad immune. This PR fixes a bug that caused them to take no damage during a rad storm. 

## Why It's Good For The Game
Makes the mechanics described in #18501 work as intended.

## Testing
Tested locally by spawning an IPC and starting the rad storm event. IPC took some brain damage and got some hallucinations.

## Notes

The amount of damage IPCs take from radiation is minuscule and should probably be looked over. In my testing the rad storm did like half a point of brain damage.

## Changelog
:cl: uc_guy
fix: IPCs now take damage in the rad storm.
/:cl: