### PR TITLE
Adds some examine helpers

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -71,13 +71,13 @@
 
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The [src]'s maintenance panel can be <b>screwed [panel_open ? "closed" : "open"]</b>.</span>"
+	. += "<span class='notice'>\The [src]'s maintenance panel can be <b>screwed [panel_open ? "closed" : "open"]</b>.</span>"
 	if(panel_open)
-		. += "<span class='notice'>Upgrades can be added to the [src] or <b>pried out</b>.</span>"
+		. += "<span class='notice'>Upgrades can be added to \the [src] or <b>pried out</b>.</span>"
 		if(!wires.CanDeconstruct())
-			. += "<span class='notice'>The [src]'s <b>internal wires</b> are preventing you from cutting it free.</span>"
+			. += "<span class='notice'>\The [src]'s <b>internal wires</b> are preventing you from cutting it free.</span>"
 		else
-			. += "<span class='notice'>The [src]'s <i>internal wires</i> are disconnected, but it can be <b>cut free</b>.</span>"
+			. += "<span class='notice'>\The [src]'s <i>internal wires</i> are disconnected, but it can be <b>cut free</b>.</span>"
 
 
 /obj/machinery/camera/emp_act(severity)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -73,11 +73,11 @@
 	. = ..()
 	. += "<span class='notice'>[src]'s maintenance panel can be <b>screwed [panel_open ? "closed" : "open"]</b>.</span>"
 	if(panel_open)
-		. += "<span class='notice'>Upgrades can be added to \the [src] or <b>pried out</b>.</span>"
+		. += "<span class='notice'>Upgrades can be added to [src] or <b>pried out</b>.</span>"
 		if(!wires.CanDeconstruct())
-			. += "<span class='notice'>\The [src]'s <b>internal wires</b> are preventing you from cutting it free.</span>"
+			. += "<span class='notice'>[src]'s <b>internal wires</b> are preventing you from cutting it free.</span>"
 		else
-			. += "<span class='notice'>\The [src]'s <i>internal wires</i> are disconnected, but it can be <b>cut free</b>.</span>"
+			. += "<span class='notice'>[src]'s <i>internal wires</i> are disconnected, but it can be <b>cut free</b>.</span>"
 
 
 /obj/machinery/camera/emp_act(severity)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -69,6 +69,17 @@
 	cancelAlarm()
 	return ..()
 
+/obj/machinery/camera/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>The [src]'s maintenance panel can be <b>screwed [panel_open ? "closed" : "open"]</b>.</span>"
+	if(panel_open)
+		. += "<span class='notice'>Upgrades can be added to the [src] or <b>pried out</b>.</span>"
+		if(!wires.CanDeconstruct())
+			. += "<span class='notice'>The [src]'s <b>internal wires</b> are preventing you from cutting it free.</span>"
+		else
+			. += "<span class='notice'>The [src]'s <i>internal wires</i> are disconnected, but it can be <b>cut free</b>.</span>"
+
+
 /obj/machinery/camera/emp_act(severity)
 	if(!status)
 		return

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -71,7 +71,7 @@
 
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>\The [src]'s maintenance panel can be <b>screwed [panel_open ? "closed" : "open"]</b>.</span>"
+	. += "<span class='notice'>[src]'s maintenance panel can be <b>screwed [panel_open ? "closed" : "open"]</b>.</span>"
 	if(panel_open)
 		. += "<span class='notice'>Upgrades can be added to \the [src] or <b>pried out</b>.</span>"
 		if(!wires.CanDeconstruct())

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -23,6 +23,19 @@
 	QDEL_LIST(upgrades)
 	return ..()
 
+/obj/item/camera_assembly/examine(mob/user)
+	. = ..()
+	switch(state)
+		if(ASSEMBLY_UNBUILT)
+			. += "<span class='notice'>The camera's <i>bolts</i> need to be secured in a wall.</span>"
+		if(ASSEMBLY_WRENCHED)
+			. += "<span class='notice'>The camera is <b>bolted</b>, but it needs to be <i>welded</i> into place.</span>"
+		if(ASSEMBLY_WELDED)
+			. += "<span class='notice'>The camera is <b>welded</b> to the wall, it's lacking <i>wires</i>.</span>"
+		if(ASSEMBLY_WIRED)
+			. += "<span class='notice'>The camera is <b>wired</b>, but the maintenence panel needs to be <i>screwed shut</i>.</span>"
+			. += "<span class='notice'>Upgrades can be added to the camera, and removed with a crowbar.</span>"
+
 /obj/item/camera_assembly/attackby(obj/item/I, mob/living/user, params)
 	if(state == ASSEMBLY_WELDED && iscoil(I))
 		var/obj/item/stack/cable_coil/C = I

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -27,14 +27,14 @@
 	. = ..()
 	switch(state)
 		if(ASSEMBLY_UNBUILT)
-			. += "<span class='notice'>The camera's <i>bolts</i> need to be secured in a wall.</span>"
+			. += "<span class='notice'>The camera assembly's <i>bolts</i> need to be secured in a wall.</span>"
 		if(ASSEMBLY_WRENCHED)
-			. += "<span class='notice'>The camera is <b>bolted</b>, but it needs to be <i>welded</i> into place.</span>"
+			. += "<span class='notice'>The camera assembly is <b>bolted</b>, but it needs to be <i>welded</i> into place.</span>"
 		if(ASSEMBLY_WELDED)
-			. += "<span class='notice'>The camera is <b>welded</b> to the wall, it's lacking <i>wires</i>.</span>"
+			. += "<span class='notice'>The camera assembly is <b>welded</b> to the wall, it's lacking <i>wires</i>.</span>"
 		if(ASSEMBLY_WIRED)
-			. += "<span class='notice'>The camera is <b>wired</b>, but the maintenence panel needs to be <i>screwed shut</i>.</span>"
-			. += "<span class='notice'>Upgrades can be added to the camera, and removed with a crowbar.</span>"
+			. += "<span class='notice'>The camera assembly is <b>wired</b>, but the maintenence panel needs to be <i>screwed shut</i>.</span>"
+			. += "<span class='notice'>Upgrades can be added to the camera assembly, and removed with a crowbar.</span>"
 
 /obj/item/camera_assembly/attackby(obj/item/I, mob/living/user, params)
 	if(state == ASSEMBLY_WELDED && iscoil(I))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -424,7 +424,7 @@
 
 /obj/structure/computerframe/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It is <b>[anchored ? "bolted to the floor" : "unbolted"]</b>. [anchored ? "" : "Alt-Click to rotate it."]</span>"
+	. += "<span class='notice'>It is <b>[anchored ? "bolted to the floor" : "unbolted"]</b>.</span>"
 	switch(state)
 		if(STATE_EMPTY)
 			. += "<span class='notice'>The frame is <b>welded together</b>, but it is missing a <i>circuit board</i>.</span>"
@@ -436,6 +436,8 @@
 			. += "<span class='notice'>The frame is <b>wired</b>, but the <i>glass</i> is missing.</span>"
 		if(STATE_GLASS)
 			. += "<span class='notice'>The glass is <b>loosely connected</b> and needs to be <i>screwed into place</i>.</span>"
+	if(!anchored)
+		. += "<span class='notice'>Alt-Click to rotate it.</span>"
 
 /obj/structure/computerframe/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -422,6 +422,21 @@
 	var/state = STATE_EMPTY
 	var/obj/item/circuitboard/circuit = null
 
+/obj/structure/computerframe/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It is <b>[anchored ? "bolted to the floor" : "unbolted"]</b>. [anchored ? "" : "Alt-Click to rotate it."]</span>"
+	switch(state)
+		if(STATE_EMPTY)
+			. += "<span class='notice'>The frame is <b>welded together</b>, but it is missing a <i>circuit board</i>.</span>"
+		if(STATE_CIRCUIT)
+			. += "<span class='notice'>A circuit board is <b>firmly connected</b>, but the cover is <i>unscrewed and open</i>.</span>"
+		if(STATE_NOWIRES)
+			. += "<span class='notice'>The cover is <b>screwed shut</b>, but the frame is missing <i>wiring</i>.</span>"
+		if(STATE_WIRES)
+			. += "<span class='notice'>The frame is <b>wired</b>, but the <i>glass</i> is missing.</span>"
+		if(STATE_GLASS)
+			. += "<span class='notice'>The glass is <b>loosely connected</b> and needs to be <i>screwed into place</i>.</span>"
+
 /obj/structure/computerframe/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))
 		drop_computer_parts()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -263,6 +263,16 @@ FIRE ALARM
 
 /obj/machinery/firealarm/examine(mob/user)
 	. = ..()
+	switch(buildstage)
+		if(FIRE_ALARM_FRAME)
+			. += "<span class='notice'>It's missing the <i>control board<i>, but the <b>mounting bolts</b> are exposed.</span>"
+		if(FIRE_ALARM_UNWIRED)
+			. += "<span class='notice'>The control board needs <i>wiring</i> and can be <b>pried out</b>.</span>"
+		if(FIRE_ALARM_READY)
+			if(wiresexposed)
+				. += "<span class='notice'>The fire alarm's <b>wires</b> are exposed by the <i>unscrewed</i> panel.</span>"
+				. += "<span class='notice'>The detection circuitry can be turned <b>[detecting ? "off" : "on"]</b> by <i>pulsing</i> the board.</span>"
+
 	. += "It shows the alert level as: <B><U>[capitalize(get_security_level())]</U></B>."
 
 /obj/machinery/firealarm/proc/reset()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -265,7 +265,7 @@ FIRE ALARM
 	. = ..()
 	switch(buildstage)
 		if(FIRE_ALARM_FRAME)
-			. += "<span class='notice'>It's missing the <i>control board<i>, but the <b>mounting bolts</b> are exposed.</span>"
+			. += "<span class='notice'>It's missing a <i>circuit board<i> and the <b>bolts</b> are exposed.</span>"
 		if(FIRE_ALARM_UNWIRED)
 			. += "<span class='notice'>The control board needs <i>wiring</i> and can be <b>pried out</b>.</span>"
 		if(FIRE_ALARM_READY)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -149,7 +149,7 @@
 		if(1)
 			. += "<span class='notice'>The speaker needs to be <i>wired</i>, though the board could be <b>pried</b> out.</span>"
 		if(2)
-			. += "<span class='notice'>The intercom is <b>wired</b>, and the maintenence panel is <i>unscrewed</i>.</span>"
+			. += "<span class='notice'>The intercom is <b>wired</b>, and the maintenance panel is <i>unscrewed</i>.</span>"
 
 /obj/item/radio/intercom/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/tape_roll)) //eww

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -141,6 +141,16 @@
 
 	return canhear_range
 
+/obj/item/radio/intercom/examine(mob/user)
+	. = ..()
+	switch(buildstage)
+		if(0)
+			. += "<span class='notice'>The frame is <b>welded</b> to the wall, but missing <i>circuitry</i>.</span>"
+		if(1)
+			. += "<span class='notice'>The speaker needs to be <i>wired</i>, though the board could be <b>pried</b> out.</span>"
+		if(2)
+			. += "<span class='notice'>The intercom is <b>wired</b>, and the maintenence panel is <i>unscrewed</i>.</span>"
+
 /obj/item/radio/intercom/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/tape_roll)) //eww
 		return

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -1100,10 +1100,11 @@
 
 /obj/machinery/alarm/examine(mob/user)
 	. = ..()
-	if(buildstage < 2)
-		. += "It is not wired."
-	if(buildstage < 1)
-		. += "The circuit is missing."
+	switch(buildstage)
+		if(AIR_ALARM_FRAME)
+			. += "<span class='notice'>The <i>control circuit</i> is missing and the <b>mounting bolts<b> are exposed.</span>"
+		if(AIR_ALARM_BUILDING)
+			. += "<span class='notice'>The frame is missing <i>wires</i>, but the control circuit can be <b>pried out</b>.</span>"
 
 /obj/machinery/alarm/proc/unshort_callback()
 	if(shorted)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -1102,9 +1102,9 @@
 	. = ..()
 	switch(buildstage)
 		if(AIR_ALARM_FRAME)
-			. += "<span class='notice'>The <i>control circuit</i> is missing and the <b>mounting bolts<b> are exposed.</span>"
+			. += "<span class='notice'>Its <i>circuit</i> is missing and the <b>bolts<b> are exposed.</span>"
 		if(AIR_ALARM_BUILDING)
-			. += "<span class='notice'>The frame is missing <i>wires</i>, but the control circuit can be <b>pried out</b>.</span>"
+			. += "<span class='notice'>The frame is missing <i>wires</i> and the control circuit can be <b>pried out</b>.</span>"
 
 /obj/machinery/alarm/proc/unshort_callback()
 	if(shorted)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -418,7 +418,7 @@
 	if(in_range(user, src))
 		switch(status)
 			if(LIGHT_OK)
-				. += "<span class='notice'>It is turned [on? "on" : "off"].</span>"
+				. += "<span class='notice'>It is turned [on ? "on" : "off"].</span>"
 			if(LIGHT_EMPTY)
 				. += "<span class='notice'>The [fitting] has been removed.</span>"
 				. += "<span class='notice'>The casing can be <b>unscrewed</b>.</span>"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -49,11 +49,11 @@
 	if(get_dist(user, src) <= 2)
 		switch(stage)
 			if(1)
-				. += "It's an empty frame."
+				. += "<span class='notice'>It's an empty frame <b>bolted</b> to the wall. It needs to be <i>wired</i>.</span>"
 			if(2)
-				. += "It's wired."
+				. += "<span class='notice'>The frame is <b>wired</b>, but the casing's cover is <i>unscrewed</i>.</span>"
 			if(3)
-				. += "The casing is closed."
+				. += "<span class='notice'>The casing is <b>screwed</b> shut.</span>"
 
 /obj/machinery/light_construct/wrench_act(mob/living/user, obj/item/I)
 	. = TRUE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -418,13 +418,14 @@
 	if(in_range(user, src))
 		switch(status)
 			if(LIGHT_OK)
-				. += "It is turned [on? "on" : "off"]."
+				. += "<span class='notice'>It is turned [on? "on" : "off"].</span>"
 			if(LIGHT_EMPTY)
-				. += "The [fitting] has been removed."
+				. += "<span class='notice'>The [fitting] has been removed.</span>"
+				. += "<span class='notice'>The casing can be <b>unscrewed</b>.</span>"
 			if(LIGHT_BURNED)
-				. += "The [fitting] is burnt out."
+				. += "<span class='notice'>The [fitting] is burnt out.</span>"
 			if(LIGHT_BROKEN)
-				. += "The [fitting] has been smashed."
+				. += "<span class='notice'>The [fitting] has been smashed.</span>"
 
 // attack with item - insert light (if right type), otherwise try to break the light
 

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -129,7 +129,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 		if(ACCELERATOR_WRENCHED)
 			. += "<span class='notice'>\The [name]'s anchoring bolts are <b>wrenched</b> in place, but it lacks <i>wiring</i>.</span>"
 		if(ACCELERATOR_WIRED)
-			. +=  "<span class='notice'>\The [name] is <b>wired</b>, but the maintenence panel is <i>unscrewed and open</i>.</span>"
+			. +=  "<span class='notice'>\The [name] is <b>wired</b>, but the maintenance panel is <i>unscrewed and open</i>.</span>"
 		if(ACCELERATOR_READY)
 			. += "<span class='notice'>\The [name] is assembled and the maintenence panel is <b>screwed shut</b>.</span>"
 			if(powered)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -125,7 +125,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	. = ..()
 	switch(construction_state)
 		if(ACCELERATOR_UNWRENCHED)
-			. += "<span class='notice'>The [name]'s anchoring bolts are <i>loose</i>. It can be rotated with Alt-Click.</span>"
+			. += "<span class='notice'>The [name]'s <i>anchoring bolts</i> are loose.</span>"
 		if(ACCELERATOR_WRENCHED)
 			. += "<span class='notice'>The [name]'s anchoring bolts are <b>wrenched</b> in place, but it lacks <i>wiring</i>.</span>"
 		if(ACCELERATOR_WIRED)
@@ -134,6 +134,8 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 			. += "<span class='notice'>The [name] is assembled and the maintenence panel is <b>screwed shut</b>.</span>"
 			if(powered)
 				desc = desc_holder
+	if(!anchored)
+		. += "<span class='notice'>Alt-click to rotate it.</span>"
 
 /obj/structure/particle_accelerator/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -125,13 +125,13 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	. = ..()
 	switch(construction_state)
 		if(ACCELERATOR_UNWRENCHED)
-			. += "<span class='notice'>The [name]'s <i>anchoring bolts</i> are loose.</span>"
+			. += "<span class='notice'>\The [name]'s <i>anchoring bolts</i> are loose.</span>"
 		if(ACCELERATOR_WRENCHED)
-			. += "<span class='notice'>The [name]'s anchoring bolts are <b>wrenched</b> in place, but it lacks <i>wiring</i>.</span>"
+			. += "<span class='notice'>\The [name]'s anchoring bolts are <b>wrenched</b> in place, but it lacks <i>wiring</i>.</span>"
 		if(ACCELERATOR_WIRED)
-			. +=  "<span class='notice'>The [name] is <b>wired</b>, but the maintenence panel is <i>unscrewed and open</i>.</span>"
+			. +=  "<span class='notice'>\The [name] is <b>wired</b>, but the maintenence panel is <i>unscrewed and open</i>.</span>"
 		if(ACCELERATOR_READY)
-			. += "<span class='notice'>The [name] is assembled and the maintenence panel is <b>screwed shut</b>.</span>"
+			. += "<span class='notice'>\The [name] is assembled and the maintenence panel is <b>screwed shut</b>.</span>"
 			if(powered)
 				desc = desc_holder
 	if(!anchored)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -122,18 +122,18 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return 1
 
 /obj/structure/particle_accelerator/examine(mob/user)
+	. = ..()
 	switch(construction_state)
-		if(0)
-			desc = text("A [name], looks like it's not attached to the flooring")
-		if(1)
-			desc = text("A [name], it is missing some cables")
-		if(2)
-			desc = text("A [name], the panel is open")
-		if(3)
-			desc = text("The [name] is assembled")
+		if(ACCELERATOR_UNWRENCHED)
+			. += "<span class='notice'>The [name]'s anchoring bolts are <i>loose</i>. It can be rotated with Alt-Click.</span>"
+		if(ACCELERATOR_WRENCHED)
+			. += "<span class='notice'>The [name]'s anchoring bolts are <b>wrenched</b> in place, but it lacks <i>wiring</i>.</span>"
+		if(ACCELERATOR_WIRED)
+			. +=  "<span class='notice'>The [name] is <b>wired</b>, but the maintenence panel is <i>unscrewed and open</i>.</span>"
+		if(ACCELERATOR_READY)
+			. += "<span class='notice'>The [name] is assembled and the maintenence panel is <b>screwed shut</b>.</span>"
 			if(powered)
 				desc = desc_holder
-	. = ..()
 
 /obj/structure/particle_accelerator/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -204,8 +204,9 @@
 	if(tracker)
 		. += "<span class='notice'>The solar assembly has a tracking circuit installed. It can be <b>pried out</b>.</span>"
 	else
-		. += "<span class='notice'>The solar assembly has a slot for a tracking circuit board.</span>"
-	.+= "<span class='notice'>The solar assembly needs <i>glass<i> to be completed.</span>"
+		. += "<span class='notice'>The solar assembly has a slot for a <i>tracking circuit<i> board.</span>"
+	if(anchored)
+		.+= "<span class='notice'>The solar assembly needs <i>glass<i> to be completed.</span>"
 
 /obj/item/solar_assembly/attackby(obj/item/W, mob/user, params)
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -198,6 +198,14 @@
 		S.amount = 2
 		glass_type = null
 
+/obj/item/solar_assembly/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>The solar assembly is <b>[anchored ? "wrenched into place" : "unwrenched"]</b>.</span>"
+	if(tracker)
+		. += "<span class='notice'>The solar assembly has a tracking circuit installed. It can be <b>pried out</b>.</span>"
+	else
+		. += "<span class='notice'>The solar assembly has a slot for a tracking circuit board.</span>"
+	.+= "<span class='notice'>The solar assembly needs <i>glass<i> to be completed.</span>"
 
 /obj/item/solar_assembly/attackby(obj/item/W, mob/user, params)
 


### PR DESCRIPTION
## What Does This PR Do
Adds a handful of construction examine-helpers (like airlock assemblies do) for the following objects:
Security Cameras, fire alarms, intercomms, air alarms, light fixtures, particle accelerators, and solar panels.

## Why It's Good For The Game
De-mystifies how to construct/deconstruct something without having to go to an external source -- also pretties up any existing examine helpers if there was one.

## Testing
Booted up a server and checked each of the objects I changed.

## Changelog
:cl:
add: Added (de)construction hints to security cams, air/fire alarms, intercoms, light fixtures, solar panels, and particle accelerators.
/:cl: