### PR TITLE
Adds cooldown to Xenomorph neurotoxin, changes stun to knockdown

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -90,9 +90,11 @@ Doesn't work on other aliens/AI.*/
 	set desc = "Spits neurotoxin at someone, paralyzing them for a short time."
 	set category = "Alien"
 
-	if(powerc(50))
+	if(powerc(50) && neurotoxin_cooldown == FALSE)
 		adjustPlasma(-50)
 		src.visible_message("<span class='danger'>[src] spits neurotoxin!", "<span class='alertalien'>You spit neurotoxin.</span>")
+		neurotoxin_cooldown = TRUE
+		addtimer(CALLBACK(src, .proc/neurotoxin_cooldown_reset), neurotoxin_cooldown_time)
 
 		var/turf/T = loc
 		var/turf/U = get_step(src, dir) // Get the tile infront of the move, based on their direction
@@ -108,6 +110,10 @@ Doesn't work on other aliens/AI.*/
 		A.fire()
 		A.newtonian_move(get_dir(U, T))
 		newtonian_move(get_dir(U, T))
+	return
+
+/mob/living/carbon/alien/humanoid/proc/neurotoxin_cooldown_reset()
+	neurotoxin_cooldown = FALSE
 	return
 
 /mob/living/carbon/alien/humanoid/proc/resin() // -- TLE

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -91,7 +91,7 @@ Doesn't work on other aliens/AI.*/
 	set category = "Alien"
 	var/obj/item/organ/internal/xenos/neurotoxin/organ = locate() in src.internal_organs
 
-	if(powerc(50) && organ.neurotoxin_cooldown == FALSE)
+	if(powerc(50) && !organ.neurotoxin_cooldown)
 		adjustPlasma(-50)
 		src.visible_message("<span class='danger'>[src] spits neurotoxin!", "<span class='alertalien'>You spit neurotoxin.</span>")
 		organ.neurotoxin_cooldown = TRUE

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -89,11 +89,11 @@ Doesn't work on other aliens/AI.*/
 	set name = "Spit Neurotoxin (50)"
 	set desc = "Spits neurotoxin at someone, paralyzing them for a short time."
 	set category = "Alien"
-	var/obj/item/organ/internal/xenos/neurotoxin/organ = locate() in src.internal_organs
+	var/obj/item/organ/internal/xenos/neurotoxin/organ = locate() in internal_organs
 
 	if(powerc(50) && !organ.neurotoxin_cooldown)
 		adjustPlasma(-50)
-		src.visible_message("<span class='danger'>[src] spits neurotoxin!", "<span class='alertalien'>You spit neurotoxin.</span>")
+		visible_message("<span class='danger'>[src] spits neurotoxin!</span>", "<span class='alertalien'>You spit neurotoxin.</span>")
 		organ.neurotoxin_cooldown = TRUE
 		addtimer(VARSET_CALLBACK(organ, neurotoxin_cooldown, FALSE), organ.neurotoxin_cooldown_time)
 

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -89,12 +89,13 @@ Doesn't work on other aliens/AI.*/
 	set name = "Spit Neurotoxin (50)"
 	set desc = "Spits neurotoxin at someone, paralyzing them for a short time."
 	set category = "Alien"
+	var/obj/item/organ/internal/xenos/neurotoxin/organ = locate() in src.internal_organs
 
-	if(powerc(50) && neurotoxin_cooldown == FALSE)
+	if(powerc(50) && organ.neurotoxin_cooldown == FALSE)
 		adjustPlasma(-50)
 		src.visible_message("<span class='danger'>[src] spits neurotoxin!", "<span class='alertalien'>You spit neurotoxin.</span>")
-		neurotoxin_cooldown = TRUE
-		addtimer(CALLBACK(src, .proc/neurotoxin_cooldown_reset), neurotoxin_cooldown_time)
+		organ.neurotoxin_cooldown = TRUE
+		addtimer(VARSET_CALLBACK(organ, neurotoxin_cooldown, FALSE), organ.neurotoxin_cooldown_time)
 
 		var/turf/T = loc
 		var/turf/U = get_step(src, dir) // Get the tile infront of the move, based on their direction
@@ -110,10 +111,6 @@ Doesn't work on other aliens/AI.*/
 		A.fire()
 		A.newtonian_move(get_dir(U, T))
 		newtonian_move(get_dir(U, T))
-	return
-
-/mob/living/carbon/alien/humanoid/proc/neurotoxin_cooldown_reset()
-	neurotoxin_cooldown = FALSE
 	return
 
 /mob/living/carbon/alien/humanoid/proc/resin() // -- TLE

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -10,6 +10,8 @@
 	var/next_attack = 0
 	var/pounce_cooldown = 0
 	var/pounce_cooldown_time = 30
+	var/neurotoxin_cooldown = FALSE
+	var/neurotoxin_cooldown_time = 5 SECONDS
 	var/leap_on_click = 0
 	var/custom_pixel_x_offset = 0 //for admin fuckery.
 	var/custom_pixel_y_offset = 0

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -10,8 +10,6 @@
 	var/next_attack = 0
 	var/pounce_cooldown = 0
 	var/pounce_cooldown_time = 30
-	var/neurotoxin_cooldown = FALSE
-	var/neurotoxin_cooldown_time = 5 SECONDS
 	var/leap_on_click = 0
 	var/custom_pixel_x_offset = 0 //for admin fuckery.
 	var/custom_pixel_y_offset = 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -288,7 +288,7 @@
 /obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = 0)
 	if(isalien(target))
 		knockdown = 0
-		nodamage = 1
+		nodamage = TRUE
 	. = ..() // Execute the rest of the code.
 
 /obj/item/projectile/bullet/cap

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -282,11 +282,12 @@
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
-	weaken = 10 SECONDS
+	stamina = 40
+	knockdown = 10 SECONDS
 
 /obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = 0)
 	if(isalien(target))
-		weaken = 0
+		knockdown = 0
 		nodamage = 1
 	. = ..() // Execute the rest of the code.
 

--- a/code/modules/surgery/organs/subtypes/xenos.dm
+++ b/code/modules/surgery/organs/subtypes/xenos.dm
@@ -141,6 +141,8 @@
 	slot = "neurotox"
 	origin_tech = "biotech=5;combat=5"
 	alien_powers = list(/mob/living/carbon/alien/humanoid/proc/neurotoxin)
+	var/neurotoxin_cooldown = FALSE
+	var/neurotoxin_cooldown_time = 5 SECONDS
 
 /obj/item/organ/internal/xenos/resinspinner
 	name = "xeno resin organ"//...there tiger....


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a 5 second cooldown to the Xenomorph neurotoxin ability. Neurotoxin no longer "weaken" stuns humans, but instead applies ten seconds of knockdown and 40 stamina damage. Neurotoxin toxin damage is untouched.

Advances #18179 and #18888
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Neurotoxin only costs 50 plasma to use, and Sentinels can store up to 500 plasma. Being able to fire up to 10 projectiles instantly with no cooldown is a little insane.

Paradise has largely moved away from instastuns in combat, and Xeno neurotoxin is one of the last holdouts. Removing instastuns from Xenomorphs so they respect Paradise's combat conventions is necessary if they're ever going to be readded to rotation.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on a local debug server.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Xenomorph neurotoxin now has a 5 second cooldown
tweak: Xeno neurotoxin now inflicts knockdown and stamina damage, instead of stun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
