### PR TITLE
style changes

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -108,6 +108,21 @@
 	update_icon()
 	//much roomier now that we've managed to remove two tools
 
+/obj/item/storage/belt/utility/syndi_researcher // A cool looking belt thats essentially a syndicate toolbox
+	desc = "A belt for holding tools, but with style."
+	icon_state = "assaultbelt"
+	item_state = "assault"
+
+/obj/item/storage/belt/utility/syndi_researcher/populate_contents()
+	new /obj/item/screwdriver(src, "red")
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool/largetank(src)
+	new /obj/item/crowbar/red(src)
+	new /obj/item/wirecutters(src, "red")
+	new /obj/item/multitool/red(src)
+	new /obj/item/stack/cable_coil(src, 30, COLOR_RED)
+	update_icon()
+
 /obj/item/storage/belt/medical
 	name = "medical belt"
 	desc = "Can hold various medical equipment."

--- a/code/modules/ruins/syndicate_space_base.dm
+++ b/code/modules/ruins/syndicate_space_base.dm
@@ -49,12 +49,12 @@
 	gloves = /obj/item/clothing/gloves/combat
 	r_ear = /obj/item/radio/headset/syndicate/alt/nocommon // See del_types above
 	back = /obj/item/storage/backpack
-	belt = /obj/item/storage/belt/utility/full/multitool
+	belt = /obj/item/storage/belt/utility/syndi_researcher
 	r_pocket = /obj/item/gun/projectile/automatic/pistol
 	id = /obj/item/card/id/syndicate/researcher
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m10mm = 1,
-		/obj/item/flashlight = 1,
+		/obj/item/flashlight/seclite = 1,
 		/obj/item/clothing/mask/gas/syndicate = 1,
 		/obj/item/tank/internals/emergency_oxygen/engi/syndi = 1
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Changes the syndicate researcher's toolbelt to be unique and contain the syndicate tools found within the syndicate toolbelt, for stylistic consistency. It also changes their flashlight to the black "seclite" because black and red syndicate colors looks better than Nanotrasen's blue flashlight.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Stylistic consistency across all the syndicate's tools is good.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
New COOL syndicate toolbelt vs average boring toolbelt
![image](https://user-images.githubusercontent.com/91113370/188323356-863ca046-132a-4ab4-ae5f-1cbeca7f94dc.png)
![image](https://user-images.githubusercontent.com/91113370/188323407-05136a51-4dd0-4e6a-a335-0493c0701e95.png)
![image](https://user-images.githubusercontent.com/91113370/188323417-ccfc1e62-1b96-4cc0-9edd-9a1ed224a8d5.png)



## Testing
<!-- How did you test the PR, if at all? -->
Opened the game, messed around with the tools, all the overlays worked. Flashlight turned on and off.

## Changelog
:cl:
tweak: The syndicate researcher's tools and toolbelt are now consistent with the syndicate toolbox.
tweak: Syndicate researchers now get a black flashlight to match their style.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
