### PR TITLE
Makes Honeycomb edible and allows plant bags to pick it up.

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -170,7 +170,7 @@
 	max_combined_w_class = 100 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	max_w_class = WEIGHT_CLASS_NORMAL
 	w_class = WEIGHT_CLASS_TINY
-	can_hold = list(/obj/item/reagent_containers/food/snacks/grown,/obj/item/seeds,/obj/item/grown,/obj/item/reagent_containers/food/snacks/grown/ash_flora)
+	can_hold = list(/obj/item/reagent_containers/food/snacks/grown,/obj/item/seeds,/obj/item/grown,/obj/item/reagent_containers/food/snacks/grown/ash_flora,/obj/item/reagent_containers/food/snacks/honeycomb)
 	resistance_flags = FLAMMABLE
 
 /obj/item/storage/bag/plants/portaseeder

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -96,7 +96,7 @@
 		if(bee_resources >= BEE_RESOURCE_HONEYCOMB_COST)
 			if(honeycombs.len < get_max_honeycomb())
 				bee_resources = max(bee_resources-BEE_RESOURCE_HONEYCOMB_COST, 0)
-				var/obj/item/reagent_containers/honeycomb/HC = new(src)
+				var/obj/item/reagent_containers/food/snacks/honeycomb/HC = new(src)
 				if(queen_bee.beegent)
 					HC.set_reagent(queen_bee.beegent.id)
 				honeycombs += HC
@@ -245,7 +245,7 @@
 						var/amtH = HF.honeycomb_capacity
 						var/fallen = 0
 						while(honeycombs.len && amtH) //let's pretend you always grab the frame with the most honeycomb on it
-							var/obj/item/reagent_containers/honeycomb/HC = pick_n_take(honeycombs)
+							var/obj/item/reagent_containers/food/snacks/honeycomb/HC = pick_n_take(honeycombs)
 							if(HC)
 								HC.forceMove(get_turf(src))
 								amtH--

--- a/code/modules/hydroponics/beekeeping/honeycomb.dm
+++ b/code/modules/hydroponics/beekeeping/honeycomb.dm
@@ -1,5 +1,5 @@
 
-/obj/item/reagent_containers/honeycomb
+/obj/item/reagent_containers/food/snacks/honeycomb
 	name = "honeycomb"
 	desc = "A hexagonal mesh of honeycomb."
 	icon = 'icons/obj/hydroponics/harvest.dmi'
@@ -11,16 +11,16 @@
 	list_reagents = list("honey" = 5)
 	var/honey_color = ""
 
-/obj/item/reagent_containers/honeycomb/Initialize(mapload)
+/obj/item/reagent_containers/food/snacks/honeycomb/Initialize(mapload)
 	. = ..()
 	pixel_x = rand(8,-8)
 	pixel_y = rand(8,-8)
 	update_icon(UPDATE_OVERLAYS)
 
-/obj/item/reagent_containers/honeycomb/set_APTFT()
+/obj/item/reagent_containers/food/snacks/honeycomb/set_APTFT()
 	set hidden = TRUE
 
-/obj/item/reagent_containers/honeycomb/update_overlays()
+/obj/item/reagent_containers/food/snacks/honeycomb/update_overlays()
 	. = ..()
 	var/image/honey
 	if(honey_color)
@@ -31,7 +31,7 @@
 	. += honey
 
 
-/obj/item/reagent_containers/honeycomb/proc/set_reagent(reagent)
+/obj/item/reagent_containers/food/snacks/honeycomb/proc/set_reagent(reagent)
 	var/datum/reagent/R = GLOB.chemical_reagents_list[reagent]
 	if(istype(R))
 		name = "honeycomb ([R.name])"

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -52,8 +52,7 @@
 
 		//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
 		/obj/item/slime_extract = list(),
-		/obj/item/reagent_containers/food = list(),
-		/obj/item/reagent_containers/honeycomb = list()
+		/obj/item/reagent_containers/food = list()
 	)
 
 	var/list/juice_items = list (


### PR DESCRIPTION
## What Does This PR Do
- Converts Honeycomb from apiaries from item/reagent_containers to item/reagent_containers/food/snacks.
- Adds item/reagent_containers/food/snacks/honeycomb to the list of permitted items in plant bags.
- Removes specific honeycomb entry from reagent grinder as it's already covered by the snacks entry.

## Why It's Good For The Game
Though honeycomb is not technically a plant, I believe that it's covered sufficiently by hydroponics to warrant its addition as a QoL change. Honeycomb is edible IRL and intuitively should be edible in-game; I perceive no harm in allowing it as well. 

## Testing
1. Attempted to eat the honeycomb. Ate it. It was delicious.
2. Placed the honeycomb in a plant bag. It fit fine.
3. Placed multiple honeycombs in a plant bag by clicking on them on the floor. This worked fine.
4. Placed multiple honeycombs with multiple reagents from the plant bag into a grinder and ground them. Also fine.
5. Placed multiple from a plant bag into disposals. A-Ok.
6. Set up an apiary and allowed bees to gather plants and make honey, then gathered the combs from the apiary and ground the results after eating one. Fine.

## Changelog
:cl:
add: Honeycombs are now edible and can be placed in plant bags. You're welcome, Botanists.
/:cl: