### PR TITLE
Flamethrower plasma spawn fix

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -38,8 +38,9 @@
 	icon_state = "mustard"
 	anchored = FALSE
 
-/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel/Initialize(newLoc, amt = 1, d = 0)
+/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel/Initialize(newLoc, amt = 2, d = 0)
 	dir = d //Setting this direction means you won't get torched by your own flamethrower.
+			//Original value for the amount was 1, causing the lit fuel to spawn on top of the user.
 	. = ..()
 
 /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel/Spread()
@@ -57,5 +58,4 @@
 		if(O.CanPass(null, S, 0, 0) && S.CanPass(null, O, 0, 0))
 			new/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel(O, amount * 0.25, d)
 			O.hotspot_expose((T20C*2) + 380,500) //Light flamethrower fuel on fire immediately.
-
 	amount *= 0.25


### PR DESCRIPTION
## What Does This PR Do
Keeps the plasma (as well as other fuels) fired from the flamethrower to always spawn one tile in front of the user, hopefully preventing immolation via flamethrower for most situations.

## Why It's Good For The Game
Reduces the chance that the flamethrower user will torch themself immediately, improving the QoL of flamethrower users.

## Testing
I opened the change in a local server, and it functioned properly, spawning one tile in front of the player, the reason this does not completely prevent immolation is that the plasma will sometimes flow backwards to the user. Overall, it compiles and works the way it was intended. 

## Changelog
:cl:LynxSolstice
tweak: Lit plasma should no longer spawn on top of the player when using a flamethrower. This does not prevent plasma flowing backwards to the user's tile.
/:cl: