### PR TITLE
Golem shells require more dexterity

### DIFF
--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -42,7 +42,7 @@
 	if(istype(I, /obj/item/stack))
 		var/obj/item/stack/O = I
 		var/species = golem_shell_species_types[O.merge_type]
-		if(!ishuman())
+		if(!ishuman(user))
 			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return
 		if(species)

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -42,7 +42,7 @@
 	if(istype(I, /obj/item/stack))
 		var/obj/item/stack/O = I
 		var/species = golem_shell_species_types[O.merge_type]
-		if(!istype(user, /mob/living/carbon/human))
+		if(!ishuman())
 			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return
 		if(species)

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -40,11 +40,12 @@
 		/obj/item/stack/sheet/plastic					= /datum/species/golem/plastic)
 
 	if(istype(I, /obj/item/stack))
-		var/obj/item/stack/O = I
-		var/species = golem_shell_species_types[O.merge_type]
 		if(!ishuman(user))
 			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return
+			
+		var/obj/item/stack/O = I
+		var/species = golem_shell_species_types[O.merge_type]
 		if(species)
 			if(O.use(10))
 				to_chat(user, "You finish up the golem shell with ten sheets of [O].")

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -42,6 +42,9 @@
 	if(istype(I, /obj/item/stack))
 		var/obj/item/stack/O = I
 		var/species = golem_shell_species_types[O.merge_type]
+		if(!istype(user, /mob/living/carbon/human))
+			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+			return
 		if(species)
 			if(O.use(10))
 				to_chat(user, "You finish up the golem shell with ten sheets of [O].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Currently there is nothing stopping borgs, drones, etc from finishing golem shells and having their own golem servants. This updates it so that humanoids are required to finish the golem.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Consistency to the idea that dexterous tasks require finer human manipulation.
Stops certain roles, such as maintenance drones, from completing golems and having their own servants when this shouldn't normally be possible.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed that it worked as expected when testing humanoid mobs, silicon mobs, etc.

## Changelog
:cl:
tweak: Golem shells need to be finished by humanoids.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
