### PR TITLE
Fix #13305. PA containment firing grids names are all the same

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle_emitter.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_emitter.dm
@@ -7,14 +7,17 @@
 	var/last_shot = 0
 
 /obj/structure/particle_accelerator/particle_emitter/center
+	name = "EM Containment Grid Center"
 	icon_state = "emitter_center"
 	reference = "emitter_center"
 
 /obj/structure/particle_accelerator/particle_emitter/left
+	name = "EM Containment Grid Left"
 	icon_state = "emitter_left"
 	reference = "emitter_left"
 
 /obj/structure/particle_accelerator/particle_emitter/right
+	name = "EM Containment Grid Right"
 	icon_state = "emitter_right"
 	reference = "emitter_right"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/13305 . Each EM Containment Grid part has a new name to indicate their correct placement in order to finish the construction.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Inclusion of placement in their names makes things more intuitive for players.

## Testing
<!-- How did you test the PR, if at all? -->
Managed to construct the PA by following the correct directions.
## Changelog
:cl:
tweak: Included correct placement in EM Containment Grid parts names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
