### PR TITLE
When removing traitor role, auto remove the uplink

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -45,6 +45,26 @@
 		owner.som = null
 
 	owner.current.client.chatOutput?.clear_syndicate_codes()
+
+	// Try removing their uplink, check PDA
+	var/mob/M = owner.current
+	var/obj/item/uplink_holder = locate(/obj/item/pda) in M.contents
+
+    // No PDA or it has no uplink? Check headset
+	if(!uplink_holder || !uplink_holder.hidden_uplink)
+		uplink_holder = locate(/obj/item/radio) in M.contents
+
+    // If the headset has an uplink, delete it
+	if(uplink_holder && uplink_holder.hidden_uplink)
+		var/uplink = locate(/obj/item/uplink/hidden) in uplink_holder.contents
+		uplink_holder.hidden_uplink = null
+		qdel(uplink)
+
+	// Check for an uplink implant
+	var/uplink_implant = locate(/obj/item/implant/uplink) in M.contents
+	if(uplink_implant)
+		qdel(uplink_implant)
+
 	return ..()
 
 /datum/antagonist/traitor/add_owner_to_gamemode()


### PR DESCRIPTION
## What Does This PR Do

When losing the traitor status, the uplink also gets deleted.

## Why It's Good For The Game

When admins de-traitor people, they need to remove their uplink as well by pressing a second button. This should be all automated, birdbrains like me might forget to take the extra step.

The "Uplink - take" button does not clear the pda/headset's `hidden_uplink` reference either.

## Images of changes

Delete PDA uplink:

https://user-images.githubusercontent.com/33333517/189718298-a5df3ce3-bd48-4419-abfe-b154a62d7935.mp4

Delete headset uplink:

https://user-images.githubusercontent.com/33333517/189719263-0fbd6fd9-c89b-460f-997b-8bd927c72d79.mp4

Delete implanter uplink:

https://user-images.githubusercontent.com/33333517/189719550-55fc12dc-1173-4a56-930f-6589d5fef756.mp4

## Testing

By doing the videos above.

## Changelog
:cl:
tweak: De-traitoring someone (via admin tools) now automatically removes their uplink.
/:cl:
