### PR TITLE
Mechs can now be emaged to remove dna lock and access

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -18,6 +18,7 @@
 	max_equip = 5
 	starting_voice = /obj/item/mecha_modkit/voice/nanotrasen
 	destruction_sleep_duration = 2 SECONDS
+	emag_proof = TRUE //no stealing CC mechs.
 
 /obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = 0)
 	. = ..()
@@ -55,6 +56,7 @@
 	max_temperature = 40000
 	wreckage = /obj/structure/mecha_wreckage/ares
 	max_equip = 4
+	emag_proof = FALSE //Gamma armory can be stolen however.
 
 /obj/mecha/combat/marauder/ares/loaded/Initialize(mapload)
 	. = ..()
@@ -112,6 +114,7 @@
 	operation_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/mauler
 	starting_voice = /obj/item/mecha_modkit/voice/syndicate
+	emag_proof = FALSE //The crew can steal a syndicate mech. As a treat.
 
 /obj/mecha/combat/marauder/mauler/loaded/Initialize(mapload)
 	. = ..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -40,6 +40,7 @@
 	var/frozen = FALSE
 	var/repairing = FALSE
 	var/emp_proof = FALSE //If it is immune to emps
+	var/emag_proof = FALSE //If it is immune to emagging. Used by CC mechs.
 
 	//inner atmos
 	var/use_internal_tank = 0
@@ -878,8 +879,14 @@
 		. = ..()
 
 /obj/mecha/emag_act(mob/user)
-	to_chat(user, "<span class='warning'>[src]'s ID slot rejects the card.</span>")
-	return
+	if(emag_proof)
+		to_chat(user, "<span class='warning'>[src]'s ID slot rejects the card.</span>")
+		return
+	user.visible_message("<span class='notice'>[user] slides a card through [src]'s id slot'.</span>", "<span class='notice'>You slide the card through [src]'s ID slot, resetting the DNA and access locks.</span>")
+	playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	dna = null
+	operation_req_access = list()
+
 
 
 /////////////////////////////////////

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -209,8 +209,5 @@
 /obj/mecha/working/ripley/emag_act(mob/user)
 	if(!emagged)
 		emagged = TRUE
-		to_chat(user, "<span class='notice'>You slide the card through [src]'s ID slot.</span>")
-		playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		desc += "</br><span class='danger'>The mech's equipment slots spark dangerously!</span>"
-	else
-		to_chat(user, "<span class='warning'>[src]'s ID slot rejects the card.</span>")
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Emaging a mech that is not CC, will remove the DNA lock and clear the required access list.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No more can the crew leave their mechs lying out with dna / access locks with no fear of them being able to be stolen.

Yes this is an emag buff but I am not making an item just for stealing mechs. That is stupid.

Syndicate mechs are not included, as nukies are often in them, and frankly it is easy to strip a nukie for their ID.

ARES not included as it is a gamma armory mech.

## Testing
<!-- How did you test the PR, if at all? -->

Spawn in a bunch of mechs + mechs in admin room.
Test that I can not get into access locked ones.
Emag removes it, but not on CC mechs.
Test with skrell for dna lock.
Confirm ripley doesn't get infinite spark descriptions.

## Changelog
:cl:
tweak: Emaging a mech now removes the DNA and access locks from it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
