### PR TITLE
Makes anomalies deadlier

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -151,6 +151,6 @@ SUBSYSTEM_DEF(throwing)
 		var/atom/movable/AM = thing
 		if(AM == thrownthing || AM == thrower)
 			continue
-		if((AM.density || istype(AM, /mob/living) && undodgeable) && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags & ON_BORDER))
+		if((AM.density || isliving(AM) && undodgeable) && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags & ON_BORDER))
 			finalize(hit = TRUE, target = AM)
 			return TRUE

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -67,7 +67,7 @@ SUBSYSTEM_DEF(throwing)
 	var/paused = FALSE
 	var/delayed_time = 0
 	var/last_move = 0
-	///When this variable is false, non dense mobs will be hit by a thrown item. Currently used by gravitational, to prevent cheese.
+	///When this variable is false, non dense mobs will be hit by a thrown item. useful for things that you dont want to be cheesed by crawling, EG. gravitational anomalies
 	var/dodgeable = TRUE
 
 /datum/thrownthing/proc/tick()

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -67,8 +67,8 @@ SUBSYSTEM_DEF(throwing)
 	var/paused = FALSE
 	var/delayed_time = 0
 	var/last_move = 0
-	///When this variable is true, non dense mobs will be hit by a thrown item. Currently used by gravitational, to prevent cheese.
-	var/undodgeable = FALSE
+	///When this variable is false, non dense mobs will be hit by a thrown item. Currently used by gravitational, to prevent cheese.
+	var/dodgeable = TRUE
 
 /datum/thrownthing/proc/tick()
 	var/atom/movable/AM = thrownthing
@@ -151,6 +151,6 @@ SUBSYSTEM_DEF(throwing)
 		var/atom/movable/AM = thing
 		if(AM == thrownthing || AM == thrower)
 			continue
-		if((AM.density || isliving(AM) && undodgeable) && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags & ON_BORDER))
+		if((AM.density || isliving(AM) && !dodgeable) && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags & ON_BORDER))
 			finalize(hit = TRUE, target = AM)
 			return TRUE

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -67,6 +67,8 @@ SUBSYSTEM_DEF(throwing)
 	var/paused = FALSE
 	var/delayed_time = 0
 	var/last_move = 0
+	///When this variable is true, non dense mobs will be hit by a thrown item. Currently used by gravitational, to prevent cheese.
+	var/undodgeable = FALSE
 
 /datum/thrownthing/proc/tick()
 	var/atom/movable/AM = thrownthing
@@ -90,6 +92,7 @@ SUBSYSTEM_DEF(throwing)
 	var/tilestomove = CEILING(min(((((world.time + world.tick_lag) - start_time + delayed_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed * MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait), 1)
 	while(tilestomove-- > 0)
 		if((dist_travelled >= maxrange || AM.loc == target_turf) && has_gravity(AM, AM.loc))
+			hitcheck() //Just to be sure
 			finalize()
 			return
 
@@ -148,6 +151,6 @@ SUBSYSTEM_DEF(throwing)
 		var/atom/movable/AM = thing
 		if(AM == thrownthing || AM == thrower)
 			continue
-		if(AM.density && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags & ON_BORDER))
+		if((AM.density || istype(AM, /mob/living) && undodgeable) && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags & ON_BORDER))
 			finalize(hit = TRUE, target = AM)
 			return TRUE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -375,7 +375,7 @@
 		step(src, AM.dir)
 	..()
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, undodgeable = FALSE)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, dodgeable = TRUE)
 	if(!target || (flags & NODROP) || speed <= 0)
 		return 0
 
@@ -415,7 +415,7 @@
 	TT.thrower = thrower
 	TT.diagonals_first = diagonals_first
 	TT.callback = callback
-	TT.undodgeable = undodgeable
+	TT.dodgeable = dodgeable
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -375,7 +375,7 @@
 		step(src, AM.dir)
 	..()
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, undodgeable = FALSE)
 	if(!target || (flags & NODROP) || speed <= 0)
 		return 0
 
@@ -415,6 +415,7 @@
 	TT.thrower = thrower
 	TT.diagonals_first = diagonals_first
 	TT.callback = callback
+	TT.undodgeable = undodgeable
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -114,7 +114,7 @@
 		if(!O.anchored && O.loc != src) // so it cannot throw the anomaly core
 			var/mob/living/target = locate() in view(4, src)
 			if(target && !target.stat)
-				O.throw_at(target, 5, 10)
+				O.throw_at(target, 5, 10, undodgeable = TRUE)
 
 /obj/effect/anomaly/grav/Crossed(atom/movable/AM)
 	. = ..()
@@ -143,6 +143,9 @@
 	var/canshock = FALSE
 	var/shockdamage = 20
 	var/explosive = TRUE
+	var/zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE
+	var/zap_range = 5
+	var/power = 5000
 
 /obj/effect/anomaly/flux/Initialize(mapload, new_lifespan, drops_core = TRUE, _explosive = TRUE)
 	. = ..()
@@ -153,6 +156,9 @@
 	canshock = TRUE
 	for(var/mob/living/M in get_turf(src))
 		mobShock(M)
+	if(explosive && prob(50)) //Let us not fuck up the sm that much
+		tesla_zap(src, zap_range, power, zap_flags)
+
 
 /obj/effect/anomaly/flux/Crossed(atom/movable/AM)
 	. = ..()
@@ -168,6 +174,7 @@
 	if(canshock && istype(M))
 		canshock = FALSE //Just so you don't instakill yourself if you slam into the anomaly five times in a second.
 		M.electrocute_act(shockdamage, name, flags = SHOCK_NOGLOVES)
+		M.Weaken(explosive ? 6 SECONDS : 3 SECONDS) //Back to being deadly if you touch it, rather than just being able to crawl out of it. Non explosive ones less deadly, since you can't loot them / vetus
 
 /obj/effect/anomaly/flux/detonate()
 	if(explosive)
@@ -191,8 +198,11 @@
 
 /obj/effect/anomaly/bluespace/anomalyEffect()
 	..()
-	for(var/mob/living/M in range(1, src))
+	for(var/mob/living/M in range(3, src))
 		do_teleport(M, locate(M.x, M.y, M.z), 4)
+	for(var/obj/item/O in range (3, src))
+		if(!O.anchored && O.invisibility == 0 && prob(50))
+			do_teleport(O, locate(O.x, O.y, O.z), 6)
 
 /obj/effect/anomaly/bluespace/Bumped(atom/movable/AM)
 	if(isliving(AM))
@@ -229,7 +239,7 @@
 
 			var/y_distance = turf_to.y - turf_from.y
 			var/x_distance = turf_to.x - turf_from.x
-			for(var/atom/movable/A in urange(12, turf_from)) // iterate thru list of mobs in the area
+			for(var/atom/movable/A in urange(16, turf_from)) // iterate thru list of mobs in the area
 				if(istype(A, /obj/item/radio/beacon))
 					continue // don't teleport beacons because that's just insanely stupid
 				if(A.anchored || A.move_resist == INFINITY)
@@ -274,6 +284,11 @@
 /obj/effect/anomaly/pyro/anomalyEffect()
 	..()
 	ticks++
+	for(var/mob/living/M in range(4, src))
+		if(prob(50))
+			M.adjust_fire_stacks(4)
+			M.IgniteMob()
+
 	if(ticks < 5)
 		return
 	else

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -114,7 +114,7 @@
 		if(!O.anchored && O.loc != src) // so it cannot throw the anomaly core
 			var/mob/living/target = locate() in view(4, src)
 			if(target && !target.stat)
-				O.throw_at(target, 5, 10, undodgeable = TRUE)
+				O.throw_at(target, 5, 10, dodgeable = FALSE)
 
 /obj/effect/anomaly/grav/Crossed(atom/movable/AM)
 	. = ..()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -2,6 +2,7 @@
 
 /// Chance of taking a step per second
 #define ANOMALY_MOVECHANCE 70
+#define BLUESPACE_MASS_TELEPORT_RANGE 16
 
 /obj/effect/anomaly
 	name = "anomaly"
@@ -239,7 +240,7 @@
 
 			var/y_distance = turf_to.y - turf_from.y
 			var/x_distance = turf_to.x - turf_from.x
-			for(var/atom/movable/A in urange(16, turf_from)) // iterate thru list of mobs in the area
+			for(var/atom/movable/A in urange(BLUESPACE_MASS_TELEPORT_RANGE, turf_from)) // iterate thru list of mobs in the area
 				if(istype(A, /obj/item/radio/beacon))
 					continue // don't teleport beacons because that's just insanely stupid
 				if(A.anchored || A.move_resist == INFINITY)
@@ -375,3 +376,4 @@
 		T.ex_act(ex_act_force)
 
 #undef ANOMALY_MOVECHANCE
+#undef BLUESPACE_MASS_TELEPORT_RANGE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -664,7 +664,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 			playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE)
 		return hit_atom.hitby(src, 0, itempush, throwingdatum = throwingdatum)
 
-/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, undodgeable)
+/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin = 1, diagonals_first = 0, datum/callback/callback, force, undodgeable)
 	thrownby = thrower?.UID()
 	callback = CALLBACK(src, .proc/after_throw, callback) //replace their callback with our own
 	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, force, undodgeable)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -664,10 +664,10 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 			playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE)
 		return hit_atom.hitby(src, 0, itempush, throwingdatum = throwingdatum)
 
-/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force)
+/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, undodgeable)
 	thrownby = thrower?.UID()
 	callback = CALLBACK(src, .proc/after_throw, callback) //replace their callback with our own
-	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, force)
+	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, force, undodgeable)
 
 /obj/item/proc/after_throw(datum/callback/callback)
 	if(callback) //call the original callback

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -664,10 +664,10 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 			playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE)
 		return hit_atom.hitby(src, 0, itempush, throwingdatum = throwingdatum)
 
-/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin = 1, diagonals_first = 0, datum/callback/callback, force, undodgeable)
+/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin = 1, diagonals_first = 0, datum/callback/callback, force, dodgeable)
 	thrownby = thrower?.UID()
 	callback = CALLBACK(src, .proc/after_throw, callback) //replace their callback with our own
-	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, force, undodgeable)
+	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, force, dodgeable)
 
 /obj/item/proc/after_throw(datum/callback/callback)
 	if(callback) //call the original callback

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -88,7 +88,7 @@
 		return Attach(AM)
 	return 0
 
-/obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force)
+/obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, datum/callback/callback, force)
 	if(!..())
 		return
 	if(stat == CONSCIOUS)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -88,7 +88,7 @@
 		return Attach(AM)
 	return 0
 
-/obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, datum/callback/callback, force)
+/obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, undodgeable)
 	if(!..())
 		return
 	if(stat == CONSCIOUS)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -88,7 +88,7 @@
 		return Attach(AM)
 	return 0
 
-/obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, undodgeable)
+/obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, dodgeable)
 	if(!..())
 		return
 	if(stat == CONSCIOUS)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1099,6 +1099,6 @@
 		if("lighting_alpha")
 			sync_lighting_plane_alpha()
 
-/mob/living/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, undodgeable)
+/mob/living/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, dodgeable)
 	stop_pulling()
 	return ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1099,6 +1099,6 @@
 		if("lighting_alpha")
 			sync_lighting_plane_alpha()
 
-/mob/living/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force)
+/mob/living/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, undodgeable)
 	stop_pulling()
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Bluespace anomalies teleport people and items in a range around them.
Increased mass teleport area slightly.

Flux anomaly periodically zaps weakly.
Flux anomaly stuns when you touch it, like it used to before the shock rework. Stun time is less if it is a sm / vetus spawned anomaly.

Pyro anomaly can light nearby mobs on fire.

Gravitational anomaly thrown items hit people lying down. You can no longer crawl up to it lying down to dodge thrown items.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Anomalies should be a bit more of a challenge to defuse, one way or another.

Recent prs (crawling, shock change) made 2 of the anomalies much easier to defuse without risk. They have been made more deadly again / prevent using crawling to reach at no risk.

## Testing
<!-- How did you test the PR, if at all? -->
Spawn each type of anomaly separately.
Confirm they worked as intended.
Confirmed only grav anomaly thrown items hit people lying down, not all items.

## Changelog
:cl:
tweak: Anomalies are deadlier, and can hit people from a distance with their effects, rather than only when touching.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
