### PR TITLE
Fixes DeltaStation Law Office and Robotics Surgery Windows

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -45269,7 +45269,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/button/windowtint{
 	dir = 4;
-	id = "HOS";
+	id = "IAA";
 	pixel_x = -24;
 	pixel_y = 6
 	},
@@ -75821,7 +75821,8 @@
 /area/assembly/robotics)
 "dvp" = (
 /obj/structure/window/reinforced/polarized{
-	dir = 8
+	dir = 8;
+	id = "RoboSurgery"
 	},
 /turf/simulated/floor/plasteel/white,
 /area/assembly/robotics)
@@ -80240,7 +80241,8 @@
 "dFw" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/polarized{
-	dir = 8
+	dir = 8;
+	id = "RoboSurgery"
 	},
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath/medical,
@@ -80275,7 +80277,8 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/button/windowtint{
 	id = "RoboSurgery";
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/white,
@@ -81275,7 +81278,8 @@
 "dHR" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/polarized{
-	dir = 8
+	dir = 8;
+	id = "RoboSurgery"
 	},
 /obj/item/mmi,
 /obj/item/storage/box/gloves{
@@ -83690,7 +83694,9 @@
 	},
 /area/medical/surgery)
 "dOc" = (
-/obj/structure/window/reinforced/polarized,
+/obj/structure/window/reinforced/polarized{
+	id = "RoboSurgery"
+	},
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 1
 	},
@@ -83965,7 +83971,9 @@
 /area/security/prison/cell_block)
 "dOD" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/obj/structure/window/reinforced/polarized,
+/obj/structure/window/reinforced/polarized{
+	id = "RoboSurgery"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -87256,7 +87264,9 @@
 	network = list("Research","SS13")
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/window/reinforced/polarized,
+/obj/structure/window/reinforced/polarized{
+	id = "RoboSurgery"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -78747,6 +78747,11 @@
 /obj/item/FixOVein,
 /obj/item/surgicaldrill,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/button/windowtint{
+	id = "RoboSurgery";
+	pixel_x = 24;
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/white,
 /area/assembly/robotics)
 "dBP" = (
@@ -80275,11 +80280,6 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/button/windowtint{
-	id = "RoboSurgery";
-	pixel_x = 24;
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/assembly/robotics)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Re-links the electrochromic windows to their window tinters at the law office and robotics surgery so they work properly again on DeltaStation.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Map bugs be bad, map fixes be good.

## Testing
<!-- How did you test the PR, if at all? -->
Edited the appropriate items
Loaded local test server
Spawned as an IA Agent and Roboticist
Tested the applicable areas as their respective role
Windows dimmed as anticpated.

## Changelog
:cl:
Fix: DeltaStation Law Office and Robotics Surgery now have functioning electrochromic windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
