### PR TITLE
Fixes an interaction between immortality talisman and the summon item spell

### DIFF
--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -110,7 +110,7 @@
 			else			//right active hand
 				if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_r_hand, FALSE, TRUE))
 					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, FALSE, TRUE))
-						butterfingers = 1
+						butterfingers = TRUE
 			if(butterfingers)
 				if(isturf(target.loc))
 					item_to_retrieve.loc = target.loc

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -115,7 +115,7 @@
 				if(isturf(target.loc))
 					item_to_retrieve.loc = target.loc
 					item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears!</span>")
-					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
 				else
 					item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] fails to appear!</span>")
 					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -20,7 +20,7 @@
 /obj/effect/proc_holder/spell/summonitem/cast(list/targets, mob/user = usr)
 	for(var/mob/living/target in targets)
 		var/list/hand_items = list(target.get_active_hand(),target.get_inactive_hand())
-		var/butterfingers = 0
+		var/butterfingers = FALSE
 		var/message
 
 		if(!marked_item) //linking item to the spell
@@ -70,13 +70,6 @@
 
 					if(ishuman(M)) //Edge case housekeeping
 						var/mob/living/carbon/human/C = M
-						/*if(C.internal_bodyparts_by_name  && item_to_retrieve in C.internal_bodyparts_by_name ) //This won't work, as we use organ datums instead of objects. --DZD
-							C.internal_bodyparts_by_name  -= item_to_retrieve
-							if(istype(marked_item, /obj/item/brain)) //If this code ever runs I will be happy
-								var/obj/item/brain/B = new /obj/item/brain(target.loc)
-								B.transfer_identity(C)
-								C.death()
-								add_attack_logs(target, C, "Magically debrained INTENT: [uppertext(target.a_intent)]")*/
 						for(var/X in C.bodyparts)
 							var/obj/item/organ/external/part = X
 							if(item_to_retrieve in part.embedded_objects)
@@ -100,26 +93,25 @@
 			if(!item_to_retrieve)
 				return
 
+			if(!isturf(target.loc))
+				to_chat(target, "<span class='caution'>You attempt to cast the spell, but it fails! Perhaps you aren't available?</span>")
+				return
+
 			item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
 
 
 			if(target.hand) //left active hand
 				if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, FALSE, TRUE))
 					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_r_hand, FALSE, TRUE))
-						butterfingers = 1
+						butterfingers = TRUE
 			else			//right active hand
 				if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_r_hand, FALSE, TRUE))
 					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, FALSE, TRUE))
 						butterfingers = TRUE
 			if(butterfingers)
-				if(isturf(target.loc))
-					item_to_retrieve.loc = target.loc
-					item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears!</span>")
-					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
-				else
-					item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] fails to appear!</span>")
-					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
-					item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] reappears in an instant!</span>")
+				item_to_retrieve.loc = target.loc
+				item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears!</span>")
+				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
 			else
 				item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears in [target]'s hand!</span>")
 				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -81,7 +81,7 @@
 							var/obj/item/organ/external/part = X
 							if(item_to_retrieve in part.embedded_objects)
 								part.remove_embedded_object(item_to_retrieve)
-								to_chat(C, "<span class='warning'>\The [item_to_retrieve] that was embedded in your [part] has mysteriously vanished. How fortunate!</span>")
+								to_chat(C, "<span class='warning'>[item_to_retrieve] that was embedded in your [part] has mysteriously vanished. How fortunate!</span>")
 								if(!C.has_embedded_objects())
 									C.clear_alert("embeddedobject")
 								break
@@ -100,7 +100,7 @@
 			if(!item_to_retrieve)
 				return
 
-			item_to_retrieve.loc.visible_message("<span class='warning'>\The [item_to_retrieve] suddenly disappears!</span>")
+			item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
 
 
 			if(target.hand) //left active hand
@@ -114,14 +114,14 @@
 			if(butterfingers)
 				if(isturf(target.loc))
 					item_to_retrieve.loc = target.loc
-					item_to_retrieve.loc.visible_message("<span class='caution'>\The [item_to_retrieve] suddenly appears!</span>")
+					item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears!</span>")
 					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
 				else
-					item_to_retrieve.loc.visible_message("<span class='caution'>\The [item_to_retrieve] fails to appear!</span>")
+					item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] fails to appear!</span>")
 					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
-					item_to_retrieve.loc.visible_message("<span class='warning'>\The [item_to_retrieve] reappears in an instant!</span>")
+					item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] reappears in an instant!</span>")
 			else
-				item_to_retrieve.loc.visible_message("<span class='caution'>\The [item_to_retrieve] suddenly appears in [target]'s hand!</span>")
+				item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears in [target]'s hand!</span>")
 				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
 
 		if(message)

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -112,9 +112,14 @@
 					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, FALSE, TRUE))
 						butterfingers = 1
 			if(butterfingers)
-				item_to_retrieve.loc = target.loc
-				item_to_retrieve.loc.visible_message("<span class='caution'>\The [item_to_retrieve] suddenly appears!</span>")
-				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+				if(isturf(target.loc))
+					item_to_retrieve.loc = target.loc
+					item_to_retrieve.loc.visible_message("<span class='caution'>\The [item_to_retrieve] suddenly appears!</span>")
+					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+				else
+					item_to_retrieve.loc.visible_message("<span class='caution'>\The [item_to_retrieve] fails to appear!</span>")
+					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+					item_to_retrieve.loc.visible_message("<span class='warning'>\The [item_to_retrieve] reappears in an instant!</span>")
 			else
 				item_to_retrieve.loc.visible_message("<span class='caution'>\The [item_to_retrieve] suddenly appears in [target]'s hand!</span>")
 				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -118,7 +118,7 @@
 					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
 				else
 					item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] fails to appear!</span>")
-					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+					playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
 					item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] reappears in an instant!</span>")
 			else
 				item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears in [target]'s hand!</span>")

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -122,7 +122,7 @@
 					item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] reappears in an instant!</span>")
 			else
 				item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears in [target]'s hand!</span>")
-				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
 
 		if(message)
 			to_chat(target, message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Probably fixes
* https://github.com/ParadiseSS13/Paradise/issues/18755

Adds some conditions to the summon item spell to handle cases where target.loc is not a turf 
(in the case of testing, it's an obj/effect.)
## Why It's Good For The Game
If both arms are full and you use the immortality talisman and the spell your item will be lost, preventing that is probably good, even if this is a niche issue.

It might apply to other situations, in the issue it somehow got passed null, I didn't look for them.

## Images of changes
<img width="145" alt="image" src="https://user-images.githubusercontent.com/40812746/183959740-ef9cbb14-8ac4-4210-baaf-3c547581aa3b.png">
(standing near it, ofc.)

## Testing
Went in game and tested it by hand. 

## Changelog
:cl: Froststahr
fix: An interaction with the immortality talisman and summon item spell that would disappear items has been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
