### PR TITLE
Removes some NanoMed Plus products, tweaks mannitol and mutadone pills, renames healing patch

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1218,15 +1218,36 @@
 	icon_panel = "wide_vendor"
 	ads_list = list("Go save some lives!","The best stuff for your medbay.","Only the finest tools.","Natural chemicals!","This stuff saves lives.","Don't you want some?","Ping!")
 	req_access_txt = "5"
-	products = list(/obj/item/reagent_containers/syringe = 12, /obj/item/reagent_containers/food/pill/patch/styptic = 4, /obj/item/reagent_containers/food/pill/patch/silver_sulf = 4, /obj/item/reagent_containers/applicator/brute = 3, /obj/item/reagent_containers/applicator/burn = 3,
-					/obj/item/reagent_containers/glass/bottle/charcoal = 4, /obj/item/reagent_containers/glass/bottle/epinephrine = 4, /obj/item/reagent_containers/glass/bottle/diphenhydramine = 4,
-					/obj/item/reagent_containers/glass/bottle/salicylic = 4, /obj/item/reagent_containers/glass/bottle/potassium_iodide =3, /obj/item/reagent_containers/glass/bottle/saline = 5,
-					/obj/item/reagent_containers/glass/bottle/morphine = 4, /obj/item/reagent_containers/glass/bottle/ether = 4, /obj/item/reagent_containers/glass/bottle/atropine = 3,
-					/obj/item/reagent_containers/glass/bottle/oculine = 2, /obj/item/reagent_containers/syringe/antiviral = 6,
-					/obj/item/reagent_containers/syringe/insulin = 6, /obj/item/reagent_containers/syringe/calomel = 10, /obj/item/reagent_containers/syringe/heparin = 4, /obj/item/reagent_containers/hypospray/autoinjector = 5, /obj/item/reagent_containers/food/pill/salbutamol = 10,
-					/obj/item/reagent_containers/food/pill/mannitol = 10, /obj/item/reagent_containers/food/pill/mutadone = 5, /obj/item/stack/medical/bruise_pack/advanced = 4, /obj/item/stack/medical/ointment/advanced = 4, /obj/item/stack/medical/bruise_pack = 4,
-					/obj/item/stack/medical/splint = 4, /obj/item/reagent_containers/glass/beaker = 4, /obj/item/reagent_containers/dropper = 4, /obj/item/healthanalyzer = 4,
-					/obj/item/healthupgrade = 4, /obj/item/reagent_containers/hypospray/safety = 2, /obj/item/sensor_device = 2, /obj/item/pinpointer/crew = 2)
+	products = list(/obj/item/reagent_containers/syringe = 12,
+					/obj/item/reagent_containers/food/pill/patch/styptic = 4,
+					/obj/item/reagent_containers/food/pill/patch/silver_sulf = 4,
+					/obj/item/reagent_containers/applicator/brute = 3,
+					/obj/item/reagent_containers/applicator/burn = 3,
+					/obj/item/reagent_containers/glass/bottle/charcoal = 4,
+					/obj/item/reagent_containers/glass/bottle/epinephrine = 4,
+					/obj/item/reagent_containers/glass/bottle/salicylic = 4,
+					/obj/item/reagent_containers/glass/bottle/potassium_iodide = 3,
+					/obj/item/reagent_containers/glass/bottle/saline = 5,
+					/obj/item/reagent_containers/glass/bottle/morphine = 4,
+					/obj/item/reagent_containers/glass/bottle/atropine = 3,
+					/obj/item/reagent_containers/glass/bottle/oculine = 2,
+					/obj/item/reagent_containers/syringe/antiviral = 6,
+					/obj/item/reagent_containers/syringe/calomel = 10,
+					/obj/item/reagent_containers/syringe/heparin = 4,
+					/obj/item/reagent_containers/hypospray/autoinjector = 5,
+					/obj/item/reagent_containers/food/pill/salbutamol = 10,
+					/obj/item/reagent_containers/food/pill/mannitol = 10,
+					/obj/item/reagent_containers/food/pill/mutadone = 5,
+					/obj/item/stack/medical/bruise_pack/advanced = 4,
+					/obj/item/stack/medical/ointment/advanced = 4,
+					/obj/item/stack/medical/bruise_pack = 4,
+					/obj/item/stack/medical/splint = 4,
+					/obj/item/reagent_containers/glass/beaker = 4,
+					/obj/item/reagent_containers/dropper = 4,
+					/obj/item/healthanalyzer/advanced = 4,
+					/obj/item/reagent_containers/hypospray/safety = 2,
+					/obj/item/sensor_device = 2,
+					/obj/item/pinpointer/crew = 2)
 	contraband = list(/obj/item/reagent_containers/glass/bottle/sulfonal = 1, /obj/item/reagent_containers/glass/bottle/pancuronium = 1)
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -29,14 +29,14 @@
 	return // thanks inheritance again
 
 /obj/item/reagent_containers/food/pill/patch/styptic
-	name = "healing patch"
+	name = "brute patch"
 	desc = "Helps with brute injuries."
 	icon_state = "bandaid_brute"
 	instant_application = 1
 	list_reagents = list("styptic_powder" = 30)
 
 /obj/item/reagent_containers/food/pill/patch/styptic/small
-	name = "healing mini-patch"
+	name = "brute mini-patch"
 	list_reagents = list("styptic_powder" = 15)
 
 /obj/item/reagent_containers/food/pill/patch/silver_sulf

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -134,11 +134,11 @@
 /obj/item/reagent_containers/food/pill/mutadone
 	name = "\improper Mutadone pill"
 	desc = "Used to cure genetic abnormalities."
-	icon_state = "pill18"
-	list_reagents = list("mutadone" = 20)
+	icon_state = "pill13"
+	list_reagents = list("mutadone" = 1)
 
 /obj/item/reagent_containers/food/pill/mannitol
 	name = "\improper Mannitol pill"
 	desc = "Used to treat cranial swelling."
-	icon_state = "pill19"
-	list_reagents = list("mannitol" = 20)
+	icon_state = "pill7"
+	list_reagents = list("mannitol" = 10)


### PR DESCRIPTION
## What Does This PR Do

Removes some NanoMed Plus products to make it less bloated and make it easier for new doctors to use it. Tweaks two pills and a patch, reasoning below.

- Renames "healing patch" to "brute patch"
- Changes "mutadone pill" from 20u to 1u
- Changes "mutadone pill" sprite
- Changes "mannitol pill" from 20u to 10u
- Changes "mannitol pill" sprite
- Replaces "health analyzer" with its advanced variant
- Removes "diphenhydramine bottle"
- Removes "ether bottle"
- Removes "insulin syringe"

## Why It's Good For The Game

**Renames "healing patch" to "brute patch"**

We have "healing" and "burn" patches, makes no sense. This way it is consistent.

**Changes "mutadone pill" from 20u to 1u and its sprite**

One unit is enough of this medicine. Changed its sprite from the generic white pill to the blue-purple sprite, as genetics itself is blue-purple as well.

**Changes "mannitol pill" from 20u to 10u and its sprite**

20 units is an overkill, we really do not need megapills. Sprite is changed because white is boring and non-descriptive, and the new yellow is not associated with any damage type either.

**Replaces "health analyzer" with its advanced variant**

The analyzer and its upgrade are almost always vended together anyhow, this way we have one less entry on the list (by removing the upgrade) and saves new doctors from accidentally using the less descriptive one.

**Removes "diphenhydramine bottle"**

Has four uses, 1) purging histamine, without an easy access to it, histamine might be actually dangerous again 2) virology removes symptoms with it, they already start with a full bottle 3) used to make crank and krokodil, not quite something NT would encourage their medical chemists to do, 4) it is an advanced virus cure, this way chemistry might get involved in the round past the 00:10 minutes mark by Medbay not having an easy access to it.

**Removes "ether bottle"**

Ether is godawful as a surgical sedative, nobody came up with a good usage for it, it can be re-added when someone makes it viable again. Its antag potential is not great either, you can get pancuronium and sulfonal from hacked nanomeds anyhow and sulfonal works twice as fast as ether.

**Removes "insulin syringe"**

Purges sugar and helps creating aranesp. It's one more thing that bloats the already huge product list the NanoMed has and if you want drugs as a medical chemist, work for it.

## Images of changes

![image](https://user-images.githubusercontent.com/33333517/187031649-ca3a1f1f-3a19-422e-aadb-5afef5645e10.png) 
![image](https://user-images.githubusercontent.com/33333517/187031655-00b4e8b8-b054-4f40-801f-1ff920a28065.png)

## Testing
Launched the Cyberiad, walked up to a NanoMed Plus, checked its contents.

## Changelog
:cl:
tweak: Renamed "healing patch" to "brute patch".
tweak: Mannitol pill and mutadone pill sprites are changed from the boring white ones.
tweak: Mannitol pills changed from 20u to 10u, mutadone pills from 10u to 1u.
tweak: Replaced the health analyzer and the health analyzer upgrade with the upgraded health analyzer variant.
del: Removed the following from NanoMed plus: diphenhydramine bottle, ether bottle, insulin syringe.
/:cl:
