### PR TITLE
Changes trying to change transfer amounts with containers that only have one possible amount

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -22,10 +22,15 @@
 	if(!usr.Adjacent(src) || !ishuman(usr) || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
 		return
 
-	var/default = null
-	if(amount_per_transfer_from_this in possible_transfer_amounts)
-		default = amount_per_transfer_from_this
-	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
+	var/picked_amount
+	if(length(possible_transfer_amounts) == 1) // If theres only one option, pick it for them.
+		picked_amount = pick(possible_transfer_amounts)
+		to_chat(usr, "<span class='warning'>[src] has only one transfer option: [picked_amount] units.</span>")
+	else
+		var/default = null
+		if(amount_per_transfer_from_this in possible_transfer_amounts)
+			default = amount_per_transfer_from_this
+		picked_amount = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
 
 	if(!usr.Adjacent(src))
 		to_chat(usr, "<span class='warning'>You have moved too far away!</span>")
@@ -34,8 +39,8 @@
 		to_chat(usr, "<span class='warning'>You can't use your hands!</span>")
 		return
 
-	if(N)
-		amount_per_transfer_from_this = N
+	if(picked_amount)
+		amount_per_transfer_from_this = picked_amount
 
 /obj/item/reagent_containers/AltClick()
 	set_APTFT()
@@ -104,4 +109,5 @@
 	// this message on examining food.
 	if(possible_transfer_amounts)
 		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this > 1 ? "s" : ""] at a time.</span>"
-		. += "<span class='notice'>Alt-click to change the transfer amount.</span>"
+		if(possible_transfer_amounts > 1)
+			. += "<span class='notice'>Alt-click to change the transfer amount.</span>"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -27,7 +27,7 @@
 		picked_amount = pick(possible_transfer_amounts)
 		to_chat(usr, "<span class='warning'>[src] has only one transfer option: [picked_amount] units.</span>")
 	else
-		var/default = null
+		var/default
 		if(amount_per_transfer_from_this in possible_transfer_amounts)
 			default = amount_per_transfer_from_this
 		picked_amount = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
@@ -109,5 +109,5 @@
 	// this message on examining food.
 	if(possible_transfer_amounts)
 		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this > 1 ? "s" : ""] at a time.</span>"
-		if(possible_transfer_amounts > 1)
+		if(length(possible_transfer_amounts) > 1)
 			. += "<span class='notice'>Alt-click to change the transfer amount.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Reagent containers that only have one transfer option (autoinjectors, damp rags), will now say that they only have one transfer option instead of pulling up a redundant menu. It will also only show the Alt-Click to change if there is more than one option.


Alternative to #18780
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Having redundant menus is confusing.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/91113370/186935462-70769cb1-e281-4278-b3de-ca5ef0b02f78.png)


## Testing
<!-- How did you test the PR, if at all? -->
Tested changing the transfer amounts of autoinjectors, damp rags, beakers, droppers, pipettes, donuts, cheese, and cheese wheels. I also examined all of them to make sure they work as intended. I also tried changing the transfer amounts on foods with reagents inside of them, which also work as intended.

## Changelog
:cl:
tweak: Changing the transfer amount of something with only one option (like an autoinjector) will tell you there is one option instead of opening a menu.
tweak: Examining an item will now only show that you can alt-click to change the transfer amount if there is more than one option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
