### PR TITLE
True map rotation

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -134,6 +134,17 @@ SUBSYSTEM_DEF(ticker)
 			addtimer(CALLBACK(src, .proc/call_reboot), 5 SECONDS)
 			if(GLOB.configuration.vote.enable_map_voting)
 				SSvote.start_vote(new /datum/vote/map)
+			else
+				// Pick random map
+				var/list/pickable_types = list()
+				for(var/x in subtypesof(/datum/map))
+					var/datum/map/M = x
+					if(initial(M.voteable))
+						pickable_types += M
+
+				var/datum/map/target_map = pick(pickable_types)
+				SSmapping.next_map = new target_map
+				to_chat(world, "<span class='interface'>Map for next round: [SSmapping.next_map.fluff_name] ([SSmapping.next_map.technical_name])</span>")
 
 /datum/controller/subsystem/ticker/proc/call_reboot()
 	if(mode.station_was_nuked)


### PR DESCRIPTION
## What Does This PR Do
Make it so the server picks a random map, **if map voting is disabled in the config**.

## Why It's Good For The Game
The box monotony must end.

## Testing
I ended a round
![image](https://user-images.githubusercontent.com/25063394/185736351-aa8c2885-c47a-418c-a89c-48e8d07e770e.png)

## Changelog
Nothing player facing as the config isn't enabled. If I change the config there will be a discord announcement about it. 