### PR TITLE
Buffs the powerfist

### DIFF
--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -14,9 +14,8 @@
 	origin_tech = "combat=5;powerstorage=3;syndicate=3"
 	var/click_delay = 1.5
 	var/fisto_setting = 1
-	var/gasperfist = 3
+	var/gasperfist = 0.5 //original consumption mod was 3, for reference
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
-
 
 /obj/item/melee/powerfist/Destroy()
 	QDEL_NULL(tank)
@@ -66,7 +65,8 @@
 		if(!tank)
 			to_chat(user, "<span class='notice'>[src] currently has no tank attached to it.</span>")
 			return
-		to_chat(user, "<span class='notice'>You detach [thetank] from [src].</span>")
+		to_chat(user, "<span class='notice'>As you detach [thetank] from [src], the fist unlocks.</span>")
+		flags &= ~NODROP
 		tank.forceMove(get_turf(user))
 		user.put_in_hands(tank)
 		tank = null
@@ -76,9 +76,10 @@
 			return
 		if(!user.unEquip(thetank))
 			return
-		to_chat(user, "<span class='notice'>You hook [thetank] up to [src].</span>")
+		to_chat(user, "<span class='notice'>As you hook [thetank] up to [src], the fist locks into place around your arm.</span>")
 		tank = thetank
 		thetank.forceMove(src)
+		flags |= NODROP
 
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -14,7 +14,7 @@
 	origin_tech = "combat=5;powerstorage=3;syndicate=3"
 	var/click_delay = 1.5
 	var/fisto_setting = 1
-	var/gasperfist = 0.5 //original consumption mod was 3, for reference
+	var/gasperfist = 0.5
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
 
 /obj/item/melee/powerfist/Destroy()


### PR DESCRIPTION

## What Does This PR Do
Reduces powerfist gas consumption by 5/6ths.

Adds nodrop whenever a gas tank is inserted into the fist, removes nodrop when the tank is removed.
## Why It's Good For The Game

The powerfist is a fairly terrible traitor item, having some of the worst ammo efficiency of any weapon in the game. With a stock oxygen tank, you can use the fist's maximum setting only twice before running dry.

This PR aims to make the fist a bit more competitive as a damage dealer.

Additionally, nodrop was added at the request of Qwertytoforty.

## Testing
- Loaded test server
- Spawned fist
- Tested loading and unloading the fist. (works with both stock oxygen and plasma tanks)
- Beat numerous vox to death
- Fist works as intended

## Changelog
:cl:
tweak: Buffed the powerfist, lowering gas consumption and adding nodrop
/:cl:

