### PR TITLE
fixes tumors not reviving dead elites out of combat (gbp no update)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -193,7 +193,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 				mychild.playsound_local(get_turf(mychild), 'sound/magic/cult_spell.ogg', 40, 0)
 				to_chat(mychild, "<span class='warning'>Someone has activated your tumor.  You will be returned to fight shortly, get ready!</span>")
 			addtimer(CALLBACK(src, .proc/return_elite), 3 SECONDS)
-			INVOKE_ASYNC(src, .proc/arena_checks)
 		if(TUMOR_INACTIVE)
 			if(HAS_TRAIT(src, TRAIT_ELITE_CHALLENGER))
 				user.visible_message("<span class='warning'>[user] reaches for [src] with [user.p_their()] arm, but nothing happens.</span>",
@@ -246,6 +245,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.health = mychild.maxHealth
 		mychild.grab_ghost()
 		notify_ghosts("\A [mychild] has been challenged in \the [get_area(src)]!", enter_link="<a href=?src=[UID()];follow=1>(Click to help)</a>", source = mychild, action = NOTIFY_FOLLOW)
+	INVOKE_ASYNC(src, .proc/arena_checks)
 
 /obj/structure/elite_tumor/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Fixes the tumor check instantly running apon someone touching the tumor, detecting the elite as dead, and dropping loot.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If an elite mob dies out of arena combat, loot does not spawn. It is supposed to spawn when it gets deleted somehow, or when it dies in arena combat. 

Interacting with the tumor is supposed to re-activate arena combat, summon and revive the elite, even if it is dead. This only happens when combat has ended, when a miner interacts with the tumor. This does not happen if elite is killed in combat. 

However, it ran the arena check too early, causing the tumor to notice the mob is dead and end combat. Whoops.

## Testing
<!-- How did you test the PR, if at all? -->
spawn elite.
die.
kill elite.
interact with tumor. works.

## Changelog
:cl:
fix: Fixes tumors failing to revive elites, spawning loot when it should not.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
