### PR TITLE
Gnashing Teeth buff - make it sharp

### DIFF
--- a/code/modules/martial_arts/combos/sleeping_carp/gnashing_teeth.dm
+++ b/code/modules/martial_arts/combos/sleeping_carp/gnashing_teeth.dm
@@ -10,7 +10,7 @@
 					"<span class='userdanger'>[user] [atk_verb] you!</span>")
 	playsound(get_turf(target), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 	add_attack_logs(user, target, "Melee attacked with martial-art [MA] : Gnashing Teeth", ATKLOG_ALL)
-	target.apply_damage(20, BRUTE, user.zone_selected, 0, TRUE)
+	target.apply_damage(20, BRUTE, user.zone_selected, sharp = TRUE)
 	if(target.health >= 0)
 		user.say(pick("HUAH!", "HYA!", "CHOO!", "WUO!", "KYA!", "HUH!", "HIYOH!", "CARP STRIKE!", "CARP BITE!"))
 	else

--- a/code/modules/martial_arts/combos/sleeping_carp/gnashing_teeth.dm
+++ b/code/modules/martial_arts/combos/sleeping_carp/gnashing_teeth.dm
@@ -10,7 +10,7 @@
 					"<span class='userdanger'>[user] [atk_verb] you!</span>")
 	playsound(get_turf(target), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 	add_attack_logs(user, target, "Melee attacked with martial-art [MA] : Gnashing Teeth", ATKLOG_ALL)
-	target.apply_damage(20, BRUTE, user.zone_selected)
+	target.apply_damage(20, BRUTE, user.zone_selected, 0, TRUE)
 	if(target.health >= 0)
 		user.say(pick("HUAH!", "HYA!", "CHOO!", "WUO!", "KYA!", "HUH!", "HIYOH!", "CARP STRIKE!", "CARP BITE!"))
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes Gnashing Teeth, a Sleeping Carp harm->harm combo, deal sharp damage.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Two reasons:
1. It's silly. Karate chopping someone's head off is pure comedy. Everyone I discussed this with absolutely loved how hilarious the idea is. We want the game to be fun, right?
2. Currently, Crashing Waves Kick offers superior damage when target hits a wall while also providing minor crowd control. If there is a wall available, CWK is pretty much always the optimal choice. This PR would give GT an _edge_, something to make people consider it over CWK.

If this makes Sleeping Carp too strong, we could consider making GT respect target's armour or otherwise reduce delimb chance.
However, my tests indicate it can easily take well over a dozen hits to behead someone, at which point they're effectively dead anyway.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in with a bunch of greys.
Sleeping Carped them until limbs started flying.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Gnashing Teeth combo from Sleeping Carp now deals sharp damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
