### PR TITLE
Maptick profiling

### DIFF
--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -4,17 +4,21 @@ SUBSYSTEM_DEF(profiler)
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	wait = 5 MINUTES
 	flags = SS_NO_TICK_CHECK
-	/// Time it took to fetch profile data (ms)
-	var/fetch_cost = 0
-	/// Time it took to write the file (ms)
-	var/write_cost = 0
+	/// Time it took to fetch normal profile data (ms)
+	var/nfetch_cost = 0
+	/// Time it took to write the normal file (ms)
+	var/nwrite_cost = 0
+	/// Time it took to fetch map profile data (ms)
+	var/mfetch_cost = 0
+	/// Time it took to write the map file (ms)
+	var/mwrite_cost = 0
 	/// Time it took to encode the data for redis (ms)
 	var/send_encode_cost = 0
 	/// Time it took to send the stuff down FFI for redis (ms)
 	var/send_ffi_cost = 0
 
 /datum/controller/subsystem/profiler/get_stat_details()
-	return "F:[round(fetch_cost, 1)]ms | W:[round(write_cost, 1)]ms | SE:[round(send_encode_cost, 1)]ms | SF:[round(send_ffi_cost, 1)]ms"
+	return "NF:[round(nfetch_cost, 1)]ms | NW:[round(nwrite_cost, 1)]ms | MF:[round(mfetch_cost, 1)]ms | MW:[round(mwrite_cost, 1)]ms | SE:[round(send_encode_cost, 1)]ms | SF:[round(send_ffi_cost, 1)]ms"
 
 /datum/controller/subsystem/profiler/Initialize()
 	if(!GLOB.configuration.general.enable_auto_profiler)
@@ -34,41 +38,73 @@ SUBSYSTEM_DEF(profiler)
 // You cant proc-call onto /world
 /datum/controller/subsystem/profiler/proc/StartProfiling()
 	world.Profile(PROFILE_START)
+	world.Profile(PROFILE_START, type = "sendmaps")
 
 /datum/controller/subsystem/profiler/proc/StopProfiling()
 	world.Profile(PROFILE_STOP)
+	world.Profile(PROFILE_STOP, type = "sendmaps")
 
 // Write the file while also cost tracking
 /datum/controller/subsystem/profiler/proc/DumpFile()
 	var/timer = TICK_USAGE_REAL
+
+	// FETCH PROC PROFILE //
+
 	// Fetch info
 	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")
-	fetch_cost = MC_AVERAGE(fetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
-	CHECK_TICK
+	nfetch_cost = MC_AVERAGE(nfetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	CHECK_TICK // this shouldnt sleep given its being called from fire() but ehhhhhhhhhhhhhhhh
+
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
-	var/json_file = file("[GLOB.log_directory]/profile.json")
+
+	var/njson_file = file("[GLOB.log_directory]/profile.json")
+
 	// Put it in a file
-	if(fexists(json_file))
-		fdel(json_file)
+	if(fexists(njson_file))
+		fdel(njson_file)
+
 	timer = TICK_USAGE_REAL
-	WRITE_FILE(json_file, current_profile_data)
-	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	WRITE_FILE(njson_file, current_profile_data)
+	nwrite_cost = MC_AVERAGE(nwrite_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+
+
+
+	// FETCH MAPTICK PROFILE //
+
+	// Fetch info
+	var/current_sendmaps_data = world.Profile(PROFILE_REFRESH, type = "sendmaps", format = "json")
+	mfetch_cost = MC_AVERAGE(mfetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	CHECK_TICK
+
+	var/mjson_file = file("[GLOB.log_directory]/profile.json")
+
+	// Put it in a file
+	if(fexists(mjson_file))
+		fdel(mjson_file)
+
+	timer = TICK_USAGE_REAL
+	WRITE_FILE(mjson_file, current_sendmaps_data)
+	mwrite_cost = MC_AVERAGE(mwrite_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+
 
 	// Send it down redis
-	if(SSredis.connected)
-		// Encode
-		timer = TICK_USAGE_REAL
+	if(!SSredis.connected)
+		return
 
-		var/list/ffi_data = list()
-		ffi_data["round_id"] = GLOB.round_id
-		// We dont have to JSON decode here. The other end can worry about a 2-layer decode.
-		// Performance matters on this end. It doesnt on the other end
-		ffi_data["profile_data"] = current_profile_data
-		var/ffi_string = json_encode(ffi_data)
-		send_encode_cost = MC_AVERAGE(send_encode_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	// Encode
+	timer = TICK_USAGE_REAL
 
-		// Now actually fire it off
-		timer = TICK_USAGE_REAL
-		SSredis.publish("profilerdaemon.input", ffi_string)
-		send_ffi_cost = MC_AVERAGE(send_ffi_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	var/list/ffi_data = list()
+	ffi_data["round_id"] = GLOB.round_id
+	// We dont have to JSON decode here. The other end can worry about a 2-layer decode.
+	// Performance matters on this end. It doesnt on the other end
+	ffi_data["profile_data"] = current_profile_data
+	ffi_data["sendmaps_data"] = current_sendmaps_data
+	var/ffi_string = json_encode(ffi_data)
+	send_encode_cost = MC_AVERAGE(send_encode_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+
+	// Now actually fire it off
+	timer = TICK_USAGE_REAL
+	SSredis.publish("profilerdaemon.input", ffi_string)
+	send_ffi_cost = MC_AVERAGE(send_ffi_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -77,7 +77,7 @@ SUBSYSTEM_DEF(profiler)
 	mfetch_cost = MC_AVERAGE(mfetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 	CHECK_TICK
 
-	var/mjson_file = file("[GLOB.log_directory]/profile.json")
+	var/mjson_file = file("[GLOB.log_directory]/map_profile.json")
 
 	// Put it in a file
 	if(fexists(mjson_file))


### PR DESCRIPTION
## What Does This PR Do
Adds maptick data to SSprofiler which will dump to a json file and the redis backend which I will update soon.

![image](https://user-images.githubusercontent.com/25063394/184475877-d3d4030c-0e68-40dd-acc6-66b15e44c8d2.png)

It has a lot of data, and while we cant precisely profile what types are taking it up, we can use this to see what parts taking the most of it, and then work around that.

![image](https://user-images.githubusercontent.com/25063394/184475916-8fa7f81f-d38d-42ca-a599-788023b4ddfd.png)

While the cost of this SS is high (relatively), its 5ms every 5 **minutes**, so its not much of an issue.

## Why It's Good For The Game
Having 120 players on a server drastically increases maptick, which decreases the amount of CPU for the rest of the server significantly. We now have about 20ms for the entire MC cycle, and this needs to be sorted out.

## Testing
- Spun it up
- Checked the JSON files
- Checked that it dispatched to redis

## Changelog
:cl:
add: Added maptick profiling
/:cl:
