### PR TITLE
Allow silicons to use electric smart fridges.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -32,6 +32,8 @@
 	var/drying = FALSE
 	/// Whether the fridge's contents are visible on the world icon.
 	var/visible_contents = TRUE
+	/// Whether the fridge is electric and thus silicon crontrollable.
+	var/silicon_controllable = TRUE
 	/// The wires controlling the fridge.
 	var/datum/wires/smartfridge/wires
 	/// Typecache of accepted item types, init it in [/obj/machinery/smartfridge/Initialize].
@@ -206,7 +208,9 @@
 		return TRUE
 
 /obj/machinery/smartfridge/attack_ai(mob/user)
-	return FALSE
+	if(!silicon_controllable)
+		return FALSE
+	return attack_hand(user)
 
 /obj/machinery/smartfridge/attack_ghost(mob/user)
 	return attack_hand(user)
@@ -220,6 +224,8 @@
 
 //Drag pill bottle to fridge to empty it into the fridge
 /obj/machinery/smartfridge/MouseDrop_T(obj/over_object, mob/user)
+	if(issilicon(user))
+		return
 	if(!istype(over_object, /obj/item/storage/pill_bottle)) //Only pill bottles, please
 		return
 	if(stat & (BROKEN|NOPOWER))
@@ -455,6 +461,7 @@
 	use_power = NO_POWER_USE
 	visible_contents = FALSE
 	face_while_pulling = FALSE
+	silicon_controllable = FALSE
 
 
 /obj/machinery/smartfridge/foodcart/Initialize(mapload)
@@ -778,6 +785,7 @@
 	visible_contents = FALSE
 	light_range_on = null
 	light_power_on = null
+	silicon_controllable = FALSE
 
 
 /obj/machinery/smartfridge/drying_rack/Initialize(mapload)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -32,7 +32,7 @@
 	var/drying = FALSE
 	/// Whether the fridge's contents are visible on the world icon.
 	var/visible_contents = TRUE
-	/// Whether the fridge is electric and thus silicon crontrollable.
+	/// Whether the fridge is electric and thus silicon controllable.
 	var/silicon_controllable = TRUE
 	/// The wires controlling the fridge.
 	var/datum/wires/smartfridge/wires


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Re-adds the ability for silicons to use electric smart fridges. 

## Why It's Good For The Game
Consistency is good.
Silicons can access all other electric devices, so accessing the smart fridges makes sense. 

## Testing
Verified AI and Cyborgs can vend products from both normal and secure smart fridges.
Verified that it is not the case from drying racks and food cart.
Verified that Cyborgs can't load the chemist smart fridge with pill bottles.

## Changelog
:cl: uc_guy
add: Adds the ability for silicons to use electric smart fridges. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
