### PR TITLE
Cyberiad - Polarized airlocks

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2919,7 +2919,7 @@
 /area/lawoffice)
 "ald" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/glass{
 	name = "Internal Affairs Office";
 	req_access_txt = "38"
 	},
@@ -2931,6 +2931,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -3757,7 +3760,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	id_tag = "hosofficedoor";
 	name = "Head of Security";
 	req_access_txt = "58"
@@ -3766,6 +3769,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "HoS"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7794,7 +7800,7 @@
 /area/security/lobby)
 "avW" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/glass{
 	name = "Internal Affairs Office";
 	req_access_txt = "38"
 	},
@@ -7803,6 +7809,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -7919,9 +7928,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
 	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Processing"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -8572,9 +8584,12 @@
 /area/security/prison/cell_block/A)
 "axP" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
 	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Processing"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -9175,7 +9190,7 @@
 /area/security/interrogation)
 "azd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/glass{
 	name = "Interrogation";
 	req_access_txt = "63"
 	},
@@ -9185,6 +9200,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Interrogation"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -10421,7 +10439,7 @@
 /area/lawoffice)
 "aCc" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/glass{
 	name = "Internal Affairs Office";
 	req_access_txt = "38"
 	},
@@ -10429,6 +10447,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -13229,9 +13250,12 @@
 /area/maintenance/fpmaint2)
 "aIM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/glass{
 	name = "Magistrate's Office";
 	req_access_txt = "74"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -13905,7 +13929,7 @@
 /area/lawoffice)
 "aKx" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/glass{
 	name = "Magistrate's Office";
 	req_access_txt = "74"
 	},
@@ -13916,6 +13940,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -14203,9 +14230,12 @@
 /area/maintenance/fpmaint2)
 "aLh" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/glass{
 	name = "Detective";
 	req_access_txt = "4"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Detective"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -15349,9 +15379,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/glass{
 	name = "Courtroom";
 	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -15745,9 +15778,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/glass{
 	name = "Courtroom";
 	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -43912,7 +43948,7 @@
 /area/janitor)
 "cdf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	id_tag = "rdofficedoor";
 	name = "Research Director's Office";
 	req_access_txt = "30"
@@ -43935,6 +43971,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rd"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -46724,13 +46763,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	id_tag = "blueshieldofficedoor";
 	name = "Blueshield's Office";
 	req_access_txt = "67"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "BS"
+	},
 /turf/simulated/floor/wood,
 /area/blueshield)
 "ckL" = (
@@ -46765,13 +46807,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	id_tag = "ntrepofficedoor";
 	name = "NT Representative's Office";
 	req_access_txt = "73"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "NT"
+	},
 /turf/simulated/floor/wood,
 /area/ntrep)
 "ckO" = (
@@ -49244,7 +49289,7 @@
 /area/toxins/hallway)
 "crA" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	id_tag = "cmoofficedoor";
 	name = "CMO's Office";
 	req_access_txt = "40"
@@ -49265,6 +49310,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CMO"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkbluefull"
@@ -49951,7 +49999,7 @@
 /area/medical/surgeryobs)
 "csX" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
+/obj/machinery/door/airlock/medical/glass{
 	name = "Operating Theatre 1";
 	req_access_txt = "45"
 	},
@@ -49971,6 +50019,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Surgery 1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -59478,7 +59529,7 @@
 /area/engine/chiefs_office)
 "cTg" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	id_tag = "ceofficedoor";
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
@@ -59490,6 +59541,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CE"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -60580,9 +60634,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CE"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -76063,11 +76120,14 @@
 /area/medical/virology)
 "jyI" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
+/obj/machinery/door/airlock/medical/glass{
 	name = "Psych Office";
 	req_access_txt = "64"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psychoffice"
+	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "jyO" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This tweaks rooms in Cyberiad with polarized windows to use polarized glass airlocks instead of plain opaque ones.

- Blueshield's office
- Chief Engineer's office
- Chief Medical Officer's office
- Courtroom
- Detective's office
- Head of Security's office
- Internal Affairs office
- Interrogation room
- Magistrate office
- NT Representative's office
- Operating Theatre 1 (Theatre 2 has no windows, and wasn't touched.)
- Processing room (The polarized windows are only on one side. The airlocks facing the brig are made polarized glass, the rest wasn't touched.)
- Psych's office
- Research Director's office

With the exception of processing, rooms/setups that only obscure one side aren't touched, as the affected cluster do not include airlocks (e.g. Robotics).

## Why It's Good For The Game
Consistency, now that airlocks have the flexibility to be polarized.

## Images of changes
https://user-images.githubusercontent.com/80771500/187209522-1c4873eb-ae7f-4967-97ff-30d3abc0e823.mp4

## Testing
Running around pressing buttons.

## Changelog
:cl:
add: Added electrochromic airlocks to the following Cyberiad rooms: Blueshield's office, Chief Engineer's office, Chief Medical Officer's office, Courtroom, Detective's office, Head of Security's office, Internal Affairs office, Interrogation room, Magistrate's office, NT Representative's office, Operating Theatre 1, Processing room, Psych's office, Research Director's office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
