### PR TITLE
Removes the pre-spawned tracking beacons from Ripleys and Odysseus

### DIFF
--- a/code/game/mecha/medical/medical.dm
+++ b/code/game/mecha/medical/medical.dm
@@ -1,7 +1,3 @@
 /obj/mecha/medical
 	turnsound = 'sound/mecha/mechmove01.ogg'
 	stepsound = 'sound/mecha/mechstep.ogg'
-
-/obj/mecha/medical/Initialize(mapload)
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -1,7 +1,2 @@
 /obj/mecha/working
 	internal_damage_threshold = 60
-
-/obj/mecha/working/Initialize(mapload)
-	. = ..()
-	if(!ruin_mecha)
-		trackers += new /obj/item/mecha_parts/mecha_tracking(src)


### PR DESCRIPTION
## What Does This PR Do

When a Ripley/Odysseus is made, they have a tracking beacon spawned in them (for some reason?). This PR removes this.

## Why It's Good For The Game

1. Makes no sense that any exosuit randomly has tracking beacons spawning in them
2. Robotics SOP already asks for tracking beacons to be added
3. If this is some kind of a safety net, then combat exosuits should get this, not utility mechs

## Images of changes

![kép](https://user-images.githubusercontent.com/33333517/188180804-5a7279f0-8291-44a7-8c2c-4c955c0c7131.png)

## Testing

1. Spawn in as an RD
2. Spawn a `/obj/mecha/medical/odysseus`
3. Look at exosuit control console
4. No beacons found

## Changelog
:cl:
del: Ripley and Odysseus mechs no longer start with a tracking beacon installed.
/:cl:
