### PR TITLE
Fixes emotes being displayed as the wrong type

### DIFF
--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -208,7 +208,7 @@
 			for(var/mob/dead/observer/ghost in viewers(user))
 				ghost.show_message("<span class=deadsay>[displayed_msg]</span>", EMOTE_VISIBLE)
 
-		else if(emote_type & EMOTE_VISIBLE || user.mind?.miming)
+		else if(emote_type & (EMOTE_AUDIBLE | EMOTE_SOUND) && !user.mind?.miming)
 			user.audible_message(displayed_msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>")
 		else
 			user.visible_message(displayed_msg, blind_message = "<span class='emote'>You hear how someone [msg]</span>")
@@ -586,6 +586,28 @@
 	if(copytext(msg, -1) in end_punctuation)
 		msg = copytext(msg, 1, -1)
 	return msg
+
+/**
+ * Pass the emote message to all hearers in range.
+ * This is shamelessly stolen from mob/audible message, and is used to find people (or objects) that would be able to hear a message
+ * that might otherwise not be sent audibly (like sound emotes with a visible portion).
+ *
+ * Arguments:
+ * * user - mob who is emitting the sound
+ * * msg - message to send out to listeners.
+ */
+/datum/emote/proc/find_hearers(mob/user, msg)
+	var/list/listening_obj = list()
+	for(var/atom/movable/A in view(7, user))
+		if(istype(A, /mob))
+			var/mob/M = A
+			for(var/obj/O in M.contents)
+				listening_obj |= O
+		else if(istype(A, /obj))
+			var/obj/O = A
+			listening_obj |= O
+	for(var/obj/O in listening_obj)
+		O.hear_message(user, msg)
 
 /**
 * Allows the intrepid coder to send a basic emote

--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -588,28 +588,6 @@
 	return msg
 
 /**
- * Pass the emote message to all hearers in range.
- * This is shamelessly stolen from mob/audible message, and is used to find people (or objects) that would be able to hear a message
- * that might otherwise not be sent audibly (like sound emotes with a visible portion).
- *
- * Arguments:
- * * user - mob who is emitting the sound
- * * msg - message to send out to listeners.
- */
-/datum/emote/proc/find_hearers(mob/user, msg)
-	var/list/listening_obj = list()
-	for(var/atom/movable/A in view(7, user))
-		if(istype(A, /mob))
-			var/mob/M = A
-			for(var/obj/O in M.contents)
-				listening_obj |= O
-		else if(istype(A, /obj))
-			var/obj/O = A
-			listening_obj |= O
-	for(var/obj/O in listening_obj)
-		O.hear_message(user, msg)
-
-/**
 * Allows the intrepid coder to send a basic emote
 * Takes text as input, sends it out to those who need to know after some light parsing
 * If you need something more complex, make it into a datum emote

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -382,7 +382,7 @@
 		return TRUE
 
 	if(prob(5))
-		user.visible_message("<span class='danger'><b>[user]</b> snaps [p_their()] fingers right off!</span>")
+		user.visible_message("<span class='danger'><b>[user]</b> snaps [user.p_their()] fingers right off!</span>")
 		playsound(user.loc, 'sound/effects/snap.ogg', 50, 1)
 		return TRUE
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes all visible emotes being treated as audible emotes when displayed, and vice versa. This also makes sure emotes with a sound component are treated as audible emotes, which fixes #18999, and means you can now use sound-producing emotes to trigger voice analyzers.
Also fixes a little bug where the `snaps their fingers off!` message was using the emote datum's pronouns. I got incredibly lucky while testing and noticed this, so I fixed it quickly lol
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Using sound-producing emotes to trigger voice analyzers was a pretty fun feature, and it's good to have it back in the game. Beyond that, having emotes go through the right handlers means that whatever relies on those messages down the line (especially w/r/t deaf/blind folks) will have them treated correctly.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/89928798/189541865-76cb5c03-dc62-4993-8610-d43a1dfb6e80.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See image.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:

fix: Audible emotes will now function correctly as audible, meaning deaf people won't hear them.
fix: Visible emotes will also function correctly as visible, meaning blind people won't see them.
fix: Voice analyzers once again work with audible/sound-producing emotes.
fix: Pronoun error in *snap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
