### PR TITLE
Fix #16297 Reinforced walls act as infinite metal rod farms

### DIFF
--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -51,15 +51,7 @@
 			d_state = RWALL_SHEATH
 			update_icon()
 		return
-	else if(d_state == RWALL_SUPPORT_LINES && istype(I, /obj/item/stack/rods))
-		var/obj/item/stack/S = I
-		if(S.use(1))
-			d_state = RWALL_INTACT
-			update_icon()
-			to_chat(user, "<span class='notice'>You replace the outer grille.</span>")
-		else
-			to_chat(user, "<span class='warning'>You don't have enough rods for that!</span>")
-		return
+
 	else if(d_state)
 		// Repairing
 		if(istype(I, /obj/item/stack/sheet/metal))
@@ -153,15 +145,18 @@
 	update_icon()
 
 /turf/simulated/wall/r_wall/wirecutter_act(mob/user, obj/item/I)
-	if(d_state != RWALL_INTACT)
+	if(d_state != RWALL_INTACT && d_state != RWALL_SUPPORT_LINES)
 		return
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	d_state = RWALL_SUPPORT_LINES
+	if(d_state == RWALL_INTACT)
+		d_state = RWALL_SUPPORT_LINES
+		to_chat(user, "<span class='notice'>You cut the outer grille.</span>")
+	else
+		d_state = RWALL_INTACT
+		to_chat(user, "<span class='notice'>You mend the outer grille.</span>")
 	update_icon()
-	new /obj/item/stack/rods(src)
-	to_chat(user, "<span class='notice'>You cut the outer grille.</span>")
 
 /turf/simulated/wall/r_wall/wrench_act(mob/user, obj/item/I)
 	if(d_state != RWALL_BOLTS && d_state != RWALL_SUPPORT_RODS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Reinforced walls won't generate 1 metal rod anymore (first deconstruction step).
Wirecutter now has to be used instead of metal rod to revert the first step of deconstruction.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/16297, Its good for consistency since metal rod is not used during reinforced wall construction.
## Testing
<!-- How did you test the PR, if at all? -->
- Was capable of deconstructing and constructing reinforced walls without a problem.
## Changelog
:cl:
tweak: Reinforced wall: wirecutter must be used to revert the first deconstruction step instead of metal rod.
fix: Reinforced wall: won't act as infinite metal rod generators anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
