### PR TITLE
Revert "Changes SR to not be an instant and unavoidable revival."

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -740,7 +740,6 @@
 	taste_description = "life"
 	harmless = FALSE
 	var/revive_type = SENTIENCE_ORGANIC //So you can't revive boss monsters or robots with it
-	var/revive_time = 5 SECONDS // How long it takes for the revive to apply, about the same as a defib
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -768,54 +767,37 @@
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
 					M.delayed_gib()
 					return
-
-				var/mob/dead/observer/ghost = M.get_ghost(TRUE)
-				if(ghost && !ghost.can_reenter_corpse || M.suiciding || HAS_TRAIT(M, TRAIT_HUSK) || HAS_TRAIT(M, TRAIT_BADDNA))
+				if(!M.ghost_can_reenter())
 					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
-					M.do_jitter_animation(50)
 					return
 
-				M.visible_message("<span class='warning'>[M] shakes violently!</span>")
-				if(ghost && ghost.can_reenter_corpse && ghost.client)
-					to_chat(ghost, "<span class='ghostalert'>Your body is being revived with Strange Reagent. Return to your body if you want to be revived!</span>")
-					window_flash(ghost.client)
-					SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))
+				if(!M.suiciding && !HAS_TRAIT(M, TRAIT_HUSK) && !HAS_TRAIT(M, TRAIT_BADDNA))
+					var/time_dead = world.time - M.timeofdeath
+					M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
+					M.adjustCloneLoss(50)
+					M.setOxyLoss(0)
+					M.adjustBruteLoss(rand(0, 15))
+					M.adjustToxLoss(rand(0, 15))
+					M.adjustFireLoss(rand(0, 15))
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						H.decaylevel = 0
+						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
+						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
+							// Per non-vital body part:
+							// 0% chance of necrosis within 1 minute of death
+							// 40% chance of necrosis after 20 minutes of death
+							if(!O.vital && prob(necrosis_prob))
+								// side effects may include: Organ failure
+								O.necrotize(FALSE)
+								if(O.status & ORGAN_DEAD)
+									O.germ_level = INFECTION_LEVEL_THREE
+						H.update_body()
 
-				M.do_jitter_animation(200)
-				addtimer(CALLBACK(src, /datum/reagent/medicine/strange_reagent/.proc/revivify, M), revive_time)
+					M.grab_ghost()
+					M.update_revive()
+					add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 	..()
-
-/datum/reagent/medicine/strange_reagent/proc/revivify(mob/living/M)
-	var/mob/dead/observer/ghost = M.get_ghost(TRUE) // update to check if they still have a ghost
-	if(ghost) // if the observer is still outside their body
-		M.visible_message("<span class='warning'>[M] stops shaking and falls limp.</span>")
-		return
-
-	var/time_dead = world.time - M.timeofdeath
-	M.adjustCloneLoss(50)
-	M.setOxyLoss(0)
-	M.adjustBruteLoss(rand(0, 15))
-	M.adjustToxLoss(rand(0, 15))
-	M.adjustFireLoss(rand(0, 15))
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.decaylevel = 0
-		var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
-		for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
-			// Per non-vital body part:
-			// 0% chance of necrosis within 1 minute of death
-			// 40% chance of necrosis after 20 minutes of death
-			if(!O.vital && prob(necrosis_prob))
-				// side effects may include: Organ failure
-				O.necrotize(FALSE)
-				if(O.status & ORGAN_DEAD)
-					O.germ_level = INFECTION_LEVEL_THREE
-		H.update_body()
-
-	M.grab_ghost()
-	M.update_revive()
-	M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>", "<span class='userdanger'>You rise from the dead!</span>")
-	add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Reverts ParadiseSS13/Paradise#18910<br><br>

because I have apparently commited a sin somewhere and I cant pinpoint it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Apparently its having some issues on production, despite working on my local server. Probably best to revert it until I can get more details about whats going on.<br><br>

It might be being caused by mind code being mindcode.
It is also possible this is being caused by having more than one datum of strange reactant in the world which is... terrible? (addtimer with src and global and.... I hate it all)
It also may be that the notification is just not showing up for telling them to enter their body?
There are many other possible factors into this that can be causing it and I cant exactly pinpoint what it is right now.

## Testing
<!-- How did you test the PR, if at all? -->
I hit the undo button on github

I cant test this in person because I'm not even near a computer but stuff failing on production is bad and needs to be fixed, if someone can just reassure me here I would appreciate it.

## Changelog
:cl:
tweak: Reverts Strange Reactant to its old form.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
