### PR TITLE
Adds implants and hair gradients to serialisation

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -18,15 +18,17 @@
 
 
 /obj/item/implant/mindshield/implant(mob/target)
-	if(..())
+	if(!..())
+		return FALSE
+	if(target.mind)
 		if(target.mind in SSticker.mode.revolutionaries)
 			SSticker.mode.remove_revolutionary(target.mind)
 		if(target.mind in SSticker.mode.cult)
 			to_chat(target, "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
-		else
-			to_chat(target, "<span class='notice'>Your mind feels hardened - more resistant to brainwashing.</span>")
 		return TRUE
-	return FALSE
+
+	to_chat(target, "<span class='notice'>Your mind feels hardened - more resistant to brainwashing.</span>")
+	return TRUE
 
 /obj/item/implant/mindshield/removed(mob/target, silent = 0)
 	if(..())

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1821,9 +1821,11 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	var/list/limbs_list = list()
 	var/list/organs_list = list()
 	var/list/equip_list = list()
+	var/list/implant_list = list()
 	data["limbs"] = limbs_list
 	data["iorgans"] = organs_list
 	data["equip"] = equip_list
+	data["implant_list"] = implant_list
 
 	data["dna"] = dna.serialize()
 	data["age"] = age
@@ -1854,12 +1856,16 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		if(thing != null)
 			equip_list[i] = thing.serialize()
 
+	for(var/obj/item/implant/implant in src)
+		implant_list[implant] = implant.serialize()
+
 	return data
 
 /mob/living/carbon/human/deserialize(list/data)
 	var/list/limbs_list = data["limbs"]
 	var/list/organs_list = data["iorgans"]
 	var/list/equip_list = data["equip"]
+	var/list/implant_list = data["implant_list"]
 	var/turf/T = get_turf(src)
 	if(!islist(data["limbs"]))
 		throw EXCEPTION("Expected a limbs list, but found none")
@@ -1890,6 +1896,13 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	for(var/organ in organs_list)
 		// As above, "New" code handles insertion, DNA sync
 		list_to_object(organs_list[organ], src)
+
+	for(var/thing in implant_list)
+		var/implant_data = implant_list[thing]
+		var/path = text2path(implant_data["type"])
+		var/obj/item/implant/implant = new path(T)
+		if(!implant.implant(src, src))
+			qdel(implant)
 
 	UpdateAppearance()
 

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -277,13 +277,8 @@ I use this so that this can be made better once the organ overhaul rolls out -- 
 
 /obj/item/organ/serialize()
 	var/data = ..()
-	if(status != 0)
+	if(status)
 		data["status"] = status
-
-	// Save the DNA datum if: The owner doesn't exist, or the dna doesn't match the owner
-	// Don't save when the organ has no initialized DNA. Happens when you spawn it in as admin
-	if(dna.unique_enzymes && !(owner && dna.unique_enzymes == owner.dna.unique_enzymes))
-		data["dna"] = dna.serialize()
 	return data
 
 /obj/item/organ/deserialize(data)
@@ -291,8 +286,4 @@ I use this so that this can be made better once the organ overhaul rolls out -- 
 		if(data["status"] & ORGAN_ROBOT)
 			robotize()
 		status = data["status"]
-	if(islist(data["dna"]))
-		// The only thing the official proc does is
-	 	//instantiate the list and call this proc
-		dna.deserialize(data["dna"])
-		..()
+	..()

--- a/code/modules/surgery/organs/subtypes/standard.dm
+++ b/code/modules/surgery/organs/subtypes/standard.dm
@@ -233,6 +233,9 @@
 	if(!length(contents))
 		. += "<span class='warning'>There is nothing left inside!</span>"
 
+/obj/item/organ/external/head/vars_to_save()
+	return list("color", "name", "h_grad_style", "h_grad_offset_x", "h_grad_offset_y", "h_grad_colour", "h_grad_alpha")
+
 /obj/item/organ/external/head/remove()
 	if(owner)
 		if(!istype(dna))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds implants (implanter-based ones like mindshields) to serialisation
Adds hair gradient data to serialisation
Removes organ DNA from serialisation (this was totally redundant and did not need to be saved)
Slight refactor of mindshield implant code to avoid runtime due to mindless mob
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admin QoL, characters can spawn in with implants already inserted
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested spawning saved characters with and without implants and hair gradients, making new jsons and spawning them
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Hair gradient and implants saved on admin character json serialisation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
