### PR TITLE
[GBP: No Update] Fixes problems with Give alerts

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -175,7 +175,7 @@
 	I.add_fingerprint(receiver)
 	I.on_give(giver, receiver)
 	receiver.visible_message("<span class='notice'>[giver] handed [I] to [receiver].</span>")
-	receiver.clear_alert("give item [item_UID]")
+	receiver.clear_alert("take item [item_UID]")
 
 
 /obj/screen/alert/take_item/do_timeout(mob/M, category)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Towards the end of my give rework I changed the alerts to be `"take item"` instead of `"give item"`, and I forgot this one, causing weird invisible alerts to stay around and fuck with other alert positioning.

Fixes #18886
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Testing
Got two player clients. Used the Give Item verb/hotkey to trade items back and forth. Confirmed no ghost alerts stuck around to fuck with other alert icons.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed an issue where Give Item alerts were not going away properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
