### PR TITLE
Keeps bumped windoors open if someone stands in front of them

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -55,10 +55,18 @@
 
 /obj/machinery/door/window/proc/open_and_close()
 	open()
-	if(check_access(null))
-		sleep(50)
-	else //secure doors close faster
-		sleep(20)
+	addtimer(CALLBACK(src, .proc/check_close), check_access(null) ? 5 SECONDS : 2 SECONDS)
+
+
+/// Check whether or not this door can close, based on whether or not someone's standing in front of it holding it open
+/obj/machinery/door/window/proc/check_close()
+	var/turf/facing_turf = get_turf(get_step(src, dir))
+	var/mob/living/blocker = locate(/mob/living) in facing_turf
+	if(blocker && !blocker.stat)
+		// kick the can down the road, someone's holding the door.
+		addtimer(CALLBACK(src, .proc/check_close), check_access(null) ? 5 SECONDS : 2 SECONDS)
+		return
+
 	close()
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -60,7 +60,7 @@
 
 /// Check whether or not this door can close, based on whether or not someone's standing in front of it holding it open
 /obj/machinery/door/window/proc/check_close()
-	var/mob/living/blocker = get_turf(get_step(src, dir))  // check the facing turf
+	var/mob/living/blocker = locate(/mob/living) in get_turf(get_step(src, dir))  // check the facing turf
 	if(!blocker)
 		blocker = locate(/mob/living) in get_turf(src)
 	if(blocker && !blocker.stat)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -61,7 +61,7 @@
 /// Check whether or not this door can close, based on whether or not someone's standing in front of it holding it open
 /obj/machinery/door/window/proc/check_close()
 	var/mob/living/blocker = locate(/mob/living) in get_turf(get_step(src, dir))  // check the facing turf
-	if(!blocker)
+	if(!blocker || blocker.stat || !allowed(blocker))
 		blocker = locate(/mob/living) in get_turf(src)
 	if(blocker && !blocker.stat && allowed(blocker))
 		// kick the can down the road, someone's holding the door.

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -60,8 +60,9 @@
 
 /// Check whether or not this door can close, based on whether or not someone's standing in front of it holding it open
 /obj/machinery/door/window/proc/check_close()
-	var/turf/facing_turf = get_turf(get_step(src, dir))
-	var/mob/living/blocker = locate(/mob/living) in facing_turf
+	var/mob/living/blocker = get_turf(get_step(src, dir))  // check the facing turf
+	if(!blocker)
+		blocker = locate(/mob/living) in get_turf(src)
 	if(blocker && !blocker.stat)
 		// kick the can down the road, someone's holding the door.
 		addtimer(CALLBACK(src, .proc/check_close), check_access(null) ? 5 SECONDS : 2 SECONDS)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -63,7 +63,7 @@
 	var/mob/living/blocker = locate(/mob/living) in get_turf(get_step(src, dir))  // check the facing turf
 	if(!blocker)
 		blocker = locate(/mob/living) in get_turf(src)
-	if(blocker && !blocker.stat)
+	if(blocker && !blocker.stat && allowed(blocker))
 		// kick the can down the road, someone's holding the door.
 		addtimer(CALLBACK(src, .proc/check_close), check_access(null) ? 5 SECONDS : 2 SECONDS)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

If you bump into a windoor and stay in front of it (or at least keep a live mob in front of it), it'll stay open. This doesn't impact the behavior of clicking windoors to keep them open indefinitely.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should hopefully do away with the obnoxious shuffle of trying to keep a windoor open for long enough to hand someone something or reach something inside if you bumped it. Think chemfridge, for instance, or HoP's desk. Because it'll still automatically close after a little bit once you move away (shorter if the window's secured), this shouldn't cause any new security issues, but might lead to some interesting gameplay of having people hold a windoor open, like how you can jam open a normal airlock. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes


https://user-images.githubusercontent.com/89928798/189540259-463a84e0-d770-466e-a4d5-5ddb01b67e58.mp4




<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See video.
Also, verified that clicking on the door would still keep it open.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Bumped windoors will now be held open as long as someone stands in front of it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
