### PR TITLE
Makes large jungle bushes use the tree transparency system

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -433,6 +433,10 @@
 	pixel_y = -12
 	layer = ABOVE_ALL_MOB_LAYER
 
+/obj/structure/flora/junglebush/large/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/largetransparency)
+
 /obj/structure/flora/rock/pile/largejungle
 	name = "rocks"
 	icon_state = "rocks1"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -435,7 +435,7 @@
 
 /obj/structure/flora/junglebush/large/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/largetransparency)
+	AddComponent(/datum/component/largetransparency, 0, 0, 0, 0)
 
 /obj/structure/flora/rock/pile/largejungle
 	name = "rocks"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes large jungle bushes semi-transparent if critical atoms are behind them, just like trees operate.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bush hiding is just as bad as tree hiding? I'm not sure. Let the github people decide!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Bush hiding
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Large jungle bushes go semi-transparent when critical atoms are behind them, similar to trees
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
