### PR TITLE
Removes weakens on tripping over simplebots

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/griefsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/griefsky.dm
@@ -53,7 +53,7 @@
 	if(ismob(AM) && AM == target)
 		var/mob/living/carbon/C = AM
 		visible_message("[src] flails his swords and pushes [C] out of it's way!" )
-		C.Weaken(4 SECONDS)
+		C.KnockDown(4 SECONDS)
 
 /mob/living/simple_animal/bot/secbot/griefsky/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -320,7 +320,7 @@
 						  	"[C] trips over [src] and falls!", \
 						  	"[C] topples over [src]!", \
 						  	"[C] leaps out of [src]'s way!")]</span>")
-			C.Weaken(10 SECONDS)
+			C.KnockDown(10 SECONDS)
 			playsound(loc, 'sound/misc/sadtrombone.ogg', 50, 1, -1)
 			if(!client)
 				speak("Honk!")

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -472,7 +472,7 @@
 						  "[C] trips over [src] and falls!", \
 						  "[C] topples over [src]!", \
 						  "[C] leaps out of [src]'s way!")]</span>")
-		C.Weaken(4 SECONDS)
+		C.KnockDown(4 SECONDS)
 		return
 	..()
 


### PR DESCRIPTION
## What Does This PR Do
Removes the weakens over tripping over simplebots, replaces them with a knockdown (4 for beepsky and griefsky, 10 for honkbot)
For note: this does not remove the stun from honk or mulebots, just the trip weaken 

## Why It's Good For The Game
"tripping" suggests you fell over, and a knockdown makes sense
also stuns bad (Pretty sure this is part of project progression) 

## Testing
Compiled, ran, checked to make sure that you got a knockdown rather than a stun, made sure beepsky can still baton you

## Changelog
:cl:
tweak: Tripping over simplebots now deals knockdown rather than weaken 
/:cl:
