### PR TITLE
Fixing visible message being visible even if the mob is in the object

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -106,6 +106,11 @@
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 
 /mob/visible_message(message, self_message, blind_message)
+	if(!isturf(src.loc)) // cant see what do mob do in a locker or something
+		if(self_message)
+			var/msg = self_message
+			src.show_message(msg, EMOTE_VISIBLE, blind_message, EMOTE_AUDIBLE)
+		return
 	for(var/mob/M in get_mobs_in_view(7, src))
 		if(M.see_invisible < invisibility)
 			continue //can't view the invisible

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -113,7 +113,7 @@
 			var/msg = message
 			if(self_message && M == src)
 				msg = self_message
-			if(!(M.loc == loc))
+			if(M.loc != loc)
 				if(!blind_message) // for some reason VISIBLE action has blind_message param so if we are not in the same object but next to it, lets show it
 					continue
 				msg = blind_message

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -106,10 +106,18 @@
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 
 /mob/visible_message(message, self_message, blind_message)
-	if(!isturf(src.loc)) // cant see what do mob do in a locker or something
-		if(self_message)
-			var/msg = self_message
-			src.show_message(msg, EMOTE_VISIBLE, blind_message, EMOTE_AUDIBLE)
+	if(!isturf(loc)) // mobs inside objects (such as lockers) shouldn't have their actions visible to those outside the object
+		for(var/mob/M in get_mobs_in_view(3, src))
+			if(M.see_invisible < invisibility)
+				continue //can't view the invisible
+			var/msg = message
+			if(self_message && M == src)
+				msg = self_message
+			if(!(M.loc == loc))
+				if(!blind_message) // for some reason VISIBLE action has blind_message param so if we are not in the same object but next to it, lets show it
+					continue
+				msg = blind_message
+			M.show_message(msg, EMOTE_VISIBLE, blind_message, EMOTE_AUDIBLE)
 		return
 	for(var/mob/M in get_mobs_in_view(7, src))
 		if(M.see_invisible < invisibility)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
If mob is covered with a locker or other object we shouldnt see their visible messages. This PR changes mob.visible_message logic to check if mob.loc is turf. If its not, we check if other mob in the same object. If they are in the same object, show message. If they are not but next to it, we show blind_message(if we have this param setted)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
You shouldnt see someone preparing their krav maga gloves attack or anything else if they are in locker or something. You may want to still see someone doing that in glass objects like cryotube or anything else but i dont think we have a lot of these objects being really used in game. This PR makes your visible messages really VISIBLE, hiding em if you are in the other object

## Testing
<!-- How did you test the PR, if at all? -->
compiled and runned on current build

## Changelog
:cl:
fix: Makes visible messages visible only if mob is on the turf or in the same object as you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
