### PR TITLE
Ports text emphasis from TG (who ported it from TGMC) ((who ported it from Citadel))

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -136,7 +136,7 @@
 
 	// Approximate text height
 	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
-	var/complete_text = "<span class='center maptext[size ? " [size]" : ""]' style='[italics ? "font-style: italic; " : ""]color: [output_color]'>[symbol][text]</span>"
+	var/complete_text = "<span class='center maptext[size ? " [size]" : ""]' style='[italics ? "font-style: italic; " : ""]color: [output_color]'>[symbol][owner.text_emphasis(text)]</span>"
 	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(complete_text, null, CHAT_MESSAGE_WIDTH))
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -425,7 +425,7 @@
 		if(type_override)
 			custom_emote_type = type_override
 
-	message = custom_emote
+	message = user.text_emphasis(custom_emote)
 	emote_type = custom_emote_type
 	. = ..()
 	message = initial(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		else
 			message = copytext(message, 3)
 
-	message = trim_left(message)
+	message = text_emphasis(trim_left(message))
 
 	//parse the language code and consume it
 	var/list/message_pieces = list()
@@ -441,3 +441,17 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 	var/image/I = image('icons/mob/talk.dmi', bubble_loc, bubble_state, FLY_LAYER)
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	INVOKE_ASYNC(GLOBAL_PROC, /.proc/flick_overlay, I, bubble_recipients, 30)
+
+/// Transforms the speech emphasis mods from [/atom/proc/text_emphasis] into the appropriate HTML tags
+#define ENCODE_HTML_EMPHASIS(input, char, html, varname) \
+	var/static/regex/##varname = regex("[char](.+?)[char]", "g");\
+	input = varname.Replace_char(input, "<[html]>$1</[html]>")
+
+/// Scans the input sentence for speech emphasis modifiers, notably |italics|, +bold+, and _underline_ -mothblocks
+/atom/proc/text_emphasis(input)
+	ENCODE_HTML_EMPHASIS(input, "\\|", "i", italics)
+	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
+	ENCODE_HTML_EMPHASIS(input, "_", "u", underline)
+	return input
+
+#undef ENCODE_HTML_EMPHASIS


### PR DESCRIPTION
Two years later, different method, yes I'm aware of https://github.com/ParadiseSS13/Paradise/pull/14959 and what happened to it. No shame in trying again.
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Ports: https://github.com/tgstation/tgstation/pull/61543
tested through and through over there for about a year, no revert, pretty neat.

Allows you to emphasise your text, what you say, and your emotes better, can't really describe it much without an image so scroll mildly down.

It uses
+bold+ for **bold**
|italics| for _italics_
_ underline _ for underline (I dont know how to underline things on github)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Giving more control over expression of characters on a server that calls itself MRP seems like a great thing to me.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
<details>

![image](https://user-images.githubusercontent.com/71735193/190492346-25613265-cade-427b-b7a2-24181f129e86.png)

![image](https://user-images.githubusercontent.com/71735193/190492367-cea433f8-329f-40a9-b246-0d02a97be8a7.png)

(italics text too but I forgor :skull: )

![image](https://user-images.githubusercontent.com/71735193/190492404-94823e19-b03f-4f14-9ad5-d8a6c0c66ca0.png)

![image](https://user-images.githubusercontent.com/71735193/190492487-bbe68a2c-afa5-4ba1-b1e1-e9e7779eaeaa.png)

![image](https://user-images.githubusercontent.com/71735193/190492506-851e64e2-08df-4380-ac1d-6e0bcc588c1a.png)

(while it was tested on a Human Man, it will also work on Vulpine Vulp, Skrelly Skrell and etc.)


</details>

## Testing
<!-- How did you test the PR, if at all? -->
Spawned.
Said something and used the tex emphasis markings.
Text was emphasised, wow.

## Changelog
:cl:
add: Added text emphasis, use +bold+, _underline_ and |italics| to apply it to text.
/:cl:


_REGEX!_
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
