### PR TITLE
Ports the shuttle console hijack from TG. Tweaks malf AI hijack.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1539,6 +1539,17 @@
 /datum/mind/proc/remove_all_antag_datums() //For the Lazy amongst us.
 	QDEL_LIST(antag_datums)
 
+/// This proc sets the hijack speed for a mob. If greater than zero, they can hijack. Outputs in seconds.
+/datum/mind/proc/get_hijack_speed()
+	var/hijack_speed = 0
+	if(special_role)
+		hijack_speed = 15 SECONDS
+	if(locate(/datum/objective/hijack) in get_all_objectives())
+		hijack_speed = 10 SECONDS
+	return hijack_speed
+
+
+
 /**
  * Returns an antag datum instance if the src mind has the specified `datum_type`. Returns `null` otherwise.
  *

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -280,7 +280,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	return 0
 
 /datum/objective/block
-	explanation_text = "Hijack the shuttle by escaping on it with no loyalist Nanotrasen crew on board and free. \
+	explanation_text = "Hijack the shuttle with no loyalist Nanotrasen crew on board and free. \
 	Syndicate agents, other enemies of Nanotrasen, cyborgs, pets, and cuffed/restrained hostages may be allowed on the shuttle alive. \
 	Using the doomsday device successfully is also an option."
 	martyr_compatible = 1

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -229,7 +229,8 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/hijack
 	martyr_compatible = 0 //Technically you won't get both anyway.
 	explanation_text = "Hijack the shuttle by escaping on it with no loyalist Nanotrasen crew on board and free. \
-	Syndicate agents, other enemies of Nanotrasen, cyborgs, pets, and cuffed/restrained hostages may be allowed on the shuttle alive."
+	Syndicate agents, other enemies of Nanotrasen, cyborgs, pets, and cuffed/restrained hostages may be allowed on the shuttle alive. \
+	Alternatively, hack the shuttle console multiple times (by alt clicking on it) until the shuttle directions are corrupted."
 	needs_target = FALSE
 
 /datum/objective/hijack/check_completion()
@@ -279,7 +280,9 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	return 0
 
 /datum/objective/block
-	explanation_text = "Do not allow any lifeforms, be it organic or synthetic to escape on the shuttle alive. AIs, Cyborgs, Maintenance drones, and pAIs are not considered alive."
+	explanation_text = "Hijack the shuttle by escaping on it with no loyalist Nanotrasen crew on board and free. \
+	Syndicate agents, other enemies of Nanotrasen, cyborgs, pets, and cuffed/restrained hostages may be allowed on the shuttle alive. \
+	Using the doomsday device successfully is also an option."
 	martyr_compatible = 1
 	needs_target = FALSE
 
@@ -292,16 +295,8 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		return FALSE
 	if(!owner.current)
 		return FALSE
-
-	var/area/A = SSshuttle.emergency.areaInstance
-
-	for(var/mob/living/player in GLOB.player_list)
-		if(issilicon(player))
-			continue // If they're silicon, they're not considered alive, skip them.
-
-		if(player.mind && player.stat != DEAD)
-			if(get_area(player) == A)
-				return FALSE // If there are any other organic mobs on the shuttle, you failed the objective.
+	if(!SSshuttle.emergency.is_hijacked(TRUE))
+		return FALSE
 
 	return TRUE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -327,13 +327,13 @@
 	return sanitize(copytext(t,1,MAX_MESSAGE_LEN))
 
 
-/proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added
+/proc/Gibberish(t, p, replace_rate = 50)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added. replace_rate is the chance a letter is corrupted.
 	/* Turn text into complete gibberish! */
 	var/returntext = ""
 	for(var/i = 1, i <= length(t), i++)
 
 		var/letter = copytext(t, i, i+1)
-		if(prob(50))
+		if(prob(replace_rate))
 			if(p >= 70)
 				letter = ""
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -1,3 +1,13 @@
+
+#define NOT_BEGUN 0
+#define STAGE_1 1
+#define STAGE_2 2
+#define STAGE_3 3
+#define STAGE_4 4
+#define HIJACKED 5
+
+
+
 /obj/machinery/computer/emergency_shuttle
 	name = "emergency shuttle console"
 	desc = "For shuttle control."
@@ -5,6 +15,23 @@
 	icon_keyboard = "tech_key"
 	var/auth_need = 3
 	var/list/authorized = list()
+	var/hijack_last_stage_increase = 0 SECONDS
+	var/hijack_stage_time = 5 SECONDS
+	var/hijack_stage_cooldown = 5 SECONDS
+	var/hijack_flight_time_increase = 30 SECONDS
+	var/hijack_completion_flight_time_set = 10 SECONDS
+	var/hijack_hacking = FALSE
+	var/hijack_announce = TRUE
+
+/obj/machinery/computer/emergency_shuttle/examine(mob/user)
+	. = ..()
+	if(hijack_announce)
+		. += "Security systems present on console. Any unauthorized tampering will result in an emergency announcement, and a fee of 20000 credits."
+	if(user?.mind?.get_hijack_speed())
+		. += "<span class='danger'>Alt click on this to attempt to hijack the shuttle. This will take multiple tries (current: stage [SSshuttle.emergency.hijack_status]/[HIJACKED]).</span>"
+		. += "<span class='danger'>It will take you [user.mind.get_hijack_speed()/ 10] seconds to reprogram a stage of the shuttle's navigational firmware, and the console will undergo automated timed lockout for [hijack_stage_cooldown/10] seconds after each stage.</span>"
+		if(hijack_announce)
+			. += "<span class='warning'>It is probably best to fortify your position as to be uninterrupted during the attempt, given the automatic announcements..</span>"
 
 /obj/machinery/computer/emergency_shuttle/attackby(obj/item/card/W, mob/user, params)
 	if(stat & (BROKEN|NOPOWER))
@@ -75,6 +102,98 @@
 		emagged = TRUE
 
 
+/obj/machinery/computer/emergency_shuttle/proc/increase_hijack_stage()
+	var/obj/docking_port/mobile/emergency/shuttle = SSshuttle.emergency
+	shuttle.hijack_status++
+	if(hijack_announce)
+		announce_hijack_stage()
+	hijack_last_stage_increase = world.time
+	atom_say("Navigational protocol error! Rebooting systems.")
+	if(shuttle.mode == SHUTTLE_ESCAPE)
+		if(shuttle.hijack_status == HIJACKED)
+			shuttle.setTimer(hijack_completion_flight_time_set)
+		else
+			shuttle.setTimer(shuttle.timeLeft(1) + hijack_flight_time_increase) //give the guy more time to hijack if it's already in flight.
+	return shuttle.hijack_status
+
+/obj/machinery/computer/emergency_shuttle/AltClick(user)
+	if(isliving(user))
+		attempt_hijack_stage(user)
+
+/obj/machinery/computer/emergency_shuttle/proc/attempt_hijack_stage(mob/living/user)
+	if(!Adjacent(user) && !isAI(user))
+		return
+	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		to_chat(user, "<span class='warning'>You need your hands free before you can manipulate [src].</span>")
+		return
+	if(!user?.mind?.get_hijack_speed())
+		to_chat(user, "<span class='warning'>You manage to open a user-mode shell on [src], and hundreds of lines of debugging output fly through your vision. It is probably best to leave this alone.</span>")
+		return
+	if(hijack_hacking == TRUE)
+		return
+	if(SSshuttle.emergency.hijack_status >= HIJACKED)
+		to_chat(user, "<span class='warning'>The emergency shuttle is already loaded with a corrupt navigational payload. What more do you want from it?</span>")
+		return
+	if(hijack_last_stage_increase >= world.time - hijack_stage_cooldown)
+		atom_say("Error - Catastrophic software error detected. Input is currently on timeout.")
+		return
+	hijack_hacking = TRUE
+	to_chat(user, "<span class='userdanger'>You [SSshuttle.emergency.hijack_status == NOT_BEGUN? "begin" : "continue"] to override [src]'s navigational protocols.</span>")
+	atom_say("Software override initiated.")
+	playsound(src, 'sound/machines/terminal_on.ogg', 100, FALSE)
+	var/turf/console_hijack_turf = get_turf(src)
+	message_admins("[src] is being overriden for hijack by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(console_hijack_turf)]")
+	. = FALSE
+	if(do_after(user, user.mind.get_hijack_speed(), target = src))
+		increase_hijack_stage()
+		console_hijack_turf = get_turf(src)
+		message_admins("[ADMIN_LOOKUPFLW(user)] has hijacked [src] in [ADMIN_VERBOSEJMP(console_hijack_turf)]. Hijack stage increased to stage [SSshuttle.emergency.hijack_status] out of [HIJACKED].")
+		log_game("[key_name(usr)] has hijacked [src]. Hijack stage increased to stage [SSshuttle.emergency.hijack_status] out of [HIJACKED].")
+		. = TRUE
+		to_chat(user, "<span class='notice'>You reprogram some of [src]'s programming, putting it on timeout for [hijack_stage_cooldown/10] seconds.</span>")
+		visible_message("<span class='warning'>[user.name] appears to be tampering with [src].</span>")
+	hijack_hacking = FALSE
+
+/obj/machinery/computer/emergency_shuttle/proc/announce_hijack_stage()
+	var/msg
+	switch(SSshuttle.emergency.hijack_status)
+		if(NOT_BEGUN)
+			return
+		if(STAGE_1)
+			if(ishuman(usr))
+				var/mob/living/carbon/human/H = usr
+				msg = "AUTHENTICATING - FAIL. AUTHENTICATING - FAIL. AUTHENTICATING - FAI###### Welcome, technician: [random_name(pick(MALE, FEMALE), H.dna.species.name)]. Debug mode: Enabled."
+			else
+				msg = "AUTHENTICATING - FAIL. AUTHENTICATING - FAIL. AUTHENTICATING - FAI###### Welcome, technician: admin_[rand(0,25)]. Debug mode: Enabled."
+		if(STAGE_2)
+			msg = "Warning: Navigational route fails \"IS_AUTHORIZED\". Please try againNN[Gibberish("againagainerroragainagain", 70, 50)]."
+		if(STAGE_3)
+			msg = "CRC mismatch at ~h~ in calculated route buffer. Full reset initiated of FTL_NAVIGATION_SERVICES. Memory decrypted for automatic repair."
+		if(STAGE_4)
+			msg = "~ACS_directive module_load(cyberdyne.exploit.nanotrasen.shuttlenav)... NT key mismatch. Confirm load? Y...###Reboot complete. CALL transponder.disable(1) ON /transmitter IN world; System link initiated with connected engines..."
+		if(HIJACKED)
+			msg = "SYSTEM OVERRIDE - Resetting course to \[[Gibberish("###########", 100, 90)]\] \
+			([Gibberish("#######", 100, 90)]/[Gibberish("#######", 100, 90)]/[Gibberish("#######", 100, 90)]) \
+			{AUTH - ROOT (uid: 0)}. <br>\
+			[SSshuttle.emergency.mode == SHUTTLE_ESCAPE ? "Diverting from existing route - Bluespace exit in <br>\
+			[hijack_completion_flight_time_set >= INFINITY ? "[Gibberish("\[ERROR\]", 50, 50)]" : hijack_completion_flight_time_set/10] seconds." : ""]"
+	announce_here("SYSTEM ERROR", Gibberish(msg, 70, rand(3,6)))
+
+
+/obj/machinery/computer/emergency_shuttle/proc/announce_here(a_header = "Emergency Shuttle", a_text = "")
+	var/area/A = get_area(src)
+	var/msg_text = "<b><font size=4 color=red>[a_header]</font><br> <font size=3><span class='robot'>[a_text]</font size></font></b></span>"
+	var/list/receivers = list()
+	for(var/mob/M in GLOB.mob_list)
+		if(!M.ckey)
+			continue
+		var/turf/T = get_turf(M)
+		if(T && T.loc && T.loc == A)
+			receivers |= M
+	for(var/mob/R in receivers)
+		to_chat(R, msg_text)
+		SEND_SOUND(R, sound('sound/misc/notice1.ogg'))
+
 /obj/docking_port/mobile/emergency
 	name = "emergency shuttle"
 	id = "emergency"
@@ -95,6 +214,8 @@
 	var/datum/announcement/priority/crew_shuttle_called = new(0, new_sound = sound('sound/AI/cshuttle.ogg'))
 	var/datum/announcement/priority/crew_shuttle_docked = new(0, new_sound = sound('sound/AI/cshuttle_dock.ogg'))
 
+	///State of the emergency shuttles hijack status.
+	var/hijack_status = NOT_BEGUN
 
 /obj/docking_port/mobile/emergency/register()
 	if(!..())
@@ -170,7 +291,9 @@
 		SSshuttle.emergencyLastCallLoc = null
 	emergency_shuttle_recalled.Announce("The emergency shuttle has been recalled.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]")
 
-/obj/docking_port/mobile/emergency/proc/is_hijacked()
+/obj/docking_port/mobile/emergency/proc/is_hijacked(fullcheck = FALSE)
+	if(hijack_status == HIJACKED && !fullcheck) //Don't even bother if it was done via computer.
+		return TRUE
 	for(var/mob/living/player in GLOB.player_list)
 		if(!player.mind)
 			continue
@@ -381,3 +504,10 @@
 	..()
 	SSshuttle.emergency = current_emergency
 	SSshuttle.backup_shuttle = src
+
+#undef NOT_BEGUN
+#undef STAGE_1
+#undef STAGE_2
+#undef STAGE_3
+#undef STAGE_4
+#undef HIJACKED

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -129,7 +129,7 @@
 	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		to_chat(user, "<span class='warning'>You need your hands free before you can manipulate [src].</span>")
 		return
-	var/speed = user?.mind?.get_hijack_speed()
+	var/speed = user.mind?.get_hijack_speed()
 	if(!speed)
 		to_chat(user, "<span class='warning'>You manage to open a user-mode shell on [src], and hundreds of lines of debugging output fly through your vision. It is probably best to leave this alone.</span>")
 		return

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -29,9 +29,9 @@
 		. += "Security systems present on console. Any unauthorized tampering will result in an emergency announcement, and a fee of 20000 credits."
 	if(user?.mind?.get_hijack_speed())
 		. += "<span class='danger'>Alt click on this to attempt to hijack the shuttle. This will take multiple tries (current: stage [SSshuttle.emergency.hijack_status]/[HIJACKED]).</span>"
-		. += "<span class='danger'>It will take you [user.mind.get_hijack_speed()/ 10] seconds to reprogram a stage of the shuttle's navigational firmware, and the console will undergo automated timed lockout for [hijack_stage_cooldown/10] seconds after each stage.</span>"
+		. += "<span class='danger'>It will take you [user.mind.get_hijack_speed() / 10] seconds to reprogram a stage of the shuttle's navigational firmware, and the console will undergo automated timed lockout for [hijack_stage_cooldown / 10] seconds after each stage.</span>"
 		if(hijack_announce)
-			. += "<span class='warning'>It is probably best to fortify your position as to be uninterrupted during the attempt, given the automatic announcements..</span>"
+			. += "<span class='warning'>It is probably best to fortify your position as to be uninterrupted during the attempt, given the automatic announcements...</span>"
 
 /obj/machinery/computer/emergency_shuttle/attackby(obj/item/card/W, mob/user, params)
 	if(stat & (BROKEN|NOPOWER))
@@ -138,7 +138,7 @@
 		atom_say("Error - Catastrophic software error detected. Input is currently on timeout.")
 		return
 	hijack_hacking = TRUE
-	to_chat(user, "<span class='userdanger'>You [SSshuttle.emergency.hijack_status == NOT_BEGUN? "begin" : "continue"] to override [src]'s navigational protocols.</span>")
+	to_chat(user, "<span class='userdanger'>You [SSshuttle.emergency.hijack_status == NOT_BEGUN ? "begin" : "continue"] to override [src]'s navigational protocols.</span>")
 	atom_say("Software override initiated.")
 	playsound(src, 'sound/machines/terminal_on.ogg', 100, FALSE)
 	var/turf/console_hijack_turf = get_turf(src)
@@ -150,7 +150,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] has hijacked [src] in [ADMIN_VERBOSEJMP(console_hijack_turf)]. Hijack stage increased to stage [SSshuttle.emergency.hijack_status] out of [HIJACKED].")
 		log_game("[key_name(usr)] has hijacked [src]. Hijack stage increased to stage [SSshuttle.emergency.hijack_status] out of [HIJACKED].")
 		. = TRUE
-		to_chat(user, "<span class='notice'>You reprogram some of [src]'s programming, putting it on timeout for [hijack_stage_cooldown/10] seconds.</span>")
+		to_chat(user, "<span class='notice'>You fiddle with [src]'s programming and manage to get a foothold, looks like it'll take [hijack_stage_cooldown / 10] seconds before you can try again!</span>")
 		visible_message("<span class='warning'>[user.name] appears to be tampering with [src].</span>")
 	hijack_hacking = FALSE
 
@@ -176,7 +176,7 @@
 			([Gibberish("#######", 100, 90)]/[Gibberish("#######", 100, 90)]/[Gibberish("#######", 100, 90)]) \
 			{AUTH - ROOT (uid: 0)}. <br>\
 			[SSshuttle.emergency.mode == SHUTTLE_ESCAPE ? "Diverting from existing route - Bluespace exit in <br>\
-			[hijack_completion_flight_time_set >= INFINITY ? "[Gibberish("\[ERROR\]", 50, 50)]" : hijack_completion_flight_time_set/10] seconds." : ""]"
+			[hijack_completion_flight_time_set >= INFINITY ? "[Gibberish("\[ERROR\]", 50, 50)]" : hijack_completion_flight_time_set / 10] seconds." : ""]"
 	announce_here("SYSTEM ERROR", Gibberish(msg, 70, rand(3,6)))
 
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -133,7 +133,7 @@
 	if(!speed)
 		to_chat(user, "<span class='warning'>You manage to open a user-mode shell on [src], and hundreds of lines of debugging output fly through your vision. It is probably best to leave this alone.</span>")
 		return
-	if(hijack_hacking == TRUE)
+	if(hijack_hacking)
 		return
 	if(SSshuttle.emergency.hijack_status >= HIJACKED)
 		to_chat(user, "<span class='warning'>The emergency shuttle is already loaded with a corrupt navigational payload. What more do you want from it?</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Lets antagonists be able to hack the shuttle console, starting a do after to progress the state of the hijack.
Each time this is done, it makes a VERY NOTICEABLE alert to everyone on the shuttle, and attempting it makes noise at the console. If shuttle is in transit, adds 30 seconds to the shuttle timer. 5 second delay between successful attempts.

Takes 15 seconds per stage for any antagonist. 10 seconds for a hijacker. Mindslaves, as per being antags, take 15 seconds, and can be used.

The old hijack system remains, and also passess objectives. 

Malf AI's block objective has been adjusted / clarified. Mentions that doomsday works for passing it, and they now use the **OLD** hijack system. This means that the shuttle must meet **CURRENT** hijack requirements, just hacking the console will not work. However, this means they can actually work with agents and other antagonists.

Adds a new var to the gibberish proc, you can now specify how often you want letters replaced.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Another way to hijack, that doesn't require bombing escape, emag rushing, some supermurderbone solution, is nice.

Instead, a(n) (group of) antagonist(s) can hijack the shuttle by holding the bridge of the shuttle instead. This means, so long as you can hold the shuttle bridge, you do not need to ensure every crewmember is in deep crit and fail since one crewmember hid where an engine was on the shuttle after breaking it.

This pr also allows malf AI to work with agents more to succeed in their goals, rather than agents either having to always take a pod, or get off station as it nukes.

## Testing
<!-- How did you test the PR, if at all? -->

Multiple attempts of spawning self in, hijacking before / after shuttle leaves, and de-antaging self some times to confirm it works with non antags on shuttle. 
Confirm examine is correct.
Confirm non antags can't do it.
Confirm it actually looks good and not complete gibberish.
Tweak how the gibberish system works.
Testing that AI has same requirements as current hijack, bar being on shuttle

## Changelog
:cl:
add: Antagonists can now hijack the shuttle by multiple hacking attempts on the shuttle console, by alt clicking it.
tweak: Malf AI can now have dead crew, animals, and antagonists on the shuttle when hijacking it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
