### PR TITLE
Removal of a security newcaster on boxstation's cargo bay

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -35574,9 +35574,9 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/head/soft,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32;
-	name = "north bump"
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Replaces the security newcaster in boxstation's cargo bay with a normal one.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Cargo is not sec sadly.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned in, check newcaster, can no longer 1984 random articles and make fancy wanted poster things.

## Changelog
:cl:
fix: Fixed Cyberiad's cargo bay having a security newcaster, not a normal one.
/:cl:

_I am deeming this a fix_

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
