### PR TITLE
BoxStation: Medbay Button

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -39583,7 +39583,7 @@
 "bSR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyerPort";
+	id_tag = "medbayfoyerport";
 	name = "Medbay Entrance";
 	req_access_txt = "5"
 	},
@@ -41797,7 +41797,7 @@
 "bYe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyerPort";
+	id_tag = "medbayfoyerport";
 	name = "Medbay Entrance";
 	req_access_txt = "5"
 	},
@@ -72738,7 +72738,7 @@
 "gKS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyerPort";
+	id_tag = "medbayfoyerport";
 	name = "Medbay Entrance";
 	req_access_txt = "5"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -68852,6 +68852,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door_control{
+	id = "medbayfoyerport";
+	pixel_y = 21;
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -35309,6 +35309,19 @@
 	icon_state = "dark"
 	},
 /area/assembly/chargebay)
+"bIf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/medical/medbay2)
 "bIh" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -68841,9 +68854,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dJl" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -78829,7 +78839,7 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyerPort";
+	id = "medbayfoyerport";
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
 	pixel_x = -9;
@@ -130693,7 +130703,7 @@ bQU
 bSw
 bEp
 vAN
-cbO
+bIf
 bWd
 bXK
 ccA


### PR DESCRIPTION
Added again the button that opens all the medbay entrace doors again in BoxStation.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR add again the button that opens all the entrance doors in medbay. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This can save a lot of time and it was in the old medbay, and almost everyone was using it. People can be let in quickly. 

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/62888630/189426820-58bc96fe-102a-4383-bfe5-a7f1110c2d08.png)


## Testing
<!-- How did you test the PR, if at all? -->
Started dream deamon.
Local host server
Entered as CMO and clicked the button, it worked. 
## Changelog
:cl:
add: Added a button to open the medbay entrance doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
