### PR TITLE
fixes bubblegum / vetus hitting twice during charge

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -238,10 +238,10 @@ Difficulty: Hard
 		return
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/ancient_robot/Bump(atom/A)
+/mob/living/simple_animal/hostile/megafauna/ancient_robot/Bump(atom/A, yes)
 	if(charging)
 		DestroySurroundings()
-		if(isliving(A))
+		if(isliving(A) && yes)
 			var/mob/living/L = A
 			if(!istype(A, /mob/living/simple_animal/hostile/ancient_robot_leg))
 				L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] tramples you into the ground!</span>")
@@ -621,10 +621,10 @@ Difficulty: Hard
 	walk_towards(src, T, movespeed)
 	DestroySurroundings()
 
-/mob/living/simple_animal/hostile/ancient_robot_leg/Bump(atom/A)
+/mob/living/simple_animal/hostile/ancient_robot_leg/Bump(atom/A, yes)
 	if(!core.charging)
 		return
-	if(isliving(A))
+	if(isliving(A) && yes)
 		if(!istype(A, /mob/living/simple_animal/hostile/megafauna/ancient_robot))
 			var/mob/living/L = A
 			L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] tramples you into the ground!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -461,8 +461,8 @@ Difficulty: Hard
 	playsound(src, 'sound/effects/meteorimpact.ogg', 200, TRUE, 2, TRUE)
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/Bump(atom/A)
-	if(charging)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/Bump(atom/A, yes)
+	if(charging && yes)
 		if(isturf(A) || isobj(A) && A.density)
 			A.ex_act(EXPLODE_HEAVY)
 		DestroySurroundings()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Bubblegum / vetus no longer bump twice, hitting for twice as much, rather than bumping once.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ever noticed that when bubblgum / vetus bumps into something, it hits them twice?
Yeah, thats a fun issue with Bump()
This hurts extra bad with bubblegum, as it ignores armor.
This PR makes them hit once (in bubblegums case for 30 brute) rather than twice for 60 brute total.

This does make the fights easier, I was considering upping the damage to 40, but this is also ideally a fix, not balance.

## Testing
<!-- How did you test the PR, if at all? -->

Spawn bubblegum / vetus.

Get charged at.

Enjoy not getting hit twice every time instead of once.

## Changelog
:cl:
fix: Fix bubblegum / vetus speculator hitting mobs twice in their charge rather than once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
