### PR TITLE
Timer Type Tracking

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -579,6 +579,45 @@ GLOBAL_LIST_EMPTY(timers_by_type)
 	text += "</ul>"
 	usr << browse(text.Join(), "window=timerlog")
 
+/client/proc/debug_timers()
+	set name = "Debug Timers"
+	set category = "Debug"
+	set desc = "Shows currently active timers, grouped by callback"
+
+	var/list/timers = list()
+	for(var/id in SStimer.timer_id_dict)
+		var/datum/timedevent/T = SStimer.timer_id_dict[id]
+		var/cbtxt = "[T.callBack.delegate]"
+		if(cbtxt in timers)
+			timers[cbtxt]++
+		else
+			timers[cbtxt] = 1
+
+
+	var/list/sorted = sortTim(timers, cmp=/proc/cmp_numeric_dsc, associative = TRUE)
+	var/list/text = list("<h1>All active timers sorted by callback</h1>", "<ul>")
+	for(var/key in sorted)
+		text += "<li>[key] - [sorted[key]]</li>"
+
+	text += "</ul>"
+
+	var/list/timers2 = list()
+
+	for(var/datum/timedevent/T in SStimer.bucket_list)
+		var/cbtxt = "[T.callBack.delegate]"
+		if(cbtxt in timers2)
+			timers2[cbtxt]++
+		else
+			timers2[cbtxt] = 1
+
+	text += "<h1>All buckets, sorted by callback</h1><ul>"
+	var/list/sorted2 = sortTim(timers2, cmp=/proc/cmp_numeric_dsc, associative = TRUE)
+	for(var/key in sorted2)
+		text += "<li>[key] - [sorted2[key]]</li>"
+
+	text += "</ul>"
+	usr << browse(text.Join(), "window=timerdebug")
+
 
 /**
  * Create a new timer and insert it in the queue.

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -174,6 +174,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/dmapi_debug,
 	/client/proc/dmapi_log,
 	/client/proc/timer_log,
+	/client/proc/debug_timers,
 	))
 GLOBAL_LIST_INIT(admin_verbs_possess, list(
 	/proc/possess,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -173,6 +173,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	#endif
 	/client/proc/dmapi_debug,
 	/client/proc/dmapi_log,
+	/client/proc/timer_log,
 	))
 GLOBAL_LIST_INIT(admin_verbs_possess, list(
 	/proc/possess,


### PR DESCRIPTION
## What Does This PR Do
Allows us to track what types are creating the most timers

![image](https://user-images.githubusercontent.com/25063394/184509025-d9afe8fb-34cf-45c3-aa66-37df29d3a527.png)

## Why It's Good For The Game
This will be useful for figuring out what creates so many timers.
![image](https://user-images.githubusercontent.com/25063394/184504228-2f739326-443a-43a3-9fd2-10d4f6a65988.png)

Pink line is how many timers exist in the server at any given moment, not only is it incredibly spiky, but this many timers being in the bucket causes **severe** lag issues.

![image](https://user-images.githubusercontent.com/25063394/184504253-ebde4388-e745-4d2a-bb93-96c7a32b9fb9.png)

I hate this, and it needs working out.

## Testing
- Start server
- Press button

## Changelog
:cl: AffectedArc07
add: Added a way to track what generates timers
/:cl:
