### PR TITLE
Buffs Alien Queens

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -4,6 +4,7 @@
 	maxHealth = 125
 	health = 125
 	icon_state = "alienh_s"
+	alien_movement_delay = -1
 
 /mob/living/carbon/alien/humanoid/hunter/Initialize(mapload)
 	. = ..()
@@ -16,7 +17,7 @@
 	. += /obj/item/organ/internal/xenos/plasmavessel/hunter
 
 /mob/living/carbon/alien/humanoid/hunter/movement_delay()
-	. = -1		//hunters are sanic
+	. = alien_movement_delay		//hunters are sanic
 	. += ..()	//but they still need to slow down on stun
 
 /mob/living/carbon/alien/humanoid/hunter/handle_environment()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -4,7 +4,7 @@
 	maxHealth = 125
 	health = 125
 	icon_state = "alienh_s"
-	alien_movement_delay = -1
+	alien_movement_delay = -1 //hunters are faster than normal xenomorphs, and people
 
 /mob/living/carbon/alien/humanoid/hunter/Initialize(mapload)
 	. = ..()
@@ -16,9 +16,6 @@
 	. = ..()
 	. += /obj/item/organ/internal/xenos/plasmavessel/hunter
 
-/mob/living/carbon/alien/humanoid/hunter/movement_delay()
-	. = alien_movement_delay		//hunters are sanic
-	. += ..()	//but they still need to slow down on stun
 
 /mob/living/carbon/alien/humanoid/hunter/handle_environment()
 	if(m_intent == MOVE_INTENT_RUN || IS_HORIZONTAL(src))

--- a/code/modules/mob/living/carbon/alien/humanoid/empress.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/empress.dm
@@ -9,6 +9,9 @@
 	bubble_icon = "alienroyal"
 	large = 1
 	ventcrawler = 0
+	move_resist = MOVE_FORCE_STRONG //Yes, big benos is huge and heavy
+	alien_disarm_damage = 60 //Empress do higher disarm stamina damage than normal aliens
+	alien_slash_damage = 30 //Empress do higher slashing damage to people
 
 /mob/living/carbon/alien/humanoid/empress/large
 	name = "alien empress"

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -15,7 +15,7 @@
 	var/custom_pixel_y_offset = 0
 	var/alien_disarm_damage = 30 //Aliens deal a good amount of stamina damage on disarm intent
 	var/alien_slash_damage = 20 //Aliens deal a good amount of damage on harm intent
-
+	var/alien_movement_delay = 0 //This can be + or -, how fast an alien moves
 	pass_flags = PASSTABLE
 
 //This is fine right now, if we're adding organ specific damage this needs to be updated

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -76,6 +76,10 @@
 
 /mob/living/carbon/alien/humanoid/var/temperature_resistance = T0C+75
 
+/mob/living/carbon/alien/humanoid/movement_delay() //Aliens have a varied movespeed
+	. = ..()
+	. += alien_movement_delay
+
 /mob/living/carbon/alien/humanoid/show_inv(mob/user as mob)
 	user.set_machine(src)
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -13,6 +13,9 @@
 	var/leap_on_click = 0
 	var/custom_pixel_x_offset = 0 //for admin fuckery.
 	var/custom_pixel_y_offset = 0
+	var/alien_disarm_damage = 30 //Aliens deal a good amount of stamina damage on disarm intent
+	var/alien_slash_damage = 20 //Aliens deal a good amount of damage on harm intent
+
 	pass_flags = PASSTABLE
 
 //This is fine right now, if we're adding organ specific damage this needs to be updated

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -39,9 +39,6 @@
 		/obj/item/organ/internal/xenos/neurotoxin,
 	)
 
-/mob/living/carbon/alien/humanoid/queen/movement_delay() //Aliens queens are slightly slower than humans
-	. = ..()
-	. += alien_movement_delay
 
 /mob/living/carbon/alien/humanoid/queen/can_inject(mob/user, error_msg, target_zone, penetrate_thick)
 	return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -12,7 +12,7 @@
 	move_resist = MOVE_FORCE_STRONG //Yes, queenos is huge and heavy
 	alien_disarm_damage = 60 //Queens do higher disarm stamina damage than normal aliens
 	alien_slash_damage = 30 //Queens do higher slashing damage to people
-	var/alien_queen_movement_delay = 1 //This represents a movement delay of 1, or roughly 80% the movement speed of a normal carbon mob
+	alien_movement_delay = 1 //This represents a movement delay of 1, or roughly 80% the movement speed of a normal carbon mob
 
 
 /mob/living/carbon/alien/humanoid/queen/Initialize(mapload)
@@ -41,7 +41,7 @@
 
 /mob/living/carbon/alien/humanoid/queen/movement_delay() //Aliens queens are slightly slower than humans
 	. = ..()
-	. += alien_queen_movement_delay
+	. += alien_movement_delay
 
 /mob/living/carbon/alien/humanoid/queen/can_inject(mob/user, error_msg, target_zone, penetrate_thick)
 	return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -9,6 +9,11 @@
 	large = 1
 	ventcrawler = 0
 	pressure_resistance = 200 //Because big, stompy xenos should not be blown around like paper.
+	move_resist = MOVE_FORCE_STRONG //Yes, queenos is huge and heavy
+	alien_disarm_damage = 60 //Queens do higher disarm stamina damage than normal aliens
+	alien_slash_damage = 30 //Queens do higher slashing damage to people
+	var/alien_queen_movement_delay = 1 //This represents a movement delay of 1, or roughly 80% the movement speed of a normal carbon mob
+
 
 /mob/living/carbon/alien/humanoid/queen/Initialize(mapload)
 	. = ..()
@@ -34,9 +39,9 @@
 		/obj/item/organ/internal/xenos/neurotoxin,
 	)
 
-/mob/living/carbon/alien/humanoid/queen/movement_delay()
+/mob/living/carbon/alien/humanoid/queen/movement_delay() //Aliens queens are slightly slower than humans
 	. = ..()
-	. += 3
+	. += alien_queen_movement_delay
 
 /mob/living/carbon/alien/humanoid/queen/can_inject(mob/user, error_msg, target_zone, penetrate_thick)
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -632,7 +632,7 @@ emp_act
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
  				"<span class='userdanger'>[M] has slashed at [src]!</span>")
 
-			apply_damage(adjustBruteLoss(M.alien_slash_damage), BRUTE, affecting, armor_block)
+			apply_damage(M.alien_slash_damage, BRUTE, affecting, armor_block)
 			add_attack_logs(M, src, "Alien attacked")
 			updatehealth("alien attack")
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -625,11 +625,6 @@ emp_act
 		if(M.a_intent == INTENT_HARM)
 			if(w_uniform)
 				w_uniform.add_fingerprint(M)
-			var/damage = prob(90) ? 20 : 0
-			if(!damage)
-				playsound(loc, 'sound/weapons/slashmiss.ogg', 50, TRUE, -1)
-				visible_message("<span class='danger'>[M] has lunged at [src]!</span>")
-				return 0
 			var/obj/item/organ/external/affecting = get_organ(ran_zone(M.zone_selected))
 			var/armor_block = run_armor_check(affecting, MELEE, armour_penetration_flat = 10)
 
@@ -637,7 +632,7 @@ emp_act
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
  				"<span class='userdanger'>[M] has slashed at [src]!</span>")
 
-			apply_damage(damage, BRUTE, affecting, armor_block)
+			apply_damage(adjustBruteLoss(M.alien_slash_damage), BRUTE, affecting, armor_block)
 			add_attack_logs(M, src, "Alien attacked")
 			updatehealth("alien attack")
 
@@ -655,7 +650,7 @@ emp_act
 				var/obj/item/organ/external/affecting = get_organ(ran_zone(M.zone_selected))
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				apply_effect(10 SECONDS, KNOCKDOWN, run_armor_check(affecting, MELEE))
-				adjustStaminaLoss(30)
+				adjustStaminaLoss(M.alien_disarm_damage)
 				add_attack_logs(M, src, "Alien tackled")
 				visible_message("<span class='danger'>[M] has tackled down [src]!</span>")
 


### PR DESCRIPTION
## What Does This PR Do
Buffs the alien queen
Ups their disarm damage to 60 from 30
Ups their slash damage to 30 from 20 (Hal helped me with this) 
Decreases their movement delay from 3 to 1
Prevents alien queens from being pulled/pushed
(all of these changes have been mirrored to empresses as well) 
## Why It's Good For The Game
Currently, alien queen is fucking boring, everyone wants someone else to go queen so they don't need to, alien queens also suck at defending themselves. Alien queens are now a force not to be fucked with, it stamcrits you in two strikes (provided you don't have an item in hand), and deals esword level damage.
The decrease to movement speed will make basic movement less of a slog, while removing the reliance on getting a hunter to pull you
Alien queens can no longer be pushed/pulled, this prevents people from pushing queens out of the nest, and fast people from grabbing and running off with them.
This should hopefully make it actually fun to play.

## Testing
Did funny stuff with a skrell and some xenos
## Changelog
:cl: GDN , hal9000
tweak: Alien queens can no longer be pulled/pushed
tweak: Alien queens deal 10 more brute damage
tweak: Alien queens deal 30 more stamina damage
tweak: Alien queens move faster
/:cl:
