### PR TITLE
Facehuggers no longer instastun, removes some RNG

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -19,7 +19,7 @@
 	var/real = TRUE //0 for the toy, 1 for real. Sure I could istype, but fuck that.
 	var/strength = 5
 	var/attached = 0
-	var/impregnation_time = 150 //Time it takes for facehugger to deposit its eggs and die.
+	var/impregnation_time = 12 SECONDS //Time it takes for facehugger to deposit its eggs and die.
 	var/min_active_time = 200 //time between being dropped and going idle
 	var/max_active_time = 400
 
@@ -144,8 +144,8 @@
 		src.loc = target
 		target.equip_to_slot_if_possible(src, slot_wear_mask, FALSE, TRUE)
 		if(!sterile)
-			M.KnockDown(impregnation_time + 10)
-			M.EyeBlind(impregnation_time + 10)
+			M.KnockDown(impregnation_time + 2 SECONDS)
+			M.EyeBlind(impregnation_time + 2 SECONDS)
 			flags = NODROP //You can't take it off until it dies... or figures out you're an IPC.
 
 	GoIdle() //so it doesn't jump the people that tear it off

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -105,9 +105,8 @@
 	if(attached)
 		return FALSE
 	else
-		attached++
-		spawn(impregnation_time)
-			attached = 0
+		attached = TRUE
+		addtimer(VARSET_CALLBACK(src, attached, FALSE), impregnation_time)
 	if(HAS_TRAIT(M, TRAIT_XENO_IMMUNE))
 		return FALSE
 	if(loc == M)
@@ -146,13 +145,11 @@
 		if(!sterile)
 			M.KnockDown(impregnation_time + 2 SECONDS)
 			M.EyeBlind(impregnation_time + 2 SECONDS)
-			flags = NODROP //You can't take it off until it dies... or figures out you're an IPC.
+			flags |= NODROP //You can't take it off until it dies... or figures out you're an IPC.
 
 	GoIdle() //so it doesn't jump the people that tear it off
 
-	spawn(impregnation_time)
-		Impregnate(M)
-
+	addtimer(CALLBACK(src, .proc/Impregnate, M), impregnation_time)
 	return TRUE
 
 /obj/item/clothing/mask/facehugger/proc/Impregnate(mob/living/target as mob)
@@ -167,14 +164,14 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(!H.check_has_mouth())
-			flags -= NODROP
+			flags &= ~NODROP
 			return
 
 	if(!sterile)
 		//target.contract_disease(new /datum/disease/alien_embryo(0)) //so infection chance is same as virus infection chance
 		target.visible_message("<span class='danger'>[src] falls limp after violating [target]'s face!</span>", \
 								"<span class='userdanger'>[src] falls limp after violating [target]'s face!</span>")
-		flags -= NODROP
+		flags &= ~NODROP
 		Die()
 		icon_state = "[initial(icon_state)]_impregnated"
 
@@ -197,10 +194,7 @@
 
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
-
-	spawn(rand(min_active_time,max_active_time))
-		GoActive()
-	return
+	addtimer(CALLBACK(src, .proc/GoActive), rand(min_active_time,max_active_time))
 
 /obj/item/clothing/mask/facehugger/proc/Die()
 	if(stat == DEAD)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -18,10 +18,11 @@
 	var/sterile = FALSE
 	var/real = TRUE //0 for the toy, 1 for real. Sure I could istype, but fuck that.
 	var/strength = 5
-	var/attached = 0
+	var/attached = FALSE
 	var/impregnation_time = 12 SECONDS //Time it takes for facehugger to deposit its eggs and die.
-	var/min_active_time = 200 //time between being dropped and going idle
-	var/max_active_time = 400
+	///Time it takes for a facehugger to become active again after going idle.
+	var/min_active_time = 20 SECONDS
+	var/max_active_time = 40 SECONDS
 
 /obj/item/clothing/mask/facehugger/Initialize(mapload)
 	. = ..()
@@ -194,7 +195,7 @@
 
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
-	addtimer(CALLBACK(src, .proc/GoActive), rand(min_active_time,max_active_time))
+	addtimer(CALLBACK(src, .proc/GoActive), rand(min_active_time, max_active_time))
 
 /obj/item/clothing/mask/facehugger/proc/Die()
 	if(stat == DEAD)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -1,11 +1,4 @@
 //TODO: Make these simple_animals
-
-#define MIN_IMPREGNATION_TIME 100 //time it takes to impregnate someone
-#define MAX_IMPREGNATION_TIME 150
-
-#define MIN_ACTIVE_TIME 200 //time between being dropped and going idle
-#define MAX_ACTIVE_TIME 400
-
 /obj/item/clothing/mask/facehugger
 	name = "alien"
 	desc = "It has some sort of a tube at the end of its tail."
@@ -22,12 +15,13 @@
 	max_integrity = 100
 
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
-
 	var/sterile = FALSE
 	var/real = TRUE //0 for the toy, 1 for real. Sure I could istype, but fuck that.
 	var/strength = 5
-
 	var/attached = 0
+	var/impregnation_time = 150 //Time it takes for facehugger to deposit its eggs and die.
+	var/min_active_time = 200 //time between being dropped and going idle
+	var/max_active_time = 400
 
 /obj/item/clothing/mask/facehugger/Initialize(mapload)
 	. = ..()
@@ -112,7 +106,7 @@
 		return FALSE
 	else
 		attached++
-		spawn(MAX_IMPREGNATION_TIME)
+		spawn(impregnation_time)
 			attached = 0
 	if(HAS_TRAIT(M, TRAIT_XENO_IMMUNE))
 		return FALSE
@@ -134,8 +128,6 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/target = M
 		if(target.wear_mask)
-			if(prob(20))
-				return FALSE
 			if(istype(target.wear_mask, /obj/item/clothing/mask/muzzle))
 				var/obj/item/clothing/mask/muzzle/S = target.wear_mask
 				if(S.do_break())
@@ -152,11 +144,13 @@
 		src.loc = target
 		target.equip_to_slot_if_possible(src, slot_wear_mask, FALSE, TRUE)
 		if(!sterile)
-			M.Paralyse(MAX_IMPREGNATION_TIME * 10 / 6) //something like 25 ticks = 20 seconds with the default settings
+			M.KnockDown(impregnation_time + 10)
+			M.EyeBlind(impregnation_time + 10)
+			flags = NODROP //You can't take it off until it dies... or figures out you're an IPC.
 
 	GoIdle() //so it doesn't jump the people that tear it off
 
-	spawn(rand(MIN_IMPREGNATION_TIME,MAX_IMPREGNATION_TIME))
+	spawn(impregnation_time)
 		Impregnate(M)
 
 	return TRUE
@@ -173,13 +167,14 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(!H.check_has_mouth())
+			flags -= NODROP
 			return
 
 	if(!sterile)
 		//target.contract_disease(new /datum/disease/alien_embryo(0)) //so infection chance is same as virus infection chance
 		target.visible_message("<span class='danger'>[src] falls limp after violating [target]'s face!</span>", \
 								"<span class='userdanger'>[src] falls limp after violating [target]'s face!</span>")
-
+		flags -= NODROP
 		Die()
 		icon_state = "[initial(icon_state)]_impregnated"
 
@@ -203,7 +198,7 @@
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
 
-	spawn(rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
+	spawn(rand(min_active_time,max_active_time))
 		GoActive()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Advances #18179

Facehuggers no longer apply an extremely long period of paralysis to their victim. Instead, they apply knockdown and blind for the facehugger's lifespan. To compensate for the victim now being fully conscious and able to interact with their environment mid-facehug, facehuggers are now `NODROP` during the impregnation attempt. After the facehugger dies (or it recognizes that it's macking on an IPC and gets bored), `NODROP` is removed.

This PR also removes several elements of RNG in facehugger code. A `proc(20)` that gives the victim a 1/5 chance to completely ignore facehugger attaches while wearing a mask has been removed. The impregnation period, which was formerly between 100 and 150 Byond Time Units™ long, is now fixed at 12 seconds; the victim's knockdown wears off an additional 2 seconds after the facehugger dies.

Finally, this PR changes several `#define`s in facehugger.dm to variables.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Facehuggers can be picked up and thrown by Xenomorphs, effectively making them a weapon. Considering how Paradise has almost entirely migrated away from instastun combat, Xenomorphs should not be able to instantly apply a fat **14 second** long stun. Instead, the victim is significantly incapacitated with knockdown + blind, leaving them very vulnerable but not utterly helpless.

Basic masks can already be ripped off by facehuggers; a 1/5 chance for the facehugger to go "meh, I will ignore you this time" doesn't make much sense, and doesn't align with Paracombat slowly moving away from RNG.

This PR doesn't tackle every issue with facehuggers, and they'll probably need a more substantial refactor to address how binary they are (helmet = win, otherwise = lose), but xenos will still be a few tweaks closer towards being on par with other antags.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server.

## Changelog
:cl:
tweak: Facehuggers no longer stun; instead, you are knocked down and blinded.
tweak: Removes 1/5 chance for facehuggers to ignore masked victims.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
