### PR TITLE
Reworks alien facehugger incubation 

### DIFF
--- a/code/__DEFINES/_math.dm
+++ b/code/__DEFINES/_math.dm
@@ -239,3 +239,6 @@
 
 /// Checks if a number is an integer, or a float
 #define IS_INT(x) (x == round(x))
+
+// Gives you the percent of two inputs
+#define PERCENT_OF(val1, val2) (val1 * (val2 / 100))

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -54,7 +54,7 @@
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/internal/body_egg/alien_embryo/egg_process()
-	if(stage < 4 && world.time > last_stage_progress + incubation_time_per_stage) //Time for incubation is increased or decreased by a deviation of 15%, then we check to see if we've passed the threshold to goto our next stage of development
+	if(stage < 4 && world.time > last_stage_progress + incubation_deviation) //Time for incubation is increased or decreased by a deviation of 15%, then we check to see if we've passed the threshold to goto our next stage of development
 		stage++
 		RefreshInfectionImage()
 		last_stage_progress = world.time

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -7,7 +7,7 @@
 	icon_state = "larva0_dead"
 	var/stage = 0
 	var/polling = FALSE
-	var/incubation_time_per_stage = 7 //How long it takes for an alien embryo to advance a stage in it's development// Pretend this is 70 seconds it basically is I swear
+	var/incubation_time_per_stage = 70 SECONDS //How long it takes for an alien embryo to advance a stage in it's development// Pretend this is 70 seconds it basically is I swear
 	var/incubation_deviation = 0 //The random deviation for how long the incubation period per stage will take, ranging from -15% to +15. NOTE! If you have a better name for this var, I'd love it
 	var/last_stage_progress = 0 //Used to keep track of when incubation progressed to the next stage
 
@@ -25,7 +25,7 @@
 	return S
 
 /obj/item/organ/internal/body_egg/alien_embryo/on_life() //I'm gonna do something about this, I swear
-	incubation_deviation = rand(85, 115) //The actual deviation location
+	incubation_deviation = PERCENT_OF(rand(85, 115), incubation_time_per_stage) //The actual deviation location, and where the magic happens
 	switch(stage)
 		if(2)
 			if(prob(2))
@@ -50,11 +50,11 @@
 				if(prob(20))
 					owner.adjustToxLoss(1)
 		if(4)
-			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your chest...</span>") //Every 2 seconds take 10 toxin damage... wtf
+			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your chest...</span>")
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/internal/body_egg/alien_embryo/egg_process()
-	if(stage < 4 && world.time > last_stage_progress + incubation_time_per_stage * incubation_deviation) //Time for incubation is increased or decreased by a deviation of 15%, then we check to see if we've passed the threshold to goto our next stage of development
+	if(stage < 4 && world.time > last_stage_progress + incubation_time_per_stage) //Time for incubation is increased or decreased by a deviation of 15%, then we check to see if we've passed the threshold to goto our next stage of development
 		stage++
 		RefreshInfectionImage()
 		last_stage_progress = world.time

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -7,9 +7,12 @@
 	icon_state = "larva0_dead"
 	var/stage = 0
 	var/polling = FALSE
-	var/incubation_time_per_stage = 70 SECONDS //How long it takes for an alien embryo to advance a stage in it's development// Pretend this is 70 seconds it basically is I swear
-	var/incubation_deviation = 0 //The random deviation for how long the incubation period per stage will take, ranging from -15% to +15. NOTE! If you have a better name for this var, I'd love it
-	var/last_stage_progress = 0 //Used to keep track of when incubation progressed to the next stage
+	//How long it takes for an alien embryo to advance a stage in it's development// Pretend this is 70 seconds it basically is I swear
+	var/incubation_time_per_stage = 70 SECONDS
+	//The random deviation for how long the incubation period per stage will take, ranging from -15% to +15. NOTE! If you have a better name for this var, I'd love it
+	var/incubation_deviation = 0
+	//Used to keep track of when incubation progressed to the next stage
+	var/last_stage_progress = 0
 
 /obj/item/organ/internal/body_egg/alien_embryo/on_find(mob/living/finder)
 	..()
@@ -25,7 +28,6 @@
 	return S
 
 /obj/item/organ/internal/body_egg/alien_embryo/on_life() //I'm gonna do something about this, I swear
-	incubation_deviation = PERCENT_OF(rand(85, 115), incubation_time_per_stage) //The actual deviation location, and where the magic happens
 	switch(stage)
 		if(2)
 			if(prob(2))
@@ -57,6 +59,7 @@
 	if(stage < 4 && world.time > last_stage_progress + incubation_deviation) //Time for incubation is increased or decreased by a deviation of 15%, then we check to see if we've passed the threshold to goto our next stage of development
 		stage++
 		RefreshInfectionImage()
+		incubation_deviation = PERCENT_OF(rand(85, 115), incubation_time_per_stage) //The actual deviation location, and where the magic happens
 		last_stage_progress = world.time
 
 	if(stage == 4)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -7,11 +7,11 @@
 	icon_state = "larva0_dead"
 	var/stage = 0
 	var/polling = FALSE
-	//How long it takes for an alien embryo to advance a stage in it's development// Pretend this is 70 seconds it basically is I swear
+	///How long it takes for an alien embryo to advance a stage in it's development
 	var/incubation_time_per_stage = 70 SECONDS
-	//The random deviation for how long the incubation period per stage will take, ranging from -15% to +15. NOTE! If you have a better name for this var, I'd love it
+	///The random deviation for how long the incubation period per stage will take, ranging from -15% to +15. NOTE! If you have a better name for this var, I'd love it
 	var/incubation_deviation = 0
-	//Used to keep track of when incubation progressed to the next stage
+	///Used to keep track of when incubation progressed to the next stage
 	var/last_stage_progress = 0
 
 /obj/item/organ/internal/body_egg/alien_embryo/on_find(mob/living/finder)
@@ -27,7 +27,7 @@
 	S.reagents.add_reagent("sacid", 10)
 	return S
 
-/obj/item/organ/internal/body_egg/alien_embryo/on_life() //I'm gonna do something about this, I swear
+/obj/item/organ/internal/body_egg/alien_embryo/on_life()
 	switch(stage)
 		if(2)
 			if(prob(2))
@@ -56,16 +56,16 @@
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/internal/body_egg/alien_embryo/egg_process()
-	if(stage < 4 && world.time > last_stage_progress + incubation_deviation) //Time for incubation is increased or decreased by a deviation of 15%, then we check to see if we've passed the threshold to goto our next stage of development
+	if(stage < 4 && world.time > last_stage_progress + incubation_deviation) ///Time for incubation is increased or decreased by a deviation of 15%, then we check to see if we've passed the threshold to goto our next stage of development
 		stage++
 		RefreshInfectionImage()
-		incubation_deviation = PERCENT_OF(rand(85, 115), incubation_time_per_stage) //The actual deviation location, and where the magic happens
+		incubation_deviation = PERCENT_OF(rand(85, 115), incubation_time_per_stage) ///The actual deviation location, and where the magic happens
 		last_stage_progress = world.time
 
 	if(stage == 4)
 		for(var/datum/surgery/S in owner.surgeries)
 			if(S.location == "chest" && S.organ_to_manipulate.open >= ORGAN_ORGANIC_OPEN)
-				AttemptGrow(burst_on_success = FALSE) //If you managed to get this far, you deserve to be rewarded somewhat
+				AttemptGrow(burst_on_success = FALSE) ///If you managed to get this far, you deserve to be rewarded somewhat
 				return
 		AttemptGrow()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes a Prob(3) check to advance a stage in facehugger incubation to a 70 second timer with 15% positive and negative deviation 
Removes stage 3 due to it being a carbon copy of stage 2
Removes a small bit of RNG that didn't function for whatever reason
This PR also adds a new def for math.dm which lets us calculate %s, made by @Vi3trice 
Part of #18888
## Why It's Good For The Game
Currently, facehuggers incubation is governed by the will of RNGjesus, and it can take 30 minutes or 30 seconds for incubation to advance. Removal of RNG is good.
The timer is 70 seconds (3 minutes on average) so that it will roughly take the same time for alien larva to fully mature before changing how this worked, and after. It's also far more understandable than "wooo magic numer"
There is a deviation of 15% so that RNG is still a slight factor, and there's no set-in-stone amount of time an alien embryo needs to become a larva (This might be a bit too small). 
## Testing
Compiled and ran, did stuff with facehuggers
## Changelog
:cl: GDN , Vi3trice
tweak: Facehugger incubation is now more consistent 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
