### PR TITLE
[GBP: No update] Fix odd airlock interference with polarized airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -364,7 +364,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 /obj/machinery/door/airlock/update_icon(state=0, override=0)
 	if(operating && !override)
 		return
-	check_unres()
+
 	icon_state = density ? "closed" : "open"
 	switch(state)
 		if(0)
@@ -553,6 +553,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	overlays += sparks_overlay
 	overlays += damag_overlay
 	overlays += note_overlay
+
+	check_unres()
 
 	//EMISSIVE ICONS
 	if(buttons_underlay != old_buttons_underlay)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -89,15 +89,6 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	var/prying_so_hard = FALSE
 	var/paintable = TRUE // If the airlock type can be painted with an airlock painter
 
-	var/image/old_frame_overlay //keep those in order to prevent unnecessary updating
-	var/image/old_filling_overlay
-	var/image/old_lights_overlay
-	var/image/old_panel_overlay
-	var/image/old_weld_overlay
-	var/image/old_sparks_overlay
-	var/image/old_dam_overlay
-	var/image/old_note_overlay
-
 	var/mutable_appearance/old_buttons_underlay
 	var/mutable_appearance/old_lights_underlay
 	var/mutable_appearance/old_damag_underlay
@@ -330,9 +321,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 
 	var/animate_color
 	var/image/polarized_image = get_airlock_overlay("[airlock_material]_closed", overlays_file)
-	polarized_image.dir = dir
 
-	overlays -= old_filling_overlay
+	polarized_image.dir = dir
 
 	if(!polarized_on)
 		polarized_image.color = "#222222"
@@ -342,12 +332,13 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 		polarized_image.color = "#FFFFFF"
 		animate_color = "#222222"
 		set_opacity(TRUE)
+	
+	overlays -= polarized_image
 
 	// Animate() does not work on overlays, so a temporary effect is used
 	new /obj/effect/temp_visual/polarized_airlock(get_turf(src), polarized_image, animate_color)
 
-	// Overlays are reset at the same time, due to some oddities when it comes dealing with the cache without changing the base airlock state.
-	addtimer(CALLBACK(src, /atom/.proc/update_icon, 0, 0, TRUE), 0.5 SECONDS)
+	addtimer(CALLBACK(src, /atom/.proc/update_icon, 0, 0), 0.5 SECONDS)
 
 //
 // Polarization toggling effect
@@ -370,7 +361,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 // Icon handling
 //
 
-/obj/machinery/door/airlock/update_icon(state=0, override=0, reset_overlays)
+/obj/machinery/door/airlock/update_icon(state=0, override=0)
 	if(operating && !override)
 		return
 	check_unres()
@@ -386,18 +377,6 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 			icon_state = "nonexistenticonstate" //MADNESS
 
 	. = ..(UPDATE_ICON_STATE) // Sent after the icon_state is changed
-
-	if(reset_overlays)
-		cut_overlays()
-
-		old_frame_overlay = null
-		old_filling_overlay = null
-		old_lights_overlay = null
-		old_panel_overlay = null
-		old_weld_overlay = null
-		old_sparks_overlay = null
-		old_dam_overlay = null
-		old_note_overlay = null
 
 	set_airlock_overlays(state)
 
@@ -564,39 +543,16 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	else
 		filling_overlay.color = "#FFFFFF"
 
-	//doesn't use overlays.Cut() for performance reasons
-	if(frame_overlay != old_frame_overlay)
-		overlays -= old_frame_overlay
-		overlays += frame_overlay
-		old_frame_overlay = frame_overlay
-	if(filling_overlay != old_filling_overlay)
-		overlays -= old_filling_overlay
-		overlays += filling_overlay
-		old_filling_overlay = filling_overlay
-	if(lights_overlay != old_lights_overlay)
-		overlays -= old_lights_overlay
-		overlays += lights_overlay
-		old_lights_overlay = lights_overlay
-	if(panel_overlay != old_panel_overlay)
-		overlays -= old_panel_overlay
-		overlays += panel_overlay
-		old_panel_overlay = panel_overlay
-	if(weld_overlay != old_weld_overlay)
-		overlays -= old_weld_overlay
-		overlays += weld_overlay
-		old_weld_overlay = weld_overlay
-	if(sparks_overlay != old_sparks_overlay)
-		overlays -= old_sparks_overlay
-		overlays += sparks_overlay
-		old_sparks_overlay = sparks_overlay
-	if(damag_overlay != old_dam_overlay)
-		overlays -= old_dam_overlay
-		overlays += damag_overlay
-		old_dam_overlay = damag_overlay
-	if(note_overlay != old_note_overlay)
-		overlays -= old_note_overlay
-		overlays += note_overlay
-		old_note_overlay = note_overlay
+	cut_overlays()
+
+	overlays += frame_overlay
+	overlays += filling_overlay
+	overlays += lights_overlay
+	overlays += panel_overlay
+	overlays += weld_overlay
+	overlays += sparks_overlay
+	overlays += damag_overlay
+	overlays += note_overlay
 
 	//EMISSIVE ICONS
 	if(buttons_underlay != old_buttons_underlay)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -396,28 +396,23 @@
 
 /obj/machinery/door/proc/check_unres() //unrestricted sides. This overlay indicates which directions the player can access even without an ID
 	if(hasPower() && unres_sides)
+		set_light(l_range = 1, l_power = 1, l_color = "#00FF00")
 		if(unres_sides & NORTH)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_n") //layer=src.layer+1
 			I.pixel_y = 32
-			set_light(l_range = 1, l_power = 1, l_color = "#00FF00")
 			add_overlay(I)
 		if(unres_sides & SOUTH)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_s") //layer=src.layer+1
 			I.pixel_y = -32
-			set_light(l_range = 1, l_power = 1, l_color = "#00FF00")
 			add_overlay(I)
 		if(unres_sides & EAST)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_e") //layer=src.layer+1
 			I.pixel_x = 32
-			set_light(l_range = 1, l_power = 1, l_color = "#00FF00")
 			add_overlay(I)
 		if(unres_sides & WEST)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_w") //layer=src.layer+1
 			I.pixel_x = -32
-			set_light(l_range = 1, l_power = 1, l_color = "#00FF00")
 			add_overlay(I)
-	else
-		set_light(0)
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/objects/items/devices/painter/airlock_painter.dm
+++ b/code/game/objects/items/devices/painter/airlock_painter.dm
@@ -58,5 +58,5 @@
 		A.icon = initial(airlock.icon)
 		A.overlays_file = initial(airlock.overlays_file)
 		A.assemblytype = initial(airlock.assemblytype)
-		A.update_icon(reset_overlays = TRUE)
+		A.update_icon()
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes stuck glass overlays in airlocks when a polarized airlock was activated within range. The caching system had to be removed as it really didn't like having color values. Performance might take a small hit, but `cut_overlays` is used so that part at least goes through the subsystem. `overlays +=` is still used due to fine timing issues.

## Why It's Good For The Game
No stuck glass.

## Images of changes
https://user-images.githubusercontent.com/80771500/187565907-e58afa89-0895-4a34-ae1a-3a927a01f9f9.mp4

## Testing
Two airlocks next to each other, one is polarized, the other isn't.

## Changelog
:cl:
fix: Glass airlocks do not have stuck glass when opened if there's an active electrochromic airlock nearby.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
