### PR TITLE
Sanity check for circuit boards without build_path

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -551,6 +551,10 @@
 				to_chat(user, "<span class='warning'>[src] does not accept circuit boards of this type!</span>")
 				return
 
+			if(!B.build_path)
+				to_chat(user, "<span class='warning'>This is not a functional computer circuit board!</span>")
+				return
+
 			B.play_tool_sound(src)
 			to_chat(user, "<span class='notice'>You place [B] inside [src].</span>")
 			name += " ([B.board_name])"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -99,6 +99,9 @@
 			if(istype(P, /obj/item/circuitboard))
 				var/obj/item/circuitboard/B = P
 				if(B.board_type == "machine")
+					if(!B.build_path)
+						to_chat(user, "<span class='warning'>This is not a functional machine board!</span>")
+						return
 					playsound(src.loc, B.usesound, 50, 1)
 					to_chat(user, "<span class='notice'>You add the circuit board to the frame.</span>")
 					circuit = P


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently, if you acquire a `circuitboard` without a `build_path`, it will runtime upon attempted construction. As far as I can tell, the only circuit boards that are missing `build_path` right now are the ones acquired from malfunctioning combat drones.
However, it's probably good to have this check just in case for future.

Users will now fail to insert an invalid circuit board into a console/machine frame and get a message informing them the action has failed.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One less possible runtime and less confusion on user end thanks to improved feedback.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in.
Acquired malfunctioning combat drones circuit boards.
Failed to insert the boards into a console, received expected error message.
Acquired circuit boards with proper `build_path` variables.
Built the consoles without any issues.

Repeated the steps with combat drones circuits var edited to be machine boards, since I'm not aware of any without a `build_path`.
Same results.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Can no longer build consoles without a valid build_path
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
