### PR TITLE
Add Owlman's utility belt to traitor uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1365,6 +1365,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/teleporter
 	cost = 8
 
+/datum/uplink_item/device_tools/utility_belt
+	name = "Owlman's Utility Belt"
+	desc = "The utility belt used by the famous vigilante Owlman! Automatically restocks itself with up to two bolas, and four smoke grenades."
+	reference = "UTL"
+	item = /obj/item/storage/belt/bluespace/owlman
+	cost = 10
+
 /datum/uplink_item/device_tools/thermal_drill
 	name = "Thermal Safe Drill"
 	desc = "A tungsten carbide thermal drill with magnetic clamps for the purpose of drilling hardened objects. Guaranteed 100% jam proof."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -664,7 +664,6 @@
 		/obj/item/restraints/legcuffs/bola
 		)
 
-	flags = NODROP
 	var/smokecount = 0
 	var/bolacount = 0
 	var/cooldown = 0
@@ -685,7 +684,7 @@
 	return ..()
 
 /obj/item/storage/belt/bluespace/owlman/process()
-	if(cooldown < world.time - 600)
+	if(cooldown < world.time - 60 SECONDS)
 		smokecount = 0
 		var/obj/item/grenade/smokebomb/S
 		for(S in src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds the unused Owlman utility belt to the traitor uplink, which is a belt that refills itself with 2 standard bolas and 4 smoke grenades every minute, for the price of 10 TC.

Also removes the no-drop flag from said belt.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The utility belt is an already existing item that is not used often, despite being a unique effect. Smoke grenades are an under-utilized tool that open up a lot of defensive options, and make for very interesting escapes. Bolas are also strong tools offensively and defensively, while the recent changes give them much more counterplay and make them much more fair to fight against. 

Nodrop was removed to make the belt easier to deal with from security's perspective, and because there were issues with the belt getting stuck to people's hands after they tried to take it off, or pick it up.

## Testing
Went into a private server, bought belt from traitor uplink
Tried putting belt down and picking back up, tried taking belt off, and tried stripping belt from someone else

## Changelog
:cl: Wilkson
add: Owlman's belt into the traitor uplink
del: Nodrop from Owlman's belt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
