### PR TITLE
Fixes removing pages from books

### DIFF
--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -255,13 +255,15 @@
 			if(!length(pages))
 				to_chat(user, "<span class='notice'>There aren't any pages in this book!</span>")
 				return
-			var/page_choice = stripped_input(user, "There are [length(pages)] pages, which page number would you like to remove?")
+			var/page_choice = text2num(stripped_input(user, "There are [length(pages)] pages, which page number would you like to remove?"))
 			if(!page_choice)
 				to_chat(user, "<span class='notice'>You change your mind.</span>")
 				return
 			if(!isnum(page_choice) || page_choice <= 0 || page_choice > length(pages))
 				to_chat(user, "<span class='notice'>That is not an acceptable value.</span")
 				return
+			if(page_choice == length(pages))
+				current_page--
 			pages -= pages[page_choice]
 
 /obj/item/book/proc/edit_page(content, page_number)

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -255,16 +255,14 @@
 			if(!length(pages))
 				to_chat(user, "<span class='notice'>There aren't any pages in this book!</span>")
 				return
-			var/page_choice = text2num(stripped_input(user, "There are [length(pages)] pages, which page number would you like to remove?"))
+			var/page_choice = input(user, "There are [length(pages)] pages, which page number would you like to remove?", "Input Page Number", null) as num|null
 			if(!page_choice)
 				to_chat(user, "<span class='notice'>You change your mind.</span>")
 				return
-			if(!isnum(page_choice) || page_choice <= 0 || page_choice > length(pages))
+			if(page_choice <= 0 || page_choice > length(pages))
 				to_chat(user, "<span class='notice'>That is not an acceptable value.</span")
 				return
-			if(page_choice == length(pages))
-				current_page--
-			pages -= pages[page_choice]
+			remove_page(page_choice)
 
 /obj/item/book/proc/edit_page(content, page_number)
 	if(!content)
@@ -284,10 +282,8 @@
 	return TRUE
 
 /obj/item/book/proc/remove_page(page_number)
-	if(length(pages) < page_number) //can't remove the page if it doesn't exist
-		return FALSE
 	pages -= pages[page_number]
-	page_number = length(pages) //if page_number is somehow at a value it shouldn't be we fix it here aswell
+	current_page = min(current_page, length(pages)) //if page_number is somehow at a value it shouldn't be we fix it here aswell
 	return TRUE //we want to make sure whatever is calling this proc knows the operation was succesful
 
 /obj/item/book/proc/carve_book(mob/user, obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes books removable by turning text input for `page_choice` into number one. This solves multiple issues that prevented actual page removal.
Removes some redundant code. `isnum()` check is no longer needed, since `page_choice` will always be a number. Checking if page exists before trying to remove it is checked elsewhere and gives intended error message to the user, so no need to check it again.
Makes actual use of `remove_page()`, as the author of the original code intended.
Makes sure `current_page` properly never refer to a page that is not on `pages` list.
Finally, makes Charlie happier because he constantly complains about insufficient amount of PRs.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stuff not working is bad. Stuff working is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Successfully removed the last page as well as middle pages. Intro page not being readable at 0 pages is intended from what I could tell.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Removing book pages now works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
