### PR TITLE
Tweaks guidelines to prevent my own slip ups

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -607,6 +607,8 @@ in the SQL/updates folder.
 
 * All new var/proc names should use the American English spelling of words. This is for consistency with BYOND.
 
+* If you are making a PR that adds a config option to change existing behaviour, said config option must default to as close to as current behaviour as possible.
+
 ### Dream Maker Quirks/Tricks
 
 Like all languages, Dream Maker has its quirks, some of them are beneficial to us, like these:


### PR DESCRIPTION
## What Does This PR Do
Tweaks contribution guidelines to enforce the following.

If you are adding a config change in a PR to change existing behaviour, you must have the config option default to whatever the closest behaviour is.

The reasoning behind this is largely so if things are merged, behaviour stays the same till that config option is added to production config and voted on between leadership.

I really didn't want to have to make PRs while out a on business trip but this was a pressing matter due to my own mistakes. 

## Why It's Good For The Game
Something something status quo I dont know Im just making a PR 

## Testing
I webedited this.

## Changelog
N/A