### PR TITLE
Experimental revert of item pickup animations

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -262,7 +262,6 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	..()
 
 /obj/item/attack_hand(mob/user as mob, pickupfireoverride = FALSE)
-	var/original_loc = loc
 	if(!user) return 0
 	if(hasorgans(user))
 		var/mob/living/carbon/human/H = user
@@ -317,17 +316,6 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	else
 		if(isliving(loc))
 			return 0
-
-	if(isturf(original_loc))
-		var/show_anim = TRUE
-		var/mob/living/carbon/human/H = user
-		if(istype(H) && H.gloves)
-			var/obj/item/clothing/gloves/G = H.gloves
-			if(istype(G) && G.pickpocket)
-				show_anim = FALSE
-
-		if(show_anim)
-			do_pickup_animation(user)
 
 	pickup(user)
 	add_fingerprint(user)
@@ -828,76 +816,3 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 /// Called on cyborg items that need special charging behavior. Override as needed for specific items.
 /obj/item/proc/cyborg_recharge(coeff = 1, emagged = FALSE)
 	return
-
-/// Show a pickup animation when an item is collected from the ground.
-/obj/item/proc/do_pickup_animation(atom/target)
-	if(!istype(loc, /turf))
-		return
-	var/image/pickup_animation = image(icon = src, loc = loc, layer = layer + 0.1)
-	pickup_animation.plane = GAME_PLANE
-	pickup_animation.transform.Scale(0.75)
-	pickup_animation.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-
-	var/turf/current_turf = get_turf(src)
-	var/direction = get_dir(current_turf, target)
-	var/to_x = target.pixel_x
-	var/to_y = target.pixel_y
-
-	if(direction & NORTH)
-		to_y += 32
-	else if(direction & SOUTH)
-		to_y -= 32
-	if(direction & EAST)
-		to_x += 32
-	else if(direction & WEST)
-		to_x -= 32
-	if(!direction)
-		to_y += 10
-		pickup_animation.pixel_x += 6 * (prob(50) ? 1 : -1) //6 to the right or left, helps break up the straight upward move
-
-	flick_overlay(pickup_animation, GLOB.clients, 4)
-	var/matrix/animation_matrix = new(pickup_animation.transform)
-	animation_matrix.Turn(pick(-30, 30))
-	animation_matrix.Scale(0.65)
-
-	animate(pickup_animation, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
-	animate(alpha = 0, transform = matrix().Scale(0.7), time = 1)
-
-/// Show a drop animation
-/obj/item/proc/do_drop_animation(atom/moving_from)
-	if(!istype(loc, /turf))
-		return
-
-	var/turf/current_turf = get_turf(src)
-	var/direction = get_dir(moving_from, current_turf)
-	var/from_x = moving_from.pixel_x
-	var/from_y = moving_from.pixel_y
-
-	if(direction & NORTH)
-		from_y -= 32
-	else if(direction & SOUTH)
-		from_y += 32
-	if(direction & EAST)
-		from_x -= 32
-	else if(direction & WEST)
-		from_x += 32
-	if(!direction)
-		from_y += 10
-		from_x += 6 * (prob(50) ? 1 : -1) //6 to the right or left, helps break up the straight upward move
-
-	//We're moving from these chords to our current ones
-	var/old_x = pixel_x
-	var/old_y = pixel_y
-	var/old_alpha = alpha
-	var/matrix/old_transform = transform
-	var/matrix/animation_matrix = new(old_transform)
-	animation_matrix.Turn(pick(-30, 30))
-	animation_matrix.Scale(0.7) // Shrink to start, end up normal sized
-
-	pixel_x = from_x
-	pixel_y = from_y
-	alpha = 0
-	transform = animation_matrix
-
-	// This is instant on byond's end, but to our clients this looks like a quick drop
-	animate(src, alpha = old_alpha, pixel_x = old_x, pixel_y = old_y, transform = old_transform, time = 3, easing = CUBIC_EASING)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -191,7 +191,6 @@
 			to_chat(user, "<span class='notice'>\The [W] is stuck to your hand, you cannot put it in \the [src]!</span>")
 			return
 		if(W)
-			W.do_drop_animation(user)
 			W.forceMove(loc)
 			return TRUE // It's resolved. No afterattack needed. Stops you from emagging lockers when putting in an emag
 	else if(can_be_emaged && (istype(W, /obj/item/card/emag) || istype(W, /obj/item/melee/energy/blade) && !broken))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -92,6 +92,10 @@
 	new /obj/structure/table/wood(loc)
 	qdel(src)
 
+/obj/structure/table/do_climb(mob/living/user)
+	. = ..()
+	item_placed(user)
+
 /obj/structure/table/attack_hand(mob/living/user)
 	..()
 	if(climber)
@@ -107,11 +111,8 @@
 /obj/structure/table/attack_tk() // no telehulk sorry
 	return
 
-/**
- * Called when an item in particular is placed onto a table.
- */
-/obj/structure/table/proc/item_placed(obj/item/I, mob/previous_holder)
-	I.do_drop_animation(get_turf(previous_holder))
+/obj/structure/table/proc/item_placed(item)
+	return
 
 /obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height == 0)
@@ -205,6 +206,7 @@
 			return FALSE
 		G.affecting.forceMove(get_turf(src))
 		G.affecting.Weaken(4 SECONDS)
+		item_placed(G.affecting)
 		G.affecting.visible_message("<span class='danger'>[G.assailant] pushes [G.affecting] onto [src].</span>", \
 									"<span class='userdanger'>[G.assailant] pushes [G.affecting] onto [src].</span>")
 		add_attack_logs(G.assailant, G.affecting, "Pushed onto a table")
@@ -230,7 +232,7 @@
 			//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
 			I.pixel_x = clamp(text2num(click_params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
 			I.pixel_y = clamp(text2num(click_params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
-			item_placed(I, user)
+			item_placed(I)
 	else
 		return ..()
 
@@ -703,7 +705,7 @@
 			continue
 		held.forceMove(NewLoc)
 
-/obj/structure/table/tray/item_placed(atom/movable/item, mob/previous_holder)
+/obj/structure/table/tray/item_placed(atom/movable/item)
 	. = ..()
 	if(is_type_in_typecache(item, typecache_can_hold))
 		held_items += item.UID()
@@ -777,7 +779,6 @@
 	if(!(W.flags & ABSTRACT))
 		if(user.drop_item())
 			W.Move(loc)
-			W.do_drop_animation(user)
 	return
 
 /obj/structure/rack/wrench_act(mob/user, obj/item/I)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -95,22 +95,11 @@
 //If both fail it drops it on the floor and returns 0.
 //This is probably the main one you need to know :)
 //Just puts stuff on the floor for most mobs, since all mobs have hands but putting stuff in the AI/corgi/ghost hand is VERY BAD.
-/**
- * Try to put an item into a mob's hands.
- *
- * Put the item into our active hand if possible. Failing that, try to put it into our inactive hand. Failing that as well, drop it onto the ground.
- * Should return TRUE if the item is successfully put into our hands, and failing that, the item will be dropped and FALSE will be returned.
- *
- * Arguments
- * * W - The item to try to put into your hands
- * * ignore_anim - If TRUE, the pickup animation of the item moving to you will be suppressed.
- */
-/mob/proc/put_in_hands(obj/item/W, ignore_anim = TRUE)
+/mob/proc/put_in_hands(obj/item/W)
 	W.forceMove(drop_location())
 	W.layer = initial(W.layer)
 	W.plane = initial(W.plane)
 	W.dropped()
-	return FALSE
 
 /mob/proc/drop_item_v()		//this is dumb.
 	if(stat == CONSCIOUS && isturf(loc))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -302,15 +302,9 @@
 		else
 			to_chat(src, "<span class='warning'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>")
 
-/mob/living/carbon/human/put_in_hands(obj/item/I, ignore_anim = FALSE)
+/mob/living/carbon/human/put_in_hands(obj/item/I)
 	if(!I)
 		return FALSE
-	if(gloves)
-		var/obj/item/clothing/gloves/G = gloves
-		if(istype(G) && G.pickpocket)
-			ignore_anim = TRUE
-	if(isturf(I.loc) && !ignore_anim)
-		I.do_pickup_animation(src)
 	if(istype(I, /obj/item/stack))
 		var/obj/item/stack/S = I
 		if(!S.get_amount())


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#18702

---

After profiling, it seems that every time an item is picked up, a full 2ms of CPU time is required.

![image](https://user-images.githubusercontent.com/25063394/184637139-393e916a-b340-4f16-8fb8-6095d37035b5.png)

Of all 11,110 calls, 8,852 of them are inside this bracket, which spans 2-4ms, meaning that approximately 80% of the calls consume 2-4ms, lets call that 3ms average.
![image](https://user-images.githubusercontent.com/25063394/184637237-6e3b971c-589e-42bb-9c23-df12c165c8e4.png)

Given how already starved we are for tick space, especially with maptick with 120 people on will eat 30ms of it, which only leaves 20ms for everything else. 

Thats 20ms to fit the entire MC cycle + all verbs + topic clicks + item pickups + everything else. 

I am going to be blunt here, using a full 10-20% of that small gap just on playing a little animation is not ok.

---

A lot of this stems from `animate()` being hot garbage. In BYOND, `animate()` calls are sent to all online players, largely so that if you walk into the zone, you see the glide occur properly. 

![image](https://user-images.githubusercontent.com/25063394/184637688-c603bdca-4b30-48ba-a7a9-b76eeaacb168.png)

Only half the usage is `flick_overlay()`, the rest being overhead from `animate()`. 