### PR TITLE
Surgery Hotfixes: Part 1

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -54,3 +54,21 @@
 /// This surgery step will be conditionally retried, so long as the surgery step's can_repeat() proc returns TRUE.
 /// Otherwise, it'll behave just like SURGERY_STEP_INCOMPLETE.
 #define SURGERY_STEP_RETRY 3
+
+// Return values for surgery_step.initiate().
+// Before you ask, yes, we need another definition for surgery steps here, since these control how we will act on the attack-chain
+// side of things.
+// Unless you're changing the mechanics of the surgery attack chain, you almost surely don't want to use these, and should
+// instead be using the above SURGERY_STEP_X defines.
+
+/// The surgery initiation isn't even going to be started. If you're working with the attack chain, this is probably what you'll be using.
+#define SURGERY_INITIATE_CONTINUE_CHAIN 0
+
+/// The surgery initiaition was a success. We're advancing the current surgery.
+#define SURGERY_INITIATE_SUCCESS 1
+
+/// The surgery initiation was interrupted, or for some reason never completed. We don't want to return FALSE to the attack chain, though.
+#define SURGERY_INITIATE_FAILURE 2
+
+/// The surgery never reached (or finished) the do_after. Go back to the state we were in before this even happened.
+#define SURGERY_INITIATE_INTERRUPTED 3

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -97,7 +97,6 @@
 
 	if(!isnull(current_surgery) && !current_surgery.step_in_progress)
 		var/datum/surgery_step/current_step = current_surgery.get_surgery_step()
-		// TODO Currently an accept_any_tool step is impossible to terminate early with the right tools.
 		if(current_step.try_op(user, target, user.zone_selected, parent, current_surgery) == SURGERY_INITIATE_SUCCESS)
 			return
 		if(istype(parent, /obj/item/scalpel/laser/manager/debug))

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -97,7 +97,8 @@
 
 	if(!isnull(current_surgery) && !current_surgery.step_in_progress)
 		var/datum/surgery_step/current_step = current_surgery.get_surgery_step()
-		if(current_step.try_op(user, target, user.zone_selected, parent, current_surgery))
+		// TODO Currently an accept_any_tool step is impossible to terminate early with the right tools.
+		if(current_step.try_op(user, target, user.zone_selected, parent, current_surgery) == SURGERY_INITIATE_SUCCESS)
 			return
 		if(istype(parent, /obj/item/scalpel/laser/manager/debug))
 			return

--- a/code/modules/surgery/abstract_steps.dm
+++ b/code/modules/surgery/abstract_steps.dm
@@ -174,7 +174,6 @@
 
 	if(overridden_tool || next_surgery == surgery || !next_surgery)
 		// Continue along with the original surgery.
-		var/datum/surgery_step/next = surgery.get_surgery_next_step()
 		return try_next_step(user, target, target_zone, tool, surgery, null, TRUE)
 
 	if(!target.can_run_surgery(next_surgery, user))

--- a/code/modules/surgery/abstract_steps.dm
+++ b/code/modules/surgery/abstract_steps.dm
@@ -45,7 +45,7 @@
 		/obj/item/scalpel/laser/manager  // IMS
 	)
 
-	/// Whether or not we should add ourselves as a step after we run a branch
+	/// Whether or not we should add ourselves as a step after we run a branch. This doesn't apply to failures, those will always add ourselves after.
 	var/insert_self_after = TRUE
 
 /datum/surgery_step/proxy/New()
@@ -133,7 +133,7 @@
 		if(istype(next_surgery_step, /datum/surgery_step/proxy))
 			// It might make sense to support this, and I think the flow could work (just treating them like a single step, sorta)
 			// but I think for simplicity's sake it's better to just say no
-			CRASH("[src] was followed by another proxy surgery step in [surgery].")
+			CRASH("[src] was followed by another proxy surgery step [next_surgery_step] in [surgery].")
 
 		if((SURGERY_TOOL_HAND in starting_tools) && next_surgery_step.accept_hand)
 			CRASH("[src] has a conflict with the next main step [next_surgery_step] in surgery [surgery]: both require an open hand.")
@@ -173,10 +173,9 @@
 		return FALSE
 
 	if(overridden_tool || next_surgery == surgery || !next_surgery)
-		// Continue along with the original surgery
-		surgery.step_number++
-		var/datum/surgery_step/next_step = surgery.get_surgery_step()
-		return next_step.try_op(user, target, target_zone, tool, surgery)
+		// Continue along with the original surgery.
+		var/datum/surgery_step/next = surgery.get_surgery_next_step()
+		return try_next_step(user, target, target_zone, tool, surgery, null, TRUE)
 
 	if(!target.can_run_surgery(next_surgery, user))
 		// Make sure the target can support the surgery.
@@ -188,20 +187,59 @@
 		// Let them try other tools if necessary.
 		return TRUE
 
-	// Insert the steps in our intermediate surgery into the current surgery.
-	// This is how we keep our surgeries still technically linear.
-	var/list/steps_to_insert = next_surgery.steps
-	if(insert_self_after)
-		// add ourselves afterwards as well so we can repeat this step
-		steps_to_insert.Add(type)
+	return try_next_step(user, target, target_zone, tool, surgery, next_surgery.steps)
 
-	// Also, bump the status so we skip past this abstract step.
-	surgery.steps.Insert(surgery.step_number + 1, next_surgery.steps)
-	surgery.step_number++
+/**
+ * Test the next step, but don't fully commit to it unless it completes successfully.
+ * If the next step doesn't fully complete (such as being interrupted or failing), we'll insert ourselves again to bring us back
+ * 	to the "base" state.
+ * If it does, we'll add the subsequent steps to the surgery and continue down the expected branch. If you complete the surgery step, it
+ * 	means you've committed to what comes next.
+ * Part of the motivation behind this is that I don't want to mutate a surgery retroactively. We can insert, but we shouldn't be changing anything
+ * 	behind us.
+ *
+ * Arguments:
+ * * next_surgery_steps - the steps for the branching surgery to add to the current surgery. If there's no branching surgery (or this would continue the main surgery) ignore this.
+ * * override_adding_self - If true, then regardless of the value of insert_self_after, we won't add ourselves in as another step.
+ * (for other arguments, see try_op())
+ */
+/datum/surgery_step/proxy/proc/try_next_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/running_surgery, list/next_surgery_steps, override_adding_self)
 
-	// force the next surgery step so we don't have to click again.
-	var/datum/surgery_step/next_step = surgery.get_surgery_step()
-	return next_step.try_op(user, target, target_zone, tool, surgery)
+	var/list/following_steps = list()
+
+	if(length(next_surgery_steps))
+
+		// add the first step from the following surgery into the surgery list, to make it the next step.
+		running_surgery.steps.Insert(running_surgery.step_number + 1, next_surgery_steps[1])
+
+		// grab the remaining steps to possibly insert after this surgery, depending on what we're doing
+		// skip the current step though, since if our try_op works, we've completed it.
+		following_steps = next_surgery_steps.Copy()
+		following_steps.Cut(1, 2)
+
+	running_surgery.step_number++
+
+	var/datum/surgery_step/next_step = running_surgery.get_surgery_step()
+	var/step_status = next_step.try_op(user, target, target_zone, tool, running_surgery)
+
+	if(step_status != SURGERY_INITIATE_SUCCESS)
+		// always add ourselves after a failure so someone can make a different choice.
+		running_surgery.steps.Insert(running_surgery.step_number + 1, type)
+		running_surgery.step_number++
+
+	else
+		// Insert the steps in our intermediate surgery into the current surgery.
+		// This is how we keep our surgeries still technically linear.
+		if(insert_self_after && !override_adding_self)
+			// add ourselves afterwards as well so we can repeat this step
+			following_steps.Add(type)
+
+		// insert at the current step number since we're not trying to bump it up
+		running_surgery.steps.Insert(running_surgery.step_number, following_steps)
+
+
+	return step_status
+
 
 // Some intermediate surgeries
 /datum/surgery/intermediate/bleeding

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -52,10 +52,51 @@
 		/datum/surgery_step/robotics/external/unscrew_hatch,
 		/datum/surgery_step/robotics/external/open_hatch,
 		/datum/surgery_step/proxy/cavity_manipulation/robotic,
+		/datum/surgery_step/cavity/close_space,
 		/datum/surgery_step/robotics/external/close_hatch
 	)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN)
 	requires_organic_bodypart = FALSE
+
+
+/datum/surgery_step/proxy/cavity_manipulation
+	name = "Cavity Manipulation (proxy)"
+	branches = list(
+		/datum/surgery/intermediate/open_cavity/implant,
+		/datum/surgery/intermediate/open_cavity/extract,
+		/datum/surgery/intermediate/bleeding
+	)
+
+	insert_self_after = TRUE
+
+/datum/surgery_step/proxy/cavity_manipulation/robotic
+	name = "Robotic Cavity Manipulation (proxy)"
+	branches = list(
+		/datum/surgery/intermediate/open_cavity/implant/robotic,
+		/datum/surgery/intermediate/open_cavity/extract/robotic
+	)
+
+/datum/surgery/intermediate/open_cavity
+	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
+
+/datum/surgery/intermediate/open_cavity/implant
+	name = "implant object"
+	steps = list(
+		/datum/surgery_step/cavity/place_item
+	)
+
+/datum/surgery/intermediate/open_cavity/extract
+	name = "extract object"
+	steps = list(
+		/datum/surgery_step/cavity/remove_item
+	)
+
+/datum/surgery/intermediate/open_cavity/implant/robotic
+	requires_organic_bodypart = FALSE
+
+/datum/surgery/intermediate/open_cavity/extract/robotic
+	requires_organic_bodypart = FALSE
+
 
 /datum/surgery_step/cavity
 
@@ -206,43 +247,6 @@
 
 	return SURGERY_STEP_INCOMPLETE
 
-/datum/surgery_step/proxy/cavity_manipulation
-	name = "Cavity Manipulation (proxy)"
-	branches = list(
-		/datum/surgery/intermediate/open_cavity/implant,
-		/datum/surgery/intermediate/open_cavity/extract
-	)
-
-	insert_self_after = TRUE
-
-/datum/surgery_step/proxy/cavity_manipulation/robotic
-	name = "Robotic Cavity Manipulation (proxy)"
-	branches = list(
-		/datum/surgery/intermediate/open_cavity/implant/robotic,
-		/datum/surgery/intermediate/open_cavity/extract/robotic
-	)
-
-/datum/surgery/intermediate/open_cavity
-	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
-
-/datum/surgery/intermediate/open_cavity/implant
-	name = "implant object"
-	steps = list(
-		/datum/surgery_step/cavity/place_item
-	)
-
-/datum/surgery/intermediate/open_cavity/extract
-	name = "extract object"
-	steps = list(
-		/datum/surgery_step/cavity/remove_item
-	)
-
-/datum/surgery/intermediate/open_cavity/implant/robotic
-	requires_organic_bodypart = FALSE
-
-/datum/surgery/intermediate/open_cavity/extract/robotic
-	requires_organic_bodypart = FALSE
-
 /datum/surgery_step/cavity/place_item
 	name = "implant object"
 	accept_any_item = TRUE
@@ -281,7 +285,7 @@
 	var/can_fit = !affected.hidden && tool.w_class <= get_max_wclass(affected)
 	if(!can_fit)
 		to_chat(user, "<span class='warning'>\The [tool] won't fit in \the [affected]!</span>")
-		return SURGERY_BEGINSTEP_ABORT
+		return SURGERY_BEGINSTEP_SKIP
 
 	user.visible_message(
 		"[user] starts putting \the [tool] inside [target]'s [get_cavity(affected)] cavity.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The PR you all knew was coming: fixes up some bugs that have popped up after the refactor, and adds some behavior that I was meaning to add, but kind of wanted to make sure everything else worked first (read: I was trying to think of the best way to do this, but I forgot).

The biggest one is that you should no longer get stuck in a branching surgery step just because you started a step and canceled it. If you're in the first step of a branching surgery and you start a particular operation that isn't completed (due to moving or some other reason), you'll be able to make any other move that the branch made available. Worth noting that you'll still be stuck in a branch that's 2+ steps long once that surgery step completes successfully; you've committed to it. This should also help with other aspects of getting stuck in surgeries with multiple steps, especially the particularly annoying ones to get out of like cavity stuff.

Synthetic cavity surgery also has a "close cavity" step now, something that I missed when I was going through.

Also, small thing, reorganizes the cavity implant file. This was a little gross and I meant to do that before.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Getting locked into surgery steps was arguably one of the most annoying things (for myself, anyway) that I introduced with the new surgery behavior. Preventing you from being locked into a path just because you used the wrong tool for a second helps keep the flexibility that I intended when I added this.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Spawned vulp, operating table, operating computer, debug IMS
- Performed cavity surgery, mashed through to the proper steps. 
- Insert some bone gel or something
- Let it succeed, note that it still shows the multi-branch stage on the operating computer.
- Try to remove it with an open hand.
- Note that the surgery computer has reverted to the multi-branch stage.
- Use the IMS again to force the surgery through.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Surgery steps with multiple options will no longer lock you in on the first step.
fix: Robotic cavity implant surgery has a close cavity step, similar to other instances.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
