### PR TITLE
fixes reactive armors working with no charge GBP NO UPDATE

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -321,13 +321,10 @@
 /obj/item/clothing/suit/armor/reactive/proc/use_power()
 	if(in_grace_period)
 		return TRUE
-	if(cell.charge <= 0) //No working if cells are dry
+	if(!cell.use(energy_cost)) //No working if cells are dry
 		return FALSE
-	else
-		in_grace_period = TRUE
-		cell.use(energy_cost) // 20 blocks for most armors, 12 blocks for the "stronger" armors
-		addtimer(VARSET_CALLBACK(src, in_grace_period, FALSE), 1 SECONDS)
-		return TRUE
+	addtimer(VARSET_CALLBACK(src, in_grace_period, FALSE), 1 SECONDS)
+	return TRUE
 
 /obj/item/clothing/suit/armor/reactive/get_cell()
 	return cell

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -321,7 +321,7 @@
 /obj/item/clothing/suit/armor/reactive/proc/use_power()
 	if(in_grace_period)
 		return TRUE
-	if(cell.charge == 0) //No working if cells are dry
+	if(cell.charge <= 0) //No working if cells are dry
 		return FALSE
 	else
 		in_grace_period = TRUE

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -323,6 +323,7 @@
 		return TRUE
 	if(!cell.use(energy_cost)) //No working if cells are dry
 		return FALSE
+	in_grace_period = TRUE
 	addtimer(VARSET_CALLBACK(src, in_grace_period, FALSE), 1 SECONDS)
 	return TRUE
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -320,11 +320,14 @@
 
 /obj/item/clothing/suit/armor/reactive/proc/use_power()
 	if(in_grace_period)
-		return
+		return TRUE
+	if(cell.charge == 0) //No working if cells are dry
+		return FALSE
 	else
 		in_grace_period = TRUE
 		cell.use(energy_cost) // 20 blocks for most armors, 12 blocks for the "stronger" armors
 		addtimer(VARSET_CALLBACK(src, in_grace_period, FALSE), 1 SECONDS)
+		return TRUE
 
 /obj/item/clothing/suit/armor/reactive/get_cell()
 	return cell
@@ -369,11 +372,10 @@
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return 0
-	if(reaction_check(hitby) && is_teleport_allowed(owner.z))
+	if(reaction_check(hitby) && is_teleport_allowed(owner.z) && use_power())
 		var/mob/living/carbon/human/H = owner
 		if(do_teleport(owner, owner, 6, safe_turf_pick = TRUE)) //Teleport on the same spot with a precision of 6 gets a random tile near the owner.
 			owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
-			use_power()
 			return TRUE
 		return FALSE
 	return FALSE
@@ -397,9 +399,8 @@
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
-	if(reaction_check(hitby))
+	if(reaction_check(hitby) && use_power())
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], sending out jets of flame!</span>")
-		use_power()
 		for(var/mob/living/carbon/C in range(6, owner))
 			if(C != owner)
 				C.fire_stacks += 8
@@ -417,14 +418,13 @@
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
-	if(reaction_check(hitby))
+	if(reaction_check(hitby) && use_power())
 		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
 		E.Copy_Parent(owner, 50)
 		E.GiveTarget(owner) //so it starts running right away
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
 		owner.make_invisible()
-		use_power()
 		addtimer(CALLBACK(owner, /mob/living/.proc/reset_visibility), 4 SECONDS)
 		return TRUE
 
@@ -435,9 +435,8 @@
 /obj/item/clothing/suit/armor/reactive/tesla/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
-	if(reaction_check(hitby))
+	if(reaction_check(hitby) && use_power())
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], sending out arcs of lightning!</span>")
-		use_power()
 		for(var/mob/living/M in view(6, owner))
 			if(M == owner)
 				continue
@@ -462,7 +461,7 @@
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
-	if(reaction_check(hitby))
+	if(reaction_check(hitby) && use_power())
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], converting the attack into a wave of force!</span>")
 		use_power()
 		var/list/thrown_atoms = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Reactive armors now check if they have charge before blocking.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

if it has no power, it should not work

## Testing
<!-- How did you test the PR, if at all? -->

spawn in
test it works with charge
test it works without charge
kick self for being so dumb

## Changelog
:cl:
fix: Reactive armors no longer work when out of charge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
