### PR TITLE
Blob now punishes crawlers. [TM pls]

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -318,6 +318,13 @@
 		return
 	var/obj/structure/blob/B = locate() in T
 	if(B)
+		var/mob/living/M = locate() in T
+		if(M)
+			if(!can_buy(5))
+				return
+			to_chat(src, "You attack [M]!")
+			blob_core.chemical_attack(T)
+			return
 		to_chat(src, "There is a blob here!")
 		return
 
@@ -329,13 +336,8 @@
 	if(!can_buy(5))
 		return
 	last_attack = world.time
-	OB.expand(T, 0, blob_reagent_datum.color)
-	for(var/mob/living/L in T)
-		if(ROLE_BLOB in L.faction) //no friendly/dead fire
-			continue
-		var/mob_protection = L.get_permeability_protection()
-		blob_reagent_datum.reaction_mob(L, REAGENT_TOUCH, 25, 1, mob_protection)
-		blob_reagent_datum.send_message(L)
+	OB.expand(T, 0, blob_reagent_datum.color, src)
+	blob_core.chemical_attack(T)
 	OB.color = blob_reagent_datum.color
 	return
 

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -33,6 +33,7 @@
 		atmosblock = FALSE
 		air_update_turf(1)
 	GLOB.blobs -= src
+	overmind = null // let us not have gc issues
 	if(isturf(loc)) //Necessary because Expand() is screwed up and spawns a blob and then deletes it
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
 	return ..()
@@ -76,11 +77,23 @@
 	// All blobs heal over time when pulsed, but it has a cool down
 	if(health_timestamp > world.time)
 		return 0
+	var/turf/T = get_turf(src)
+	chemical_attack(T)
 	if(obj_integrity < max_integrity)
 		obj_integrity = min(max_integrity, obj_integrity + 1)
 		check_integrity()
-		health_timestamp = world.time + 10 // 1 seconds
+	health_timestamp = world.time + 10 // 1 seconds
 
+/obj/structure/blob/proc/chemical_attack(turf/T)
+	for(var/mob/living/L in T)
+		if(ROLE_BLOB in L.faction) //no friendly/dead fire
+			continue
+		if(!overmind)
+			continue
+		var/mob_protection = L.get_permeability_protection()
+		overmind.blob_reagent_datum.reaction_mob(L, REAGENT_TOUCH, 25, 1, mob_protection)
+		overmind.blob_reagent_datum.send_message(L)
+		L.blob_act(src)
 
 /obj/structure/blob/proc/Pulse(pulse = 0, origin_dir = 0, a_color)//Todo: Fix spaceblob expand
 	RegenHealth()
@@ -101,7 +114,7 @@
 		var/turf/T = get_step(src, dirn)
 		var/obj/structure/blob/B = (locate(/obj/structure/blob) in T)
 		if(!B)
-			expand(T,1,a_color)//No blob here so try and expand
+			expand(T,1,a_color, overmind)//No blob here so try and expand
 			return
 		B.adjustcolors(a_color)
 
@@ -119,7 +132,7 @@
 	if(iswallturf(loc))
 		loc.blob_act(src) //don't ask how a wall got on top of the core, just eat it
 
-/obj/structure/blob/proc/expand(turf/T = null, prob = 1, a_color)
+/obj/structure/blob/proc/expand(turf/T = null, prob = 1, a_color, _overmind = null)
 	if(prob && !prob(obj_integrity))
 		return
 	if(istype(T, /turf/space) && prob(75)) 	return
@@ -136,6 +149,7 @@
 	var/obj/structure/blob/normal/B = new /obj/structure/blob/normal(src.loc, min(obj_integrity, 30))
 	B.color = a_color
 	B.density = TRUE
+	B.overmind = _overmind
 	if(T.Enter(B,src))//Attempt to move into the tile
 		B.density = initial(B.density)
 		B.loc = T
@@ -145,6 +159,11 @@
 		qdel(B)
 
 	for(var/atom/A in T)//Hit everything in the turf
+		if(isliving(A) && !A.density && overmind) // Crawling mob / small mob? Extra damage.
+			var/mob/living/M = A
+			var/mob_protection = M.get_permeability_protection()
+			overmind.blob_reagent_datum.reaction_mob(M, REAGENT_TOUCH, 25, 1, mob_protection)
+			overmind.blob_reagent_datum.send_message(M)
 		A.blob_act(src)
 	return 1
 

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -114,7 +114,7 @@
 		var/turf/T = get_step(src, dirn)
 		var/obj/structure/blob/B = (locate(/obj/structure/blob) in T)
 		if(!B)
-			expand(T,1,a_color, overmind)//No blob here so try and expand
+			expand(T, 1, a_color, overmind)//No blob here so try and expand
 			return
 		B.adjustcolors(a_color)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Would like a TM, everything worked fine on my end, but balance / just making sure there is nothing fucky with putting the overmind var on all normal blob tiles.

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Non dense mobs getting attacked by blobs experience double chemical reaction (As a finisher to someone in crit, or to punish someone who is trying to crawl to blob so they can only be attacked once)

Blobs can now attack people on blob tiles for 5 points, rather than having to destroy the tile to attack first.

Blobs will passively attack mobs ON THEIR OWN TILE when pulsed, at **most** once per second. Realistically, 2-4+ between attacks. This will not affect people beside blobs, only people inside a blob, most likely due to being in crit, or because they were crawling.

Normal blob tiles actually get their overmind variable now, so they have the proper description / name.

If we ever wanted to use /datum/reagent/blob/proc/damage_reaction, it will now work on non special blob tiles.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Blob should not be easily cheeseable when small by crawling up to it. If the blob crawls over you, you should be hit more, and be easier to hit.

This PR means blobs will hit harder on people who are crawling, be it on purpose or on crit, and will passively attack mobs inside blobs.

It also means if some teleporting mob / mech teleports beside / onto the blob, the blob will be able to attack it.

## Testing
<!-- How did you test the PR, if at all? -->

Spawning in the blob, testing that spread is the same, untill mob is stam crited, where chemicals applied twice. 
Tested attacking mob on blob. 
Tested mob passively being attacked in mob. 
Tested blob spores not dying inside a blob. 
Tested GC issues by bombing the fuck out of the blob, no faliures.

## Changelog
:cl:
tweak: Blobs now apply their chemical affects twice to mobs that are not dense or lying down.
tweak: Blobs can now manually attack mobs inside the blob.
tweak: Blob tiles passively attack mobs on their tile, so long as a node or core is close enough.
fix: Blob tiles no longer are always named dead / fragile blob tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
