### PR TITLE
Makes that Turbine Scrubbers no longer fight against Turbine itself

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -13140,8 +13140,9 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "aNU" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	level = 1
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
@@ -13175,7 +13176,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "aNY" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
@@ -13653,6 +13654,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "aPm" = (
@@ -13669,6 +13673,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "aPn" = (
@@ -13680,6 +13687,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
@@ -13731,6 +13741,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "Exhaust Reuse"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -13748,7 +13761,9 @@
 	},
 /area/maintenance/incinerator)
 "aPt" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "Exhaust Disposal"
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -14393,9 +14408,7 @@
 	dir = 1;
 	id = "incineratorturbine"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
@@ -97275,6 +97288,12 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block)
+"wok" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/incinerator)
 "wpr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -118238,9 +118257,9 @@ abj
 aLQ
 abj
 aLT
-abj
-aaa
-abj
+aNT
+aPk
+aNT
 acF
 aaa
 abj
@@ -118495,9 +118514,9 @@ aGX
 aJK
 aGX
 acF
-aNT
-aPk
-aNT
+aGZ
+wok
+aGZ
 aWR
 abj
 abj

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -14354,10 +14354,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "aQM" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4;
-	frequency = 1441;
-	id = "mix_in"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11635,9 +11635,6 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "aRQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
@@ -18368,10 +18365,10 @@
 /area/security/checkpoint2)
 "biB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
 /obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "biC" = (
@@ -19399,7 +19396,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bkY" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -19415,8 +19411,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "bla" = (
@@ -22436,7 +22434,6 @@
 	},
 /area/hallway/primary/port)
 "brW" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plasteel,
@@ -30003,12 +30000,6 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/library)
-"bKx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "bKy" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -31930,13 +31921,8 @@
 /turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "bQA" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 0;
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	pressure_checks = 2;
-	releasing = 0
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/maintenance/turbine)
@@ -34619,7 +34605,6 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bXO" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
@@ -34824,6 +34809,7 @@
 "bYh" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine/vacuum,
 /area/maintenance/turbine)
 "bYi" = (
@@ -38969,11 +38955,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cjD" = (
@@ -39125,15 +39108,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/maintenance/turbine)
-"ckc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ckd" = (
@@ -39606,7 +39580,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "clz" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -39636,7 +39609,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "clF" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
@@ -41289,7 +41261,6 @@
 /area/maintenance/turbine)
 "cqQ" = (
 /obj/machinery/atmospherics/binary/pump/on,
-/obj/structure/disposalpipe/segment,
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/maintenance/turbine)
@@ -42051,11 +42022,6 @@
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
-"cts" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "ctt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -42595,6 +42561,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
 /turf/simulated/floor/engine/vacuum,
 /area/maintenance/turbine)
 "cuS" = (
@@ -43090,6 +43059,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine/vacuum,
 /area/maintenance/turbine)
 "cwC" = (
@@ -45721,6 +45691,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/meter,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cEE" = (
@@ -58007,16 +57980,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medmaint)
-"fyZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/space,
-/area/space/nearstation)
 "fza" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sink{
@@ -58947,6 +58910,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"fVW" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "fWg" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -62682,6 +62655,14 @@
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
+"hNa" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/space/nearstation)
 "hNv" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 1
@@ -64210,6 +64191,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
+"iAP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/turbine)
 "iAS" = (
 /obj/machinery/vending/hatdispenser,
 /obj/machinery/light,
@@ -72086,6 +72080,13 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
+"mpF" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/atmos)
 "mpP" = (
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	dir = 8;
@@ -75856,6 +75857,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"omW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/space,
+/area/space/nearstation)
 "onF" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -77181,6 +77187,14 @@
 	icon_state = "white"
 	},
 /area/medical/paramedic)
+"oYa" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/space/nearstation)
 "oYO" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "C1"
@@ -79665,6 +79679,18 @@
 /area/quartermaster/miningdock{
 	name = "\improper Mining Office"
 	})
+"qlS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/turbine)
 "qlX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80454,6 +80480,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
+"qMg" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on{
+	dir = 1
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/maintenance/turbine)
 "qMU" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -92938,6 +92970,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)
+"xfm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/space/nearstation)
 "xfn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -134227,18 +134267,18 @@ asJ
 lRY
 aoG
 ciF
-ckc
+clz
 clz
 bkY
 brW
 clF
 cqQ
-bKx
-bKx
-bKx
+qee
+qee
+qee
 bXO
-cts
-fyZ
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134494,7 +134534,7 @@ clA
 clA
 clA
 cyn
-abq
+aaa
 aaa
 aaa
 aaa
@@ -134751,8 +134791,8 @@ clB
 bQA
 clA
 clA
+clA
 cyu
-aaa
 aaa
 aaa
 aaa
@@ -134999,8 +135039,8 @@ aoG
 cgW
 chX
 cjB
-cmM
-cmM
+iAP
+qlS
 cmM
 cqa
 cqP
@@ -135008,8 +135048,8 @@ ctn
 cuQ
 cwB
 bYh
+qMg
 ctv
-aaa
 aaa
 aaa
 aaa
@@ -135265,9 +135305,9 @@ clB
 cuO
 clA
 clA
+clA
 cyu
 bNP
-iju
 abq
 iju
 abq
@@ -135513,7 +135553,7 @@ axh
 bCM
 fmX
 bCM
-bzL
+mpF
 clA
 clA
 clA
@@ -135521,9 +135561,9 @@ clA
 clA
 bSl
 clA
-aaa
-aaa
-aaa
+hNa
+omW
+fVW
 aaa
 aaa
 aaa
@@ -135770,15 +135810,15 @@ bCU
 rjm
 pmE
 bCM
-abq
-abq
-abq
-abq
-abq
-abq
-abq
-aaa
-aaa
+oYa
+omW
+omW
+omW
+omW
+omW
+omW
+omW
+xfm
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -42527,10 +42527,8 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1443;
-	id = "air_in"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/maintenance/turbine)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -66370,11 +66370,11 @@
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
 "dmz" = (
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on{
-	dir = 1
-	},
 /obj/structure/sign/vacuum{
 	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
@@ -66386,6 +66386,10 @@
 	},
 /obj/machinery/igniter{
 	id = "gasturbine"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	level = 1
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
@@ -66486,6 +66490,7 @@
 	comp_id = "incineratorturbine";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
 "dmP" = (
@@ -66650,6 +66655,7 @@
 "dne" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
 "dnf" = (
@@ -84576,6 +84582,12 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"qIz" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/turbine)
 "qIW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -131987,8 +131999,8 @@ dln
 dmy
 dgS
 dgS
+dgS
 dnx
-aaa
 doE
 aaa
 aaa
@@ -132244,8 +132256,8 @@ dmh
 dmA
 dmO
 dne
+qIz
 dnI
-aaa
 doE
 aaa
 aaa
@@ -132501,8 +132513,8 @@ dln
 dmz
 dgS
 dgS
+dgS
 dnx
-aaa
 doE
 aaa
 aaa

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -66362,10 +66362,8 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "dmy" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1443;
-	id = "air_in"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Repositions Turbine Scrubber behind Turbine so that it no longer reduces pressure in the burn room, and instead scrubs exhaust if you want to do something fancy with it (like clean it out of CO2 and put it back into the burn room).

Also adds valve between Turbine Exhaust pipe and Turbine intake pipe on other stations (already exists on Cyberiad) so you can  put the exhaust back into intake (which never 100% burns so it still have 85% of old burn mix).

Optimization will still take time and effort, but no-brain "just mix 50-50 Plasma-Oxygen and let it burn" now produces 100kW instead of 60-70, and consumes stuff slower. Also fully upgraded Turbine gives 600kW.
Before to achieve that you needed to disable or unwrench that scrubber.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Turbine is rarely used and the scrubber action is really dumb and not in any way like it should be
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![turbine_meta](https://user-images.githubusercontent.com/5380208/186650257-65c7bdd5-3a2d-418a-b4aa-7552c96acb54.png)
![turbine_cyberiad](https://user-images.githubusercontent.com/5380208/186650261-d5a55de4-eb01-424d-9d8a-2bc2b9ca26e6.png)
![turbine_delta](https://user-images.githubusercontent.com/5380208/186650264-f3d7c18e-64c2-48d8-9a99-9cb8d9361dd6.png)


## Testing
Start Box station. Spawn as Atmosian.
Go to atmos, max pumps from O2 to mix, and from Plasma to Mix.
Disable Mix to Scrubber pump, max Mix to Turbine Pump
Enable Mixer valve in Turbine, Enable and max all pumps except for Mix to Exhaust.
Ignite
See that it scrubs now behind the Turbine and there is a space behind Turbine where exhaust gas is collected instead of being immediately spaced.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: changed turbine exhaust and scrubber on all stations so that scrubber no longer fights against the turbine input and instead lets you reuse (and filter if you want) the unburned parts of exhaust
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
