### PR TITLE
Fixes taking uplinks away

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1571,7 +1571,8 @@
 /datum/mind/proc/take_uplink()
 	var/list/A = current.actions //remove uplink implant action button
 	for(var/datum/action/item_action/hands_free/activate/I in A)
-		if(istype(I.target, /obj/item/implant/uplink))
+		var/obj/item/implant/uplink/U = I.target
+		if(!isnull(U.hidden_uplink))
 			I.Remove(current)
 
 	var/list/L = current.get_contents() //set all hidden_uplink vars to null

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1571,6 +1571,11 @@
 	if(H)
 		qdel(H)
 
+	var/list/L = current.get_contents()
+		for(var/obj/item/I in L)
+			if(!isnull(I.hidden_uplink))
+				I.hidden_uplink = null
+
 /datum/mind/proc/make_Traitor()
 	if(!has_antag_datum(/datum/antagonist/traitor))
 		add_antag_datum(/datum/antagonist/traitor)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1564,17 +1564,17 @@
 	for(var/obj/item/I in L)
 		if(I.hidden_uplink)
 			return I.hidden_uplink
-	return null
+	return
 
 /datum/mind/proc/take_uplink()
+	var/list/L = current.get_contents()
+	for(var/obj/item/I in L)
+		if(!isnull(I.hidden_uplink))
+			I.hidden_uplink = null
 	var/obj/item/uplink/hidden/H = find_syndicate_uplink()
 	if(H)
 		qdel(H)
-
-	var/list/L = current.get_contents()
-		for(var/obj/item/I in L)
-			if(!isnull(I.hidden_uplink))
-				I.hidden_uplink = null
+	return
 
 /datum/mind/proc/make_Traitor()
 	if(!has_antag_datum(/datum/antagonist/traitor))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1562,16 +1562,24 @@
 /datum/mind/proc/find_syndicate_uplink()
 	var/list/L = current.get_contents()
 	for(var/obj/item/I in L)
-		if(I.hidden_uplink)
+		if(I.hidden_uplink) //find items disguised as uplinks
 			return I.hidden_uplink
+		if(istype(I, /obj/item/implant/uplink)) //find uplink implants
+			return I
 	return
 
 /datum/mind/proc/take_uplink()
-	var/list/L = current.get_contents()
+	var/list/A = current.actions //remove uplink implant action button
+	for(var/datum/action/item_action/hands_free/activate/I in A)
+		if(istype(I.target, /obj/item/implant/uplink))
+			I.Remove(current)
+
+	var/list/L = current.get_contents() //set all hidden_uplink vars to null
 	for(var/obj/item/I in L)
 		if(!isnull(I.hidden_uplink))
 			I.hidden_uplink = null
-	var/obj/item/uplink/hidden/H = find_syndicate_uplink()
+
+	var/obj/item/uplink/hidden/H = find_syndicate_uplink() //remove all uplinks
 	if(H)
 		qdel(H)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #18581
Makes traitor panel and uplink items no longer break when taking uplinks away.
Makes take uplink button search for all uplinks on a person and remove them all.
Makes crystals button sum up TC across all uplinks and, when admin sets a specific amount, that amount is put in a single uplink. All other uplinks have their TC completely removed.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Apparently, on top of adding an uplink to an item, giving an uplink also makes `hidden_uplink` variable refer to the new uplink.
When taking an uplink away, it would remove the uplink from the item, but not set the variable back to `null`.
This prevented the traitor panel from updating correctly and caused the items to act weirdly.
Actually working admin tool that doesn't break items is good.

Additionally, traitor panel checking for _all_ uplinks on a person instead of picking effectively a random item makes sure that the button is always available while the player has an uplink. This makes hiding uplinks from admins significantly harder. One button removing all uplinks is mostly a convenience thing. I assume when an admin uses the button, they want _all_ uplinks gone.
Probably the most important change here is that the code now recognizes uplink implants as hidden uplinks. Previously players could use them to hide their uplinks from traitor panel.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in.
Made myself a traitor.
Gave myself a PDA uplink.
Took the PDA uplink away.
Gave myself a radio headset uplink.
Took the radio headset uplink away.
Gave myself an uplink implant.
Took the uplink implant away.
Gave myself all three types of uplinks at once.
Took them all with a single button.
Items worked, traitor panel updated properly.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed taking away uplinks in traitor panel for admins.
tweak: Take uplink button in traitor panel now takes away all uplinks.
tweak: Crystals button in traitor panel now properly set total TC available to a traitor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
