### PR TITLE
The most experimental PR in the world - Moves turf atmos init from New() to Initialize()

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -269,7 +269,7 @@
 	levelupdate()
 	CalculateAdjacentTurfs()
 
-	if(SSair && !ignore_air)
+	if(!ignore_air)
 		SSair.add_to_active(src)
 
 	//update firedoor adjacency

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -58,10 +58,8 @@
 
 	var/atmos_overlay_type = null //current active overlay
 
-// Dont make this Initialize(), youll break all of atmos
-// Challenge accepted in a few years -aa07
-/turf/simulated/New()
-	..()
+/turf/simulated/Initialize(mapload)
+	. = ..()
 	if(!blocks_air)
 		air = new
 

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -170,6 +170,7 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 				var/turf/T = t
 				// we do this after we load everything in. if we don't; we'll have weird atmos bugs regarding atmos adjacent turfs
 				T.AfterChange(TRUE, keep_cabling = TRUE)
+				CHECK_TICK
 		return bounds
 
 /**


### PR DESCRIPTION
## What Does This PR Do
Moves atmos init from `/turf/New()` to `/turf/Initialize()`

## Why It's Good For The Game
`/New()` must die.

## Testing
- Started a server
- Did a ton of turf replacements
- Bombed a few areas to make sure atmos still works
- Tested on station and lavaland to see how different baseturfs work

## Changelog
:cl: AffectedArc07
experiment: Reworked turf atmos init. Oh god.
/:cl:
