### PR TITLE
Tweak rechargers icon handling so they don't update every process

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -105,7 +105,6 @@
 		WRENCH_ANCHOR_MESSAGE
 	else
 		WRENCH_UNANCHOR_MESSAGE
-	update_icon()
 
 /obj/machinery/recharger/attack_hand(mob/user)
 	if(issilicon(user))

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -105,6 +105,7 @@
 		WRENCH_ANCHOR_MESSAGE
 	else
 		WRENCH_UNANCHOR_MESSAGE
+	update_icon()
 
 /obj/machinery/recharger/attack_hand(mob/user)
 	if(issilicon(user))
@@ -130,9 +131,13 @@
 /obj/machinery/recharger/process()
 	if(stat & (NOPOWER|BROKEN) || !anchored || panel_open)
 		return
+	if(!charging)
+		return
 
+	var/old_power_state = using_power
 	using_power = try_recharging_if_possible()
-	update_icon()
+	if(using_power != old_power_state)
+		update_icon()
 
 /obj/machinery/recharger/emp_act(severity)
 	if(stat & (NOPOWER|BROKEN) || !anchored)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check for a state change so it only updates the icon in process when it's appropriate. An early return is also added since it doesn't need to try to process further if there's nothing inserted into the recharger.

## Why It's Good For The Game
Calling `update_icon` on every process isn't a good idea.

## Testing
Used a recharger in its various states. Nothing changed visually, this is just so it doesn't go overboard with procs.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
