### PR TITLE
Don't spawn spiderling remains for grown spiders.

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -112,7 +112,8 @@
 /obj/structure/spider/spiderling/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	entry_vent = null
-	new /obj/effect/decal/cleanable/spiderling_remains(get_turf(src))
+	if (amount_grown < 100)
+		new /obj/effect/decal/cleanable/spiderling_remains(get_turf(src))
 	return ..()
 
 /obj/structure/spider/spiderling/Bump(atom/user)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -112,7 +112,7 @@
 /obj/structure/spider/spiderling/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	entry_vent = null
-	if (amount_grown < 100)
+	if(amount_grown < 100)
 		new /obj/effect/decal/cleanable/spiderling_remains(get_turf(src))
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Checks to only spawn spiderling remains if the spiderling didn't reach the growth threshold before being qdeleted.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A spiderling that grows up should not also be a green stain on the floor.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

Before:
![Paradise Station 13-18_27_12](https://user-images.githubusercontent.com/59303604/190524380-cedc46f0-b26f-4317-9356-a6e67c7b8055.png)
After:
![Paradise Station 13-19_06_02](https://user-images.githubusercontent.com/59303604/190524385-cf0653c5-2e79-48f5-93d6-0a2d2e0a6b4f.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Tested princess terror laying.

## Changelog
:cl:
fix: Grown spiderlings now no longer also spawn remains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
