### PR TITLE
Chainsaw attempted surgery exploit fix

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -617,6 +617,8 @@
 		icon_state = "chainsaw0"
 
 /obj/item/twohanded/chainsaw/attack(mob/living/target, mob/living/user)
+	if(can_operate(target) && (user.a_intent == INTENT_HELP))
+		return ..()
 	if(wielded)
 		playsound(loc, 'sound/weapons/chainsaw.ogg', 100, 1, -1) //incredibly loud; you ain't goin' for stealth with this thing. Credit to Lonemonk of Freesound for this sound.
 		if(isrobot(target))

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -617,7 +617,7 @@
 		icon_state = "chainsaw0"
 
 /obj/item/twohanded/chainsaw/attack(mob/living/target, mob/living/user)
-	if(can_operate(target) && (user.a_intent == INTENT_HELP))
+	if(can_operate(target) && (user.a_intent == INTENT_HELP)) // stops you from triggering STATUS_EFFECT_CHAINSAW_SLAYING if you are trying to operate on a valid mob
 		return ..()
 	if(wielded)
 		playsound(loc, 'sound/weapons/chainsaw.ogg', 100, 1, -1) //incredibly loud; you ain't goin' for stealth with this thing. Credit to Lonemonk of Freesound for this sound.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #18787
Not sure if it's the best way to handle that, but it's definitely better than letting another chainsaw-related exploit to exist.
Surgery steps with a chainsaw will be silent, but I'm pretty sure they always were.
~An alternative would be removing the chainsaw from the surgery tools list, since it's horribly ineffective and basically serves as nothing more than a joke.~ This won't work, since starting surgery is tied to the chainsaw being sharp, not being a surgery tool.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is completely unintended and definitely should be considered an exploit.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in with a bunch of greys and a roller bed.
Killed a standing grey using a Syndicate chainsaw on all four intents.
Buckled another grey to a roller bed.
Could perform surgery on help intent, both wielded and unwielded.
Could attack on the other three intents and successfully butchered the buckled grey on harm intent.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Syndicate chainsaw no longer gives its buff when attempting to surgically operate on a target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
