### PR TITLE
fixes katana runtime GBP NO UPDATE

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -588,7 +588,7 @@
 	playsound(src, 'sound/weapons/genhit3.ogg', 50, TRUE)
 	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, .proc/strike_throw_impact)
 	var/atom/throw_target = get_edge_target_turf(target, user.dir)
-	target.throw_at(throw_target, 5, 3, user, FALSE, callback = CALLBACK(/datum/.proc/UnregisterSignal, target, COMSIG_MOVABLE_IMPACT))
+	target.throw_at(throw_target, 5, 3, user, FALSE, callback = CALLBACK(target, /datum/.proc/UnregisterSignal, target, COMSIG_MOVABLE_IMPACT))
 	target.apply_damage(17, BRUTE, BODY_ZONE_CHEST)
 	to_chat(target, "<span class='userdanger'>You've been struck by [user]!</span>")
 	user.do_attack_animation(target, ATTACK_EFFECT_PUNCH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

fixes harm harm disarm katana move from making a runtime.

I did not test after moving the UnregisterSignal into the throw callback. This is on me, and I should know better.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

bugs bad.

## Testing
<!-- How did you test the PR, if at all? -->

Spawned in targets, used katana move on them, ensured that it did not runtime for real this time.

## Changelog
:cl:
fix: Fixed cursed katana runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
