### PR TITLE
pyro gloves only work in glove slot [GBP NO UPDATE]

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -911,6 +911,10 @@
 	else
 		. += "<span class='warning'>It is missing a pyroclastic anomaly core.</span>"
 
+/obj/item/clothing/gloves/color/black/pyro_claws/item_action_slot_check(slot)
+	if(slot == slot_gloves)
+		return TRUE
+
 /obj/item/clothing/gloves/color/black/pyro_claws/ui_action_click(mob/user)
 	if(!core)
 		to_chat(user, "<span class='notice'>[src] has no core to power it!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Pyro gloves action button now only shows up when in gloves slot.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

no deploying gloves from pocket.

## Testing
<!-- How did you test the PR, if at all? -->
Spawn gloves
put in core.
Confirm only work in gloves slot.

(Could have sworn I already gave it this check)

## Changelog
:cl:
fix: Fixed pyro gloves working in your hands / pocket
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
