### PR TITLE
Fixes tower cap logs being choppable in bags

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -52,6 +52,9 @@
 
 /obj/item/grown/log/attackby(obj/item/W, mob/user, params)
 	if(is_sharp(W))
+		if(in_inventory)
+			to_chat(user, "<span class='warning'>You need to place [src] on a flat surface to make [plank_name].</span>")
+			return
 		user.show_message("<span class='notice'>You make [plank_name] out of \the [src]!</span>", 1)
 		var/seed_modifier = 0
 		if(seed)


### PR DESCRIPTION
## What Does This PR Do

Makes you unable to chop logs when you have them in your bag or holding them in your hands.

Fixes #18714 

## Why It's Good For The Game

It fixes the invisibility issue above, plus it makes no sense that you can make proper planks while they are in your purse.

## Images of changes

![image](https://user-images.githubusercontent.com/33333517/187616712-05eb4a8f-3cf0-4b33-b0fb-887c2786e15e.png)

## Testing

1. Spawn `/obj/item/hatchet`
2. Spawn `/obj/item/grown/log`
3. Pick up log
4. Click log with hatchet, get error message
5. Put log into bag
6. Click log with hatchet, get error message
7. Drop log on the floor
8. Click log with hatchet, becomes plank

## Changelog
:cl:
fix: Fixed logs being choppable in hands or bags, consequently turning the new planks invisible.
/:cl:
