### PR TITLE
Fixes Med-Sci Remap Oversights

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -92138,7 +92138,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/virology,
+/obj/machinery/door/airlock/virology{
+	name = "Virology Bedroom";
+	req_access_txt = "39"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -54584,6 +54584,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "cGi" = (
@@ -90356,9 +90361,6 @@
 	name = "east bump";
 	pixel_x = 28
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -91741,6 +91743,9 @@
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -73466,6 +73466,16 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgeryobs)
+"hpY" = (
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit)
 "hqe" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP2";
@@ -79942,6 +79952,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"mSJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/hallway/secondary/exit)
 "mTj" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -138879,10 +138902,10 @@ lqd
 cLQ
 oVH
 cBR
-cxN
-cxN
-cxN
-cxN
+cBR
+cBR
+cBR
+cBR
 cZt
 lUp
 lKO
@@ -143711,7 +143734,7 @@ bEF
 bEF
 dBt
 rFe
-rFe
+hpY
 glD
 kTU
 bHV
@@ -147061,7 +147084,7 @@ nHv
 swk
 snH
 bSc
-oMz
+mSJ
 bEF
 bEF
 aaa

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -1081,6 +1081,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
+"afr" = (
+/obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "afs" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
@@ -4310,6 +4317,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -9446,6 +9454,9 @@
 /area/security/lobby)
 "azG" = (
 /obj/machinery/atmospherics/portable/canister/oxygen,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage{
 	name = "\improper Science Toxin Storage"
@@ -17849,6 +17860,10 @@
 	name = "Garage Door Control";
 	req_access_txt = "66";
 	pixel_x = -24
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/paramedic)
@@ -27258,13 +27273,6 @@
 "boJ" = (
 /turf/simulated/floor/carpet,
 /area/chapel/main)
-"boK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology)
 "boL" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -30125,6 +30133,10 @@
 "bvP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -31162,6 +31174,7 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
+/obj/item/book/manual/wiki/sop_science,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "purple"
@@ -31805,10 +31818,6 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "bzl" = (
-/obj/machinery/newscaster{
-	name = "south bump";
-	pixel_y = -32
-	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -33875,6 +33884,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
+"bER" = (
+/obj/effect/landmark/start/scientist,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "bES" = (
 /obj/machinery/door/poddoor{
 	id_tag = "ToxinsVenting";
@@ -34145,7 +34160,7 @@
 /area/hallway/primary/starboard/east)
 "bFw" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 6"
+	c_tag = "Starboard Primary Hallway 5"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34243,6 +34258,10 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -34511,9 +34530,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 28
+/obj/machinery/ai_status_display{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -34680,7 +34698,7 @@
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bGE" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -34708,7 +34726,15 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/storage/belt/utility,
+/obj/item/book/manual/wiki/sop_science{
+	pixel_y = 3;
+	pixel_x = -3
+	},
+/obj/item/book/manual/ripley_build_and_repair,
+/obj/item/book/manual/wiki/robotics_cyborgs{
+	pixel_y = -3;
+	pixel_x = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -34739,14 +34765,14 @@
 	dir = 9;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bGL" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bGM" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/beach/sand,
@@ -35152,6 +35178,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "bHO" = (
@@ -35327,6 +35357,7 @@
 	},
 /area/assembly/robotics)
 "bIl" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -35336,7 +35367,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bIp" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -35389,7 +35420,7 @@
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bIz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -36012,11 +36043,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKg" = (
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Body delivery system"
-	},
 /obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Body delivery system";
+	req_access_txt = "6"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -36038,7 +36070,7 @@
 	dir = 10;
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bKj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -36047,7 +36079,7 @@
 	dir = 6;
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bKk" = (
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
@@ -36071,7 +36103,7 @@
 	dir = 10;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bKp" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
@@ -36128,7 +36160,7 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bKy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36298,6 +36330,7 @@
 	dir = 8;
 	layer = 2.9
 	},
+/obj/item/storage/belt/utility,
 /obj/item/clothing/head/welding{
 	pixel_x = -3;
 	pixel_y = 5
@@ -36506,7 +36539,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastright{
-	dir = 1;
+	dir = 2;
 	name = "Medical Reception";
 	req_access_txt = "5"
 	},
@@ -36515,6 +36548,11 @@
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -36606,11 +36644,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
-"bLW" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
-/area/hallway/primary/starboard/east)
 "bLX" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -36789,7 +36822,7 @@
 	dir = 10;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bMu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37086,9 +37119,6 @@
 	},
 /area/assembly/chargebay)
 "bNj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/mecha_part_fabricator,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -37096,9 +37126,6 @@
 	},
 /area/assembly/robotics)
 "bNk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/table,
 /obj/item/robotanalyzer,
 /obj/item/stack/sheet/metal{
@@ -37115,15 +37142,15 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkpurple"
 	},
 /area/assembly/robotics)
 "bNl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/table,
 /obj/item/assembly/prox_sensor{
 	pixel_x = -8;
@@ -37169,7 +37196,7 @@
 	dir = 8;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bNq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -37190,6 +37217,11 @@
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -37229,6 +37261,12 @@
 /obj/item/stock_parts/manipulator,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -37290,7 +37328,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bND" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -37394,6 +37432,9 @@
 /area/maintenance/port)
 "bNQ" = (
 /obj/structure/closet/secure_closet/roboticist,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -37675,7 +37716,7 @@
 /area/engine/gravitygenerator)
 "bOv" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -38037,7 +38078,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bPp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -38143,7 +38184,7 @@
 	dir = 8;
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "bPE" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -38840,7 +38881,6 @@
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "bRm" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkpurple"
@@ -38872,6 +38912,10 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -39371,6 +39415,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -39381,6 +39430,11 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -39391,8 +39445,13 @@
 	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -39464,6 +39523,14 @@
 	req_one_access_txt = "33;5"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	desc = "You have the public fridge, pal, lube off.";
+	dir = 1;
+	icon_state = "left";
+	name = "Security Shield";
+	req_access_txt = "33"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteyellowfull"
@@ -39484,7 +39551,7 @@
 	desc = "You have the public fridge, pal, lube off.";
 	dir = 1;
 	icon_state = "left";
-	name = "Anti-Theft Shield";
+	name = "Security Shield";
 	req_access_txt = "33"
 	},
 /obj/machinery/smartfridge/medbay,
@@ -39567,6 +39634,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -39587,6 +39657,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -39606,6 +39679,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39663,6 +39739,9 @@
 "bTg" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/ai_status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplecorner"
 	},
@@ -39870,13 +39949,15 @@
 "bTI" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
-/obj/machinery/newscaster{
-	name = "west bump";
-	pixel_x = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay Chemistry";
 	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Chemistry Requests Console";
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40031,6 +40112,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -40044,6 +40130,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -42546,6 +42636,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -42598,6 +42692,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -42658,6 +42757,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -42715,6 +42819,13 @@
 /obj/item/reagent_containers/spray/cleaner{
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
 	name = "Surgery Cleaner"
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/reagent_dispensers/fueltank/chem{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -43049,7 +43160,7 @@
 /area/hallway/primary/central/se)
 "cbn" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	name = "Server Room";
 	req_access_txt = "30"
 	},
@@ -43804,7 +43915,8 @@
 "cdf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
-	name = "Research Director";
+	id_tag = "rdofficedoor";
+	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
 /obj/structure/cable{
@@ -44865,7 +44977,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Medbay Maintenance";
-	req_one_access_txt = "5;32"
+	req_access_txt = "5"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -46503,7 +46615,7 @@
 "ckz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Medbay Maintenance";
-	req_one_access_txt = "5;32"
+	req_access_txt = "5"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
@@ -46895,15 +47007,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
-"clu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
 "clv" = (
 /obj/structure/closet,
 /obj/machinery/light_switch{
@@ -47488,6 +47591,11 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage{
 	name = "\improper Science Toxin Storage"
@@ -47660,18 +47768,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
-"cnC" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cnD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -47880,8 +47976,7 @@
 "coe" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/power/apc{
-	cell_type = 5000;
-	name = "south bump Important Area";
+	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -48327,7 +48422,7 @@
 "cpo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Medbay Maintenance";
-	req_one_access_txt = "5;32"
+	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48390,8 +48485,8 @@
 "cpv" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on/server,
 /obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+	name = "east bump";
+	pixel_x = 28
 	},
 /obj/machinery/camera{
 	c_tag = "Research Server Room";
@@ -48919,11 +49014,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cqW" = (
@@ -49185,6 +49275,11 @@
 "crB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "crC" = (
@@ -49437,11 +49532,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -49464,6 +49554,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -49819,6 +49914,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "csW" = (
@@ -50105,6 +50205,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -50246,6 +50349,11 @@
 "ctL" = (
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -50626,12 +50734,11 @@
 "cuZ" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/power/apc{
-	dir = 8;
+/obj/machinery/light_switch{
+	dir = 4;
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "cva" = (
@@ -50892,6 +50999,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "cvS" = (
@@ -51008,27 +51120,11 @@
 /area/maintenance/aft)
 "cwo" = (
 /obj/machinery/dna_scannernew,
-/obj/machinery/firealarm{
-	name = "north bump";
-	pixel_y = 24
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkpurple"
 	},
 /area/medical/genetics)
-"cwq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation B";
-	req_access_txt = "39"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/medical/virology)
 "cwr" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2{
@@ -52683,6 +52779,7 @@
 	name = "south bump";
 	pixel_y = -32
 	},
+/obj/item/book/manual/wiki/sop_science,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkpurple"
 	},
@@ -53180,10 +53277,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
-"cBK" = (
-/obj/effect/spawner/random_spawners/fungus_maybe,
-/turf/simulated/wall/r_wall,
-/area/maintenance/aft)
 "cBL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -53516,7 +53609,7 @@
 	},
 /area/toxins/explab)
 "cCV" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -53680,13 +53773,15 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/structure/sign/poster/official/help_others{
-	pixel_y = -30
-	},
 /obj/machinery/camera{
 	c_tag = "Research Genetics";
 	dir = 1;
 	network = list("SS13","Research")
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkpurple"
@@ -53765,6 +53860,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -54007,6 +54106,7 @@
 /area/engine/controlroom)
 "cEk" = (
 /obj/structure/table,
+/obj/item/clipboard,
 /obj/item/paper_bin{
 	pixel_x = 1;
 	pixel_y = 9
@@ -54021,9 +54121,12 @@
 	},
 /area/toxins/explab)
 "cEn" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_x = 30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -54975,10 +55078,7 @@
 /area/maintenance/aft)
 "cHe" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitehall"
-	},
+/turf/simulated/wall,
 /area/maintenance/aft)
 "cHf" = (
 /obj/machinery/space_heater,
@@ -55106,6 +55206,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_y = -30
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -55149,6 +55255,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -55370,6 +55481,9 @@
 "cHZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
+/obj/structure/sign/chemistry{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitehall"
@@ -55403,13 +55517,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
-"cIc" = (
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper/precision,
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cId" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55595,14 +55702,14 @@
 /area/toxins/misc_lab)
 "cID" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = -30
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the horrors within the test chamber.";
+	name = "Research Monitor";
+	network = list("TestChamber");
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -55668,6 +55775,15 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "E.X.P.E.R.I-MENTOR Lab Maintenance";
 	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -56097,6 +56213,7 @@
 	req_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -57032,6 +57149,11 @@
 /area/toxins/xenobiology)
 "cMS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cMT" = (
@@ -57143,7 +57265,11 @@
 	},
 /area/maintenance/aft)
 "cNl" = (
-/obj/structure/closet/l3closet/scientist,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -57173,6 +57299,11 @@
 "cNs" = (
 /obj/effect/spawner/random_spawners/grille_maybe,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cNt" = (
@@ -57500,6 +57631,11 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cOq" = (
@@ -57678,6 +57814,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cOT" = (
@@ -57913,7 +58054,7 @@
 	base_state = "left";
 	dir = 1;
 	icon_state = "left";
-	name = "Research Division Delivery";
+	name = "Area control access";
 	req_access_txt = "47"
 	},
 /turf/simulated/floor/engine,
@@ -58653,6 +58794,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cRz" = (
@@ -58914,14 +59059,14 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cSf" = (
-/obj/item/extinguisher,
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_y = 30
 	},
-/obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 1;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
@@ -58931,11 +59076,8 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/glasses/science,
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59621,12 +59763,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"cTQ" = (
-/obj/item/toy/plushie/tuxedo_cat{
-	name = "Runtime plushie"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cTT" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -60574,6 +60710,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -61571,7 +61711,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -61597,6 +61736,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -62406,6 +62546,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "dcx" = (
@@ -62853,6 +62994,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "ddM" = (
@@ -62964,6 +63110,10 @@
 "dea" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
@@ -64408,15 +64558,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
-"dia" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "dib" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -68459,7 +68600,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "dDd" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/chair/stool{
 	dir = 1
 	},
@@ -68492,6 +68632,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/launch)
+"dFe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "dFG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
@@ -68576,6 +68723,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dJl" = (
@@ -68722,7 +68870,7 @@
 /area/hallway/primary/aft)
 "dMD" = (
 /obj/structure/disposalpipe/junction{
-	dir = 2
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -68844,6 +68992,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dSH" = (
@@ -69043,6 +69194,13 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
+"ebS" = (
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper/precision,
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "ece" = (
 /obj/structure/table,
 /obj/item/candle,
@@ -69218,7 +69376,6 @@
 	},
 /area/security/prisonlockers)
 "egI" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes{
 	pixel_y = 3
@@ -69229,6 +69386,10 @@
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 6;
 	pixel_y = -2
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -69333,11 +69494,6 @@
 /area/hallway/secondary/exit)
 "ekQ" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage{
@@ -69360,7 +69516,8 @@
 "emy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
-	name = "Containment Pen"
+	name = "Containment Pen";
+	id_tag = "maintcham2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -69391,6 +69548,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
+	},
+/obj/item/desk_bell{
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -69614,12 +69774,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"eyh" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "eyl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
@@ -69743,7 +69897,7 @@
 	dir = 5;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "eES" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -69878,6 +70032,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -70132,6 +70289,7 @@
 	},
 /obj/structure/table,
 /obj/item/stack/cable_coil,
+/obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -70495,7 +70653,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "fmg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -70515,6 +70673,12 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"fmn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/maintenance/asmaint)
 "fmD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -70637,6 +70801,10 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "frm" = (
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitepurple"
@@ -70676,8 +70844,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
@@ -71044,6 +71215,15 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"fGT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door_control{
+	pixel_x = 26;
+	id = "maintcham";
+	name = "Containment Control"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "fHD" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/oxygen,
@@ -71100,6 +71280,7 @@
 /obj/structure/sign/xenobio{
 	pixel_x = -31
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "fJu" = (
@@ -71164,6 +71345,13 @@
 	temperature = 80
 	},
 /area/toxins/xenobiology)
+"fMi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "fMM" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass,
@@ -71199,14 +71387,6 @@
 	icon_state = "darkred"
 	},
 /area/security/brig)
-"fOY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random_spawners/grille_often,
-/obj/structure/sign/deathsposal{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "fPq" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -71311,15 +71491,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"fRN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/random_barrier/obstruction,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "fSp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -71630,6 +71801,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "gea" = (
@@ -71646,7 +71818,7 @@
 	dir = 6;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "gei" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -71685,6 +71857,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
+"gfi" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/medical/surgery)
 "ggO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -72158,6 +72340,9 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/stripes/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -72209,7 +72394,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "gCL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72388,6 +72573,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -72698,7 +72884,7 @@
 "gUY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Medbay Maintenance";
-	req_one_access_txt = "5;32"
+	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73075,15 +73261,6 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
-"hhD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/asmaint)
 "hhX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Cafeteria"
@@ -73234,13 +73411,6 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
-"hnb" = (
-/obj/structure/sign/poster/official/healthy{
-	pixel_x = 31
-	},
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "hnB" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -73402,6 +73572,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
 	},
@@ -73548,6 +73721,11 @@
 	name = "south bump";
 	pixel_y = -24
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -73664,6 +73842,12 @@
 	icon_state = "red"
 	},
 /area/security/permabrig)
+"hBu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/robotanalyzer,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "hCr" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel,
@@ -73709,6 +73893,10 @@
 	id_tag = "Biohazard";
 	name = "Biohazard Shutter"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "hDl" = (
@@ -73748,10 +73936,6 @@
 	},
 /area/security/prisonlockers)
 "hEz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
@@ -73795,15 +73979,6 @@
 /obj/effect/spawner/window/reinforced/tinted,
 /turf/simulated/floor/plating,
 /area/chapel/main)
-"hHU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/asmaint)
 "hIc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -74078,9 +74253,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -74513,6 +74685,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	step_size = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -74727,15 +74903,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"itP" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "itZ" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -75093,6 +75260,11 @@
 "iKr" = (
 /obj/structure/table,
 /obj/item/trash/chips,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
 "iMG" = (
@@ -75333,7 +75505,7 @@
 /obj/machinery/door/airlock/medical{
 	locked = 1;
 	name = "Abandoned Equipment Storage";
-	req_access_txt = "64"
+	req_access_txt = "5"
 	},
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
@@ -75413,15 +75585,6 @@
 	dir = 1
 	},
 /area/medical/virology)
-"jdu" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/random_spawners/grille_maybe,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "jdz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75735,9 +75898,10 @@
 	},
 /area/maintenance/aft)
 "jrt" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology)
+/obj/structure/rack,
+/obj/item/storage/box/monkeycubes/wolpincubes,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "jsy" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -75809,6 +75973,19 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"jwu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = -32;
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/hallway/secondary/exit)
 "jwP" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -76058,6 +76235,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
+"jFf" = (
+/obj/structure/closet/crate/secure{
+	req_one_access = list(33,41);
+	req_one_access_txt = "33;41"
+	},
+/obj/item/circuitboard/chem_dispenser,
+/obj/item/storage/pill_bottle/random_drug_bottle,
+/obj/item/storage/pill_bottle/random_drug_bottle,
+/obj/item/storage/pill_bottle/random_drug_bottle,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "jFo" = (
 /obj/structure/table,
 /obj/item/roller{
@@ -76079,14 +76267,12 @@
 	},
 /area/security/permabrig)
 "jIE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/landmark/spawner/rev,
-/turf/simulated/floor/bluegrid{
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
+/obj/machinery/camera{
+	c_tag = "Xenobiology Module Hazard Pen";
+	dir = 1;
+	network = list("Research","SS13")
 	},
+/turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "jIX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -76202,12 +76388,16 @@
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on/coldroom{
 	dir = 1
 	},
+/obj/machinery/ai_status_display{
+	pixel_x = 32;
+	step_size = 0
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jPw" = (
 /obj/machinery/door/airlock/freezer,
 /obj/structure/barricade/wooden,
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "jPx" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -76225,7 +76415,13 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
 /area/maintenance/asmaint)
 "jQG" = (
 /obj/item/stack/sheet/wood{
@@ -76461,14 +76657,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
-"jYQ" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/item/mounted/frame/apc_frame,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "jYZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -76499,19 +76687,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
-"kae" = (
-/obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
-"kaD" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology)
 "kbU" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -76577,6 +76752,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
+"kdP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "kee" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
@@ -76599,7 +76793,7 @@
 	},
 /area/toxins/hallway)
 "keZ" = (
-/obj/effect/spawner/random_barrier/wall_probably,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "kfn" = (
@@ -76617,6 +76811,10 @@
 /area/maintenance/asmaint)
 "kgc" = (
 /obj/item/reagent_containers/food/drinks/cans/badminbrew,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
+"kgg" = (
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "khU" = (
@@ -76745,6 +76943,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "kmE" = (
@@ -76760,6 +76962,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "kmN" = (
@@ -76895,6 +77101,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
+"krV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door_control{
+	pixel_x = -26;
+	id = "maintcham2";
+	name = "Containment Control"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "ksj" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -76925,6 +77140,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table/glass,
+/obj/item/book/manual/wiki/sop_science,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -76946,6 +77162,9 @@
 	dir = 1;
 	network = list("Research","SS13")
 	},
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -77248,6 +77467,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "kKD" = (
@@ -77491,6 +77711,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77657,6 +77882,16 @@
 /obj/effect/spawner/random_barrier/wall_probably,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"ldn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint)
 "ldD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -77759,6 +77994,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "lkw" = (
@@ -78095,14 +78331,13 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
-"lER" = (
-/obj/structure/sign/chemistry{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "lEZ" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
@@ -78141,6 +78376,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/hallway)
 "lGY" = (
@@ -78159,11 +78398,6 @@
 "lHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/oil_maybe,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "lHw" = (
@@ -78227,6 +78461,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
+"lKO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/toxins/xenobiology)
 "lKP" = (
 /obj/structure/reflector/single{
 	anchored = 1;
@@ -78415,7 +78671,7 @@
 "lRy" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "lSz" = (
 /obj/structure/railing{
 	dir = 1
@@ -78469,6 +78725,20 @@
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
+"lUp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "lUC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -78834,7 +79104,6 @@
 	c_tag = "Xenobiology Access";
 	network = list("Research","SS13")
 	},
-/obj/structure/closet/l3closet/scientist,
 /obj/structure/sign/securearea{
 	pixel_x = 32
 	},
@@ -78853,10 +79122,11 @@
 /area/medical/morgue)
 "mjg" = (
 /obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/fancy/cigarettes/cigpack_random,
+/obj/item/deck/cards{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -79166,6 +79436,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -79317,11 +79588,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/hallway)
 "mDx" = (
 /obj/structure/table,
-/obj/item/clipboard,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the E.X.P.E.R.I-MENTOR chamber.";
 	layer = 4;
@@ -79329,6 +79602,11 @@
 	network = list("Telepad");
 	pixel_x = -32
 	},
+/obj/item/book/manual/wiki/sop_science{
+	pixel_y = 3;
+	pixel_x = -3
+	},
+/obj/item/book/manual/wiki/experimentor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -79415,11 +79693,6 @@
 /area/security/permabrig)
 "mJi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/molten_object/large,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -79615,14 +79888,6 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/asmaint2)
-"mPV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/hallway)
 "mPX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79894,7 +80159,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "ncT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -80082,6 +80347,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -80113,7 +80379,7 @@
 	dir = 8;
 	invuln = 1;
 	name = "Hardened Bomb-Test Security Camera";
-	network = list("Toxins","Research","SS13")
+	network = list("Research","SS13")
 	},
 /turf/simulated/floor/indestructible,
 /area/toxins/test_area)
@@ -80289,6 +80555,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/morgue)
+"nuO" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "nuW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -80418,6 +80696,14 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
+"nBI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor{
+	name = "Containment Pen";
+	id_tag = "maintcham"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "nBN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -80571,15 +80857,10 @@
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
-"nHi" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Module Hazard Pen";
-	dir = 1;
-	network = list("Research","SS13")
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/engine,
-/area/toxins/xenobiology)
+"nHv" = (
+/obj/machinery/status_display,
+/turf/simulated/wall,
+/area/hallway/secondary/exit)
 "nHM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80633,16 +80914,19 @@
 	icon_state = "whitegreenfull"
 	},
 /area/medical/virology)
+"nJm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint)
 "nKO" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pestspray,
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cultivator/rake,
-/obj/machinery/alarm{
-	name = "north bump";
-	pixel_y = 24
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -80659,6 +80943,9 @@
 /obj/item/stack/sheet/metal/fifty{
 	pixel_x = -2;
 	pixel_y = -2
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -80733,16 +81020,6 @@
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
-"nNY" = (
-/obj/machinery/atmospherics/portable/canister/toxins,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/storage{
-	name = "\improper Science Toxin Storage"
-	})
 "nOo" = (
 /turf/simulated/floor/plasteel,
 /area/toxins/hallway)
@@ -80859,6 +81136,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"nXu" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/item/hemostat,
+/obj/item/scalpel,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "nXB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80995,9 +81281,6 @@
 /area/maintenance/apmaint)
 "ocX" = (
 /obj/structure/table,
-/obj/structure/reagent_dispensers/fueltank/chem{
-	pixel_y = 32
-	},
 /obj/item/circular_saw,
 /obj/item/surgicaldrill,
 /obj/item/cautery,
@@ -81200,7 +81483,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "ooD" = (
 /obj/machinery/conveyor/west{
 	id = "garbage"
@@ -81261,6 +81544,11 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/stripes/full,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -81312,8 +81600,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/toxins/xenobiology)
 "otn" = (
@@ -81326,7 +81613,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "oto" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
@@ -81418,9 +81704,6 @@
 	},
 /area/medical/medbay2)
 "ouW" = (
-/obj/structure/table/reinforced,
-/obj/item/scalpel,
-/obj/item/hemostat,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -81434,6 +81717,7 @@
 	tag_exterior_door = "xeno_airlock_exterior";
 	tag_interior_door = "xeno_airlock_interior"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -81507,10 +81791,6 @@
 "oyO" = (
 /obj/item/stack/packageWrap,
 /obj/structure/table/glass,
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -81606,17 +81886,6 @@
 	icon_state = "whitegreencorner"
 	},
 /area/crew_quarters/sleep)
-"oDe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "oDE" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -81710,15 +81979,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/apmaint)
-"oGe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/asmaint)
 "oGf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cola/free,
@@ -81909,6 +82169,11 @@
 	name = "north bump";
 	pixel_y = 24
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "oNT" = (
@@ -82025,6 +82290,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -82168,6 +82437,13 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"oYN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "oZa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82236,6 +82512,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/poster/official/healthy{
+	pixel_x = 31
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitecorner"
@@ -82529,6 +82808,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "pnT" = (
@@ -82628,11 +82908,6 @@
 /area/security/permabrig)
 "pqA" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "prd" = (
@@ -82716,6 +82991,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -82898,6 +83176,10 @@
 "pAH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -83235,6 +83517,7 @@
 	dir = 4
 	},
 /obj/structure/bed/dogbed/runtime,
+/obj/item/toy/cattoy,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -83250,6 +83533,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"pSb" = (
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Test Chamber";
+	dir = 8;
+	network = list("TestChamber","SS13","Research")
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "pTa" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -83454,6 +83745,12 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/assembly/assembly_line)
+"qdO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint)
 "qei" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -83667,10 +83964,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
-"qmE" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/primary/starboard/east)
 "qmX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -83746,17 +84039,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"qoY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "qpf" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
@@ -83943,17 +84225,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"qxc" = (
-/obj/structure/closet/crate/secure{
-	req_one_access = list(33,41);
-	req_one_access_txt = "33;41"
-	},
-/obj/item/storage/pill_bottle/random_drug_bottle,
-/obj/item/storage/pill_bottle/random_drug_bottle,
-/obj/item/storage/pill_bottle/random_drug_bottle,
-/obj/item/circuitboard/chem_dispenser,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "qxh" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -83990,6 +84261,16 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
+"qyq" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/newscaster{
+	name = "south bump";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "qyM" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -84131,6 +84412,7 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "qEv" = (
@@ -84373,9 +84655,13 @@
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "qKZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/landmark/spawner/rev,
+/turf/simulated/floor/bluegrid{
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
 /area/toxins/xenobiology)
 "qLd" = (
 /obj/machinery/hologram/holopad,
@@ -84569,15 +84855,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"qWu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "qWR" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -84628,7 +84905,7 @@
 /area/toxins/xenobiology)
 "qZD" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -84639,9 +84916,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mounted/frame/firealarm{
-	pixel_x = -26
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "rao" = (
@@ -84666,13 +84940,17 @@
 /obj/item/folder/white{
 	pixel_y = 3
 	},
-/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 3
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/megaphone,
+/obj/item/megaphone{
+	pixel_x = -3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkbluefull"
@@ -84684,11 +84962,6 @@
 /area/engine/hardsuitstorage)
 "rbZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -84758,6 +85031,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"rda" = (
+/obj/item/radio/intercom/department/medbay{
+	pixel_x = 28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/medical/reception)
 "rdL" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -84769,6 +85051,20 @@
 	icon_state = "bluefull"
 	},
 /area/medical/reception)
+"ree" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/east)
 "rek" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
@@ -85029,6 +85325,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"rvD" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/toxins/hallway)
 "rwZ" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -85657,14 +85957,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"sbx" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "scM" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -85958,6 +86250,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "soR" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "purple"
@@ -85973,23 +86267,12 @@
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "spr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "spH" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
-/obj/item/deck/cards{
-	pixel_x = 6
-	},
-/obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -86168,6 +86451,11 @@
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -86256,6 +86544,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "sCl" = (
@@ -86340,6 +86632,10 @@
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"sFy" = (
+/obj/structure/closet/l3closet/scientist,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "sFz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86696,6 +86992,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "sYo" = (
@@ -86737,8 +87034,6 @@
 	},
 /area/toxins/hallway)
 "sYT" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -86754,7 +87049,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "sZe" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -86962,17 +87257,6 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/toxins/xenobiology)
-"tln" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple"
-	},
 /area/toxins/xenobiology)
 "tlI" = (
 /obj/machinery/vending/snack/free,
@@ -87219,6 +87503,9 @@
 /area/maintenance/incinerator)
 "tzW" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/toy/plushie/tuxedo_cat{
+	name = "Runtime plushie"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "tAb" = (
@@ -87238,6 +87525,23 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
+"tAp" = (
+/obj/item/extinguisher,
+/obj/item/extinguisher{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/structure/table/glass,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "tBS" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -87268,7 +87572,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "tDn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -87500,7 +87804,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
@@ -87586,10 +87889,6 @@
 /turf/simulated/floor/plating,
 /area/engine/hardsuitstorage)
 "tPD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -88066,7 +88365,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "ueT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -88221,6 +88520,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"ulK" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint2)
 "uma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -88525,11 +88831,25 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
 	},
 /area/assembly/robotics)
+"uzh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "uzM" = (
 /obj/structure/rack{
 	dir = 1
@@ -88588,6 +88908,10 @@
 /obj/machinery/atmospherics/unary/passive_vent,
 /turf/space,
 /area/maintenance/asmaint)
+"uCK" = (
+/obj/structure/closet/wardrobe/white,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "uCU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
@@ -88642,10 +88966,6 @@
 "uDR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/portable/pump,
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "uEr" = (
@@ -88818,6 +89138,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "uMu" = (
@@ -88852,6 +89175,15 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/structure/sign/poster/official/help_others{
+	pixel_y = -30
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Genetics Requests Console";
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -89116,6 +89448,11 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/wood,
 /area/maintenance/apmaint)
+"vet" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/toxins/hallway)
 "vfc" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -89171,6 +89508,11 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -89350,6 +89692,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "vnO" = (
@@ -89459,11 +89806,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
-"vtS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology)
 "vue" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89490,7 +89832,9 @@
 /obj/structure/sign/deathsposal{
 	pixel_x = 32
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitepurple"
@@ -89729,15 +90073,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"vCe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/asmaint)
 "vCM" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -89784,6 +90119,10 @@
 	layer = 2.9
 	},
 /obj/item/storage/box/bodybags,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -89865,7 +90204,7 @@
 	dir = 4;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "vGq" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard{
@@ -89934,6 +90273,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -90079,7 +90419,7 @@
 	dir = 6;
 	icon_state = "whitepurple"
 	},
-/area/hallway/primary/starboard/east)
+/area/toxins/hallway)
 "vOB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
@@ -90162,8 +90502,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "vSi" = (
@@ -90376,15 +90716,6 @@
 	icon_state = "dark"
 	},
 /area/medical/genetics)
-"vZF" = (
-/obj/effect/spawner/random_spawners/oil_maybe,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "vZV" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/table,
@@ -91126,10 +91457,9 @@
 "wIr" = (
 /obj/machinery/door/window/southright{
 	dir = 1;
-	name = "Containment Pen";
+	name = "Kill Chamber";
 	req_access_txt = "55"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/turf_decal/stripes/full,
 /turf/simulated/floor/plasteel,
@@ -91610,7 +91940,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 7"
+	c_tag = "Starboard Primary Hallway 6"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -91692,6 +92022,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/toxins/hallway)
 "xrG" = (
@@ -91807,10 +92138,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A";
-	req_access_txt = "39"
-	},
+/obj/machinery/door/airlock/virology,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
@@ -91836,10 +92164,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "xyr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -91934,7 +92262,6 @@
 	},
 /area/toxins/hallway)
 "xFt" = (
-/obj/structure/closet/firecloset/full,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -92030,16 +92357,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"xJJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "xJO" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/turf_decal/caution{
@@ -92223,11 +92540,19 @@
 /area/space/nearstation)
 "xRP" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitehall"
 	},
 /area/maintenance/aft)
+"xRU" = (
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "xRY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -92290,14 +92615,13 @@
 /area/toxins/xenobiology)
 "xUX" = (
 /obj/machinery/door/window/southright{
-	name = "Containment Pen";
+	name = "Kill Chamber";
 	req_access_txt = "55"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio1";
 	name = "Chamber 1 Containment Blast Doors"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/turf_decal/stripes/full,
 /turf/simulated/floor/engine,
@@ -92473,15 +92797,6 @@
 	icon_state = "whitegreen"
 	},
 /area/maintenance/aft)
-"xYr" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "xYu" = (
 /obj/structure/table,
 /obj/item/clothing/under/shorts/black{
@@ -92499,6 +92814,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"yak" = (
+/obj/machinery/atmospherics/portable/canister/air,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "yao" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -92570,11 +92889,26 @@
 	icon_state = "black"
 	},
 /area/security/permabrig)
+"yeH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "yeL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access_txt = "6"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -92638,6 +92972,28 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgeryobs)
+"yhm" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "yhw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -124390,7 +124746,7 @@ chc
 bYQ
 chc
 chd
-cnC
+cep
 cqV
 cKO
 cep
@@ -127490,9 +127846,9 @@ cCW
 cxn
 ddw
 czg
-czg
+gfi
 sAi
-kcQ
+yhm
 cep
 cOT
 cQg
@@ -128779,7 +129135,7 @@ ahA
 cDf
 cKi
 cLO
-cBK
+cxO
 cQp
 aab
 cQp
@@ -129258,7 +129614,7 @@ can
 can
 bOF
 can
-can
+rda
 can
 bNz
 can
@@ -130317,7 +130673,7 @@ bLK
 cxx
 sEn
 cep
-chf
+cDm
 cep
 cjq
 cts
@@ -134697,9 +135053,9 @@ cED
 xmj
 tAb
 cHe
-lER
 chf
-cTQ
+chf
+chf
 chf
 ehQ
 cJv
@@ -134941,7 +135297,7 @@ kXD
 iEg
 txr
 wQK
-hYo
+kBK
 mjg
 cuQ
 rao
@@ -134954,9 +135310,9 @@ uAo
 rAi
 xRP
 chf
-chf
-chf
-chf
+ebS
+nyh
+jFf
 chf
 cyJ
 dxN
@@ -135208,8 +135564,8 @@ cuQ
 cuQ
 paW
 cyJ
-uAo
-xRP
+ogr
+xrV
 chf
 pak
 ukQ
@@ -135454,23 +135810,23 @@ cQk
 eeJ
 wGj
 bGG
-mRO
-kBK
+oYN
+hYo
 spH
-cuQ
+ulK
 sYT
 pio
 cBH
 cDg
 cuQ
-hnb
-kae
-ogr
-xrV
 chf
-cIc
-nyh
-qxc
+chf
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
 cBR
 cBR
 cBR
@@ -135703,7 +136059,7 @@ cpU
 oHl
 ctw
 cuK
-cwq
+xwg
 oVU
 cxD
 gkn
@@ -135720,15 +136076,15 @@ pKi
 smW
 soR
 cuQ
-cuQ
-cuQ
+bGG
+uCK
 cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+cJK
+cJK
+cJK
+tlj
+nET
+xRU
 fsR
 pZK
 iip
@@ -135980,12 +136336,12 @@ cuQ
 jxu
 dbg
 cBR
+gGQ
+taM
 cJK
-cJK
-cJK
-tlj
-nET
-tln
+vXT
+vLF
+cVf
 osI
 eoT
 cEH
@@ -136237,12 +136593,12 @@ xsC
 bGG
 cEE
 cBR
-gGQ
-taM
-cJK
-vXT
-vLF
-cEH
+cJL
+cMk
+cMk
+cIs
+jWg
+qKu
 cNr
 cEH
 cNh
@@ -136494,11 +136850,11 @@ tLJ
 fog
 qkC
 cBR
-cJL
-cMk
-cMk
-cIs
-jWg
+cxN
+smP
+cIb
+qKN
+icn
 qKu
 eYK
 cVf
@@ -136751,11 +137107,11 @@ cuQ
 upd
 cuQ
 cBR
-cxN
-smP
-cIb
-qKN
-icn
+cJK
+cJK
+cJK
+tif
+cJz
 vTk
 fSz
 dGR
@@ -137008,12 +137364,12 @@ lqd
 qHH
 eaO
 cBR
+gGQ
+taM
 cJK
-cJK
-cJK
-tif
-cJz
-qKu
+cIt
+vLF
+cEH
 spK
 mrK
 cEH
@@ -137265,12 +137621,12 @@ cuQ
 pUR
 bGG
 cBR
-gGQ
-taM
-cJK
-cIt
-vLF
-cEH
+dQM
+cMk
+cMk
+ivZ
+jWg
+qKu
 sHq
 aqF
 cNh
@@ -137522,11 +137878,11 @@ cQx
 qHH
 dgy
 cBR
-dQM
-cMk
-cMk
-ivZ
-jWg
+cxN
+cRY
+cMj
+cMI
+cZq
 qKu
 ndV
 sen
@@ -137779,11 +138135,11 @@ cuQ
 cLQ
 cLR
 cBR
-cxN
-cRY
-cMj
-cMI
-cZq
+cJK
+cJK
+cJK
+cMQ
+cZs
 vTk
 gqE
 umH
@@ -138036,12 +138392,12 @@ cuQ
 nHM
 cuQ
 cBR
+gGQ
+taM
 cJK
-cJK
-cJK
-cMQ
-cZs
-qKu
+cMJ
+vLF
+cEH
 qEJ
 urf
 cEH
@@ -138293,12 +138649,12 @@ lqd
 cLQ
 bKl
 cBR
-gGQ
-taM
-cJK
-cMJ
-vLF
-cEH
+iGI
+cMk
+cMk
+cNa
+fig
+qKu
 jKB
 xbd
 hlo
@@ -138550,13 +138906,13 @@ lqd
 cLQ
 oVH
 cBR
-iGI
-cMk
-cMk
-cNa
-fig
-vTk
-gqE
+cxN
+cxN
+cxN
+cxN
+cZt
+lUp
+lKO
 cEH
 cNh
 hTF
@@ -138565,7 +138921,7 @@ cBR
 cBR
 cBR
 cBR
-cBR
+chf
 jdP
 chf
 chf
@@ -138807,22 +139163,22 @@ cuQ
 cLQ
 bGG
 cBR
-cxN
-cxN
-cxN
-cxN
-cZt
-kaD
+cBR
+tAp
+xUK
+hqo
+cZy
+nqa
 vRY
 cEH
 tfN
 kiq
 cBR
 cJK
-cJK
 nIF
 cJK
 ecZ
+kMc
 kdc
 csL
 cDm
@@ -139056,8 +139412,8 @@ csv
 cGB
 cHA
 cIN
-bGG
-bGG
+bUI
+bUI
 cMS
 cNs
 cOp
@@ -139066,20 +139422,20 @@ bGG
 cQs
 cBR
 cSf
-xUK
-hqo
-cZy
-nqa
+cEH
+cEH
+bER
+oLS
 cKZ
 cVf
 hNp
 oDE
 iun
 fpG
-cJK
 fMb
 cJK
 cBR
+cQC
 dhR
 csL
 ciY
@@ -139326,7 +139682,7 @@ cSH
 cXA
 cEH
 cZv
-oLS
+nXu
 sqC
 pgX
 hEz
@@ -139335,7 +139691,7 @@ xUX
 tMx
 qKZ
 jIE
-nHi
+cBR
 jrt
 dMD
 aPn
@@ -139590,11 +139946,11 @@ hRc
 hOz
 iun
 dvM
-cJK
 tQn
 cJK
 cBR
-csL
+sFy
+dhR
 nMd
 ctq
 ciY
@@ -139789,7 +140145,7 @@ aYP
 bvg
 bHI
 cfy
-bte
+rKV
 bGK
 bNp
 bNp
@@ -139847,11 +140203,11 @@ tPD
 jPb
 cBR
 cJK
-cJK
 fET
 cJK
 ecZ
-cga
+bUx
+dFe
 csL
 ciY
 ciY
@@ -140046,7 +140402,7 @@ aYQ
 bvg
 bHI
 cfy
-qmE
+gLu
 bGL
 bPD
 bKi
@@ -140102,13 +140458,13 @@ cBR
 cBR
 cBR
 cBR
-boK
-jrt
-jrt
-jrt
-jrt
-vtS
-ePu
+cBR
+cBR
+cBR
+cBR
+cBR
+kMc
+nJm
 csL
 djP
 cQC
@@ -140304,8 +140660,8 @@ sUy
 tLN
 bIv
 flN
-bIv
-bIv
+rvD
+rvD
 ued
 bKx
 bMt
@@ -140351,7 +140707,7 @@ dnY
 cBR
 lCQ
 cWr
-qEJ
+kdP
 cNl
 cBR
 tlI
@@ -140365,7 +140721,7 @@ reO
 rCg
 ugC
 cga
-cga
+dFe
 hyk
 ePu
 hyk
@@ -140561,7 +140917,7 @@ bvg
 bHQ
 wjC
 tDg
-wjC
+vet
 bIo
 onM
 ncf
@@ -140622,7 +140978,7 @@ gPb
 ciY
 csL
 jPx
-ePu
+nJm
 ciY
 ciY
 ciY
@@ -140818,10 +141174,10 @@ bvg
 bHI
 bwv
 lRy
-bwv
-bwv
+nOo
+nOo
 gCJ
-bLW
+spl
 vOq
 sSQ
 fxD
@@ -140856,7 +141212,7 @@ svS
 spl
 hug
 exw
-mPV
+spl
 spl
 rKV
 yku
@@ -140879,7 +141235,7 @@ dup
 ciY
 ugC
 csL
-cpE
+afr
 ciY
 aaa
 ciY
@@ -141074,7 +141430,7 @@ aYQ
 bvg
 bHI
 cXh
-qmE
+gLu
 bGD
 bIy
 bKj
@@ -141136,7 +141492,7 @@ wUT
 ciY
 cQC
 csL
-hyk
+qdO
 cBQ
 aaa
 cBQ
@@ -141331,7 +141687,7 @@ aYP
 bFB
 bHI
 cXh
-bte
+rKV
 eER
 vGj
 vGj
@@ -141348,7 +141704,7 @@ dVG
 tjz
 tjz
 azG
-nNY
+ekQ
 qvV
 ekQ
 cmX
@@ -141375,7 +141731,7 @@ aab
 cBQ
 hcj
 puC
-hcj
+krV
 emy
 jmU
 ciY
@@ -141393,7 +141749,7 @@ dci
 ciY
 cQC
 csL
-csL
+dhR
 cBQ
 fpO
 cBQ
@@ -141583,7 +141939,7 @@ bcD
 bcD
 boJ
 boJ
-bjD
+qyq
 aYP
 xmi
 bHI
@@ -141650,7 +142006,7 @@ ugC
 cBe
 cga
 cga
-csL
+dhR
 dSu
 aaa
 ciY
@@ -141907,7 +142263,7 @@ uuH
 ePu
 hyk
 cga
-csL
+dhR
 ciY
 ciY
 ciY
@@ -142151,7 +142507,7 @@ mxA
 pnB
 fJa
 qEt
-csL
+fMi
 ciY
 csL
 cAd
@@ -142160,7 +142516,7 @@ ueT
 pAH
 sXX
 dIQ
-hlu
+ldn
 lko
 dIQ
 kJI
@@ -142410,8 +142766,8 @@ ciY
 eaT
 kmA
 hyf
-hlu
-hlu
+ldn
+ldn
 dIQ
 dIQ
 kmI
@@ -142426,7 +142782,7 @@ ePu
 ePu
 dkv
 isD
-isD
+csL
 jPw
 fqt
 lHw
@@ -142613,7 +142969,7 @@ aab
 aaa
 aaa
 bte
-bvh
+ree
 bHI
 cXh
 iAN
@@ -142912,7 +143268,7 @@ pCx
 cAP
 cLe
 fEI
-cLe
+pSb
 sSP
 cLb
 cLb
@@ -143155,11 +143511,11 @@ cuW
 cqb
 csV
 crB
-cuW
-gpq
-gpq
-gpq
-kfv
+nuO
+nXc
+nXc
+nXc
+yeH
 cAP
 cDH
 cFb
@@ -143431,8 +143787,8 @@ aab
 ciY
 iDg
 fbw
-cga
-emy
+fGT
+nBI
 tVF
 ciY
 ylP
@@ -143673,7 +144029,7 @@ cgs
 cgs
 tVF
 csL
-vJN
+uzh
 rSS
 cAP
 poC
@@ -143925,12 +144281,12 @@ iJf
 cqj
 cmQ
 csh
-clu
+qAo
 cuZ
 cgs
 kos
 csL
-vJN
+uzh
 ugC
 cAP
 cAP
@@ -144456,7 +144812,7 @@ lpu
 ciY
 ciY
 kos
-dia
+cga
 vJN
 ePu
 cga
@@ -144713,15 +145069,15 @@ ciY
 ciY
 uHX
 csL
-jdu
-oDe
+ugC
+opZ
 spr
-dIQ
-qoY
-xJJ
-xJJ
-cOm
-hHU
+gpq
+kfv
+cKF
+cKF
+csL
+ePu
 csL
 ciY
 dbi
@@ -144978,7 +145334,7 @@ rjh
 ciY
 cQw
 cQw
-hhD
+ePu
 csL
 ciY
 ciY
@@ -145193,7 +145549,7 @@ bmm
 wVi
 ciY
 csL
-cKF
+kgg
 ciY
 vBX
 cga
@@ -145235,7 +145591,7 @@ oBz
 xde
 ciY
 djP
-hhD
+ePu
 wew
 ciY
 odD
@@ -145450,7 +145806,7 @@ bmm
 bGJ
 ciY
 csL
-jcP
+yak
 ciY
 fAH
 mlv
@@ -145476,11 +145832,11 @@ rfn
 mON
 ciY
 csL
-cga
+fmn
 qth
 csL
 oXK
-eyh
+isD
 ciY
 hyk
 hyk
@@ -145489,10 +145845,10 @@ rMb
 csL
 psT
 fQI
-sbx
-fRN
-itP
-vCe
+csL
+cja
+djP
+ePu
 cDo
 ciY
 rfh
@@ -145736,7 +146092,7 @@ ciY
 csL
 awx
 jPZ
-cga
+fmn
 csL
 slp
 cga
@@ -145961,7 +146317,7 @@ oWE
 oWE
 enR
 bmm
-oMz
+jwu
 bmm
 bmm
 bEF
@@ -145976,8 +146332,8 @@ bES
 bES
 cgs
 kzo
-fDJ
 uid
+fDJ
 rAN
 fDJ
 fDJ
@@ -146001,9 +146357,9 @@ pTs
 cKE
 ciY
 kiF
-cDo
+hBu
 gRU
-xYr
+cpE
 cQw
 ciY
 ePu
@@ -146256,11 +146612,11 @@ ciY
 cKF
 uxB
 cQw
-jYQ
-qWu
+csL
+cga
 vlh
 wvD
-vZF
+dbX
 cga
 cQw
 hcj
@@ -146515,7 +146871,7 @@ ePu
 cja
 csL
 rbZ
-oGe
+ePu
 mJi
 pqA
 cIu
@@ -146724,11 +147080,11 @@ mxH
 bzs
 gWn
 gSE
-bEF
+nHv
 iek
 oWE
 gOd
-bEF
+nHv
 swk
 snH
 bSc
@@ -147542,7 +147898,7 @@ xmq
 csL
 sem
 sem
-fOY
+jgA
 vrA
 vMa
 pXY

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -40105,10 +40105,6 @@
 	name = "Morgue";
 	req_access_txt = "6"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -79874,14 +79870,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
-"mON" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "mPM" = (
 /obj/structure/fermenting_barrel,
 /turf/simulated/floor/wood{
@@ -80228,10 +80216,6 @@
 /turf/simulated/floor/noslip,
 /area/engine/engineering)
 "ngS" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "coroner"
 	},
@@ -85066,14 +85050,10 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "rek" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "coroner"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/medical/morgue)
 "rex" = (
@@ -85109,11 +85089,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -145832,7 +145807,7 @@ uDR
 cgs
 qCZ
 rfn
-mON
+csL
 ciY
 csL
 fmn

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -52096,8 +52096,8 @@
 	name = "Operating Theatre 3";
 	req_access_txt = "45"
 	},
-/obj/effect/spawner/random_barrier/obstruction,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "czb" = (
@@ -52132,7 +52132,6 @@
 /obj/structure/computerframe{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "czi" = (
@@ -76471,7 +76470,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Coldroom Maintenance";
-	req_one_access_txt = "5;32"
+	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78172,7 +78171,6 @@
 	},
 /area/maintenance/asmaint)
 "lHU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/sleeper{
 	dir = 2
 	},
@@ -90524,7 +90522,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Coldroom Maintenance";
-	req_one_access_txt = "5;32"
+	req_one_access_txt = "5;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -54683,11 +54683,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "cGi" = (
@@ -90676,6 +90671,9 @@
 	name = "east bump";
 	pixel_x = 28
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -92049,9 +92047,6 @@
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

A point because it applies as a blanket: Moves various pieces of wall furniture for easier reading/access

### Medbay

- Replaces random obstruction spawners with wooden barricades on OR 3
- Removes construction access from the internal medbay maintenance doors
- Removes construction access from the coldroom storage on the medbay facing side
- Replaces construction access on the coldroom storage maintenance side with atmospheric technician
- Tweaks dirt spawners in OR 3
- Changed the abandoned medical equipment storage to require medbay access instead of psychologist
- Adds an extra fire alarm below the coroner office
- Adds a medical intercom to medbay lobby
- Adds coroner access to the body disposal door, and makes it a reinforced windoor due to the speed of bodies ejected into it
- Adds morgue, paramedic's office and virology to medbay's quarantine lockdown
- Makes medbay treatment 2's APC in line with the rest of medbay regarding charge
- Adds a request console to Chemistry
- Adds another windoor to Chemistry for further security
- Gives Runtime a cat toy
- Replaces Viro's glass airlocks with solid airlocks for isolation rooms

### Science

- Re-areas science lobby to be science hallway instead of primary hallway (No player facing change)
- Adds a cell charger, scanning modules, AI status display and status display to Research and Development
- Adjust's robotics floor decals around the fabricators
- Adds Sci SOP to Experimentor, R&D, Genetics and Robotics
- Also adds Cyborg and Ripley manuals to Robotics, as well as AI status and regular status displays
- Connects the RD office door button with the door
- Changed the solid airlock to a glass airlock leading to the server room from the RD office
- Adds fire alarm to Sci chem and firelocks
- Renames the windoor in the test chamber from Research Delivery to Area control access
- Also adds camera viewing equipment for the test chamber when the blast doors are activated
- Adds intercom to genetics back room
- Adds requests console and status display to Genetics, re-arranges the location of the fire alarm so 2 aren't required almost side by side
- Adds a fire closet, a requests console, and experimentor guide to the Experimentor
- Adds a light switch to toxins mixing and a fire alarm to the launch room
- Made Xeno more aesthetic by adjusting the size of the kill room down by a tile, and shifting the top set of pens left one tile
   - This resulted in minor changes to the abandoned medical stuff in the maintenance beside
- Downsizes the amount of biohazard suits in Xenobio from 5 to 3
- Adds an intercom to the xenobio airlock
- Adds AI status and status displays to Xenobio
- Re-route's xeno's space disposal system to not run under walls but instead through maintenance
- Adds Biohazard lockdown to Experimentor, Xenobiology, and Genetics
- Adds a bell to Robotics desk, R&D, Medical reception and Chemistry

### Departures

- Adds a few more status displays
- Adds an intercom to Departures security
- Adds an emergency locker and an air cannister to departures maintenance

### Maintenance

- Removed the wiring set up for maintenance robotics to prevent accidental area shenanigans
    - Removed the air alarm in the weed room for the same reason
    - As well as the APC outside janitorial
    - Same with the fire alarm in maintenance medical
    - And the APC in Toxins EVA maintenance
- Adds cyborg analyzer to maintenance robotics
- Removed DISPOSALS TO SPACE from maintenance robotics
    - No disposals are present
- Adds finishing touches to maintenance bathroom
- Adds blast door controls for maintenance xenobiology
- Removed the wall under the freezer airlock and wooden barricade to the Kentucky Fried Vox room
- Adds a bell to the rage cage
- Adds firelocks to Turbine airlocks
- Relocates a fungus spawner to prevent what could be a bug where it overwrote the reinforced wall with a regular wall
- Connects the atmospherics maintenance room with the engineering checkpoint
- Adds 2 more maintenance power cable connections for both departments
   - This is done because each department only had one point of connection to the main power grid. These are still in maintenance and thus sabotageable
- Replaced a random obstruction spawner with a grille to ensure relative easy of movement by the engineering checkpoint

Fixes #18793 (to close the issue)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Oversights and whoopsies are bad.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

As most of these are small changes (or outright invisible as it's variables), I will post the bigger/notable ones here. MapDiffBot can show you the specifics if you want every nook and cranny.

Xenobio

![image](https://user-images.githubusercontent.com/16112919/184706862-3a792061-f6eb-4ab1-a401-f85238116004.png)

Morgue

![image](https://user-images.githubusercontent.com/16112919/184707035-ca5acaa9-2f6f-4667-93a3-52f5cd06784e.png)

Robotics reading

![image](https://user-images.githubusercontent.com/16112919/184707104-8d2ca553-44fa-421f-8d5f-79633b077807.png)

For Science's viewing pleasure

![image](https://user-images.githubusercontent.com/16112919/184707206-e8732767-7489-4a77-a8b9-3c731a327cd2.png)

Genetics adjustments

![image](https://user-images.githubusercontent.com/16112919/184707310-617f33a9-bf94-4630-ad31-8b066aa865ab.png)

Experiment safely

![image](https://user-images.githubusercontent.com/16112919/184707440-93d80cda-97b8-4465-81a6-c3cee216452e.png)

Atmos checkpoint connection

![image](https://user-images.githubusercontent.com/16112919/184707551-c39d04e4-4bb0-43ca-a45b-fcc9c356221e.png)

THE most important change in this PR:

![image](https://user-images.githubusercontent.com/16112919/184713079-f537e564-43e3-4d43-8ac8-36be27208ebb.png)

## Testing
<!-- How did you test the PR, if at all? -->
Loaded up local server
Checked OR 3
Checked access changes on doors in medical first as CE for the former construction access, then as CMO to ensure it still worked
Same with the stuff in the morgue
Activated quarantine lockdown to check doors
Became RD, checked on Biohazard control to ensure it worked as intended
Wandered maintenance, made sure there were no breaches/extraneous area equipment
Checked on departures to make sure changes applied there
Viewed runtimes to ensure nothing else occured

## Changelog
:cl:
tweak: Various mapping tweaks to Medical and Science on BoxStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
