### PR TITLE
Moves chainsaw buff application to afterattack()

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -122,7 +122,6 @@
 				add_splatter_floor(location)
 				if(get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
 					user.add_mob_blood(src)
-		return TRUE //successful attack
 
 /mob/living/simple_animal/attacked_by(obj/item/I, mob/living/user)
 	if(!I.force)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -617,20 +617,23 @@
 		icon_state = "chainsaw0"
 
 /obj/item/twohanded/chainsaw/attack(mob/living/target, mob/living/user)
+	. = ..()
 	if(wielded)
 		playsound(loc, 'sound/weapons/chainsaw.ogg', 100, 1, -1) //incredibly loud; you ain't goin' for stealth with this thing. Credit to Lonemonk of Freesound for this sound.
-		if(isnull(..())) //necessary check, successful attacks return null, without it target will drop any shields they may have before they get a chance to block
+		if(isnull(.)) //necessary check, successful attacks return null, without it target will drop any shields they may have before they get a chance to block
 			target.KnockDown(8 SECONDS)
-	return
 
 /obj/item/twohanded/chainsaw/afterattack(mob/living/target, mob/living/user, proximity)
 	if(!proximity) //only works on adjacent targets, no telekinetic chainsaws
 		return
-	if(wielded)
-		if(!isliving(target)) //no buff from attacking inanimate objects
-			return
-		if(target.stat != DEAD) //no buff from attacking dead targets
-			user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
+	if(!wielded)
+		return
+	if(isrobot(target)) //no buff from attacking robots
+		return
+	if(!isliving(target)) //no buff from attacking inanimate objects
+		return
+	if(target.stat != DEAD) //no buff from attacking dead targets
+		user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
 	return
 
 /obj/item/twohanded/chainsaw/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -619,20 +619,18 @@
 /obj/item/twohanded/chainsaw/attack(mob/living/target, mob/living/user)
 	if(wielded)
 		playsound(loc, 'sound/weapons/chainsaw.ogg', 100, 1, -1) //incredibly loud; you ain't goin' for stealth with this thing. Credit to Lonemonk of Freesound for this sound.
-		if(isrobot(target))
-			..()
-			return
-		if(!isliving(target))
-			return
-		else
-			if(target.stat != DEAD)
-				user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
-			if(isnull(..())) // attack returns null if the attack was successful, (against humans)
-				target.KnockDown(8 SECONDS)
+		target.KnockDown(8 SECONDS)
+	return ..()
+
+/obj/item/twohanded/chainsaw/afterattack(mob/living/target, mob/living/user, proximity)
+	if(!proximity) //only works on adjacent targets, no telekinetic chainsaws
 		return
-	else
-		playsound(loc, "swing_hit", 50, 1, -1)
-		return ..()
+	if(wielded)
+		if(isrobot(target) || !isliving(target)) //no buff from attacking robots or inanimate objects
+			return
+		if(target.stat != DEAD) //no buff from attacking dead targets
+			user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
+	return
 
 /obj/item/twohanded/chainsaw/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -634,7 +634,6 @@
 		return
 	if(target.stat != DEAD) //no buff from attacking dead targets
 		user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)
-	return
 
 /obj/item/twohanded/chainsaw/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -619,14 +619,15 @@
 /obj/item/twohanded/chainsaw/attack(mob/living/target, mob/living/user)
 	if(wielded)
 		playsound(loc, 'sound/weapons/chainsaw.ogg', 100, 1, -1) //incredibly loud; you ain't goin' for stealth with this thing. Credit to Lonemonk of Freesound for this sound.
-		target.KnockDown(8 SECONDS)
-	return ..()
+		if(isnull(..())) //necessary check, successful attacks return null, without it target will drop any shields they may have before they get a chance to block
+			target.KnockDown(8 SECONDS)
+	return
 
 /obj/item/twohanded/chainsaw/afterattack(mob/living/target, mob/living/user, proximity)
 	if(!proximity) //only works on adjacent targets, no telekinetic chainsaws
 		return
 	if(wielded)
-		if(isrobot(target) || !isliving(target)) //no buff from attacking robots or inanimate objects
+		if(!isliving(target)) //no buff from attacking inanimate objects
 			return
 		if(target.stat != DEAD) //no buff from attacking dead targets
 			user.apply_status_effect(STATUS_EFFECT_CHAINSAW_SLAYING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #18787
Moves the actual application of the Syndicate chainsaw buff to `afterattack()` to prevent it from triggering on attempted surgery. This prevents exploiting it to maintain indefinite buff without harming anyone.
Removes some redundant code, like playing a sound effect for unwielded chainsaw, which is played anyway.
Removes actually wrong code from `item_attack.dm`. Successful attacks return null, not TRUE. Necessary for the chainsaw to work on simple mobs properly.
This marginally nerfs the chainsaw, as the killing strike will not grant the buff. The target will die and only after that `afterattack()` will check if they're alive.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One less exploit is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in with a bunch of greys.
Killed a standing grey using a Syndicate chainsaw on all four intents.
Butchered the grey.
Buckled another grey to a roller bed.
Performed surgery on help intent, both wielded and unwielded.
Attacked on the other three intents and successfully butchered the buckled grey on harm intent.
Gave yet another grey a riot shield.
Got the buff from blocked attacks.
Got the buff from simple mobs.
Got no buff from attacking cyborgs.
Got no buff from attacking inanimate objects.
Killed everything and destroyed whatever was meant to be destroyable.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Syndicate chainsaw no longer grants its buff upon attempting a surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
