### PR TITLE
Removes xenomorphs from xenobiology gold slimes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -36,11 +36,6 @@
 	deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw..."
 	footstep_type = FOOTSTEP_MOB_CLAW
 
-/mob/living/simple_animal/hostile/alien/xenobio
-	maxHealth = 60
-	health = 60
-	gold_core_spawnable = HOSTILE_SPAWN
-
 /mob/living/simple_animal/hostile/alien/drone
 	name = "alien drone"
 	icon_state = "aliend_running"
@@ -50,11 +45,6 @@
 	melee_damage_upper = 15
 	var/plant_cooldown = 30
 	var/plants_off = 0
-
-/mob/living/simple_animal/hostile/alien/drone/xenobio
-	maxHealth = 60
-	health = 60
-	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/alien/drone/handle_automated_action()
 	if(!..()) //AIStatus is off
@@ -80,12 +70,6 @@
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 
-
-/mob/living/simple_animal/hostile/alien/sentinel/xenobio
-	health = 75
-	maxHealth = 75
-	gold_core_spawnable = HOSTILE_SPAWN
-
 /mob/living/simple_animal/hostile/alien/queen
 	name = "alien queen"
 	icon_state = "alienq_running"
@@ -107,11 +91,6 @@
 	var/plants_off = 0
 	var/egg_cooldown = 30
 	var/plant_cooldown = 30
-
-/mob/living/simple_animal/hostile/alien/queen/xenobio
-	health = 100
-	maxHealth = 100
-	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/alien/queen/handle_automated_action()
 	if(!..())


### PR DESCRIPTION
## What Does This PR Do

Removes xenomorphs from the xenobiology gold slime spawn pool. (By deleting their xenobiology subtypes.)

## Why It's Good For The Game

Xenomorphs were re-added to rotation. As they are proper biohazards, just like terror spiders or blobs, they should not be seen every second round - the crew does not take xenomorphs seriously, since "they are probably friendly". This does not occur with any other existing biohazard mob, thus this PR will make them fall in line.

## Images of changes

...

## Testing

1. Spawn a `/obj/item/reagent_containers/syringe`
2. Spawn 15-20 `/obj/item/slime_extract/gold`
3. Spawn mobs with blood
4. It works properly and doesn't spawn xenomorphs (other than the lusty xenomorph maid)

## Changelog
:cl:
del: Xenomorphs can no longer be spawned via xenobiology gold slimes.
/:cl:
