### PR TITLE
Beer2 no longer instastuns

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -454,10 +454,20 @@
 /datum/reagent/beer2/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	switch(current_cycle)
-		if(1 to 50)
-			M.Sleeping(4 SECONDS)
+		if(1 to 5)
+			if(prob(25))
+				M.emote("yawn")
+		if(6 to 9)
+			M.AdjustEyeBlurry(10 SECONDS)
+			if(prob(35))
+				M.emote("yawn")
+		if(10)
+			M.emote("faint")
+			M.Weaken(4 SECONDS)
+		if(11 to 50)
+			M.Paralyse(4 SECONDS)
 		if(51 to INFINITY)
-			M.Sleeping(4 SECONDS)
+			M.Paralyse(4 SECONDS)
 			update_flags |= M.adjustToxLoss((current_cycle - 50)*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Advances #18179

Beer2/Mickey Finn's Special Brew, the unique reagent that emagged service borgs can produce, no longer instantly puts people to sleep on the first cycle after ingestion.

Instead, ingesting beer2 will cause the imbiber to become drowsy, have blurred vision, and go unconscious **after the 10th cycle**, similar to ketamine. The victim will then remain unconscious for as long as the reagent remains in their system, and begin taking toxin damage after the 50th cycle as usual.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Beer2 is one of the more egregious stuns still left in Paradise; it is unique in that even _extremely_ small amounts can put players to sleep for extended periods of time. **0.2u** is enough to cuff someone twice over, but you have little reason to conserve beer2 since your emagged pal can produce infinite amounts of it. Combine this with an instant method of delivery (sleepy pen, syringe gun, chem grenade, etc.) and you have a devastating instastun with virtually no counterplay, all for the cost of an emag. That's the sort of combat that's been seeing its way out in recent months, hence this PR.

I don't believe this constitutes a nerf to emagged service borgs in any way other than "your syndicate master will be less inclined to milk you for 50 units of beer2". In fact, food and drink adulterated with beer2 will now be far less suspicious since your mark no longer instantly falls asleep the moment they take a bite...
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Mickey Finn's Special Brew now gradually lulls you to sleep over time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
