### PR TITLE
Fixes anomalies spawning in walls

### DIFF
--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -1,4 +1,5 @@
 #define TURF_FIND_TRIES 10
+
 /datum/event/anomaly
 	name = "Anomaly: Energetic Flux"
 	var/obj/effect/anomaly/anomaly_path = /obj/effect/anomaly/flux

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -16,6 +16,8 @@
 			if(!is_blocked_turf(candidate,TRUE))
 				target_turf = candidate
 				break
+		if(target_turf)
+			break
 	if(!target_turf)
 		CRASH("Anomaly: No valid turfs found for [impact_area] - [impact_area.type]")
 

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -1,23 +1,29 @@
+#define TURF_FIND_TRIES 10
 /datum/event/anomaly
 	name = "Anomaly: Energetic Flux"
 	var/obj/effect/anomaly/anomaly_path = /obj/effect/anomaly/flux
+	var/turf/target_turf
 	announceWhen = 1
 
 /datum/event/anomaly/setup()
-	impact_area = findEventArea()
-	if(!impact_area)
-		CRASH("No valid areas for anomaly found.")
-	var/list/turf_test = get_area_turfs(impact_area)
-	if(!length(turf_test))
+	for(var/tries in 0 to TURF_FIND_TRIES)
+		impact_area = findEventArea()
+		if(!impact_area)
+			CRASH("No valid areas for anomaly found.")
+		var/list/candidate_turfs = get_area_turfs(impact_area)
+		while(length(candidate_turfs))
+			var/turf/candidate = pick_n_take(candidate_turfs)
+			if(!is_blocked_turf(candidate,TRUE))
+				target_turf = candidate
+				break
+	if(!target_turf)
 		CRASH("Anomaly: No valid turfs found for [impact_area] - [impact_area.type]")
 
 /datum/event/anomaly/announce()
 	GLOB.event_announcement.Announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_flux.ogg')
 
 /datum/event/anomaly/start()
-	var/turf/T = pick(get_area_turfs(impact_area))
-	var/newAnomaly
-	if(T)
-		newAnomaly = new anomaly_path(T)
-	if(newAnomaly)
-		announce_to_ghosts(newAnomaly)
+	var/newAnomaly = new anomaly_path(target_turf)
+	announce_to_ghosts(newAnomaly)
+
+#undef TURF_FIND_TRIES

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -20,7 +20,7 @@
 		if(target_turf)
 			break
 	if(!target_turf)
-		CRASH("Anomaly: No valid turfs found for [impact_area] - [impact_area.type]")
+		CRASH("Anomaly: Unable to find a valid turf to spawn the anomaly. Last area tried: [impact_area] - [impact_area.type]")
 
 /datum/event/anomaly/announce()
 	GLOB.event_announcement.Announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_flux.ogg')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes anomalies no longer spawning in dense turfs.

## Why It's Good For The Game
Allows anomalies to move around in a room as intended.
Anomalies spawning in walls can sometimes be hard to get to.


## Testing
Spawned a lot of anomalies. None of the anomalies spawned in a wall or other dense turf.

## Changelog
:cl: uc_guy
fix: Anomalies can no longer spawn in walls or dense turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
