### PR TITLE
Fixes runtime on dehydrated space carp

### DIFF
--- a/code/game/objects/items/dehy_carp.dm
+++ b/code/game/objects/items/dehy_carp.dm
@@ -43,9 +43,9 @@
 	icon = 'icons/mob/carp.dmi'
 	flick("carp_swell", src)
 	// Wait for animation to end
-	addtimer(CALLBACK(src, .proc/MakeCarp), 6)
+	addtimer(CALLBACK(src, .proc/make_carp), 6)
 
-/obj/item/toy/carpplushie/dehy_carp/proc/MakeCarp()
+/obj/item/toy/carpplushie/dehy_carp/proc/make_carp()
 	// Make space carp
 	var/mob/living/simple_animal/hostile/carp/C = new /mob/living/simple_animal/hostile/carp(get_turf(src))
 	// Make carp non-hostile to user, yes this means

--- a/code/game/objects/items/dehy_carp.dm
+++ b/code/game/objects/items/dehy_carp.dm
@@ -43,9 +43,9 @@
 	icon = 'icons/mob/carp.dmi'
 	flick("carp_swell", src)
 	// Wait for animation to end
-	addtimer(CALLBACK(src, .proc/Spawn), 6)
+	addtimer(CALLBACK(src, .proc/MakeCarp), 6)
 
-/obj/item/toy/carpplushie/dehy_carp/proc/Spawn()
+/obj/item/toy/carpplushie/dehy_carp/proc/MakeCarp()
 	// Make space carp
 	var/mob/living/simple_animal/hostile/carp/C = new /mob/living/simple_animal/hostile/carp(get_turf(src))
 	// Make carp non-hostile to user, yes this means

--- a/code/game/objects/items/dehy_carp.dm
+++ b/code/game/objects/items/dehy_carp.dm
@@ -39,12 +39,13 @@
 /obj/item/toy/carpplushie/dehy_carp/proc/Swell()
 	desc = "It's growing!"
 	visible_message("<span class='notice'>[src] swells up!</span>")
-
 	// Animation
 	icon = 'icons/mob/carp.dmi'
 	flick("carp_swell", src)
 	// Wait for animation to end
-	sleep(6)
+	addtimer(CALLBACK(src, .proc/Spawn), 6)
+
+/obj/item/toy/carpplushie/dehy_carp/proc/Spawn()
 	// Make space carp
 	var/mob/living/simple_animal/hostile/carp/C = new /mob/living/simple_animal/hostile/carp(get_turf(src))
 	// Make carp non-hostile to user, yes this means


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes a `sleep()` in dehy_carp.dm to `addtimer()`, which avoids a runtime when hydrating dehydrated space carp. Splits `/obj/item/toy/carpplushie/dehy_carp/proc/Swell()` into two procs. No player-facing changes.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on a local debug server.
<!-- How did you test the PR, if at all? -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
