### PR TITLE
Fixes the dimensional rift being able to spawn in maintenance

### DIFF
--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -1854,10 +1854,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Secure Storage"
 	icon_state = "storage"
 
-/area/ai_monitored/storage/emergency
-	name = "Emergency Storage"
-	icon_state = "storage"
-
 /area/turret_protected/
 	ambientsounds = list('sound/ambience/ambimalf.ogg', 'sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
 
@@ -2140,7 +2136,6 @@ GLOBAL_LIST_INIT(the_station_areas, list(
 	/area/construction,
 	/area/ai_monitored/storage/eva, //do not try to simplify to "/area/ai_monitored" --rastaf0
 	/area/ai_monitored/storage/secure,
-	/area/ai_monitored/storage/emergency,
 	/area/turret_protected/ai_upload, //do not try to simplify to "/area/turret_protected" --rastaf0
 	/area/turret_protected/ai_upload_foyer,
 	/area/turret_protected/ai,

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -3,35 +3,6 @@
 	var/obj/effect/anomaly/anomaly_path = /obj/effect/anomaly/flux
 	announceWhen = 1
 
-/datum/event/anomaly/proc/findEventArea()
-	var/static/list/allowed_areas
-	if(!allowed_areas)
-		//Places that shouldn't explode
-		var/list/safe_area_types = typecacheof(list(
-		/area/turret_protected/ai,
-		/area/turret_protected/ai_upload,
-		/area/ai_monitored/storage/emergency,
-		/area/engine,
-		/area/solar,
-		/area/holodeck,
-		/area/shuttle,
-		/area/maintenance,
-		/area/toxins/test_area)
-		)
-
-		//Subtypes from the above that actually should explode.
-		var/list/unsafe_area_subtypes = typecacheof(list(
-		/area/engine/break_room,
-		/area/engine/equipmentstorage,
-		/area/engine/chiefs_office,
-		/area/engine/controlroom
-		))
-
-		allowed_areas = typecacheof(GLOB.the_station_areas) - safe_area_types + unsafe_area_subtypes
-	var/list/possible_areas = typecache_filter_list(SSmapping.existing_station_areas, allowed_areas)
-	if(length(possible_areas))
-		return pick(possible_areas)
-
 /datum/event/anomaly/setup()
 	impact_area = findEventArea()
 	if(!impact_area)

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -19,47 +19,29 @@
 	return
 
 /proc/findEventArea() //Here's a nice proc to use to find an area for your event to land in!
-	var/area/candidate = null
-
-	var/list/safe_areas = list(
+	var/list/safe_areas = typecacheof(list(
 	/area/turret_protected/ai,
 	/area/turret_protected/ai_upload,
 	/area/engine,
 	/area/solar,
 	/area/holodeck,
-	/area/shuttle/arrival,
-	/area/shuttle/escape,
-	/area/shuttle/escape_pod1/station,
-	/area/shuttle/escape_pod2/station,
-	/area/shuttle/escape_pod3/station,
-	/area/shuttle/escape_pod5/station,
-	/area/shuttle/specops/station,
-	/area/shuttle/prison/station,
-	/area/shuttle/administration/station
-	)
+	/area/shuttle,
+	/area/maintenance,
+	/area/toxins/test_area))
 
 	//These are needed because /area/engine has to be removed from the list, but we still want these areas to get fucked up.
 	var/list/danger_areas = list(
 	/area/engine/break_room,
-	/area/engine/chiefs_office)
+	/area/engine/equipmentstorage,
+	/area/engine/chiefs_office,
+	/area/engine/controlroom)
 
-	var/list/event_areas = list()
+	var/list/allowed_areas = list()
 
-	for(var/areapath in GLOB.the_station_areas)
-		event_areas += typesof(areapath)
-	for(var/areapath in safe_areas)
-		event_areas -= typesof(areapath)
-	for(var/areapath in danger_areas)
-		event_areas += typesof(areapath)
+	allowed_areas = typecacheof(GLOB.the_station_areas) - safe_areas + danger_areas
+	var/list/possible_areas = typecache_filter_list(SSmapping.existing_station_areas, allowed_areas)
 
-	while(event_areas.len > 0)
-		var/list/event_turfs = null
-		candidate = locate(pick_n_take(event_areas))
-		event_turfs = get_area_turfs(candidate)
-		if(event_turfs.len > 0)
-			break
-
-	return candidate
+	return pick(possible_areas)
 
 // Returns how many characters are currently active(not logged out, not AFK for more than 10 minutes)
 // with a specific role.


### PR DESCRIPTION
## What Does This PR Do

1. Unifies the `findEventArea()` proc for anomalies and dimensional tears, thus fixing the dimensional tear spawning in bad areas like maintenance
2. Removes the unused `/area/ai_monitored/storage/emergency` area both from the possible spawns and its declaration

## Why It's Good For The Game

The issue: both anomalies and the dimensional tear check for an area to start in, via `findEventArea()`. However, the anomaly's `findEventArea()` is pretty much a copy-paste of the original proc with a few added paths of no-no zones that the dimensional tear doesn't have (like maintenance). The tear's area check didn't check for subtypes either.

The solution: both of these will use the same proc, thus having the same list of possible and excluded areas. This way, the dimensional tear can no longer spawn in the following areas: maintenance, solar control rooms, engineering secure storage, the SM chamber, the room around the SM, engineering hardsuit storage.

## Images of changes

none

## Testing

1. Go to Event / Event Manager Panel
2. Set Moderate event to Bluespace Anomaly
3. Decrease timer to 0
4. Anomaly spawns
5. Set Moderate event to Dimensional Tear
6. Decrease timer to 0
7. Dimensional Tear spawns

## Changelog
:cl:
fix: The Dimensional Tear can no longer spawn in the following areas: maintenance, solar control rooms, engineering secure storage, the SM chamber, the room around the SM, engineering hardsuit storage.
/:cl:

