### PR TITLE
Makes empty implanters initialize properly.

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -46,6 +46,7 @@
 
 /obj/item/implanter/Initialize(mapload)
 	. = ..()
-	if(implant_type)
-		imp = new implant_type()
-		update_icon(UPDATE_ICON_STATE)
+	if(!implant_type)
+		return
+	imp = new implant_type()
+	update_icon(UPDATE_ICON_STATE)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -11,7 +11,7 @@
 	materials = list(MAT_METAL = 600, MAT_GLASS = 200)
 	toolspeed = 1
 	var/obj/item/implant/imp
-	var/implant_type = /obj/item/implant
+	var/obj/item/implant/implant_type
 
 /obj/item/implanter/update_icon_state()
 	if(imp)
@@ -46,5 +46,6 @@
 
 /obj/item/implanter/Initialize(mapload)
 	. = ..()
-	imp = new implant_type()
-	update_icon(UPDATE_ICON_STATE)
+	if(implant_type)
+		imp = new implant_type()
+		update_icon(UPDATE_ICON_STATE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
New empty implanters now are actually empty when initialized.

Fixes: #19037
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Due to a bug empty implanters would be initialized with a non-functional implant in it (/obj/item/implant).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Looked in tracking implant box, empty implanter was empty.
Looked in mindshield lockbox, filled implanter was filled.
Printed a new implant at a protolathe, empty implanter was empty.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Empty implanters no longer generate with a useless implant inside of them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
