### PR TITLE
Removes the need for `ComponentInitialize`

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -125,8 +125,6 @@
 	if(loc)
 		SEND_SIGNAL(loc, COMSIG_ATOM_INITIALIZED_ON, src) // Used for poolcontroller / pool to improve performance greatly. However it also open up path to other usage of observer pattern on turfs.
 
-	ComponentInitialize()
-
 	if(length(smoothing_groups))
 		sortTim(smoothing_groups) //In case it's not properly ordered, let's avoid duplicate entries with the same values.
 		SET_BITFLAG_LIST(smoothing_groups)
@@ -140,10 +138,6 @@
 
 //called if Initialize returns INITIALIZE_HINT_LATELOAD
 /atom/proc/LateInitialize()
-	return
-
-// Put your AddComponent() calls here
-/atom/proc/ComponentInitialize()
 	return
 
 /atom/proc/onCentcom()

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -29,7 +29,7 @@
 	base_state = "pflash"
 	density = TRUE
 
-/obj/machinery/flasher/portable/Initialize()
+/obj/machinery/flasher/portable/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor)
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -29,7 +29,7 @@
 	base_state = "pflash"
 	density = TRUE
 
-/obj/machinery/flasher/portable/ComponentInitialize()
+/obj/machinery/flasher/portable/Initialize()
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -22,16 +22,13 @@
 
 /obj/machinery/recycler/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_PLASTIC, MAT_BLUESPACE), 0, TRUE, null, null, null, TRUE)
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/recycler(null)
 	component_parts += new /obj/item/stock_parts/matter_bin(null)
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	RefreshParts()
 	update_icon(UPDATE_ICON_STATE)
-
-/obj/machinery/recycler/ComponentInitialize()
-	..()
-	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_PLASTIC, MAT_BLUESPACE), 0, TRUE, null, null, null, TRUE)
 
 /obj/machinery/recycler/RefreshParts()
 	var/amt_made = 0

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -16,7 +16,7 @@
 	max_equip = 3
 	starting_voice = /obj/item/mecha_modkit/voice/honk
 
-/obj/mecha/combat/honker/ComponentInitialize()
+/obj/mecha/combat/honker/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/squeak, list('sound/effects/clownstep1.ogg' = 1, 'sound/effects/clownstep2.ogg' = 1), 50, falloff_exponent = 20, squeak_on_move = TRUE) //die off quick please
 

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -8,6 +8,5 @@
 	. = INITIALIZE_HINT_QDEL
 	var/turf/T = loc
 	if(!istype(T)) //you know this will happen somehow
-		stack_trace("Turf decal initialized in an object/nullspace")
-		return
+		CRASH("Turf decal initialized in an object/nullspace")
 	T.AddComponent(/datum/component/decal, icon, icon_state, dir, CLEAN_GOD, color, null, null, alpha)

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -4,12 +4,10 @@
 	layer = TURF_DECAL_LAYER
 
 /obj/effect/turf_decal/Initialize(mapload)
-	. = ..()
-	qdel(src) // return INITIALIZE_HINT_QDEL <-- Doesn't work
-
-/obj/effect/turf_decal/ComponentInitialize()
-	. = ..()
+	..()
+	. = INITIALIZE_HINT_QDEL
 	var/turf/T = loc
 	if(!istype(T)) //you know this will happen somehow
-		CRASH("Turf decal initialized in an object/nullspace")
+		stack_trace("Turf decal initialized in an object/nullspace")
+		return
 	T.AddComponent(/datum/component/decal, icon, icon_state, dir, CLEAN_GOD, color, null, null, alpha)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -572,7 +572,7 @@
 	name = "grumpy fox"
 	desc = "An ancient plushie that seems particularly grumpy."
 
-/obj/item/toy/plushie/orange_fox/grump/ComponentInitialize()
+/obj/item/toy/plushie/orange_fox/grump/Initialize()
 	. = ..()
 	var/static/list/grumps = list("Ahh, yes, you're so clever, var editing that.", "Really?", "If you make a runtime with var edits, it's your own damn fault.",
 	"Don't you dare post issues on the git when you don't even know how this works.", "Was that necessary?", "Ohhh, setting admin edited var must be your favorite pastime!",

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -572,7 +572,7 @@
 	name = "grumpy fox"
 	desc = "An ancient plushie that seems particularly grumpy."
 
-/obj/item/toy/plushie/orange_fox/grump/Initialize()
+/obj/item/toy/plushie/orange_fox/grump/Initialize(mapload)
 	. = ..()
 	var/static/list/grumps = list("Ahh, yes, you're so clever, var editing that.", "Really?", "If you make a runtime with var edits, it's your own damn fault.",
 	"Don't you dare post issues on the git when you don't even know how this works.", "Was that necessary?", "Ohhh, setting admin edited var must be your favorite pastime!",

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -15,7 +15,7 @@
 	var/armed = FALSE
 	var/timepassed = 0
 
-/obj/item/caution/proximity_sign/Initialize()
+/obj/item/caution/proximity_sign/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor)
 

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -15,7 +15,7 @@
 	var/armed = FALSE
 	var/timepassed = 0
 
-/obj/item/caution/proximity_sign/ComponentInitialize()
+/obj/item/caution/proximity_sign/Initialize()
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor)
 

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -29,10 +29,8 @@
 	qdel(src)
 	return
 
-/obj/item/grown/bananapeel/traitorpeel/New(newloc, obj/item/seeds/new_seed)
+/obj/item/grown/bananapeel/traitorpeel/Initialize(mapload)
 	. = ..()
-	// The reason this AddComponent is here and not in ComponentInitialize() is because if it's put there, it will be ran before the parent New proc for /grown types.
-	// And then be overriden by the generic component placed onto it by the `/datum/plant_gene/trait/slip`.
 	AddComponent(/datum/component/slippery, src, 14 SECONDS, 100, 4, FALSE)
 
 /obj/item/grown/bananapeel/traitorpeel/after_slip(mob/living/carbon/human/H)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -13,7 +13,7 @@
 	discrete = 1
 	var/cleanspeed = 50 //slower than mop
 
-/obj/item/soap/Initialize()
+/obj/item/soap/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/slippery, src, 8 SECONDS, 100, 0, FALSE)
 

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -13,7 +13,8 @@
 	discrete = 1
 	var/cleanspeed = 50 //slower than mop
 
-/obj/item/soap/ComponentInitialize()
+/obj/item/soap/Initialize()
+	. = ..()
 	AddComponent(/datum/component/slippery, src, 8 SECONDS, 100, 0, FALSE)
 
 /obj/item/soap/afterattack(atom/target, mob/user, proximity)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -11,7 +11,8 @@
 	layer = 9
 
 //Adds the transparency component, exists to be overridden for different args.
-/obj/structure/flora/tree/ComponentInitialize()
+/obj/structure/flora/tree/Initialize()
+	. = ..()
 	AddComponent(/datum/component/largetransparency)
 
 /obj/structure/flora/tree/pine
@@ -32,7 +33,8 @@
 	icon = 'icons/obj/flora/deadtrees.dmi'
 	icon_state = "tree_1"
 
-/obj/structure/flora/tree/dead/ComponentInitialize()
+/obj/structure/flora/tree/dead/Initialize()
+	. = ..()
 	AddComponent(/datum/component/largetransparency, 0, 1, 0, 0)
 
 /obj/structure/flora/tree/dead/Initialize(mapload)
@@ -57,10 +59,8 @@
 	pixel_y = -20
 
 /obj/structure/flora/tree/jungle/Initialize(mapload)
-	icon_state = "[icon_state][rand(1, 6)]"
 	. = ..()
-
-/obj/structure/flora/tree/jungle/ComponentInitialize()
+	icon_state = "[icon_state][rand(1, 6)]"
 	AddComponent(/datum/component/largetransparency, -1, 1, 2, 2)
 
 /obj/structure/flora/tree/jungle/small
@@ -68,7 +68,8 @@
 	pixel_x = -32
 	icon = 'icons/obj/flora/jungletreesmall.dmi'
 
-/obj/structure/flora/tree/jungle/small/ComponentInitialize()
+/obj/structure/flora/tree/jungle/small/Initialize()
+	. = ..()
 	AddComponent(/datum/component/largetransparency)
 
 //grass

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -11,7 +11,7 @@
 	layer = 9
 
 //Adds the transparency component, exists to be overridden for different args.
-/obj/structure/flora/tree/Initialize()
+/obj/structure/flora/tree/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/largetransparency)
 
@@ -33,7 +33,7 @@
 	icon = 'icons/obj/flora/deadtrees.dmi'
 	icon_state = "tree_1"
 
-/obj/structure/flora/tree/dead/Initialize()
+/obj/structure/flora/tree/dead/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/largetransparency, 0, 1, 0, 0)
 
@@ -68,7 +68,7 @@
 	pixel_x = -32
 	icon = 'icons/obj/flora/jungletreesmall.dmi'
 
-/obj/structure/flora/tree/jungle/small/Initialize()
+/obj/structure/flora/tree/jungle/small/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/largetransparency)
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -13,7 +13,7 @@
 	var/timing = FALSE
 	var/time = 10
 
-/obj/item/assembly/prox_sensor/ComponentInitialize()
+/obj/item/assembly/prox_sensor/Initialize()
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor, _always_active = TRUE)
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -13,7 +13,7 @@
 	var/timing = FALSE
 	var/time = 10
 
-/obj/item/assembly/prox_sensor/Initialize()
+/obj/item/assembly/prox_sensor/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor, _always_active = TRUE)
 

--- a/code/modules/clothing/ears/ears.dm
+++ b/code/modules/clothing/ears/ears.dm
@@ -8,7 +8,7 @@
 	put_on_delay = 25
 	resistance_flags = FLAMMABLE
 
-/obj/item/clothing/ears/earmuffs/ComponentInitialize()
+/obj/item/clothing/ears/earmuffs/Initialize()
 	. = ..()
 	AddElement(/datum/element/earhealing)
 

--- a/code/modules/clothing/ears/ears.dm
+++ b/code/modules/clothing/ears/ears.dm
@@ -8,7 +8,7 @@
 	put_on_delay = 25
 	resistance_flags = FLAMMABLE
 
-/obj/item/clothing/ears/earmuffs/Initialize()
+/obj/item/clothing/ears/earmuffs/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/earhealing)
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -126,7 +126,7 @@
 	name = "synthesized banana peel"
 	desc = "A synthetic banana peel."
 
-/obj/item/grown/bananapeel/specialpeel/Initialize()
+/obj/item/grown/bananapeel/specialpeel/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/slippery, src, 4 SECONDS, 100, 0, FALSE)
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -126,7 +126,8 @@
 	name = "synthesized banana peel"
 	desc = "A synthetic banana peel."
 
-/obj/item/grown/bananapeel/specialpeel/ComponentInitialize()
+/obj/item/grown/bananapeel/specialpeel/Initialize()
+	. = ..()
 	AddComponent(/datum/component/slippery, src, 4 SECONDS, 100, 0, FALSE)
 
 /obj/item/grown/bananapeel/specialpeel/after_slip(mob/living/carbon/human/H)

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -58,14 +58,11 @@
 /obj/item/clothing/suit/space/hostile_environment/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
+	AddComponent(/datum/component/spraycan_paintable)
 
 /obj/item/clothing/suit/space/hostile_environment/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
-
-/obj/item/clothing/suit/space/hostile_environment/ComponentInitialize()
-	..()
-	AddComponent(/datum/component/spraycan_paintable)
 
 /obj/item/clothing/suit/space/hostile_environment/process()
 	var/mob/living/carbon/C = loc
@@ -88,9 +85,6 @@
 /obj/item/clothing/head/helmet/space/hostile_environment/Initialize(mapload)
 	. = ..()
 	update_icon()
-
-/obj/item/clothing/head/helmet/space/hostile_environment/ComponentInitialize()
-	..()
 	AddComponent(/datum/component/spraycan_paintable)
 
 /obj/item/clothing/head/helmet/space/hostile_environment/update_overlays()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -55,12 +55,10 @@
 	/// The currently inserted design disk.
 	var/obj/item/disk/design_disk/inserted_disk
 
-/obj/machinery/mineral/ore_redemption/ComponentInitialize()
-	..()
-	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE), INFINITY, FALSE, /obj/item/stack, null, CALLBACK(src, .proc/on_material_insert))
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE), INFINITY, FALSE, /obj/item/stack, null, CALLBACK(src, .proc/on_material_insert))
 	ore_buffer = list()
 	files = new /datum/research/smelter(src)
 	// Stock parts

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -14,8 +14,8 @@
 	speed_process = TRUE
 
 
-/obj/machinery/mineral/mint/ComponentInitialize()
-	..()
+/obj/machinery/mineral/mint/Initialize()
+	. = ..()
 	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_URANIUM, MAT_DIAMOND, MAT_BANANIUM, MAT_TRANQUILLITE), MINERAL_MATERIAL_AMOUNT * 50, FALSE, /obj/item/stack)
 
 /obj/machinery/mineral/mint/process()

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -14,7 +14,7 @@
 	speed_process = TRUE
 
 
-/obj/machinery/mineral/mint/Initialize()
+/obj/machinery/mineral/mint/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_URANIUM, MAT_DIAMOND, MAT_BANANIUM, MAT_TRANQUILLITE), MINERAL_MATERIAL_AMOUNT * 50, FALSE, /obj/item/stack)
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -29,7 +29,7 @@
 
 	var/attached = 0
 
-/obj/item/clothing/mask/facehugger/ComponentInitialize()
+/obj/item/clothing/mask/facehugger/Initialize()
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor)
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -29,7 +29,7 @@
 
 	var/attached = 0
 
-/obj/item/clothing/mask/facehugger/Initialize()
+/obj/item/clothing/mask/facehugger/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -19,6 +19,7 @@
 
 	UpdateAppearance()
 	GLOB.human_list += src
+	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_HUMAN, 1, -6)
 
 /**
   * Sets up DNA and species.
@@ -44,9 +45,6 @@
 /mob/living/carbon/human/proc/setup_other()
 	create_reagents(330)
 	physiology = new()
-
-/mob/living/carbon/human/ComponentInitialize()
-	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_HUMAN, 1, -6)
 
 /mob/living/carbon/human/OpenCraftingMenu()
 	if(!handcrafting)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -59,12 +59,9 @@
 /mob/living/simple_animal/hostile/poison/bees/Process_Spacemove(movement_dir = 0)
 	return TRUE
 
-/mob/living/simple_animal/hostile/poison/bees/ComponentInitialize()
-	..()
-	AddComponent(/datum/component/swarming)
-
 /mob/living/simple_animal/hostile/poison/bees/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/swarming)
 	generate_bee_visuals()
 
 /mob/living/simple_animal/hostile/poison/bees/Destroy()

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -38,7 +38,7 @@
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings."
 	ttone = "honk"
 
-/obj/item/pda/clown/Initialize()
+/obj/item/pda/clown/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/slippery, src, 16 SECONDS, 100)
 

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -38,7 +38,8 @@
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings."
 	ttone = "honk"
 
-/obj/item/pda/clown/ComponentInitialize()
+/obj/item/pda/clown/Initialize()
+	. = ..()
 	AddComponent(/datum/component/slippery, src, 16 SECONDS, 100)
 
 /obj/item/pda/mime

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -799,7 +799,7 @@
 	/// Light colour
 	var/brightness_color = null
 
-/obj/item/light/Initialize()
+/obj/item/light/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/caltrop, force)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -799,7 +799,7 @@
 	/// Light colour
 	var/brightness_color = null
 
-/obj/item/light/ComponentInitialize()
+/obj/item/light/Initialize()
 	. = ..()
 	AddComponent(/datum/component/caltrop, force)
 

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -14,8 +14,8 @@
 	var/efficiency_coeff = 1
 	var/list/categories = list()
 
-/obj/machinery/r_n_d/ComponentInitialize()
-	..()
+/obj/machinery/r_n_d/Initialize()
+	. = ..()
 	materials = AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE, MAT_PLASTIC), 0, TRUE, /obj/item/stack, CALLBACK(src, .proc/is_insertion_ready), CALLBACK(src, .proc/AfterMaterialInsert))
 	materials.precise_insertion = TRUE
 

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -14,7 +14,7 @@
 	var/efficiency_coeff = 1
 	var/list/categories = list()
 
-/obj/machinery/r_n_d/Initialize()
+/obj/machinery/r_n_d/Initialize(mapload)
 	. = ..()
 	materials = AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE, MAT_PLASTIC), 0, TRUE, /obj/item/stack, CALLBACK(src, .proc/is_insertion_ready), CALLBACK(src, .proc/AfterMaterialInsert))
 	materials.precise_insertion = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the `ComponentInitialize()` proc and the need for it. All `AddComponent()`s are now down in `Initialize()`
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Saves a bit of initialization time due to avoiding proc call overhead. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled, ran server, had no runtimes. Took a look at all objects which were using `ComponentInitialize`. Load order seems to be unaffected, as objects don't have dependency on having a component loaded or not.
<!-- How did you test the PR, if at all? -->

## Changelog
Backend only.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
