### PR TITLE
Fixes dish drive not picking up snack bowl and spamming the chat

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -13,6 +13,7 @@
 	var/static/list/collectable_items = list(/obj/item/trash/waffles,
 		/obj/item/trash/plate,
 		/obj/item/trash/tray,
+		/obj/item/trash/snack_bowl,
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
 		/obj/item/kitchen/utensil/fork,
 		/obj/item/shard,
@@ -20,6 +21,7 @@
 	var/static/list/disposable_items = list(/obj/item/trash/waffles,
 		/obj/item/trash/plate,
 		/obj/item/trash/tray,
+		/obj/item/trash/snack_bowl,
 		/obj/item/shard,
 		/obj/item/broken_bottle)
 	var/time_since_dishes = 0
@@ -129,6 +131,4 @@
 		Beam(bin, icon_state = "rped_upgrade", time = 5)
 		bin.update_icon()
 		flick("synthesizer_beam", src)
-	else
-		visible_message("<span class='notice'>There are no disposable items in [src]!</span>")
 	time_since_dishes = world.time + 60 SECONDS


### PR DESCRIPTION
## What Does This PR Do

Makes the dish drive pick up snack bowls, left behind by soups mainly.

Removes an unnecessary visible message.

## Why It's Good For The Game

This is a neat item to keep the kitchen empty, it not picking up snack bowls was an oversight.

Less spam is good.

## Images of changes

https://user-images.githubusercontent.com/33333517/189480028-09ddba4f-c5a3-4d60-9cc4-57dcb0909118.mp4

## Testing

1. Spawn an `/obj/item/coin`
2. Add it to the ChefDrobe, vend a DIY Dish Drive Kit
3. Assemble it
4. Spawn a `/obj/item/reagent_containers/food/snacks/soup/tomatosoup`
5. Eat it
6. Drop the snack bowl on the ground

## Changelog
:cl:
fix: The dish drive now picks up snack bowls as well.
/:cl:
