### PR TITLE
Fixes queued smoothing items not being removed on del

### DIFF
--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -27,6 +27,8 @@ DEFINE_BITFIELD(smoothing_flags, list(
 
 #define QUEUE_SMOOTH_NEIGHBORS(thing_to_queue) for(var/neighbor in orange(1, thing_to_queue)) {var/atom/atom_neighbor = neighbor; QUEUE_SMOOTH(atom_neighbor)}
 
+#define REMOVE_FROM_SMOOTH_QUEUE(thing_to_remove) if(thing_to_remove.smoothing_flags & SMOOTH_QUEUED) {SSicon_smooth.remove_from_queues(thing_to_remove)}
+
 /**SMOOTHING GROUPS
  * Groups of things to smooth with.
  * * Contained in the `list/smoothing_groups` variable.

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -28,12 +28,11 @@
 /obj/structure/Destroy()
 	if(SSticker)
 		GLOB.cameranet.updateVisibility(src)
-	if(smoothing_flags & SMOOTH_QUEUED)
-		REMOVE_FROM_SMOOTH_QUEUE(src)
 	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 		var/turf/T = get_turf(src)
 		spawn(0)
 			QUEUE_SMOOTH_NEIGHBORS(T)
+	REMOVE_FROM_SMOOTH_QUEUE(src)
 	return ..()
 
 /obj/structure/proc/climb_on()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -30,8 +30,7 @@
 		GLOB.cameranet.updateVisibility(src)
 	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 		var/turf/T = get_turf(src)
-		spawn(0)
-			QUEUE_SMOOTH_NEIGHBORS(T)
+		QUEUE_SMOOTH_NEIGHBORS(T)
 	REMOVE_FROM_SMOOTH_QUEUE(src)
 	return ..()
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -28,6 +28,8 @@
 /obj/structure/Destroy()
 	if(SSticker)
 		GLOB.cameranet.updateVisibility(src)
+	if(smoothing_flags & SMOOTH_QUEUED)
+		REMOVE_FROM_SMOOTH_QUEUE(src)
 	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 		var/turf/T = get_turf(src)
 		spawn(0)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -88,8 +88,7 @@
 		for(var/A in B.contents)
 			qdel(A)
 		return
-	if(smoothing_flags & SMOOTH_QUEUED)
-		REMOVE_FROM_SMOOTH_QUEUE(src)
+	REMOVE_FROM_SMOOTH_QUEUE(src)
 	// Adds the adjacent turfs to the current atmos processing
 	for(var/turf/simulated/T in atmos_adjacent_turfs)
 		SSair.add_to_active(T)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -88,6 +88,8 @@
 		for(var/A in B.contents)
 			qdel(A)
 		return
+	if(smoothing_flags & SMOOTH_QUEUED)
+		REMOVE_FROM_SMOOTH_QUEUE(src)
 	// Adds the adjacent turfs to the current atmos processing
 	for(var/turf/simulated/T in atmos_adjacent_turfs)
 		SSair.add_to_active(T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops `smooth_icon()` being called on atoms that are being/have been deleted, as they never previously got removed from the smooth queue on del.
Chills out the DD error log window going mental.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Testing
Did things that used to cause errors, like letting swarmers walk on lava, exploding many things, etc.
<!-- How did you test the PR, if at all? -->

## Changelog
No player facing changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
