### PR TITLE
pyro anomalies no longer light people on fires through walls

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -285,7 +285,7 @@
 /obj/effect/anomaly/pyro/anomalyEffect()
 	..()
 	ticks++
-	for(var/mob/living/M in range(4, src))
+	for(var/mob/living/M in hearers(4, src))
 		if(prob(50))
 			M.adjust_fire_stacks(4)
 			M.IgniteMob()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Pyro anomalies no longer light people on fire through walls.

Bluespace still does because it's bluespace, and just a teleport.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Hot things working through walls is strange.

## Testing
<!-- How did you test the PR, if at all? -->
spawned like 10 pyro anomalies on the other side of the walls
made sure people on the other side did not catch on fire.

## Changelog
:cl:
fix: Pyro anomalies no longer light people on fires through walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
