### PR TITLE
Adds diagnostic huds to pAIs and fixes a visual glitch with their hud menu

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -58,6 +58,7 @@
 
 	var/secHUD = FALSE			// Toggles whether the Security HUD is active or not
 	var/medHUD = FALSE			// Toggles whether the Medical  HUD is active or not
+	var/dHUD = FALSE			// Toggles whether the Diagnostic HUD is active or not
 
 	/// Currently active software
 	var/datum/pai_software/active_software

--- a/code/modules/mob/living/silicon/pai/software/pai_toggles.dm
+++ b/code/modules/mob/living/silicon/pai/software/pai_toggles.dm
@@ -8,6 +8,8 @@
 
 /datum/pai_software/sec_hud/toggle(mob/living/silicon/pai/user)
 	user.secHUD = !user.secHUD
+	user.medHUD = FALSE
+	user.dHUD = FALSE
 	user.remove_med_sec_hud()
 	if(user.secHUD)
 		user.add_sec_hud()
@@ -25,12 +27,32 @@
 
 /datum/pai_software/med_hud/toggle(mob/living/silicon/pai/user)
 	user.medHUD = !user.medHUD
+	user.secHUD = FALSE
+	user.dHUD = FALSE
 	user.remove_med_sec_hud()
 	if(user.medHUD)
 		user.add_med_hud()
 
 /datum/pai_software/med_hud/is_active(mob/living/silicon/pai/user)
 	return user.medHUD
+
+/datum/pai_software/d_hud
+	name = "Diagnostic HUD"
+	ram_cost = 20
+	id = "d_hud"
+	ui_icon = "bolt"
+	toggle_software = TRUE
+
+/datum/pai_software/d_hud/toggle(mob/living/silicon/pai/user)
+	user.dHUD = !user.dHUD
+	user.secHUD = FALSE
+	user.medHUD = FALSE
+	user.remove_med_sec_hud()
+	if(user.dHUD)
+		user.add_diag_hud()
+
+/datum/pai_software/d_hud/is_active(mob/living/silicon/pai/user)
+	return user.dHUD
 
 // Universal Translator //
 /datum/pai_software/translator


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Allows pAIs to buy a diagnostic hud for 20 RAM. It also fixes a glitch in the TGUI menu showing you had multiple huds active, even if you didn't, purely a visual glitch in the menu.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->pAIs can already access sec and med huds, diagnostic huds will allow them to help people away from shocked doors and be able to tell the health of IPCs. Plus it makes them a bit more fun to play since you cant buy basically all the huds, doorjack, and almost everything else.

## Testing
<!-- How did you test the PR, if at all? -->
Booted up a local server with two clients, tested a bunch with pAIs, fixed the bug with multiple huds showing in the TGUI menu but only one being active.

## Changelog
:cl:
add: pAIs can now buy diagnostic huds!
fix: Fixes a visual bug where it shows you have multiple huds active in a menu, when you only have one active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
