### PR TITLE
Mapping indictors for lootdrops are readable now

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -30,7 +30,6 @@
 /obj/effect/spawner/lootdrop/maintenance
 	name = "maintenance loot spawner (1 item)"
 	icon_state = "loot"
-	color = null
 
 	//How to balance this table
 	//-------------------------

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -1,7 +1,6 @@
 /obj/effect/spawner/lootdrop
 	icon = 'icons/effects/spawner_icons.dmi'
 	icon_state = "questionmark"
-	color = "#00FF00"
 	var/lootcount = 1		//how many items will be spawned
 	var/lootdoubles = TRUE		//if the same item can be spawned twice
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
@@ -190,8 +189,6 @@
 /obj/effect/spawner/lootdrop/trade_sol/
 	name = "trader item spawner"
 	lootcount = 6
-	color = "#00FFFF"
-
 
 /obj/effect/spawner/lootdrop/trade_sol/civ
 	name = "1. civilian gear"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Removes the colors from lootdrop icon_states, making them actually visible and not black question marks

The color lines were last touched SEVEN years ago. How did we go this long without ever noticing this.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Being able to see what you're mapping is good

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Before:
![image](https://user-images.githubusercontent.com/91113370/189467395-1ba3b3aa-c74e-409f-b4e0-bc48acf4c2f4.png)
After:
![image](https://user-images.githubusercontent.com/91113370/189467386-4ec5d82d-6a6d-4800-bf55-6ee8d3d6ce4c.png)


## Testing
<!-- How did you test the PR, if at all? -->
Opening mapping software: I can read the maps. Game still compiles and runs.

## Changelog
Nothing player facing, just mapper facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
