### PR TITLE
DeltaStation Medical Tweaks

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -61604,7 +61604,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/medical/medbay)
 "cPO" = (
-/obj/machinery/door/firedoor,
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Psych"
 	},
@@ -71361,8 +71360,9 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+	name = "custom placement";
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -90521,15 +90521,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
-"jat" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whiteblue"
-	},
-/area/medical/reception)
 "jav" = (
 /obj/machinery/door/airlock{
 	name = "Magistrate's Office";
@@ -97774,13 +97765,12 @@
 	},
 /area/hallway/primary/starboard)
 "xLC" = (
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Psych"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
+	},
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Psych"
 	},
 /turf/simulated/floor/plating,
 /area/medical/psych)
@@ -141029,7 +141019,7 @@ bqu
 cHN
 cJh
 nCu
-jat
+npp
 cbH
 ceQ
 ckS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

- Removes firelocks from underneath the psychiatrist office windows on DeltaStation
- Removes a rogue intercom that was on the floor in the medical lobby
- Moves the paramedic office light switch so they could use the button to open the garage door

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Map bugs be bad, map fixes be good

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Firelock-be-gone
![image](https://user-images.githubusercontent.com/16112919/184463069-675eb2c0-67f3-471a-89c6-1fc3cd3a4f68.png)

Light switch, switched
![image](https://user-images.githubusercontent.com/16112919/184463084-359df992-fe50-47da-9469-3be508d652f6.png)


## Testing
<!-- How did you test the PR, if at all? -->
Loaded up local server
Pulled psychiatrist fire alarm
Confirmed the lack of intercom on the floor in the lobby
Confirmed that the light switch had been moved in the paramedic office and still operated

## Changelog
:cl:
fix: Paramedic can now access the garage door button on DeltaStation
fix: Removes firelocks from Psych Office windows on DeltaStation
fix: Removes the rogue intercom from the floor in the Medbay Lobby on DeltaStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
