### PR TITLE
Wall closets don't spam the chat when successfully closing

### DIFF
--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -12,7 +12,7 @@
 	icon_opened = "wall-lockeropen"
 
 /obj/structure/closet/walllocker/close()
-	..()
+	. = ..()
 	density = FALSE //It's a locker in a wall, you aren't going to be walking into it.
 
 /obj/structure/closet/walllocker/emerglocker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stores the returned value of the parent `close` for wall closets. `toggle` is dependent on the returned value, and wall closets would always return false as they didn't store the called parent.

## Why It's Good For The Game
Wall closets won't spam the chat unless it's actually meeting that condition.

## Images of changes
https://user-images.githubusercontent.com/80771500/185192203-ffc475bc-57ae-4631-8fe9-e0f79d848c22.mp4

## Testing
Messed with wall closets. The repro was 100% regardless of what the closet would do.

## Changelog
:cl:
fix: Wall closets do not spam the chat saying it won't budge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
