### PR TITLE
Preemptive schema bump for an upcoming project

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -287,6 +287,7 @@ CREATE TABLE `player` (
   `ghost_darkness_level` tinyint(1) UNSIGNED NOT NULL DEFAULT '255',
   `colourblind_mode` VARCHAR(48) NOT NULL DEFAULT 'None' COLLATE 'utf8mb4_general_ci',
   `keybindings` LONGTEXT COLLATE 'utf8mb4_unicode_ci' DEFAULT NULL,
+  `server_region` VARCHAR(32) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`),
   KEY `lastseen` (`lastseen`),

--- a/SQL/updates/43-44.sql
+++ b/SQL/updates/43-44.sql
@@ -1,0 +1,3 @@
+# Updating SQL from 43 to 44 -AffectedArc07
+# Adding new column for server region settings
+ALTER TABLE `player` ADD COLUMN `server_region` VARCHAR(32) NULL DEFAULT NULL AFTER `keybindings`;

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -371,7 +371,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 43
+#define SQL_VERSION 44
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -145,7 +145,7 @@ ipc_screens = [
 # Enable/disable the database on a whole
 sql_enabled = false
 # SQL version. If this is a mismatch, round start will be delayed
-sql_version = 43
+sql_version = 44
 # SQL server address. Can be an IP or DNS name
 sql_address = "127.0.0.1"
 # SQL server port


### PR DESCRIPTION
## What Does This PR Do
Bumps SQL from 43 to 44 and adds a column for server region.

## Why It's Good For The Game
Im doing this now because theres lots of components that need to be made here, and I can do them in order and get this column in now without having to slow the repo or keep stuff TM'd for no reason.

## Testing
Ran the queries

## Changelog
N/A