### PR TITLE
Fixes emagged deep fryer softlock

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -136,7 +136,12 @@
 			else
 				L.death()
 		break
-	sleep(cooktime)
+	addtimer(CALLBACK(src, .proc/finish_cook, I, user), cooktime)
+
+/obj/machinery/cooker/proc/finish_cook(obj/item/I, mob/user, params)
+	if(QDELETED(I)) //For situations where the item being cooked gets deleted mid-cook (primed grenades)
+		turnoff()
+		return
 	if(I && I.loc == src)
 		//New interaction to allow special foods to be made/cooked via deepfryer without removing original functionality
 		//Define the foods/results on the specific machine		--FalseIncarnate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes #18871

Emagged deep fryers will now properly finish their cooking cycle if a primed grenade detonates inside of them.

`cooker.dm` has also been very mildly refactored to replace an instance of `sleep` with `addtimer` and separate the final steps of cooking into its own proc.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs are bad!

## Testing
<!-- How did you test the PR, if at all? -->
Compiled and tested on a local debug server. Visual Studio spat out one error in `timer.dm`, but I was told this is a new issue with compiling for Dream Daemon in VSC.

## Changelog
:cl:
fix: Primed grenades no longer softlock emagged deep fryers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
