### PR TITLE
Combines the major disease outbreak event with the moderate.

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -81,8 +81,9 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 				diseases_moderate += candidate
 			if(DANGEROUS, BIOHAZARD)
 				diseases_major += candidate
-	if(MAJOR_INTO_MODERATE)
+	#ifdef MAJOR_INTO_MODERATE
 		diseases_moderate += diseases_major
+	#endif
 
 /datum/event/disease_outbreak/proc/populate_symptoms()
 	for(var/candidate in subtypesof(/datum/symptom))

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,6 +1,3 @@
-#define MAJOR_INTO_MODERATE TRUE  //If true folds die major diseases/symptoms into moderate ones
-
-
 GLOBAL_LIST_EMPTY(current_pending_diseases)
 /datum/event/disease_outbreak
 	/// The type of disease that patient zero will be infected with.
@@ -11,11 +8,10 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 										/datum/disease/advance/hullucigen, /datum/disease/advance/sensory_restoration, /datum/disease/advance/voice_change)
 	var/static/list/transmissable_symptoms = list()
 	var/static/list/diseases_minor = list()
-	var/static/list/diseases_moderate = list()
-	var/static/list/diseases_major = list()
+	var/static/list/diseases_moderate_major = list()
 
 /datum/event/disease_outbreak/setup()
-	if(isemptylist(diseases_minor) && isemptylist(diseases_moderate) && isemptylist(diseases_major))
+	if(isemptylist(diseases_minor) && isemptylist(diseases_moderate_major))
 		populate_diseases()
 	if(isemptylist(transmissable_symptoms))
 		populate_symptoms()
@@ -25,15 +21,13 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 			if(EVENT_LEVEL_MUNDANE)
 				virus = pick(diseases_minor)
 			if(EVENT_LEVEL_MODERATE)
-				virus = pick(diseases_moderate)
-			if(EVENT_LEVEL_MAJOR)
-				virus = pick(diseases_major)
+				virus = pick(diseases_moderate_major)
 			else
-				stack_trace("Disease Outbreak: Invalid Event Level [severity]. Expected: 1-3")
+				stack_trace("Disease Outbreak: Invalid Event Level [severity]. Expected: 1-2")
 				virus = /datum/disease/cold
 		chosen_disease = new virus()
 	else
-		if(severity == EVENT_LEVEL_MODERATE && MAJOR_INTO_MODERATE)
+		if(severity == EVENT_LEVEL_MODERATE)
 			chosen_disease = create_virus(severity * pick(2,3))	//50% chance for a major disease instead of a moderate one
 		else
 			chosen_disease = create_virus(severity * 2)
@@ -77,18 +71,11 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 		switch(CD.severity)
 			if(NONTHREAT, MINOR)
 				diseases_minor += candidate
-			if(MEDIUM, HARMFUL)
-				diseases_moderate += candidate
-			if(DANGEROUS, BIOHAZARD)
-				diseases_major += candidate
-	#ifdef MAJOR_INTO_MODERATE
-		diseases_moderate += diseases_major
-	#endif
+			if(MEDIUM, HARMFUL, DANGEROUS, BIOHAZARD)
+				diseases_moderate_major += candidate
 
 /datum/event/disease_outbreak/proc/populate_symptoms()
 	for(var/candidate in subtypesof(/datum/symptom))
 		var/datum/symptom/CS = candidate
 		if(initial(CS.transmittable) > 1)
 			transmissable_symptoms += candidate
-
-#undef MAJOR_INTO_MODERATE

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -200,7 +200,6 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			85, is_one_shot = TRUE),										// 8.4% on high pop, 9.4% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",	/datum/event/spider_terror, 	20,						list(ASSIGNMENT_SECURITY = 4), TRUE),	// 7.1% on high pop, 5.3% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	10,  is_one_shot = TRUE),	// 3% on high pop, 2.1% on low pop
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Disease Outbreak",/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), TRUE),
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = TRUE)
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Combines the major and moderate disease outbreak into one.

## Why It's Good For The Game
Major disease outbreak was firing too often.
Even major diseases are not as catastrophic for the station as other events in the major category thus "wasting" a midround with a non-event.

## Testing
Verified that the disease generation, ghost message and infection are still working as intended.

## Changelog
:cl: uc_guy
tweak: Combines the major and moderate disease outbreak events into one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
