### PR TITLE
External organ icon handling tweak

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -428,6 +428,9 @@
 	SIGNAL_HANDLER
 	SHOULD_CALL_PARENT(TRUE)
 
+	if(updates & NONE)
+		return // NONE is being sent on purpose, and thus no signal should be sent. 
+
 	updates &= ~SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_ICON, updates)
 	if(updates & UPDATE_ICON_STATE)
 		update_icon_state()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	// blend the individual damage states with our icons
 	for(var/D in bodyparts)
 		var/obj/item/organ/external/E = D
-		E.update_icon()
+		E.update_state()
 		if(E.damage_state == "00")
 			continue
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -7,6 +7,9 @@
 	max_damage = 0
 	dir = SOUTH
 	organ_tag = "limb"
+
+	blocks_emissive = FALSE
+
 	var/brute_mod = 1
 	var/burn_mod = 1
 
@@ -249,7 +252,7 @@
 
 	if(owner_old)
 		owner_old.updatehealth("limb receive damage")
-	return update_icon()
+	return update_state()
 
 #undef LIMB_SHARP_THRESH_INT_DMG
 #undef LIMB_THRESH_INT_DMG
@@ -269,7 +272,7 @@
 	if(updating_health)
 		owner.updatehealth("limb heal damage")
 
-	return update_icon()
+	return update_state()
 
 /obj/item/organ/external/emp_act(severity)
 	if(!is_robotic() || emp_proof)
@@ -322,7 +325,7 @@ This function completely restores a damaged organ to perfect condition.
 
 	if(owner)
 		owner.updatehealth("limb rejuvenate")
-	update_icon()
+	update_state()
 	if(!owner)
 		START_PROCESSING(SSobj, src)
 

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -185,8 +185,8 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 
 // new damage icon system
 // adjusted to set damage_state to brute/burn code only (without r_name0 as before)
-/obj/item/organ/external/update_icon(updates=NONE)
-	..()
+
+/obj/item/organ/external/proc/update_state()
 	var/n_is = damage_state_text()
 	if(n_is != damage_state)
 		damage_state = n_is

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 
 // new damage icon system
 // adjusted to set damage_state to brute/burn code only (without r_name0 as before)
-/obj/item/organ/external/update_icon(updates=ALL)
+/obj/item/organ/external/update_icon(updates=NONE)
 	..()
 	var/n_is = damage_state_text()
 	if(n_is != damage_state)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an early return for `update_icon`, make external organs call a separate update proc instead of `update_icon`, and also make them not emissive blockers. Not realistic, but the odds of having a limb lying around also blocking an item are low and this cuts down on them managing the blocker. This doesn't affect the mobs and they still block emissives.

## Why It's Good For The Game
External organs don't need to go through the whole `update_icon` process as its handled by the mob itself. Likewise if something doesn't want to update its icon on purpose, it shouldn't be sending signals that it just did.

## Testing
Shot at unathis, damage display is still handled properly. Also stuck a stack trace in `update_icon` for debugging purposes.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
