### PR TITLE
get_idcard now checks for ID in the PDA slot

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -504,6 +504,10 @@
 	var/obj/item/pda/pda = wear_id
 	if(istype(pda) && pda.id)
 		id = pda.id
+	else
+		pda = wear_pda
+		if(istype(pda) && pda.id)
+			id = pda.id
 
 	if(check_hands)
 		if(istype(get_active_hand(), /obj/item/card/id))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The `get_idcard()` proc in human.dm now checks for ID inside PDAs on the PDA slot.

This fixes unintended behavior with the Jestographic Sequencer where ID checks fail if the user loads their ID into their PDA.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
`get_idcard()` is now more thorough in doing its job, and a traitor item works as people expect it to.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested locally on a private debug server.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Jestographic Sequencer now properly checks ID loaded into PDAs on the PDA slot
/:cl:
