### PR TITLE
More positions for body scanners and sleepers when using a wrench

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -12,7 +12,6 @@
 	density = TRUE
 	anchored = TRUE
 	dir = WEST
-	var/orient = "LEFT" // "RIGHT" changes the dir suffix to "-r"
 	var/mob/living/carbon/human/occupant = null
 	var/possible_chems = list("ephedrine", "salglu_solution", "salbutamol", "charcoal")
 	var/emergency_chems = list("ephedrine") // Desnowflaking
@@ -383,12 +382,20 @@
 	if(panel_open)
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 		return
-	if(dir == EAST)
-		orient = "LEFT"
-		setDir(WEST)
-	else
-		orient = "RIGHT"
-		setDir(EAST)
+
+	switch(dir)
+		if(EAST)
+			setDir(SOUTH)
+			return
+		if(SOUTH)
+			setDir(WEST)
+			return
+		if(WEST)
+			setDir(NORTH)
+			return
+		else
+			setDir(EAST)
+			return
 
 /obj/machinery/sleeper/ex_act(severity)
 	if(filtering)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -383,19 +383,7 @@
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 		return
 
-	switch(dir)
-		if(EAST)
-			setDir(SOUTH)
-			return
-		if(SOUTH)
-			setDir(WEST)
-			return
-		if(WEST)
-			setDir(NORTH)
-			return
-		else
-			setDir(EAST)
-			return
+	setDir(turn(dir, -90))
 
 /obj/machinery/sleeper/ex_act(severity)
 	if(filtering)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -103,19 +103,8 @@
 	if(panel_open)
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 		return
-	switch(dir)
-		if(EAST)
-			setDir(SOUTH)
-			return
-		if(SOUTH)
-			setDir(WEST)
-			return
-		if(WEST)
-			setDir(NORTH)
-			return
-		else
-			setDir(EAST)
-			return
+
+	setDir(turn(dir, -90))
 
 /obj/machinery/bodyscanner/MouseDrop_T(mob/living/carbon/human/H, mob/user)
 	if(!istype(H))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -103,10 +103,19 @@
 	if(panel_open)
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 		return
-	if(dir == EAST)
-		setDir(WEST)
-	else
-		setDir(EAST)
+	switch(dir)
+		if(EAST)
+			setDir(SOUTH)
+			return
+		if(SOUTH)
+			setDir(WEST)
+			return
+		if(WEST)
+			setDir(NORTH)
+			return
+		else
+			setDir(EAST)
+			return
 
 /obj/machinery/bodyscanner/MouseDrop_T(mob/living/carbon/human/H, mob/user)
 	if(!istype(H))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #18797
Makes sleepers and body scanners use all four sprites when a wrench is applied to them.
Removes a vestigial variable, `orient`, which wasn't actually doing anything.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Someone was bothered by it enough to write a bug report. More options is generally a good thing, too.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in.
Used a wrench on both machines.
Confirmed both rotate properly.
Successfully put a grey into both machines in all four positions.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Wrenches can now make sleepers and body scanners face north and south.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
