### PR TITLE
Partially revert "Nukes all of the OpenDream warnings (#17636)"

### DIFF
--- a/code/modules/persistence/persistence.dm
+++ b/code/modules/persistence/persistence.dm
@@ -45,7 +45,8 @@
 /atom/serialize()
 	var/list/data = ..()
 	for(var/thing in vars_to_save())
-		data[thing] = vars[thing] // Can't check initial() because it doesn't work on a list index
+		if(vars[thing] != initial(vars[thing]))
+			data[thing] = vars[thing]
 	return data
 
 


### PR DESCRIPTION
This partially reverts commit 78dd3765384e20a868e25b639597231bc256889c.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reverts the bit in #17636 that broke serialising mobs into jsons.

This fixes part of https://github.com/ParadiseSS13/Paradise/issues/17836, namely NEW serialised mobs will work as intended. Older serialised jsons might still cause problems.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Custom admin characters can actually be saved. The PR that introduces this was not tested and has caused so many issues.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Made a new character, serialised and deserialised, worked as intended.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed serialising of mobs so it actually outputs something that works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
