### PR TITLE
Fixes Glowshrooms being able to be pulled.

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -3,6 +3,7 @@
 /obj/structure/glowshroom
 	name = "glowshroom"
 	desc = "Mycena Bregprox, a species of mushroom that glows in the dark."
+	anchored = TRUE
 	opacity = FALSE
 	density = FALSE
 	icon = 'icons/obj/lighting.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes glowshrooms being able to be pulled

## Why It's Good For The Game
bugs bad

## Testing
Compiled, made sure the glowshrooms and other variants couldn't be moved
## Changelog
:cl:
fix: Glowshrooms/shadowshrooms/glowcaps can no longer be pulled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
