### PR TITLE
IDs now take priority over PDAs in get_idcard

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -502,12 +502,13 @@
 /mob/living/carbon/human/proc/get_idcard(check_hands = FALSE)
 	var/obj/item/card/id/id = wear_id
 	var/obj/item/pda/pda = wear_id
-	if(istype(pda) && pda.id)
-		id = pda.id
-	else
-		pda = wear_pda
+	if(!istype(id)) //We only check for PDAs if there isn't an ID in the ID slot. IDs take priority.
 		if(istype(pda) && pda.id)
 			id = pda.id
+		else
+			pda = wear_pda
+			if(istype(pda) && pda.id)
+				id = pda.id
 
 	if(check_hands)
 		if(istype(get_active_hand(), /obj/item/card/id))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Resolves #19049

`get_idcard()` now only checks PDAs for ID if there's no ID present in the ID card slot. If a user has multiple ID cards (i.e. one in the ID slot and one in their PDA), only the one in the ID slot will be checked.

If a user has no ID card in their ID slot, their PDA will be checked for ID as normal.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
`get_idcard()` can only return one ID, even if the user is wearing multiple. Before this PR, IDs in PDAs in the PDA slot took priority over visible ID, which was counterintuitive to some people. Talked with a head, and they agreed that visible ID should take priority so you don't get situations where an Agent ID in your PDA prevents you from using vending machines that your real, visible ID would be allowed to use.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Visible IDs in the ID slot now take priority over IDs in PDAs for ID checks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
