### PR TITLE
Changes Neo-Russikya to display in Cyrillics.

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -467,15 +467,15 @@
 	key = "?"
 	space_chance = 65
 	english_names = 1
-	syllables = list("dyen","bar","bota","vyek","tvo","slov","slav","syen","doup","vah","laz","gloz","yet",
-					 "nyet","da","sky","glav","glaz","netz","doomat","zat","moch","boz",
-					 "comy","vrad","vrade","tay","bli","ay","nov","livn","tolv","glaz","gliz",
-					 "ouy","zet","yevt","dat","botat","nev","novy","vzy","nov","sho","obsh","dasky",
-					 "key","skey","ovsky","skaya","bib","kiev","studen","var","bul","vyan",
-					 "tzion","vaya","myak","gino","volo","olam","miti","nino","menov","perov",
-					 "odasky","trov","niki","ivano","dostov","sokol","oupa","pervom","schel",
-					 "tizan","chka","tagan","dobry","okt","boda","veta","idi","cyk","blyt","hui","na",
-					 "udi","litchki","casa","linka","toly","anatov","vich","vech","vuch","toi","ka","vod")
+	syllables = list("дыен","бар","бота","выек","тво","слов","слав","сыен","доуп","вах","лаз","глоз","йет",
+					 "нет","да","скй","глав","глаз","нетз","доомат","дома","зат","молчат","боз","сомы",
+					 "вгад","враде","таы","бли","аы","нов","ливн","толв","глаз","глиз","оуй","зет","йевт",
+					 "дат","ботат","нев","новы","взя","новаия","что","обш","дафский","кеы","щкей","овскй",
+					 "скайа","бибю","киев","элек","студех","вар","бйл","вйаня","цион","вая","мыяак","гино",
+					 "воло","олам","мити","ниноская","мынов","перов","одаскй","тров","ники","ивано","достов",
+					 "достоевский","соколов","опа","первом","щел","тизан","чх","таган","добрый","охт","бода",
+					 "вета","иди","на","хуй","сук","бля","уди","литчки","кас","лиха","лихз","толй","анатов",
+					 "вич","веч","вуч","тои","ха","вод")
 
 /datum/language/wryn
 	name = "Wryn Hivemind"


### PR DESCRIPTION
## What Does This PR Do
It changes the syllables for Neo-Russkiya in-game to display in Cyrillic, as well as adding a few new words (notably: молчат, достоевский, and дома), and changing the order or pronunciation of a majority of the words, as they were not 1:1 with their Cyrillic counterparts.

## Why It's Good For The Game
This PR simply adds flavor to the already existing system of randomized syllables, when speaking Neo-Russkiya to someone in-game who does not have the language available to them to use (ie. They perhaps chose clownish instead.)

## Testing
I wrote in Cyrillic characters in-game, the rune-chat was heavily blurred, however the characters appeared unchanged in the bottom right text box.

## Changelog
:cl:LynxSolstice#8534
tweak: Neo-Russkiya now uses Cyrillic, enjoy!
/:cl:
