### PR TITLE
Adds a cooldown to scanning someone's ass with a photocopier

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -150,6 +150,7 @@
 			H.emote("scream")
 		else
 			copymob.apply_damage(30, BURN)
+			sleep(PHOTOCOPIER_DELAY)
 		to_chat(copymob, "<span class='notice'>Something smells toasty...</span>")
 	if(ishuman(copymob)) //Suit checks are in check_mob
 		var/mob/living/carbon/human/H = copymob

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -317,6 +317,7 @@
 		for(var/i in copies to 1 step -1)
 			if(!copyass())
 				break
+			sleep(PHOTOCOPIER_DELAY)
 			toner -= 5
 	else
 		to_chat(usr, "<span class='warning'>\The [copyitem] can't be copied by \the [src], ejecting.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a cooldown to scanning someone's ass with a photocopier, the cooldown is 1.5 seconds to match all other cooldowns on printing. 

## Why It's Good For The Game
We already have a cooldown for printing, adding a cooldown for this is good so you can't instantly kill people by hitting copy fast. 

Fixes #18875 

Turns out it wasn't limited to just simple animals
## Testing
Compiled, tried to melt someone using it, got the correct error message
Tried to melt a prince of terror, couldn't. 
## Changelog
:cl:
tweak: Adds a cooldown to the photocopiers 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
