### PR TITLE
Reworks the exosuit tracking beacon

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -733,7 +733,7 @@
 		// Check if a tracker exists
 		var/obj/item/mecha_parts/mecha_tracking/new_tracker = W
 		for(var/obj/item/mecha_parts/mecha_tracking/current_tracker in trackers)
-			if(new_tracker.ai_beacon && current_tracker.ai_beacon || trackers)
+			if(new_tracker.ai_beacon == current_tracker.ai_beacon)
 				to_chat(user, "<span class='warning'>This exosuit already has \a [new_tracker.ai_beacon ? "AI" : "tracking"] beacon.</span>")
 				user.put_in_hands(new_tracker)
 				return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -729,9 +729,18 @@
 		if(!user.unEquip(W))
 			to_chat(user, "<span class='notice'>\the [W] is stuck to your hand, you cannot put it in \the [src]</span>")
 			return
-		W.forceMove(src)
+
+		// Check if a tracker exists
+		var/obj/item/mecha_parts/mecha_tracking/new_tracker = W
+		for(var/obj/item/mecha_parts/mecha_tracking/current_tracker in trackers)
+			if(new_tracker.ai_beacon && current_tracker.ai_beacon || trackers)
+				to_chat(user, "<span class='warning'>This exosuit already has \a [new_tracker.ai_beacon ? "AI" : "tracking"] beacon.</span>")
+				user.put_in_hands(new_tracker)
+				return
+
+		new_tracker.forceMove(src)
 		trackers += W
-		user.visible_message("[user] attaches [W] to [src].", "<span class='notice'>You attach [W] to [src].</span>")
+		user.visible_message("[user] attaches [new_tracker] to [src].", "<span class='notice'>You attach [new_tracker] to [src].</span>")
 		diag_hud_set_mechtracking()
 		return
 

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -55,9 +55,14 @@
 				return TRUE
 		if("shock")
 			var/obj/item/mecha_parts/mecha_tracking/MT = locateUID(params["mt"])
-			if(istype(MT))
-				MT.shock()
-				return TRUE
+			if(!istype(MT))
+				return
+			// Is it sabotaged already?
+			var/error_message = MT.shock()
+			if(error_message)
+				atom_say(error_message)
+				return FALSE
+			return TRUE
 		if("get_log")
 			var/obj/item/mecha_parts/mecha_tracking/MT = locateUID(params["mt"])
 			if(istype(MT))
@@ -75,6 +80,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "programming=2;magnets=2"
 	var/ai_beacon = FALSE //If this beacon allows for AI control. Exists to avoid using istype() on checking.
+	var/charges_left = 2
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_info()
 	if(!in_mecha())
@@ -154,11 +160,28 @@
 		return loc
 	return FALSE
 
+// Makes the user lose control over the exosuit's coordination system.
+// They can still move around and use tools, they just cannot tell the exosuit which way to go.
 /obj/item/mecha_parts/mecha_tracking/proc/shock()
-	var/obj/mecha/M = in_mecha()
-	if(M)
-		M.emp_act(2)
-	qdel(src)
+	var/obj/mecha/mech = in_mecha()
+	var/error_message
+
+	if(!mech)
+		error_message = "This tracking beacon is no longer in an exosuit."
+		return error_message
+
+	if(mech.internal_damage & MECHA_INT_CONTROL_LOST)
+		error_message = "The exosuit's coordination system is not responding."
+		return error_message
+
+	mech.setInternalDamage(MECHA_INT_CONTROL_LOST)
+	if(mech.occupant)
+		mech.occupant_message("<span class='danger'>Coordination system calibration failure. Manual restart required.</span>")
+		SEND_SOUND(mech.occupant, sound('sound/machines/warning-buzzer.ogg'))
+
+	charges_left--
+	if(charges_left < 1)
+		qdel(src)
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_log()
 	if(!in_mecha())


### PR DESCRIPTION
## What Does This PR Do

1. Removes the exosuit tracking beacon's EMP act and replaces it with a movement sabotaging one
2. Makes the tracking beacon have 2 charges
3. Exosuits can no longer accept more than one tracker (of each type)

#### New effect (video ---> https://streamable.com/btundj)

When an exosuit is pulsed, the occupant gets an audio and visual cue about their exosuit's movement being impaired. This is the same movement impair an exosuit gets when it takes too much melee damage.

The exosuit is able to move around and use everything, but its movement is randomised. To fix this, the occupant has to start a recalibration process, and the exosuit has to stand still for 10 seconds. During this timeframe, the occupant is free to leave the exosuit.

#### Two charges

The new beacon has two charges. While the exosuit's movement is gimped, no other charges can be used. After the second charge, the beacon gets destroyed as usual.

#### Only one beacon per type

You can no longer put infinite amount of trackers into an exosuit: only one tracking and one AI beacon (so a total of two).

## Why It's Good For The Game

The current tracking beacon is quite frankly, useless. It can be also stacked infinitely.

This beacon will reward players who coordinate their actions - if one pulsed an exosuit which is far away from its assailants (be it security or antagonists), they would waste a charge, since the exosuit will fix itself quickly and safely. If one pulsed the exosuit when it was actively engaged, however, then the assailants might get the upper hand in the fight.

One can also just break into the RD office and mess with security by pulsing their combat mechs and watch them weep because they have no idea how to fix it. 

## Images of changes

Video of how it works: https://streamable.com/btundj

## Testing

New tracker: did the video above
Tracker stacking:

1. Spawn `/obj/mecha/combat/gygax/loaded`
2. Spawn two `/obj/item/mecha_parts/mecha_tracking`
3. Add first one, succeeds, add second one, fails and item is put back into your hands
4. Spawn two `/obj/item/mecha_parts/mecha_tracking/ai_control`
5. Add first one, succeeds, add second one, fails
6. Spawn another `/obj/mecha/combat/gygax/loaded`
7. Add an AI beacon, succeed
8. Add a tracking beacon, succeed
9. Try adding an AI beacon or a tracking beacon, both fail

## Changelog
:cl:
add: The exosuit tracking beacon was reworked. Instead of an EMP, it now randomizes the movement of the target exosuit, while keeping everything else intact: it can shoot and use its modules. The occupant gets an audio and visual cue of the error. To fix it, the occupant manually has to start a process and exosuit has to stand in place for ten seconds (but it is free to use any of its modules). The occupant is free to leave the exosuit during this time.
add: The exosuit tracking beacon now has two charges.
tweak: Only one beacon per type can be added to exosuits, instead of an infinite amount.
/:cl:
