### PR TITLE
Hardsuit Tech Levels

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -438,7 +438,7 @@
 	allowed = list(/obj/item/gun, /obj/item/ammo_box,/obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	jetpack = /obj/item/tank/jetpack/suit
-	origin_tech = "combat=8;toxins=9;powerstorage=7;materials=7"
+	origin_tech = "combat=8;powerstorage=7;materials=7"
 
 /obj/item/clothing/suit/space/hardsuit/syndi/update_icon_state()
 	icon_state = "hardsuit[on]-[item_color]"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -438,6 +438,7 @@
 	allowed = list(/obj/item/gun, /obj/item/ammo_box,/obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	jetpack = /obj/item/tank/jetpack/suit
+	origin_tech = "combat=8;toxins=9;powerstorage=7;materials=7"
 
 /obj/item/clothing/suit/space/hardsuit/syndi/update_icon_state()
 	icon_state = "hardsuit[on]-[item_color]"


### PR DESCRIPTION
## What Does This PR Do
Adds origin_tech to the blood-red hardsuit. The levels are "combat=8;powerstorage=7;materials=7"

## Why It's Good For The Game
It's a rare item you can find while exploring space, I'd like to eventually overhaul quite a few of the higher grade items that can't be RnD'd at the moment, but I believe a good place to start would be with the blood-red.

## Testing
I opened the local server from VSC, and spawned the blood-red hardsuit. I put it into the destructive analyzer, it showed up with the proper tech levels, and it applied the levels when destroyed.

## Changelog
:cl:LynxSolstice
add: Added tech levels to the Blood-Red Hardsuit! It will be a significant boon to the RnD department if you happen to acquire one, either through exploration or killing/capturing a Syndicate operator wearing it!
/:cl: