### PR TITLE
Making assemblies will no longer be dropped

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -105,6 +105,7 @@
 	holder = new /obj/item/assembly_holder(get_turf(src))
 	if(holder.attach(A, src, user))
 		to_chat(user, "<span class='notice'>You attach [A] to [src]!</span>")
+		user.put_in_active_hand(holder)
 		return TRUE
 	return FALSE
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -179,12 +179,15 @@
 		var/turf/T = get_turf(src)
 		if(!T)
 			return FALSE
+		user.unEquip(src, TRUE, TRUE)
 		if(a_left)
 			a_left.holder = null
 			a_left.forceMove(T)
-		if(a_right)
+			user.put_in_active_hand(a_left)
+		if(a_right) // Right object is the secondary item, hence put in inactive hand
 			a_right.holder = null
 			a_right.forceMove(T)
+			user.put_in_inactive_hand(a_right)
 		qdel(src)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Making a new assembly will keep it in your hands instead of dropping it on the floor.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Dropping the items on the floor is kinda awkward. It would make more sense that they stay in your hands since you are putting them together with your hands.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/91113370/190971608-4e378929-6ab9-4298-bbc1-997d7329aea0.mp4



## Testing
<!-- How did you test the PR, if at all? -->
\> Be assistant
\> Smash together igniters and signallers
\> Remote bomb with welding tank
Disassembly of them works also, see attached video.
Having one hand full when disassembling works too, dropping the second item onto the floor
![image](https://user-images.githubusercontent.com/91113370/190971852-a67e4e1c-42c7-49b5-a408-e05a184234c5.png)
![image](https://user-images.githubusercontent.com/91113370/190971865-61aee817-a113-4669-9fdc-82e82630fb03.png)


## Changelog
:cl:
tweak: Making and dissassembling assemblies will now not drop them to the floor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
