### PR TITLE
Improves thermal drill clarity

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_EMPTY(safes)
 	if(..())
 		return TRUE
 
-	if(drill)
+	if(drill && !broken)
 		switch(alert("What would you like to do?", "Thermal Drill", "Turn [drill_timer ? "Off" : "On"]", "Remove Drill", "Cancel"))
 			if("Turn On")
 				if(do_after(user, 2 SECONDS, target = src))
@@ -166,6 +166,10 @@ GLOBAL_LIST_EMPTY(safes)
 					update_icon()
 			if("Cancel")
 				return
+	else if(drill && broken)
+		user.put_in_hands(drill)
+		drill = null
+		update_icon()
 	else
 		ui_interact(user)
 
@@ -346,9 +350,11 @@ GLOBAL_LIST_EMPTY(safes)
 	broken = TRUE
 	drill_timer = null
 	drill.soundloop.stop()
+	playsound(loc, 'sound/machines/ding.ogg', 50, 1)
+	cut_overlay(progress_bar)
 	update_icon()
 	STOP_PROCESSING(SSobj, src)
-
+	
 /**
   * # Floor Safe
   *

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -155,6 +155,7 @@ GLOBAL_LIST_EMPTY(safes)
 					deltimer(drill_timer)
 					drill_timer = null
 					drill.soundloop.stop()
+					cut_overlay(progress_bar)
 					update_icon()
 					STOP_PROCESSING(SSobj, src)
 			if("Remove Drill")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Progress bar for thermal drill properly gets removed once it's done.
Thermal drill now automatically gets removed when clicked on if it's done drilling.
Thermal drill now makes a ding noise when done drilling

fixes: #18916
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously players have been confused about when the thermal drill was done due to the progress bar not being properly removed. This PR also slightly streamlines removing the drill once it is done drilling.

What does a thermal drill have in common with a microwave?
They both go 'ping!' When their done.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Attached drill to safe.
Turned drill on
Turned drill off
Removed drill after it's done drilling
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Progress bar for thermal drill properly gets removed once it's done.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
