### PR TITLE
Adds config option to prevent repeating maps

### DIFF
--- a/code/controllers/configuration/sections/vote_configuration.dm
+++ b/code/controllers/configuration/sections/vote_configuration.dm
@@ -12,12 +12,15 @@
 	var/disable_default_vote = TRUE
 	/// Enable map voting?
 	var/enable_map_voting = FALSE
+	/// If TRUE, you will not be able to vote for the current map
+	var/non_repeating_maps = FALSE
 
 /datum/configuration_section/vote_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
 	CONFIG_LOAD_BOOL(prevent_dead_voting, data["prevent_dead_voting"])
 	CONFIG_LOAD_BOOL(disable_default_vote, data["disable_default_vote"])
 	CONFIG_LOAD_BOOL(enable_map_voting, data["enable_map_voting"])
+	CONFIG_LOAD_BOOL(non_repeating_maps, data["non_repeating_maps"])
 
 	CONFIG_LOAD_NUM(vote_time, data["vote_time"])
 	CONFIG_LOAD_NUM(autotransfer_initial_time, data["autotransfer_initial_time"])

--- a/code/controllers/configuration/sections/vote_configuration.dm
+++ b/code/controllers/configuration/sections/vote_configuration.dm
@@ -13,7 +13,7 @@
 	/// Enable map voting?
 	var/enable_map_voting = FALSE
 	/// If TRUE, you will not be able to vote for the current map
-	var/non_repeating_maps = FALSE
+	var/non_repeating_maps = TRUE
 
 /datum/configuration_section/vote_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line

--- a/code/modules/vote/vote_presets.dm
+++ b/code/modules/vote/vote_presets.dm
@@ -21,8 +21,11 @@
 /datum/vote/map/generate_choices()
 	for(var/x in subtypesof(/datum/map))
 		var/datum/map/M = x
-		if(initial(M.voteable))
-			choices.Add("[initial(M.fluff_name)] ([initial(M.technical_name)])")
+		if(!initial(M.voteable))
+			continue
+		if(GLOB.configuration.vote.non_repeating_maps && istype(SSmapping.map_datum, M))
+			continue
+		choices.Add("[initial(M.fluff_name)] ([initial(M.technical_name)])")
 
 /datum/vote/map/announce()
 	..()

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -814,7 +814,8 @@ prevent_dead_voting = false
 disable_default_vote = true
 # Enable voting for a map on end round
 enable_map_voting = false
-
+# Set to true to prevent the same map from being voted on twice in a row
+non_repeating_maps = false
 
 ################################################################
 

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -815,7 +815,7 @@ disable_default_vote = true
 # Enable voting for a map on end round
 enable_map_voting = false
 # Set to true to prevent the same map from being voted on twice in a row
-non_repeating_maps = false
+non_repeating_maps = true
 
 ################################################################
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a config option that, when enabled, prevents the current map from showing up in the map vote options
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More flexibility to allow different map rotation styles
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
All i hear is the map vote noise now
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Added a config option to prevent the same map from being voted on twice in a row
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
