### PR TITLE
Server regions

### DIFF
--- a/code/controllers/configuration/sections/system_configuration.dm
+++ b/code/controllers/configuration/sections/system_configuration.dm
@@ -28,6 +28,8 @@
 	var/external_tos_handler = FALSE
 	/// Map datum of the map to use, overriding the defaults, and `data/next_map.txt`
 	var/override_map = null
+	/// Assoc list of region names and their server IPs. Used for geo-routing.
+	var/list/region_map = list()
 
 /datum/configuration_section/system_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
@@ -48,3 +50,9 @@
 	CONFIG_LOAD_STR(internal_ip, data["internal_ip"])
 
 	CONFIG_LOAD_STR(override_map, data["override_map"])
+
+	// Load region overrides
+	if(islist(data["regional_servers"]))
+		region_map.Cut()
+		for(var/list/kvset in data["regional_servers"])
+			region_map[kvset["name"]] = kvset["ip"]

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -159,8 +159,13 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	// Send the reboot banner to all players
 	for(var/client/C in GLOB.clients)
 		C << output(list2params(list(secs_before_auto_reconnect)), "browseroutput:reboot")
-		if(GLOB.configuration.url.server_url) // If you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
-			C << link("byond://[GLOB.configuration.url.server_url]")
+		if(C.prefs.server_region)
+			// Keep them on the same relay
+			C << link(GLOB.configuration.system.region_map[C.prefs.server_region])
+		else
+			// Use the default
+			if(GLOB.configuration.url.server_url) // If you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
+				C << link("byond://[GLOB.configuration.url.server_url]")
 
 	// And begin the real shutdown
 	rustg_log_close_all() // Past this point, no logging procs can be used, at risk of data loss.

--- a/code/modules/client/login_processing/10-load_preferences.dm
+++ b/code/modules/client/login_processing/10-load_preferences.dm
@@ -2,6 +2,8 @@
 	priority = 10
 
 /datum/client_login_processor/load_preferences/get_query(client/C)
+	// If you ever need to remove a column from here, just replace the column name with NULL
+	// This saves you having to go around the entire codebase and fix columns
 	var/datum/db_query/query = SSdbcore.NewQuery({"SELECT
 		ooccolor,
 		UI_style,
@@ -24,7 +26,8 @@
 		screentip_color,
 		ghost_darkness_level,
 		colourblind_mode,
-		keybindings
+		keybindings,
+		server_region
 		FROM player
 		WHERE ckey=:ckey"}, list(
 			"ckey" = C.ckey

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -123,6 +123,8 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	var/list/datum/keybindings = list()
 	/// Keybinding overrides ("name" => ["key"...])
 	var/list/keybindings_overrides = null
+	/// Player's region override for routing optimisation
+	var/server_region = null
 
 /datum/preferences/New(client/C, datum/db_query/Q) // Process our query
 	parent = C

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -26,6 +26,7 @@
 		ghost_darkness_level = query.item[20]
 		colourblind_mode = query.item[21]
 		keybindings = init_keybindings(raw = query.item[22])
+		server_region = query.item[23]
 
 	lastchangelog_2 = lastchangelog // Clone please
 
@@ -48,6 +49,11 @@
 	screentip_color = sanitize_hexcolor(screentip_color, initial(screentip_color))
 	ghost_darkness_level = sanitize_integer(ghost_darkness_level, 0, 255, initial(ghost_darkness_level))
 	colourblind_mode = sanitize_inlist(colourblind_mode, list(COLOURBLIND_MODE_NONE, COLOURBLIND_MODE_DEUTER, COLOURBLIND_MODE_PROT, COLOURBLIND_MODE_TRIT), COLOURBLIND_MODE_NONE)
+
+	// Sanitize the region
+	if(!(server_region in GLOB.configuration.system.region_map))
+		server_region = null // This region doesnt exist anymore
+
 	return TRUE
 
 /datum/preferences/proc/save_preferences(client/C)
@@ -82,7 +88,8 @@
 		screentip_color=:screentip_color,
 		ghost_darkness_level=:ghost_darkness_level,
 		colourblind_mode=:colourblind_mode,
-		keybindings=:keybindings
+		keybindings=:keybindings,
+		server_region=:server_region
 		WHERE ckey=:ckey"}, list(
 			// OH GOD THE PARAMETERS
 			"ooccolour" = ooccolor,
@@ -107,6 +114,7 @@
 			"colourblind_mode" = colourblind_mode,
 			"keybindings" = json_encode(keybindings_overrides),
 			"ckey" = C.ckey,
+			"server_region" = server_region,
 		))
 
 	if(!query.warn_execute())

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -748,6 +748,12 @@ external_tos_handler = false
 # Do not use in production.
 # Comment out to disable.
 #override_map = "/datum/map/test_tiny"
+# Regional servers.
+# This is not for separate DD instances per region, but if you have a geo-routing setup deployed to optimise routing for players
+# I am 99.9% certain you will never need to fill this out
+regional_servers = [
+	#{name = "UK", ip = "byond://uk.paradisestation.org:6666"},
+]
 
 
 ################################################################


### PR DESCRIPTION
## What Does This PR Do
This PR adds a verb for picking a server region for your user, and then routing you via it. **It does not route by default on connect to avoid connection loops, that will be handled by the proxy server.**

## Why It's Good For The Game
I did some testing, and discovered that routing players nearer to their connection can result in ping reduction

<details>
<summary>Nerdposting on why this works</summary>

Lets say for imagine you are in the UK, connecting to Paradise, which is in NYC. Your router and ISP have to figure out how to get data from your house all the way over the ocean to the Paradise server in NYC, and this can result in you getting bad routes with added latency, degraded bandwidth or in the worst case scenario, packet loss.

However, its a lot easier for your ISP to figure out how to get you from your house to London, and then the datacentre in London can get your traffic over the atlantic. This may seem counter intuitive, but not only do datacentre connections tend to have better routing (since connections matter a lot more in a datacentre that residentially), but large service providers (AWS, Azure, Google, OVH, etc) have their own private, dedicated overseas links, free from traffic from the rest of the internet, and free from being assigned routes by other providers. This results in a latency reduction and a much more playable experience overall (My UK average ping dropped from 90-100ms to 70-80ms).
</details>

## Testing
Swapped regions, it updated the pref and re-routed me 

## Changelog
:cl: AffectedArc07
add: Added a verb to switch server region. This may be useful to reduce your ping.
/:cl:
