### PR TITLE
Xenomorphs can now die

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -1,5 +1,8 @@
 /mob/living/carbon/alien/humanoid/Life(seconds, times_fired)
 	. = ..()
+	//If you're in crit you need to die eventually
+	if(health <= HEALTH_THRESHOLD_CRIT && stat != DEAD)
+		apply_damage(2, BRUTE)
 	update_icons()
 
 /mob/living/carbon/alien/humanoid/proc/adjust_body_temperature(current, loc_temp, boost)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Xenomorphs that enter crit now take a steady trickle of brute damage over time. This damage will eventually kill them unless they're on alien weeds, in which case the weed's regeneration will outheal the DOT, and the Xeno will recover.

Fixes a very nasty bug where Xenos who enter crit are stuck in limbo until an admin intervenes to give them a merciful death. Yes, until this PR Xenos could stay in crit indefinitely.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Going into crit in a pipe and having to ahelp because you neither die nor leave crit is bad. How was this not found years ago?
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Xenomorphs who enter crit will now slowly bleed out over time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
