### PR TITLE
Fixes Kerberos virology APC and the PANDEMIC

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -83035,11 +83035,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -83309,7 +83304,6 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5
 	},
-/obj/machinery/computer/pandemic,
 /obj/machinery/requests_console{
 	department = "Virology";
 	departmentType = 3;
@@ -83579,6 +83573,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/computer/pandemic,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreencorner"
@@ -83596,16 +83591,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/item/twohanded/required/kirbyplants,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -97375,6 +97361,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
+"wdL" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreen"
+	},
+/area/medical/virology)
 "web" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -146341,7 +146332,7 @@ abj
 abj
 dFG
 dNY
-dRf
+wdL
 dMz
 dNn
 dWT


### PR DESCRIPTION
## What Does This PR Do

1. Moves the PANDEMIC machine one tile to the right, because it spawns on top of a glass table
2. Removes an extra APC because this area has two, fixes #18985 

## Why It's Good For The Game

They are bugs that need to be fixed.

## Images of changes

Before:

![image](https://user-images.githubusercontent.com/33333517/188845623-45d7bf42-61b8-4ec0-a0f7-7c98bbba56eb.png)

After:

![image](https://user-images.githubusercontent.com/33333517/188845261-3de080e0-9c33-436d-a22f-09a7be32e7df.png)

The other APC works properly:

![image](https://user-images.githubusercontent.com/33333517/188845351-bc86bfd7-5651-453e-b64b-57970340c922.png)

## Testing

1. Spawned in as a virologist
2. Checked area power
3. Checked machine location

## Changelog
:cl:
fix: Kerberos' virology machine no longer spawns on top of a glass table.
fix: Kerberos' virology no longer has two APCs for the same area.
/:cl:
