### PR TITLE
DeltaStation Security Tweaks

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -39125,9 +39125,8 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
 "bRa" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Detective";
-	req_access_txt = "4"
+/obj/machinery/door/airlock/security{
+	name = "Detective"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -92834,6 +92833,10 @@
 	icon_state = "dark"
 	},
 /area/security/execution)
+"nQk" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/space/nearstation)
 "nQq" = (
 /obj/machinery/atm{
 	pixel_x = 32
@@ -155902,7 +155905,7 @@ vbN
 abj
 aaa
 aaa
-jQY
+qBV
 qBV
 jYK
 bRd
@@ -157703,7 +157706,7 @@ bPS
 oEG
 oEG
 abj
-abj
+nQk
 abj
 oEG
 oEG

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -33911,7 +33911,7 @@
 "bGa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "1"
+	req_access_txt = "63"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -48052,7 +48052,7 @@
 "cla" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "1"
+	req_access_txt = "63"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -49269,7 +49269,7 @@
 "cnT" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "1"
+	req_access_txt = "63"
 	},
 /obj/structure/cable{
 	d1 = 1;

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -39126,7 +39126,8 @@
 /area/storage/tools)
 "bRa" = (
 /obj/machinery/door/airlock/security{
-	name = "Detective"
+	name = "Detective";
+	req_access_txt = "4"
 	},
 /obj/structure/cable{
 	d1 = 1;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

- Adds a wall to prevent accidental spacewalks from the gamma armoury
- Detective's office now has a solid airlock to give them privacy with the use of their electrochromic windows
- Re-areas a rogue wall to be more appropriate
- Changes the required access for the security maintenance from `1` to `63`
    - This is the access we commonly use across basic security doors
    - This also now allows the Detective to use the maintenance doors

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Map bugs be bad, map fixes be good

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

Rogue Wall is now Security Office
![image](https://user-images.githubusercontent.com/16112919/184461655-b93309e2-937e-45cd-a38c-ae05f9db15db.png)

Newbie Officer Safety Net
![image](https://user-images.githubusercontent.com/16112919/184461858-fa22a8c8-ef8d-4cfe-af67-3e071a004888.png)

![image](https://user-images.githubusercontent.com/16112919/184461979-41857d81-afee-44e0-a9fe-fb7659985010.png)
![image](https://user-images.githubusercontent.com/16112919/184462022-f9a9b0c3-b633-40c1-b38b-b23643a444ab.png)


## Testing
<!-- How did you test the PR, if at all? -->
Loaded up local server
Confirmed solid airlock status in Detective Office
Checked area of wall to confirm it's status as no longer being Security Equipment Storage
Parked the gamma armoury shuttle to confirm the wall lined up with the airlock.

## Changelog
:cl:
tweak: DeltaDetective now has a solid airlock instead of a glass airlock
tweak: DeltaSecurity now has a wall to block off the unused gamma armoury shuttle airlock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
