### PR TITLE
Allows toggling of crate locks with Alt-Click

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -217,6 +217,13 @@
 	else
 		to_chat(user, "<span class='notice'>Access Denied</span>")
 
+/obj/structure/closet/crate/secure/AltClick(mob/user)
+	if(Adjacent(user) && !opened)
+		verb_togglelock()
+		return
+
+	. = ..()
+
 /obj/structure/closet/crate/secure/verb/verb_togglelock()
 	set src in oview(1) // One square distance
 	set category = null

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -208,7 +208,7 @@
 
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user)
 	if(locked)
-		boom(user)
+		attack_hand(user)
 	else
 		..()
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -740,7 +740,6 @@
 	taste_description = "life"
 	harmless = FALSE
 	var/revive_type = SENTIENCE_ORGANIC //So you can't revive boss monsters or robots with it
-	var/revive_time = 5 SECONDS // How long it takes for the revive to apply, about the same as a defib
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -765,56 +764,40 @@
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
-				var/mob/dead/observer/ghost = M.get_ghost(TRUE)
-				if(ghost && !ghost.can_reenter_corpse || ghost && !ghost.client || M.suiciding || HAS_TRAIT(M, TRAIT_HUSK) || HAS_TRAIT(M, TRAIT_BADDNA))
-					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
-					M.do_jitter_animation(50)
-					return
-
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
 					M.delayed_gib()
 					return
+				if(!M.ghost_can_reenter())
+					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
+					return
 
-				M.visible_message("<span class='warning'>[M] shakes violently!</span>")
-				if(ghost && ghost.can_reenter_corpse && ghost.client)
-					to_chat(ghost, "<span class='ghostalert'>Your body is being revived with Strange Reagent. Return to your body if you want to be revived!</span>")
-					window_flash(ghost.client)
-					ghost << sound('sound/effects/genetics.ogg')
+				if(!M.suiciding && !HAS_TRAIT(M, TRAIT_HUSK) && !HAS_TRAIT(M, TRAIT_BADDNA))
+					var/time_dead = world.time - M.timeofdeath
+					M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
+					M.adjustCloneLoss(50)
+					M.setOxyLoss(0)
+					M.adjustBruteLoss(rand(0, 15))
+					M.adjustToxLoss(rand(0, 15))
+					M.adjustFireLoss(rand(0, 15))
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						H.decaylevel = 0
+						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
+						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
+							// Per non-vital body part:
+							// 0% chance of necrosis within 1 minute of death
+							// 40% chance of necrosis after 20 minutes of death
+							if(!O.vital && prob(necrosis_prob))
+								// side effects may include: Organ failure
+								O.necrotize(FALSE)
+								if(O.status & ORGAN_DEAD)
+									O.germ_level = INFECTION_LEVEL_THREE
+						H.update_body()
 
-				M.do_jitter_animation(200)
-				addtimer(CALLBACK(src, /datum/reagent/medicine/strange_reagent/.proc/revivify, M), revive_time)
+					M.grab_ghost()
+					M.update_revive()
+					add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 	..()
-
-/datum/reagent/medicine/strange_reagent/proc/revivify(mob/living/M)
-	var/mob/dead/observer/ghost = M.get_ghost(TRUE) // update to check if they still have a ghost
-	if(ghost) // if the observer is still outside their body
-		M.visible_message("<span class='warning'>[M] stops shaking and falls limp.</span>")
-		return
-
-	var/time_dead = world.time - M.timeofdeath
-	M.adjustCloneLoss(50)
-	M.setOxyLoss(0)
-	M.adjustBruteLoss(rand(0, 15))
-	M.adjustToxLoss(rand(0, 15))
-	M.adjustFireLoss(rand(0, 15))
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.decaylevel = 0
-		var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
-		for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
-			// Per non-vital body part:
-			// 0% chance of necrosis within 1 minute of death
-			// 40% chance of necrosis after 20 minutes of death
-			if(!O.vital && prob(necrosis_prob))
-				// side effects may include: Organ failure
-				O.necrotize(FALSE)
-				if(O.status & ORGAN_DEAD)
-					O.germ_level = INFECTION_LEVEL_THREE
-		H.update_body()
-
-	M.update_revive()
-	M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>", "<span class='userdanger'>You rise from the dead!</span>")
-	add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -740,6 +740,7 @@
 	taste_description = "life"
 	harmless = FALSE
 	var/revive_type = SENTIENCE_ORGANIC //So you can't revive boss monsters or robots with it
+	var/revive_time = 5 SECONDS // How long it takes for the revive to apply, about the same as a defib
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -764,40 +765,56 @@
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
+				var/mob/dead/observer/ghost = M.get_ghost(TRUE)
+				if(ghost && !ghost.can_reenter_corpse || ghost && !ghost.client || M.suiciding || HAS_TRAIT(M, TRAIT_HUSK) || HAS_TRAIT(M, TRAIT_BADDNA))
+					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
+					M.do_jitter_animation(50)
+					return
+
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
 					M.delayed_gib()
 					return
-				if(!M.ghost_can_reenter())
-					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
-					return
 
-				if(!M.suiciding && !HAS_TRAIT(M, TRAIT_HUSK) && !HAS_TRAIT(M, TRAIT_BADDNA))
-					var/time_dead = world.time - M.timeofdeath
-					M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
-					M.adjustCloneLoss(50)
-					M.setOxyLoss(0)
-					M.adjustBruteLoss(rand(0, 15))
-					M.adjustToxLoss(rand(0, 15))
-					M.adjustFireLoss(rand(0, 15))
-					if(ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.decaylevel = 0
-						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
-						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
-							// Per non-vital body part:
-							// 0% chance of necrosis within 1 minute of death
-							// 40% chance of necrosis after 20 minutes of death
-							if(!O.vital && prob(necrosis_prob))
-								// side effects may include: Organ failure
-								O.necrotize(FALSE)
-								if(O.status & ORGAN_DEAD)
-									O.germ_level = INFECTION_LEVEL_THREE
-						H.update_body()
+				M.visible_message("<span class='warning'>[M] shakes violently!</span>")
+				if(ghost && ghost.can_reenter_corpse && ghost.client)
+					to_chat(ghost, "<span class='ghostalert'>Your body is being revived with Strange Reagent. Return to your body if you want to be revived!</span>")
+					window_flash(ghost.client)
+					ghost << sound('sound/effects/genetics.ogg')
 
-					M.grab_ghost()
-					M.update_revive()
-					add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
+				M.do_jitter_animation(200)
+				addtimer(CALLBACK(src, /datum/reagent/medicine/strange_reagent/.proc/revivify, M), revive_time)
 	..()
+
+/datum/reagent/medicine/strange_reagent/proc/revivify(mob/living/M)
+	var/mob/dead/observer/ghost = M.get_ghost(TRUE) // update to check if they still have a ghost
+	if(ghost) // if the observer is still outside their body
+		M.visible_message("<span class='warning'>[M] stops shaking and falls limp.</span>")
+		return
+
+	var/time_dead = world.time - M.timeofdeath
+	M.adjustCloneLoss(50)
+	M.setOxyLoss(0)
+	M.adjustBruteLoss(rand(0, 15))
+	M.adjustToxLoss(rand(0, 15))
+	M.adjustFireLoss(rand(0, 15))
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.decaylevel = 0
+		var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
+		for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
+			// Per non-vital body part:
+			// 0% chance of necrosis within 1 minute of death
+			// 40% chance of necrosis after 20 minutes of death
+			if(!O.vital && prob(necrosis_prob))
+				// side effects may include: Organ failure
+				O.necrotize(FALSE)
+				if(O.status & ORGAN_DEAD)
+					O.germ_level = INFECTION_LEVEL_THREE
+		H.update_body()
+
+	M.update_revive()
+	M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>", "<span class='userdanger'>You rise from the dead!</span>")
+	add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Allows toggling of crates with alt click, also slightly changes trying to toggle the lock on a locked lootcrate so it doesnt blow you up when you accidently alt click it. It now makes you attack it with your hand, allowing you to enter the code like you would with an empty hand.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Lockers and secure crates are very similar and its annoying trying to lock them with verbs.

## Testing
<!-- How did you test the PR, if at all? -->
Blew myself up with a secure/loot crate, and changed it. Made sure that toggling the lock only works when you have the correct access.

## Changelog
:cl:
tweak: You can now alt-click to lock/unlock crates, similar to lockers.
tweak: Alt-clicking a locked lootcrate will pop up the code entry menu, allowing you to solve it without switching hands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
