### PR TITLE
Clarifies that DNA injectors cannot be used with syringe guns 

### DIFF
--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/syringe
 	name = "syringe gun"
-	desc = "A spring loaded rifle designed to fit syringes, used to incapacitate unruly patients from a distance."
+	desc = "A spring loaded rifle designed to fit syringes, used to incapacitate unruly patients from a distance. Not compatible with DNA-Injectors."
 	icon_state = "syringegun"
 	item_state = "syringegun"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -77,6 +77,9 @@
 			return TRUE
 		else
 			to_chat(user, "<span class='notice'>[src] cannot hold more syringes.</span>")
+	else if(istype(A, /obj/item/dnainjector))
+		to_chat(user, "<span class='notice'>[src] is incompatible with DNA-Injectors.</span>")
+		return
 	else
 		return ..()
 /obj/item/gun/syringe/rapidsyringe_old

--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -84,13 +84,13 @@
 		return ..()
 /obj/item/gun/syringe/rapidsyringe_old
 	name = "rapid syringe gun"
-	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to six syringes."
+	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to six syringes. Not compatible with DNA-Injectors"
 	icon_state = "rapidsyringegun"
 	max_syringes = 6
 
 /obj/item/gun/syringe/syndicate
 	name = "dart pistol"
-	desc = "A small spring-loaded sidearm that functions identically to a syringe gun."
+	desc = "A small spring-loaded sidearm that functions identically to a syringe gun. Not compatible with DNA-Injectors"
 	icon_state = "syringe_pistol"
 	item_state = "gun" //Smaller inhand
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -80,8 +80,8 @@
 	else if(istype(A, /obj/item/dnainjector))
 		to_chat(user, "<span class='notice'>[src] is incompatible with DNA-Injectors.</span>")
 		return
-	else
-		return ..()
+
+	return ..()
 /obj/item/gun/syringe/rapidsyringe_old
 	name = "rapid syringe gun"
 	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to six syringes. Not compatible with DNA-Injectors."

--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -84,13 +84,13 @@
 		return ..()
 /obj/item/gun/syringe/rapidsyringe_old
 	name = "rapid syringe gun"
-	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to six syringes. Not compatible with DNA-Injectors"
+	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to six syringes. Not compatible with DNA-Injectors."
 	icon_state = "rapidsyringegun"
 	max_syringes = 6
 
 /obj/item/gun/syringe/syndicate
 	name = "dart pistol"
-	desc = "A small spring-loaded sidearm that functions identically to a syringe gun. Not compatible with DNA-Injectors"
+	desc = "A small spring-loaded sidearm that functions identically to a syringe gun. Not compatible with DNA-Injectors."
 	icon_state = "syringe_pistol"
 	item_state = "gun" //Smaller inhand
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an alert and an examine message to the syringe gun, dart pistol, and the oldRSG stating that you cannot use DNA-Injectors with them.

Adds the line "Not compatible with DNA-Injectors." to the three syringe-based syringe guns 

Adds the alert text "[Syringe gun type] is incompatible with DNA-Injectors." Upon attempting to add a DNA-Injector to these weapons. 

Fixes #18844 

## Why It's Good For The Game
Injectors do look similar to syringes, and currently gives no feedback upon denying one from use. This adds visual feedback, so the player knows that this is intended behavior. 

## Testing
Compiled code and ran, attempted both interactions, text showed up when it should, attempted normal syringe interactions, correct text showed up and no behavior was altered. 

## Changelog
:cl:
spellcheck: Adds messages for the DNA-Injectors not being useable with the syringe gun 
/:cl:

