### PR TITLE
Set light power based on switch state on init, and turn off lights of most areas without crew spawns by default.

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -6887,7 +6887,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -9803,7 +9805,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -19816,7 +19820,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/cryopod{
 	dir = 4
@@ -20270,7 +20276,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/item/clothing/head/bearpelt,
 /obj/item/folder/documents,
@@ -26769,7 +26777,9 @@
 /obj/item/clothing/mask/breath,
 /obj/machinery/light_switch{
 	name = "north bump";
-	pixel_y = 24
+	pixel_y = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
@@ -28943,7 +28953,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -29038,7 +29050,9 @@
 "bsW" = (
 /obj/machinery/light_switch{
 	name = "north bump";
-	pixel_y = 24
+	pixel_y = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -29917,7 +29931,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -34014,7 +34030,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -38451,7 +38469,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -38520,7 +38540,9 @@
 	},
 /obj/machinery/light_switch{
 	name = "north bump";
-	pixel_y = 24
+	pixel_y = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/structure/dresser,
 /obj/machinery/power/apc{
@@ -38941,7 +38963,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -39939,7 +39963,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room South";
@@ -40598,7 +40624,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40764,7 +40792,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -42972,7 +43002,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/camera{
 	c_tag = "Messaging Server";
@@ -43010,7 +43042,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -46545,7 +46579,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -50377,7 +50413,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50938,7 +50976,9 @@
 "cvZ" = (
 /obj/machinery/light_switch{
 	name = "north bump";
-	pixel_y = 24
+	pixel_y = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -51294,7 +51334,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51469,7 +51509,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -52527,7 +52567,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -52977,7 +53017,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -53553,7 +53595,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -54836,7 +54880,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -55359,7 +55405,7 @@
 	dir = 4;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -56604,7 +56650,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -57785,7 +57833,7 @@
 	input_tag = "tox_in";
 	name = "Toxin Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -57859,7 +57907,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/machinery/vending/engidrobe,
 /turf/simulated/floor/plasteel,
@@ -59456,7 +59506,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor"="Tank")
+	sensors = list("waste_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -61098,7 +61148,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -61863,7 +61913,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
@@ -62170,7 +62222,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/machinery/camera{
@@ -63364,7 +63418,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -64108,7 +64162,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -64235,7 +64291,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -64263,7 +64319,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -64294,7 +64350,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -66944,7 +67000,9 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -68549,7 +68607,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
@@ -69332,7 +69392,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -87393,7 +87455,9 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -88612,7 +88676,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1222;
 	name = "Bomb Mix Monitor";
-	sensors = list("burn_sensor"="Burn Mix")
+	sensors = list("burn_sensor" = "Burn Mix")
 	},
 /obj/machinery/door_control{
 	id = "ToxinsVenting";
@@ -89257,7 +89321,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -7;
 	pixel_y = 24;
-	name = "custom placement"
+	name = "custom placement";
+	on = 0;
+	icon_state = "light0"
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -92391,7 +92457,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	on = 0;
+	icon_state = "light0"
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -43,8 +43,7 @@
 		if(!name)
 			name = "light switch([area.name])"
 
-		src.on = src.area.lightswitch
-		update_icon(UPDATE_ICON_STATE)
+		toggle_on_off_state(on)
 
 /obj/machinery/light_switch/Initialize()
 	..()
@@ -82,13 +81,8 @@
 	. = ..()
 	. += "A light switch. It is [on ? "on" : "off"]."
 
-/obj/machinery/light_switch/attack_ghost(mob/user)
-	if(user.can_advanced_admin_interact())
-		return attack_hand(user)
-
-/obj/machinery/light_switch/attack_hand(mob/user)
-	on = !on
-	playsound(src, 'sound/machines/lightswitch.ogg', 10, TRUE)
+/obj/machinery/light_switch/proc/toggle_on_off_state(new_state)
+	on = new_state
 	update_icon(UPDATE_ICON_STATE)
 
 	if(light_connect)
@@ -104,6 +98,14 @@
 			L.update_icon(UPDATE_ICON_STATE)
 
 		area.power_change()
+
+/obj/machinery/light_switch/attack_ghost(mob/user)
+	if(user.can_advanced_admin_interact())
+		return attack_hand(user)
+
+/obj/machinery/light_switch/attack_hand(mob/user)
+	toggle_on_off_state(!on)
+	playsound(src, 'sound/machines/lightswitch.ogg', 10, TRUE)
 
 /obj/machinery/light_switch/proc/handle_output()
 	if(!radio_connection)		//can't output without this


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

1. Changes light switches to update their state on Initialize based on the initial value of `on`.
2. Modifies station maps so that areas that start with no crew spawners start with their light switches off.

The map change is automated.

### Affected Areas
```
/area/ai_monitored/storage/eva
/area/assembly/assembly_line
/area/assembly/chargebay
/area/civilian/pet_store
/area/construction
/area/crew_quarters/captain/bedroom
/area/crew_quarters/mrchangs
/area/crew_quarters/sleep
/area/engine/controlroom
/area/engine/equipmentstorage
/area/engine/gravitygenerator
/area/medical/cmostore
/area/medical/surgery
/area/quartermaster/storage
/area/security/checkpoint2
/area/security/interrogation
/area/security/nuke_storage
/area/security/range
/area/security/securearmoury
/area/security/vacantoffice
/area/server
/area/storage/emergency2
/area/storage/office
/area/storage/secure
/area/storage/tech
/area/storage/tools
/area/teleporter
/area/toxins/explab_chamber
/area/toxins/launch
/area/toxins/server
/area/toxins/storage
```

### Ignored Areas

Ignored areas include areas with crew spawns, the AI sat, most of the brig, all hallways, the bridge and bridge meeting room, all atmos areas, areas around the engine, and others.

```
/area/aisat
/area/aisat/entrance
/area/aisat/maintenance
/area/atmos
/area/atmos/control
/area/atmos/distribution
/area/bridge
/area/bridge/meeting_room
/area/engine/engine_smes
/area/engine/engineering
/area/engine/hardsuitstorage
/area/hallway/primary/aft
/area/hallway/primary/central/east
/area/hallway/primary/central/ne
/area/hallway/primary/central/north
/area/hallway/primary/central/nw
/area/hallway/primary/central/se
/area/hallway/primary/central/south
/area/hallway/primary/central/sw
/area/hallway/primary/central/west
/area/hallway/primary/fore
/area/hallway/primary/port
/area/hallway/primary/starboard/east
/area/hallway/primary/starboard/west
/area/hallway/secondary/entry
/area/hallway/secondary/exit
/area/hallway/secondary/garden
/area/maintenance/abandonedbar
/area/maintenance/aft
/area/maintenance/aft2
/area/maintenance/apmaint
/area/maintenance/apmaint2
/area/maintenance/asmaint
/area/maintenance/asmaint2
/area/maintenance/auxsolarport
/area/maintenance/auxsolarstarboard
/area/maintenance/disposal
/area/maintenance/electrical
/area/maintenance/fore
/area/maintenance/fpmaint
/area/maintenance/fpmaint2
/area/maintenance/fsmaint
/area/maintenance/incinerator
/area/maintenance/maintcentral
/area/maintenance/port
/area/maintenance/portsolar
/area/maintenance/starboardsolar
/area/maintenance/storage
/area/maintenance/turbine
/area/security/brig
/area/security/evidence
/area/security/permabrig
/area/security/prison/cell_block/A
/area/security/prisonlockers
/area/security/processing
/area/shuttle/arrival/station
/area/shuttle/gamma/station
/area/shuttle/pod_1
/area/shuttle/pod_2
/area/shuttle/pod_3
/area/shuttle/pod_4
/area/space
/area/space/nearstation
/area/toxins/test_area
/area/turret_protected/ai
/area/turret_protected/ai_upload
/area/turret_protected/aisat_interior
```

Neither courtroom nor gateway have light switches.

## Why It's Good For The Game

There's been a lot of changes made recently to create a more immersive atmosphere in game, such as new light bulb behavior in emergencies and glowing vendor/wall bumps. I think this is a good change to compliment those. In rooms that start with no external light sources, this adds a tiny bit of tension to entering the rooms.

There's two other considerations, the AI, and antags. Many areas such as gravgen are now pitch-black, which is a boon to antags and a bane for AIs. It will now be much harder for AIs to spot things happening in unused areas by default. AIs can toggle camera lights but that's not a localized action, and I'm not really sure I see AI often using it, so I'm not sure how to approach that.

Maybe we want every room to have at least one, incredibly small, light source?

Also maybe gravgen should generate some kind of light on its own? It is a giant green glowing ball most of the time.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![Paradise Station 13-19_17_47](https://user-images.githubusercontent.com/59303604/184516451-6ee64cb5-8cbf-4fe2-afdd-0b7524259c98.png)
![Paradise Station 13-19_17_55](https://user-images.githubusercontent.com/59303604/184516452-09312854-5b8f-4305-b4d8-46878e5cc348.png)
![Paradise Station 13-19_18_40](https://user-images.githubusercontent.com/59303604/184516453-c4963924-736a-4024-92d6-7d310fc3d204.png)
![Paradise Station 13-19_18_44](https://user-images.githubusercontent.com/59303604/184516454-148624be-1084-4748-bc01-9484a4985c0a.png)
![Paradise Station 13-19_19_06](https://user-images.githubusercontent.com/59303604/184516455-e4f32719-2d58-49cd-aab8-5a03e08ad4c0.png)
![Paradise Station 13-19_19_15](https://user-images.githubusercontent.com/59303604/184516456-767387c1-bbb6-4149-8b44-ef6fc0ccc9b2.png)
![Paradise Station 13-19_21_06](https://user-images.githubusercontent.com/59303604/184516457-bd6fee2a-f8c8-483e-aacc-4addd16e8b51.png)
![Paradise Station 13-19_17_00](https://user-images.githubusercontent.com/59303604/184516458-f43eb534-69d8-4a80-ac71-946dcb0467bb.png)
![Paradise Station 13-19_17_07](https://user-images.githubusercontent.com/59303604/184516459-3601a783-4658-4037-94bb-281c6df0ba5f.png)
![Paradise Station 13-19_17_15](https://user-images.githubusercontent.com/59303604/184516460-3d419f65-3ce2-409a-9ee5-9f27809e387d.png)
![Paradise Station 13-19_17_36](https://user-images.githubusercontent.com/59303604/184516461-1111594f-0501-4a59-98e2-d2b295942d37.png)
![Paradise Station 13-19_17_40](https://user-images.githubusercontent.com/59303604/184516462-feb438ed-68e0-4900-9da9-54e2d79aa118.png)


## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Areas without crew spawns have their lights turned off at round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
