### PR TITLE
Buffs His Grace

### DIFF
--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -96,7 +96,7 @@
 		drowse()
 		return
 	if(bloodthirst < HIS_GRACE_CONSUME_OWNER && !ascended)
-		adjust_bloodthirst(0.5 + FLOOR(length(contents) * 0.25, 1)) //Maybe adjust this?
+		adjust_bloodthirst(0.5 + FLOOR(length(contents) * 0.25, 1))
 	else
 		adjust_bloodthirst(0.5) //don't cool off rapidly once we're at the point where His Grace consumes all.
 	var/mob/living/master = get_atom_on_turf(src, /mob/living)

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -14,7 +14,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	w_class = WEIGHT_CLASS_GIGANTIC
-	force = 12
+	force = 15
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
 	drop_sound = 'sound/items/handling/toolbox_drop.ogg'
@@ -96,9 +96,9 @@
 		drowse()
 		return
 	if(bloodthirst < HIS_GRACE_CONSUME_OWNER && !ascended)
-		adjust_bloodthirst(1 + FLOOR(length(contents) * 0.5, 1)) //Maybe adjust this?
+		adjust_bloodthirst(0.5 + FLOOR(length(contents) * 0.25, 1)) //Maybe adjust this?
 	else
-		adjust_bloodthirst(1) //don't cool off rapidly once we're at the point where His Grace consumes all.
+		adjust_bloodthirst(0.5) //don't cool off rapidly once we're at the point where His Grace consumes all.
 	var/mob/living/master = get_atom_on_turf(src, /mob/living)
 	var/list/held_items = list()
 	if(istype(master))


### PR DESCRIPTION

## What Does This PR Do
Buffs His Grace, greatly increasing the death timer on it, and slightly buffing its damage.

## Why It's Good For The Game
At its current state, it is nigh-impossible to reach ascension as the bloodthirst timer simply ticks down too fast.

Now, while the timer still increases rapidly near ascension, it is far more lenient to begin with, giving players some needed room for error.

The damage was buffed to put it in line with the traitor toolbox, and because numbers divisible by 5 make me happy.

## Testing
- Loaded into test server
- Spawned the funny toolbox
- Beat numerous vox to death
- Countdown is now nice and slow to start with, still fast once you go into the double digits
## Changelog
:cl:
tweak: Buffed his grace, increasing his timer and damage
/:cl: