### PR TITLE
Makes defib shocks dangerous

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -473,10 +473,10 @@
 
 						SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 						if(ishuman(H.pulledby)) // for some reason, pulledby isnt a list despite it being possible to be pulled by multiple people
-							excess_shock(H, H.pulledby)
+							excess_shock(user, H, H.pulledby)
 						for(var/obj/item/grab/G in H.grabbed_by)
 							if(ishuman(G.assailant))
-								excess_shock(H, G.assailant)
+								excess_shock(user, H, G.assailant)
 
 						H.med_hud_set_health()
 						H.med_hud_set_status()
@@ -510,10 +510,14 @@
 		update_icon(UPDATE_ICON_STATE)
 
 /*
+user = the person using the defib
 origin = person being revived
 affecting = person being shocked with excess energy from the defib (not neccessarily the defib user)
 */
-/obj/item/twohanded/shockpaddles/proc/excess_shock(mob/living/carbon/human/origin, mob/living/carbon/human/affecting)
+/obj/item/twohanded/shockpaddles/proc/excess_shock(mob/user, mob/living/carbon/human/origin, mob/living/carbon/human/affecting)
+	if(user == affecting)
+		return
+
 	if(electrocute_mob(affecting, defib.cell, origin)) // shock anyone touching them >:)
 		var/obj/item/organ/internal/heart/HE = affecting.get_organ_slot("heart")
 		if(HE.parent_organ == "chest" && affecting.has_both_hands()) // making sure the shock will go through their heart (drask hearts are in their head), and that they have both arms so the shock can cross their heart inside their chest

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -510,9 +510,9 @@
 		update_icon(UPDATE_ICON_STATE)
 
 /*
-user = the person using the defib
-origin = person being revived
-affecting = person being shocked with excess energy from the defib (not neccessarily the defib user)
+ * user = the person using the defib
+ * origin = person being revived
+ * affecting = person being shocked with excess energy from the defib
 */
 /obj/item/twohanded/shockpaddles/proc/excess_shock(mob/user, mob/living/carbon/human/origin, mob/living/carbon/human/affecting)
 	if(user == affecting)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -516,7 +516,7 @@ affecting = person being shocked with excess energy from the defib (not neccessa
 /obj/item/twohanded/shockpaddles/proc/excess_shock(mob/living/carbon/human/origin, mob/living/carbon/human/affecting)
 	if(electrocute_mob(affecting, defib.cell, origin)) // shock anyone touching them >:)
 		var/obj/item/organ/internal/heart/HE = affecting.get_organ_slot("heart")
-		if(prob(5) && HE.parent_organ == "chest" && affecting.has_both_hands()) // Random chance, making sure the shock will go through their heart (drask hearts are in their head), and that they have both arms so the shock can cross their heart
+		if(HE.parent_organ == "chest" && affecting.has_both_hands()) // making sure the shock will go through their heart (drask hearts are in their head), and that they have both arms so the shock can cross their heart inside their chest
 			affecting.visible_message("<span class='danger'>[affecting]'s entire body shakes as a shock travels up their arm!</span>", \
 							"<span class='userdanger'>You feel a powerful shock travel up your [affecting.hand ? affecting.get_organ("l_arm") : affecting.get_organ("r_arm")] and back down your [affecting.hand ? affecting.get_organ("r_arm") : affecting.get_organ("l_arm")]!</span>")
 			affecting.set_heartattack(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Anyone pulling/grabbing anybody that is getting successfully revived with a defib will be shocked and may stop their heart. Notably, Drasks do not have their hearts in their chest and cannot be killed via excess shock stopping their heart. This only applies to the big blue defibs and only occurs when a body is being brought back from the dead.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->It makes the game more immersive, and more likely to introduce roleplay with doctors shouting "Clear!" and such.

## Testing
<!-- How did you test the PR, if at all? -->
Ran on local test server, grabbed and pulled a bunch of skrells while they were being revived, I eventually got shocked and suffered a heart attack. Tried to get 

## Changelog
:cl:
add: Grabbing or pulling a dead body while its being defibrillated back to life with a large blue defib will shock you if you are not the one defibrillating them.
add: Being shocked from excess energy from a defibrillator will stop your heart if its in your chest
tweak: Cyborg's defibrillators now have special anti-shock technology that will prevent any excess shocking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
