### PR TITLE
mobs with zero environment damage can hurt mechs, mech damage more consistant

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -545,15 +545,15 @@
 		return FALSE
 	else
 		var/play_soundeffect = 1
+		var/animal_damage = rand(user.melee_damage_lower,user.melee_damage_upper)
+		if(user.obj_damage)
+			animal_damage = max(animal_damage, user.obj_damage)
+		animal_damage = max(animal_damage, min(20 * user.environment_smash, 40))
+		if(animal_damage)
+			add_attack_logs(user, OCCUPANT_LOGGING, "Animal attacked mech [src]")
 		if(user.environment_smash)
 			play_soundeffect = 0
 			playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
-		var/animal_damage = rand(user.melee_damage_lower,user.melee_damage_upper)
-		if(user.obj_damage)
-			animal_damage = user.obj_damage
-		animal_damage = min(animal_damage, 20*user.environment_smash)
-		if(animal_damage)
-			add_attack_logs(user, OCCUPANT_LOGGING, "Animal attacked mech [src]")
 		attack_generic(user, animal_damage, user.melee_damage_type, MELEE, play_soundeffect)
 		return TRUE
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -544,7 +544,7 @@
 		user.custom_emote(EMOTE_VISIBLE, "[user.friendly] [src].")
 		return FALSE
 	else
-		var/play_soundeffect = 1
+		var/play_soundeffect = TRUE
 		var/animal_damage = rand(user.melee_damage_lower,user.melee_damage_upper)
 		if(user.obj_damage)
 			animal_damage = max(animal_damage, user.obj_damage)
@@ -552,7 +552,7 @@
 		if(animal_damage)
 			add_attack_logs(user, OCCUPANT_LOGGING, "Animal attacked mech [src]")
 		if(user.environment_smash)
-			play_soundeffect = 0
+			play_soundeffect = FALSE
 			playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
 		attack_generic(user, animal_damage, user.melee_damage_type, MELEE, play_soundeffect)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Mech damage is now the higher value between object damage and melee damage for simple mobs. This way, if something has 50 melee damage (but 5 object damage for some reason), it will do 50 damage, not 5.

Mobs now choose the higher value between  20x enviroment damage and the previous damage roll, rather than the minimum. This means something with 40 damage / object damage doesnt do 20 with an enviroment damage of 1, or things like legions / guardians with melee damage being unable to damage  mechs. Also caps the enviroment damage multiplier to 40 damage, so things like terrors that break walls do not deal 80 damage to mechs

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More consistent mech damage is good.

Guardians able to damage mechs is good, same with legion skull

## Testing
<!-- How did you test the PR, if at all? -->

Testing by adjusting values on a terror spider to see if damage was as expected

## Changelog
:cl:
tweak: Mech damage is now the higher value between melee and object damage, guardians and legion skulls can hurt mechs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
