### PR TITLE
Small container transfer rate change improvements

### DIFF
--- a/code/modules/detective_work/footprints_and_rag.dm
+++ b/code/modules/detective_work/footprints_and_rag.dm
@@ -16,7 +16,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "rag"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = list(5)
+	possible_transfer_amounts = null
 	volume = 5
 	flags = NOBLUDGEON
 	container_type = OPENCONTAINER

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -9,6 +9,7 @@
 	container_type = OPENCONTAINER
 	consume_sound = 'sound/items/drink.ogg'
 	possible_transfer_amounts = list(5,10,15,20,25,30,50)
+	visible_transfer_rate = TRUE
 	volume = 50
 	resistance_flags = NONE
 	antable = FALSE

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -125,7 +125,7 @@
 	throwforce = 1
 	amount_per_transfer_from_this = 5
 	materials = list(MAT_METAL=100)
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	volume = 5
 	flags = CONDUCT
 	container_type = OPENCONTAINER
@@ -249,7 +249,7 @@
 	desc = "A paper water cup."
 	icon_state = "water_cup_e"
 	item_state = "coffee"
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	volume = 10
 
 /obj/item/reagent_containers/food/drinks/sillycup/on_reagent_change()

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -3,6 +3,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/reagent_containers/food
 	possible_transfer_amounts = null
+	visible_transfer_rate = FALSE
 	volume = 50 //Sets the default container amount for all food items.
 	var/filling_color = "#FFFFFF" //Used by sandwiches.
 	var/junkiness = 0  //for junk food. used to lower human satiety.

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -12,6 +12,7 @@
 	icon_state = "emptycondiment"
 	container_type = OPENCONTAINER
 	possible_transfer_amounts = list(1, 5, 10, 15, 20, 25, 30, 50)
+	visible_transfer_rate = TRUE
 	volume = 50
 	//Possible_states has the reagent id as key and a list of, in order, the icon_state, the name and the desc as values. Used in the on_reagent_change() to change names, descs and sprites.
 	var/list/possible_states = list(

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -204,7 +204,7 @@
 	icon_state = "condi_empty"
 	volume = 10
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	possible_states = list("ketchup" = list("condi_ketchup", "Ketchup", "You feel more American already."), "capsaicin" = list("condi_hotsauce", "Hotsauce", "You can almost TASTE the stomach ulcers now!"), "soysauce" = list("condi_soysauce", "Soy Sauce", "A salty soy-based flavoring"), "frostoil" = list("condi_frostoil", "Coldsauce", "Leaves the tongue numb in it's passage"), "sodiumchloride" = list("condi_salt", "Salt Shaker", "Salt. From space oceans, presumably"), "blackpepper" = list("condi_pepper", "Pepper Mill", "Often used to flavor food or make people sneeze"), "cornoil" = list("condi_cornoil", "Corn Oil", "A delicious oil used in cooking. Made from corn"), "sugar" = list("condi_sugar", "Sugar", "Tasty spacey sugar!"))
 
 /obj/item/reagent_containers/food/condiment/pack/attack(mob/M, mob/user, def_zone) //Can't feed these to people directly.

--- a/code/modules/hydroponics/beekeeping/honeycomb.dm
+++ b/code/modules/hydroponics/beekeeping/honeycomb.dm
@@ -4,7 +4,7 @@
 	desc = "A hexagonal mesh of honeycomb."
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "honeycomb"
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	disease_amount = 0
 	volume = 10
 	amount_per_transfer_from_this = 0

--- a/code/modules/hydroponics/beekeeping/honeycomb.dm
+++ b/code/modules/hydroponics/beekeeping/honeycomb.dm
@@ -8,6 +8,7 @@
 	disease_amount = 0
 	volume = 10
 	amount_per_transfer_from_this = 0
+	visible_transfer_rate = FALSE
 	list_reagents = list("honey" = 5)
 	var/honey_color = ""
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -5,6 +5,7 @@
 	icon_state = null
 	w_class = WEIGHT_CLASS_TINY
 	var/amount_per_transfer_from_this = 5
+	var/visible_transfer_rate = TRUE
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
 	var/list/list_reagents = null
@@ -102,8 +103,9 @@
 /obj/item/reagent_containers/examine(mob/user)
 	. = ..()
 
-	// Food has no valid possible_transfer_amounts, and we don't want to show
-	// this message on examining food.
-	if(possible_transfer_amounts)
+	if(visible_transfer_rate)
 		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this > 1 ? "s" : ""] at a time.</span>"
+
+	// Items that have no valid possible_transfer_amounts shouldn't say their transfer rate is variable
+	if(possible_transfer_amounts)
 		. += "<span class='notice'>Alt-click to change the transfer amount.</span>"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -104,7 +104,7 @@
 	. = ..()
 
 	if(visible_transfer_rate)
-		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this > 1 ? "s" : ""] at a time.</span>"
+		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this != 1 ? "s" : ""] at a time.</span>"
 
 	// Items that have no valid possible_transfer_amounts shouldn't say their transfer rate is variable
 	if(possible_transfer_amounts)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -26,6 +26,8 @@
 	if(amount_per_transfer_from_this in possible_transfer_amounts)
 		default = amount_per_transfer_from_this
 	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
+	if(!N)
+		return
 
 	if(!usr.Adjacent(src))
 		to_chat(usr, "<span class='warning'>You have moved too far away!</span>")
@@ -34,8 +36,7 @@
 		to_chat(usr, "<span class='warning'>You can't use your hands!</span>")
 		return
 
-	if(N)
-		amount_per_transfer_from_this = N
+	amount_per_transfer_from_this = N
 
 /obj/item/reagent_containers/AltClick()
 	set_APTFT()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -25,8 +25,8 @@
 	var/default = null
 	if(amount_per_transfer_from_this in possible_transfer_amounts)
 		default = amount_per_transfer_from_this
-	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
-	if(!N)
+	var/new_transfer_rate = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
+	if(!new_transfer_rate)
 		return
 
 	if(!usr.Adjacent(src))
@@ -36,7 +36,7 @@
 		to_chat(usr, "<span class='warning'>You can't use your hands!</span>")
 		return
 
-	amount_per_transfer_from_this = N
+	amount_per_transfer_from_this = new_transfer_rate
 	to_chat(usr, "<span class='notice'>[src] will now transfer [amount_per_transfer_from_this] units at a time.</span>")
 
 /obj/item/reagent_containers/AltClick()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -37,6 +37,7 @@
 		return
 
 	amount_per_transfer_from_this = N
+	to_chat(usr, "<span class='notice'>[src] will now transfer [amount_per_transfer_from_this] units at a time.</span>")
 
 /obj/item/reagent_containers/AltClick()
 	set_APTFT()

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -6,6 +6,7 @@
 	item_state = "mender"
 	volume = 200
 	possible_transfer_amounts = null
+	visible_transfer_rate = FALSE
 	resistance_flags = ACID_PROOF
 	container_type = REFILLABLE | AMOUNT_VISIBLE
 	temperature_min = 270

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -240,7 +240,7 @@
 	desc = "A baggie. Can hold up to 10 units."
 	icon_state = "baggie"
 	amount_per_transfer_from_this = 2
-	possible_transfer_amounts = 2
+	possible_transfer_amounts = null
 	volume = 10
 	container_type = OPENCONTAINER
 	can_assembly = 0

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -86,7 +86,7 @@
 	name = "combat stimulant injector"
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
 	amount_per_transfer_from_this = 15
-	possible_transfer_amounts = list(15)
+	possible_transfer_amounts = null
 	icon_state = "combat_hypo"
 	volume = 90
 	ignore_flags = 1 // So they can heal their comrades.
@@ -104,7 +104,7 @@
 	item_state = "autoinjector"
 	belt_icon = "autoinjector"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(10)
+	possible_transfer_amounts = null
 	volume = 10
 	ignore_flags = TRUE //so you can medipen through hardsuits
 	container_type = DRAWABLE
@@ -151,7 +151,6 @@
 	desc = "Rapidly stimulates and regenerates the body's organ system."
 	icon_state = "stimpen"
 	amount_per_transfer_from_this = 50
-	possible_transfer_amounts = list(50)
 	volume = 50
 	list_reagents = list("stimulants" = 50)
 
@@ -168,7 +167,6 @@
 	desc = "After a short period of time the nanites will slow the body's systems and assist with bone repair. Nanomachines son."
 	icon_state = "bonepen"
 	amount_per_transfer_from_this = 30
-	possible_transfer_amounts = list(30)
 	volume = 30
 	list_reagents = list("nanocalcium" = 30)
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -10,7 +10,7 @@
 	icon_state = "0"
 	belt_icon = "syringe"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	volume = 15
 	sharp = TRUE
 	var/busy = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
1. Fixes certain reagent containers having lists of possible transfer rates that were either empty, contained only the default value, or were not even lists. All of these were intended to have fixed transfer rates, but triggered the `Alt-click to change the transfer amount.` examine message and had the `Set transfer amount` verb regardless. All of these were changed to `null` which blocks altering the transfer rate, suppresses the examine message, and removes the verb when initializing.
2. Moved the sanity checks around in `set_APTFT()` so that canceling while in a position that would normally trigger one of the warnings does not produce one (since you're choosing to do nothing anyway).
3. Added a quality-of-life feedback message when transfer rate of a container was changed successfully.
4. Unhardcodes the `It will transfer X units at a time.` message check, tying it to a separate var instead of `possible_transfer_amounts`, to allow items with fixed transfer rates to show it.
5. Fixed a grammar typo where pipette (and other reagent containers) set to decimal transfer values would have `It will transfer 0.6 unit at a time.` in its examine note, lacking the plural `s`.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs bad, avoiding negative feedback when it doesn't matter good, feedback on action success good, correct grammar good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Spawned in a syringe (had `possible_transfer_amounts = list()`), a damp rag (`list(5)`), and a baggie (`2`).
- Examined all of 'em, saw no transfer rate modification note
- Picked up all of 'em, saw no `Set transfer amount` verb in `Object` tab
- Alt+Clicked all of 'em, saw you still can't change the transfer amount
​
- Alt+Clicked a beaker while in range
- Moved away from beaker during the input prompt
- Cancelled the input, saw no unnecessary `You have moved too far away!` warning message
- Re-tested the intended use of the warning, saw that it still shows up
​
- Alt+Clicked a beaker while in range
- Successfully selected one of possible transfer rates, saw new feedback message
- Re-tested the fail case, saw that the new feedback message correctly doesn't show up
​
- Examined a beaker (regular case), a syringe (fixed transfer rate), an auto-mender (custom transfer logic), a tomato (food), a hot chocolate cup (subtype of food), a sugar bottle (different subtype of food)
- Saw that whether the above report their transfer rates or not matches current master
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Successfully changing a reagent container's transfer rate now produces a reassuring feedback message
fix: Fixed some reagent containers with fixed transfer rates showing the Alt+Click transfer rate change examine note
spellcheck: Fixed pipettes set to fractional transfer rates having incorrect grammar in their examine message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
