### PR TITLE
Radio uplinks use the proper sprite

### DIFF
--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -248,7 +248,6 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 /obj/item/radio/uplink/New()
 	..()
 	hidden_uplink = new(src)
-	icon_state = "radio"
 
 /obj/item/radio/uplink/attack_self(mob/user as mob)
 	if(hidden_uplink)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This removes the line that would set the radio uplink sprite to that of a plain box radio.

## Why It's Good For The Game
The uplink would actually have the name and desc of a bounced radio, but would set its icon_state to something else entirely. It's not very discreet due to a name/icon disparity.

## Images of changes
https://user-images.githubusercontent.com/80771500/190911202-5d2322a6-0fdf-4a1c-ae98-aaf67b067154.mp4

## Testing
Spawned the radio uplink and the station bounced radio side by side.

## Changelog
:cl:
fix: Radio uplinks look like station bounced radios
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
