### PR TITLE
CC tcomms QoL

### DIFF
--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -43,6 +43,13 @@
 		visible_message("<span class='warning'>Error: Another core is already active in this sector. Power-up cancelled due to radio interference.</span>")
 	update_icon()
 
+	if(mapload) //Automatically links new midround tcomms cores to the cc relay
+		return
+	var/obj/machinery/tcomms/relay/cc/cc_relay = locateUID(GLOB.cc_tcomms_relay)
+	if(cc_relay?.linked_core) //if we are already linked, ignore!
+		return
+	cc_relay.AddLink(src)
+
 /**
   * Destructor for the core.
   *

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -45,7 +45,7 @@
 
 	if(mapload) //Automatically links new midround tcomms cores to the cc relay
 		return
-	var/obj/machinery/tcomms/relay/cc/cc_relay = locateUID(GLOB.cc_tcomms_relay)
+	var/obj/machinery/tcomms/relay/cc/cc_relay = locateUID(GLOB.cc_tcomms_relay_uid)
 	if(cc_relay?.linked_core) //if we are already linked, ignore!
 		return
 	cc_relay.AddLink(src)

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -106,7 +106,7 @@
 		return TRUE
 
 	// Now we generate the list of where that signal should go to
-	tcm.zlevels = reachable_zlevels
+	tcm.zlevels = reachable_zlevels.Copy()
 	tcm.zlevels |= tcm.source_level
 
 	// Now check if they actually have pieces, if so, broadcast

--- a/code/game/machinery/tcomms/presets.dm
+++ b/code/game/machinery/tcomms/presets.dm
@@ -31,7 +31,7 @@
 	hidden_link = TRUE
 	password_bypass = TRUE
 
-GLOBAL_VAR(cc_tcomms_relay)
+GLOBAL_VAR(cc_tcomms_relay_uid)
 /obj/machinery/tcomms/relay/cc/Initialize(mapload)
 	. = ..()
-	GLOB.cc_tcomms_relay = UID(src)
+	GLOB.cc_tcomms_relay_uid = UID(src)

--- a/code/game/machinery/tcomms/presets.dm
+++ b/code/game/machinery/tcomms/presets.dm
@@ -34,4 +34,4 @@
 GLOBAL_VAR(cc_tcomms_relay_uid)
 /obj/machinery/tcomms/relay/cc/Initialize(mapload)
 	. = ..()
-	GLOB.cc_tcomms_relay_uid = UID(src)
+	GLOB.cc_tcomms_relay_uid = UID()

--- a/code/game/machinery/tcomms/presets.dm
+++ b/code/game/machinery/tcomms/presets.dm
@@ -31,3 +31,7 @@
 	hidden_link = TRUE
 	password_bypass = TRUE
 
+GLOBAL_VAR(cc_tcomms_relay)
+/obj/machinery/tcomms/relay/cc/Initialize(mapload)
+	. = ..()
+	GLOB.cc_tcomms_relay = UID(src)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -465,10 +465,8 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 			addtimer(CALLBACK(src, .proc/broadcast_callback, tcm), 2 SECONDS)
 		else
 			// Nukeops + Deathsquad headsets are instant and should work the same, whether there is comms or not, on all z levels
-			for(var/zlevel in 1 to length(GLOB.space_manager.z_list))
-				if(zlevel in tcm.zlevels)
-					continue
-				LAZYADD(tcm.zlevels, zlevel)
+			for(var/z in 1 to world.maxz)
+				tcm.zlevels |= z
 			broadcast_message(tcm)
 			qdel(tcm) // Delete the message datum
 		return TRUE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -464,7 +464,11 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 			// Simulate two seconds of lag
 			addtimer(CALLBACK(src, .proc/broadcast_callback, tcm), 2 SECONDS)
 		else
-			// Nukeops + Deathsquad headsets are instant and should work the same, whether there is comms or not
+			// Nukeops + Deathsquad headsets are instant and should work the same, whether there is comms or not, on all z levels
+			for(var/zlevel in 1 to length(GLOB.space_manager.z_list))
+				if(zlevel in tcm.zlevels)
+					continue
+				LAZYADD(tcm.zlevels, zlevel)
 			broadcast_message(tcm)
 			qdel(tcm) // Delete the message datum
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When not already linked to a core, the CC tcomms relay will auto-link to any new built tcomms cores.
ERT commander, CC, DS, and nukie headsets now transmit across all Z levels when tcomms is down or out, not just the local Z.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is not a perfect solution to the issue of unlinked tcomms cores, but it hopefully will cut down on the need for admins to manually re-link the relays when station cores are deleted and later re-made.

The headset change also makes it easier for an admin SOO/NNO/event character to communicate with an away team from CC. Previously, admins had to teleport into space somewhere to do this when tcomms is down.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned a bunch of stuff, linked and unlinked, etc.

Screamed obscenities into headsets.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: CC tcomms relay auto-links to new cores when not already linked to a core.
tweak: Headsets that do not require tcomms to work now work across all z-levels when tcomms is down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
