### PR TITLE
Heaters/Freezers now conserve energy instead of producing it

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -105,10 +105,10 @@
 
 	//todo: have current temperature affected. require power to bring down current temperature again
 
-	var/temperature_delta= abs(old_temperature - air_contents.temperature)
+	var/temperature_delta = abs(old_temperature - air_contents.temperature)
 	if(temperature_delta > 1)
 		active_power_usage = (heat_capacity * temperature_delta) + idle_power_usage
-		parent.update = 1
+		parent.update = TRUE
 	else
 		active_power_usage = idle_power_usage
 	return 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -107,7 +107,7 @@
 
 	var/temperature_delta= abs(old_temperature - air_contents.temperature)
 	if(temperature_delta > 1)
-		active_power_usage = (heat_capacity * temperature_delta) / 10 + idle_power_usage
+		active_power_usage = (heat_capacity * temperature_delta) + idle_power_usage
 		parent.update = 1
 	else
 		active_power_usage = idle_power_usage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Electronic heaters and freezers no longer produce energy by consuming x10 less energy then they should have to convert given amount.

**Definitely needs a testmerge**, but it will affect at most 3-4 atmos players and will make their life a bit more interesting
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Conservation of energy is good for the game, and while breaking the physics is fun, breaking it with "Cooler<-TEG->Heater" is very easy and very not fun.
Currently this affects power draw for Toxins and Medbay, but shouldn't be that much. Biggest effect is its usage to generate energy. Atmos already has space so they can easily cool using spaceloop, leaving freezers to deal with emergencies.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. Load the master branch
2. Build a TEG with 1 heater on one side, 1 cooler on the other.
3. Pipe it, fill stuff with plasma, disconnect the cold from hot loop.
4. Turn TEG and heater/freezer on
5. Watch power going up
6. Load this branch
7. Do steps 2-4
8. Watch batteries drain pretty fast (or slower if you maxed out the manipulators on heater/freezer)
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Removed Pipe Heater/Freezer's ability to generate infinite energy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
