### PR TITLE
Fix head damage not displaying properly until another bodypart was updated

### DIFF
--- a/code/modules/surgery/organs/subtypes/standard.dm
+++ b/code/modules/surgery/organs/subtypes/standard.dm
@@ -262,7 +262,7 @@
 	..()
 
 /obj/item/organ/external/head/receive_damage(brute, burn, sharp, used_weapon = null, list/forbidden_limbs = list(), ignore_resists = FALSE, updating_health = TRUE)
-	..()
+	. = ..()
 	if(brute_dam + burn_dam > 50 && !(status & ORGAN_DISFIGURED))
 		disfigure()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the head's `receive_damage` properly store the parent's return value, as its meant to return it in order to properly update its damage state.

## Why It's Good For The Game
Consistency. It's gone unnoticed for a long time due to the damage displaying properly if another part prompted an update of the body.

Oh, and fixes #19054

## Images of changes
![Heads](https://user-images.githubusercontent.com/80771500/190232047-ed5671fc-c6ed-4ab1-80ea-8bb1d2ecfeee.PNG)

https://user-images.githubusercontent.com/80771500/190263526-86e1a5ac-c1d5-47b9-b7b8-df612fda32f3.mp4


## Testing
Spawned a mob, and shot its head without hitting any other limb.

## Changelog
:cl:
fix: Head damage is displayed properly without requiring another bodypart taking a hit to show
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
