### PR TITLE
Removes a line of code that causes a runtime 

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -14,7 +14,6 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 
 	var/datum/controller/exclude_these = new
 	gvars_datum_in_built_vars = exclude_these.vars + list("gvars_datum_protected_varlist", "gvars_datum_in_built_vars", "gvars_datum_init_order")
-	QDEL_IN(exclude_these, 0)	//signal logging isn't ready
 
 	Initialize()
 


### PR DESCRIPTION
## What Does This PR Do
Removes an unused section of code that causes a bad index runtime (pretty sure AA asked for this to be removed). 

## Why It's Good For The Game
I like when my debugger doesn't need to ask me if I want to continue

## Testing
Compiled and started, no runtime
Shot stuff and blew stuff up, no runtimes
Purposefully caused a runtime to make sure that I didn't accidentally stop runtimes from appearing 
## Changelog 
No player facing changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->