### PR TITLE
wizard can now hit forced crawlers with fireball by clicking on them

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -379,6 +379,8 @@
 
 	var/obj/item/projectile/magic/fireball/FB = new fireball_type(user.loc)
 	FB.current = get_turf(user)
+	FB.original = target
+	FB.firer = user
 	FB.preparePixelProjectile(target, get_turf(target), user)
 	FB.fire()
 	user.newtonian_move(get_dir(U, T))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Stunned / force crawling people can be hit by a fireball, by clicking on them directly, similar to how a gun works.

Fireballs no longer blow up in the wizards face

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fireball not hitting people stunned when you clicked on them was always stupid. Now you can.

## Testing
<!-- How did you test the PR, if at all? -->
Fireballed manual crawler without clicking on. Hit.
Fireballed at forced crawler by clicking over. Miss.
Fireballed at forced crawler by clicking on them. Hit.

## Changelog
:cl:
tweak: Fireball spell acts more like a gun, and can hit stunned / crawling mobs when clicking on them directly.
fix: Fireballs no longer blow up in the wizards face
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
