### PR TITLE
Elite balance tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/goliath_broodmother.dm
@@ -154,11 +154,12 @@
 	ranged_cooldown = world.time + 4 SECONDS * revive_multiplier()
 	visible_message("<span class='warning'>The ground shakes near [src]!</span>")
 	var/list/directions = GLOB.cardinal.Copy() + GLOB.diagonals.Copy()
-	for(var/mob/child in children_list)
+	for(var/mob/living/child in children_list)
 		var/spawndir = pick_n_take(directions)
 		var/turf/T = get_step(src, spawndir)
 		if(T)
 			child.forceMove(T)
+			child.revive() // at most this is a 29 hp heal.
 			playsound(src, 'sound/effects/bamf.ogg', 100, 1)
 
 //The goliath's children.  Pretty weak, simple mobs which are able to put a single tentacle under their target when at range.
@@ -249,7 +250,7 @@
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "broodmother_tongue"
 	denied_type = /obj/item/crusher_trophy/broodmother_tongue
-	bonus_value = 25
+	bonus_value = 75 // same reasoning as legionnaire trophy, target if moving will dodge it, and things like hiero trophy does more anyway.
 	/// Time at which the item becomes usable again
 	var/use_time
 
@@ -257,7 +258,7 @@
 	return "mark detonation to have a <b>[bonus_value]%</b> chance to summon a patch of goliath tentacles at the target's location"
 
 /obj/item/crusher_trophy/broodmother_tongue/on_mark_detonation(mob/living/target, mob/living/user)
-	if(rand(1, 100) <= bonus_value && target.stat != DEAD)
+	if(prob(bonus_value) && target.stat != DEAD)
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother/patch(get_turf(target), user)
 
 /obj/item/crusher_trophy/broodmother_tongue/attack_self(mob/user)
@@ -272,7 +273,7 @@
 		return
 	living_user.weather_immunities += "lava"
 	to_chat(living_user, "<b>You squeeze the tongue, and some transluscent liquid shoots out all over you.</b>")
-	addtimer(CALLBACK(src, .proc/remove_lava, living_user), 10 SECONDS)
+	addtimer(CALLBACK(src, .proc/remove_lava, living_user), 20 SECONDS)
 	use_time = world.time + 60 SECONDS
 
 /obj/item/crusher_trophy/broodmother_tongue/proc/remove_lava(mob/living/user)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/herald.dm
@@ -150,14 +150,14 @@
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	var/target_turf = get_turf(target)
 	var/angle_to_target = get_angle(src, target_turf)
+	say("Pray.")
+	SLEEP_CHECK_DEATH(0.75 SECONDS)// no point blank instant shotgun.
 	shoot_projectile(target_turf, angle_to_target, FALSE, TRUE)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 0.2 SECONDS)
-	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 0.4 SECONDS)
 	if(health < maxHealth * 0.5 && !is_mirror)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 1 SECONDS)
 		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 1.2 SECONDS)
-		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 1.4 SECONDS)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_circleshot(offset)
 	var/static/list/directional_shot_angles = list(1, 45, 90, 135, 180, 225, 270, 315) //Trust me, use 1. It really doesn't like zero.

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/herald.dm
@@ -150,7 +150,7 @@
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	var/target_turf = get_turf(target)
 	var/angle_to_target = get_angle(src, target_turf)
-	say("Pray.")
+	say("Pray")
 	SLEEP_CHECK_DEATH(0.75 SECONDS)// no point blank instant shotgun.
 	shoot_projectile(target_turf, angle_to_target, FALSE, TRUE)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 0.2 SECONDS)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
@@ -160,7 +160,7 @@
 		to_chat(L, "<span class='userdanger'>[src] tramples you and kicks you away!</span>")
 		L.throw_at(throwtarget, 10, 1, src)
 		L.KnockDown(1 SECONDS)
-		L.adjustBruteLoss(melee_damage_upper)
+		L.adjustBruteLoss(25)
 	addtimer(CALLBACK(src, .proc/legionnaire_charge_to, move_dir, (times_ran + 1)), 0.7)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/head_detach(target)
@@ -200,7 +200,7 @@
 	visible_message("<span class='danger'>The top of [src]'s spine leaks a black liquid, forming into a skull!</span>")
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/bonfire_teleport()
-	ranged_cooldown = world.time + 0.5 SECONDS * revive_multiplier()
+	ranged_cooldown = world.time + 2 SECONDS * revive_multiplier()
 	if(isnull(mypile))
 		var/obj/structure/legionnaire_bonfire/newpile = new /obj/structure/legionnaire_bonfire(loc)
 		mypile = newpile
@@ -312,7 +312,7 @@
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "legionnaire_spine"
 	denied_type = /obj/item/crusher_trophy/legionnaire_spine
-	bonus_value = 25
+	bonus_value = 75 // listen this dies in on hit, this can be a high chance.
 	/// Time at which the item becomes usable again
 	var/next_use_time
 

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
@@ -312,7 +312,7 @@
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "legionnaire_spine"
 	denied_type = /obj/item/crusher_trophy/legionnaire_spine
-	bonus_value = 75 // listen this dies in on hit, this can be a high chance.
+	bonus_value = 75 // listen this dies in one hit, this can be a high chance.
 	/// Time at which the item becomes usable again
 	var/next_use_time
 

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
@@ -116,7 +116,7 @@
 		recalculation_speed = 2
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/chaser_burst(target)
-	ranged_cooldown = world.time + cooldown_time * 2.5 // this fucks at low hp, so needs higher cooldown than other attacks
+	ranged_cooldown = world.time + cooldown_time * 2.5 // this shreads people incredibly effectivly at low hp, so needs higher cooldown than other attacks
 	var/active_chasers = 0
 	for(var/mob/living/M in orange(7, src))
 		if(M.faction_check_mob(src))

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
@@ -116,7 +116,7 @@
 		recalculation_speed = 2
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/chaser_burst(target)
-	ranged_cooldown = world.time + cooldown_time * 2
+	ranged_cooldown = world.time + cooldown_time * 2.5 // this fucks at low hp, so needs higher cooldown than other attacks
 	var/active_chasers = 0
 	for(var/mob/living/M in orange(7, src))
 		if(M.faction_check_mob(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Goliath broodmother heals it's children on recall.

Broodmother trophy has a 75% to spawn tentacles vs 25%, and lava immunity doubled on use to 20 seconds.

Herald telegraphs it's shotgun attack, shoots 6 / 12 projectiles instead of 9/18

Legionnaire charge damage per hit down to 25 brute from 35 brute. 

Legionnaire trophy has a 75% chance to spawn a skull vs 25%.

Pandora chaser move up to 2.5 base cooldown instead of 2 seconds.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Broodmother has no way to see health of children / hurt them, might as well let recall heal them.

Brood Trophy had too low activation chance, and 10 seconds of lava immunity is nothing.

Heralds shotgun way too strong. Telegraph / less bullets will help.

Legionnaires charge hits like a truck if it multi hits. Still does, just slightly less.

Same thing with legionnare trophy, activation too low.

Pandoras chasers are INSANE under 25% hp. This is fine, but should have a  *slightly* longer cooldown on the move because of it.

## Testing
<!-- How did you test the PR, if at all? -->

Numbers changes, but tested a bit to be sure it feels good.

## Changelog
:cl:
tweak: Tweaked the stats of some elites moves. Check pr for details.
tweak: Broodmother trophy has 75% activation chance, and doubled lava immunity time. Legionnaire trophy has 75% activation chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
