### PR TITLE
Fixes armour blocking combat log

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -167,7 +167,7 @@
 
 	var/additional_log_text
 	if(blocked)
-		additional_log_text = " [blocked]% blocked"
+		additional_log_text = " [ARMOUR_VALUE_TO_PERCENTAGE(blocked)]% blocked"
 	if(reagents && reagents.reagent_list)
 		var/reagent_note = "REAGENTS:"
 		for(var/datum/reagent/R in reagents.reagent_list)


### PR DESCRIPTION
## What Does This PR Do
Makes the percentage display as the actual percentage and not raw armour value.

## Why It's Good For The Game
Accuracy.

## Testing
I shot myself on my local server again.