### PR TITLE
Allow changing PDA owners.

### DIFF
--- a/code/modules/pda/core_apps.dm
+++ b/code/modules/pda/core_apps.dm
@@ -27,6 +27,7 @@
 		if("UpdateInfo")
 			pda.ownjob = pda.id.assignment
 			pda.ownrank = pda.id.rank
+			pda.owner = pda.id.registered_name
 			pda.name = "PDA-[pda.owner] ([pda.ownjob])"
 			if(!pda.silent)
 				playsound(pda, 'sound/machines/terminal_processing.ogg', 15, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Right now you can only name the PDA once by clicking it with an ID. Different IDs just put the IDs into the PDA. Clicking "Update Info" only updates the job, not the owner name.
This PR allows you to change the PDA owner using the "Update Info" button in the PDA

## Why It's Good For The Game
The most important improvement is to allow traitors with a chameleon PDA to change their PDA names multiple times and not to be stuck with the first name they choose.

I'm open to making this a chameleon PDA only feature if it is unwanted on all PDAs.
## Testing
Verified, that name change does indeed work using "Update Info"

## Changelog
:cl: uc_guy
tweak: PDA owner can now be updated using "Update Info"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
