### PR TITLE
Reset personnel locker overlays when lock/unlocking.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -51,6 +51,8 @@
 		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
 
 	else if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
+		cut_overlays()
+
 		//they can open all lockers, or nobody owns this, or they own this locker
 		locked = !locked
 		if(locked)


### PR DESCRIPTION
## What Does This PR Do
Fixes #18912.

I don't 100% get overlay order/equivalency but adding lock/unlock light overlays without resetting them first results in confusing behavior.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lockers should correctly display their lock status.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Before:

https://user-images.githubusercontent.com/59303604/190535153-5bfe26bf-0e2c-4a6b-b579-b4b3336693f6.mp4

After:

https://user-images.githubusercontent.com/59303604/190535215-3681b1e4-928c-4c24-aad4-d3866423c53b.mp4

## Changelog
:cl:
fix: Personnel lockers properly display their lock status.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
