### PR TITLE
Refactors ants. Yes, ants.

### DIFF
--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -36,6 +36,8 @@
 	return ..()
 
 /obj/item/reagent_containers/food/process()
+	if(!antable)
+		return PROCESS_KILL
 	if(world.time > last_ant_time + 5 MINUTES)
 		check_for_ants()
 
@@ -44,9 +46,6 @@
 	..()
 
 /obj/item/reagent_containers/food/proc/check_for_ants()
-	if(!antable)
-		return
-
 	var/turf/T = get_turf(src)
 	if(isturf(loc) && !locate(/obj/structure/table) in T)
 		if(ant_location == T)

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -15,7 +15,8 @@
 	var/can_taste = TRUE//whether you can taste eating from this
 	var/antable = TRUE // Will ants come near it?
 	var/ant_location = null
-	var/ant_timer = null
+	/// Time we last checked for ants
+	var/last_ant_time = 0
 	resistance_flags = FLAMMABLE
 	container_type = INJECTABLE
 
@@ -24,14 +25,19 @@
 	pixel_x = rand(-5, 5) //Randomizes postion
 	pixel_y = rand(-5, 5)
 	if(antable)
+		START_PROCESSING(SSobj, src)
 		ant_location = get_turf(src)
-		ant_timer = addtimer(CALLBACK(src, .proc/check_for_ants), 3000, TIMER_STOPPABLE)
+		last_ant_time = world.time
 
 /obj/item/reagent_containers/food/Destroy()
 	ant_location = null
-	if(ant_timer)
-		deltimer(ant_timer)
+	if(isprocessing)
+		STOP_PROCESSING(SSobj, src)
 	return ..()
+
+/obj/item/reagent_containers/food/process()
+	if(world.time > last_ant_time + 5 MINUTES)
+		check_for_ants()
 
 /obj/item/reagent_containers/food/set_APTFT()
 	set hidden = TRUE
@@ -40,6 +46,7 @@
 /obj/item/reagent_containers/food/proc/check_for_ants()
 	if(!antable)
 		return
+
 	var/turf/T = get_turf(src)
 	if(isturf(loc) && !locate(/obj/structure/table) in T)
 		if(ant_location == T)
@@ -49,10 +56,7 @@
 					antable = FALSE
 					desc += " It appears to be infested with ants. Yuck!"
 					reagents.add_reagent("ants", 1) // Don't eat things with ants in it you weirdo.
-					if(ant_timer)
-						deltimer(ant_timer)
 		else
 			ant_location = T
-	if(ant_timer)
-		deltimer(ant_timer)
-	ant_timer = addtimer(CALLBACK(src, .proc/check_for_ants), 3000, TIMER_STOPPABLE)
+
+	last_ant_time = world.time


### PR DESCRIPTION
## What Does This PR Do
Refactors ants to use their own processing with a time check on SSobj instead of creating hundreds of timers.

Before:
![image](https://user-images.githubusercontent.com/25063394/184518584-3798860a-5b66-4bea-a160-0d5df5e74136.png)

After:
![image](https://user-images.githubusercontent.com/25063394/184518587-f95824c6-666e-4c5f-90df-c557ed94dcbd.png)


<details>
<summary>Why creating 1000 timers every 5 minutes is bad</summary>

Currently, ants use timer callbacks, which are set to recursively check for ants every 5 minutes. This is a major issue due to how timer buckets work.

![image](https://user-images.githubusercontent.com/25063394/184515205-6c890313-97a3-4638-99f0-4b05b3014580.png)

The pink lines here are the amount of timers in the bucket. As you can see, this spikes a lot when it really shouldn't, but thats not the major issue.

The timer system "bucket" can be seen as sequential queue list, where timers at the front of the list run a lot faster than timers at the back of the list. When this list is huge, adding in a timer can take a **very** long time, as seen in the graph below.

![image](https://user-images.githubusercontent.com/25063394/184515240-b0c349ab-0df0-4d68-a673-c8ff2ce75342.png)

The better solution here is to just use a subsystem, like I am doing here.
</details>

## Why It's Good For The Game
Performance good

## Testing
- Started local server
- Spawned food
- Waited for breakpoint

## Changelog
:cl: AffectedArc07
add: Added performance
/:cl:
