### PR TITLE
Contractor Post-Prison Injuries

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -500,42 +500,44 @@
   * * M - The target mob.
   */
 /datum/syndicate_contract/proc/injure_target(mob/living/M)
-	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
-		var/obj/item/organ/external/injury_target
-		if(prob(20)) //remove a limb
-			if(prob(50))
-				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
-				if(!injury_target)
-					default_damage(M)
-					return
-				injury_target.droplimb()
-				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! Oh god something's missing!</span>")
-		else //fracture
-			if(ismachineperson(M))
-				M.emp_act(EMP_HEAVY)
-				M.adjustBrainLoss(30)
-				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your components are loose!</span>")
+	if(!prob(RETURN_INJURY_CHANCE) && M.health >= 50)
+		return
 
-			else if(isslimeperson(M))
-				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
-				if(!injury_target)
-					default_damage(M)
-					return
-				injury_target.cause_internal_bleeding()
+	var/obj/item/organ/external/injury_target
+	if(prob(20)) //remove a limb
+		if(prob(50))
+			injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
+			if(!injury_target)
+				default_damage(M)
+				return
+			injury_target.droplimb()
+			to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! Oh god something's missing!</span>")
+	else //fracture
+		if(ismachineperson(M))
+			M.emp_act(EMP_HEAVY)
+			M.adjustBrainLoss(30)
+			to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your components are loose!</span>")
 
-				injury_target = M.get_organ(BODY_ZONE_CHEST)
-				injury_target.cause_internal_bleeding()
-				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like your inner membrane has been punctured!</span>")
+		else if(isslimeperson(M))
+			injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
+			if(!injury_target)
+				default_damage(M)
+				return
+			injury_target.cause_internal_bleeding()
 
-			if(prob(25))
-				injury_target = M.get_organ(BODY_ZONE_CHEST)
-				injury_target.fracture()
-			else
-				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_LEG, BODY_ZONE_R_LEG))
-				if(!injury_target)
-					default_damage(M)
-					return
-				injury_target.fracture()
+			injury_target = M.get_organ(BODY_ZONE_CHEST)
+			injury_target.cause_internal_bleeding()
+			to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like your inner membrane has been punctured!</span>")
+
+		if(prob(25))
+			injury_target = M.get_organ(BODY_ZONE_CHEST)
+			injury_target.fracture()
+		else
+			injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_LEG, BODY_ZONE_R_LEG))
+			if(!injury_target)
+				default_damage(M)
+				return
+			injury_target.fracture()
 
 /**
   * Handles the target's return to station.

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -526,7 +526,6 @@
 	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
 		var/obj/item/organ/external/injury_target
 		var/nolimb = FALSE
-		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
 		if(prob(20)) //remove a limb
 			if(prob(50))
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
@@ -534,25 +533,23 @@
 					nolimb = TRUE
 					return
 				injury_target.droplimb()
+				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! Oh god something's missing!</span>")
 		else //fracture
 			if(ismachineperson(M))
-				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your componenets are loose!</span>")
 				M.emp_act(1)
 				M.adjustBrainLoss(30)
+				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your componenets are loose!</span>")
 
 			if(isslimeperson(M))
-				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like your inner membrane has been punctured!</span>")
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 				if(!injury_target)
 					nolimb = TRUE
 					return
 				injury_target.cause_internal_bleeding()
 
-				injury_target = M.get_organ(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST))
-				if(!injury_target)
-					nolimb = TRUE
-					return
+				injury_target = M.get_organ(BODY_ZONE_CHEST)
 				injury_target.cause_internal_bleeding()
+				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like your inner membrane has been punctured!</span>")
 
 			else if(prob(10))
 				injury_target = M.get_organ(BODY_ZONE_CHEST)
@@ -563,6 +560,10 @@
 					nolimb = TRUE
 					return
 				injury_target.fracture()
+		if(nolimb)//if no limb is found, damage them..
+			M.adjustBruteLoss(40)
+			M.adjustBrainLoss(25)
+
 
 	// Return them a bit confused.
 	M.visible_message("<span class='notice'>[M] vanishes...</span>")

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -524,24 +524,21 @@
 		var/obj/item/souvenir = pick(souvenirs)
 		new souvenir(closet)
 	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
-		var/item/organ/external/injurytarget = NULL
 		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
 		if(prob(10)) //remove a limb
 			if(prob(50))
-				injurytarget = M.get_organ(FOOT_RIGHT)
-				injurytarget.droplimb()
+				M.get_organ(ARM_RIGHT).droplimb()
 			else
-				injurytarget = M.get_organ(HAND_LEFT)
-				injurytarget.droplimb()
+				M.get_organ(LEG_LEFT).droplimb()
 
-		else if(prob(50))//steal an organ
-			if(prob(50))
-
+		else
+			if(prob(10))
+				M.get_organ(BODY_ZONE_CHEST).fracture()
+			else if(prob(25))
+				M.get_organ(LEG_RIGHT).fracture()
 			else
-
-
-		else//break a bone
-
+				M.get_organ(HAND_LEFT).fracture()
+		M.adjustBruteLoss(25)
 
 	// Return them a bit confused.
 	M.visible_message("<span class='notice'>[M] vanishes...</span>")

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -528,10 +528,7 @@
 		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
 		if(prob(20)) //remove a limb
 			if(prob(50))
-				injury_target = M.get_organ(BODY_ZONE_R_ARM)
-				injury_target.droplimb()
-			else
-				injury_target = M.get_organ(BODY_ZONE_L_LEG)
+				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND,BODY_ZONE_PRECISE_L_HAND,BODY_ZONE_PRECISE_R_FOOT,BODY_ZONE_PRECISE_L_FOOT))
 				injury_target.droplimb()
 		else
 			if(prob(10))

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -500,7 +500,7 @@
   * * M - The target mob.
   */
 /datum/syndicate_contract/proc/injure_target(mob/living/M)
-	if(!prob(RETURN_INJURY_CHANCE) && M.health >= 50)
+	if(!prob(RETURN_INJURY_CHANCE) || M.health < 50)
 		return
 
 	var/obj/item/organ/external/injury_target

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -530,8 +530,11 @@
 			if(prob(50))
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND,BODY_ZONE_PRECISE_L_HAND,BODY_ZONE_PRECISE_R_FOOT,BODY_ZONE_PRECISE_L_FOOT))
 				injury_target.droplimb()
-		else
-			if(prob(10))
+		else //fracture
+			if(ismachineperson(M) || isslime(M)) //They dont have bones, will need something here
+				return //TEMP
+
+			else if(prob(10))
 				injury_target = M.get_organ(BODY_ZONE_CHEST)
 				injury_target.fracture()
 			else

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -525,20 +525,29 @@
 		new souvenir(closet)
 	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
 		var/obj/item/organ/external/injury_target
-		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
 		if(prob(20)) //remove a limb
 			if(prob(50))
-				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND,BODY_ZONE_PRECISE_L_HAND,BODY_ZONE_PRECISE_R_FOOT,BODY_ZONE_PRECISE_L_FOOT))
+				to_chat(M, "<span class='warning'>You were interrogated by your captors severely before being sent back!</span>")
+				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 				injury_target.droplimb()
-		else //fracture
-			if(ismachineperson(M) || isslime(M)) //They dont have bones, will need something here
-				return //TEMP
+		else //fracture and/or interrogate
+			if(ismachineperson(M))
+				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your componenets are loose!</span>")
+				M.emp_act(1)
+				M.adjustBrainLoss(30)
+
+			if(isslimeperson(M))
+				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
+				injury_target.cause_internal_bleeding()
+
+				injury_target = M.get_organ(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST))
+				injury_target.cause_internal_bleeding()
 
 			else if(prob(10))
 				injury_target = M.get_organ(BODY_ZONE_CHEST)
 				injury_target.fracture()
 			else
-				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND,BODY_ZONE_PRECISE_L_HAND,BODY_ZONE_R_LEG,BODY_ZONE_R_LEG))
+				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_LEG, BODY_ZONE_R_LEG))
 				injury_target.fracture()
 
 	// Return them a bit confused.

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -3,7 +3,7 @@
 #define EXTRACTION_PHASE_PREPARE 5 SECONDS
 #define EXTRACTION_PHASE_PORTAL 5 SECONDS
 #define COMPLETION_NOTIFY_DELAY 5 SECONDS
-#define RETURN_INJURY_CHANCE 80
+#define RETURN_INJURY_CHANCE 85
 #define RETURN_BRUISE_DAMAGE 20
 #define RETURN_SOUVENIR_CHANCE 10
 
@@ -461,7 +461,7 @@
 	// Narrate their kidnapping and torturing experience.
 	if(M.stat != DEAD)
 		// Heal them up - gets them out of crit/soft crit.
-		M.reagents.add_reagent("omnizine", 20)
+		M.reagents.add_reagent("omnizine", 10)
 
 		to_chat(M, "<span class='warning'>You feel strange...</span>")
 		M.Paralyse(30 SECONDS)
@@ -525,12 +525,11 @@
 		new souvenir(closet)
 	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
 		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
-		if(prob(10)) //remove a limb
+		if(prob(20)) //remove a limb
 			if(prob(50))
-				M.get_organ(ARM_RIGHT).droplimb()
+				M.get_organ(BODY_ZONE_R_ARM).droplimb()
 			else
-				M.get_organ(LEG_LEFT).droplimb()
-
+				M.get_organ(BODY_ZONE_L_LEG).droplimb()
 		else
 			if(prob(10))
 				M.get_organ(BODY_ZONE_CHEST).fracture()
@@ -538,7 +537,6 @@
 				M.get_organ(LEG_RIGHT).fracture()
 			else
 				M.get_organ(HAND_LEFT).fracture()
-		M.adjustBruteLoss(25)
 
 	// Return them a bit confused.
 	M.visible_message("<span class='notice'>[M] vanishes...</span>")

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -484,7 +484,15 @@
 
 		to_chat(M, "<span class='danger'><font size=3>You have been kidnapped and interrogated for valuable information! You will be sent back to the station in a few minutes...</font></span>")
 
-
+/**
+  * Default damage if no injury is possible.
+  *
+  * Arguments:
+  * * M - The target mob.
+  */
+/datum/syndicate_contract/proc/default_damage(mob/living/M)
+	M.adjustBruteLoss(40)
+	M.adjustBrainLoss(25)
 /**
   * Handles the target's injury/interrogation at the Syndicate Jail.
   *
@@ -494,12 +502,11 @@
 /datum/syndicate_contract/proc/injure_target(mob/living/M)
 	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
 		var/obj/item/organ/external/injury_target
-		var/do_damage = FALSE
 		if(prob(20)) //remove a limb
 			if(prob(50))
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 				if(!injury_target)
-					do_damage = TRUE
+					default_damage(M)
 					return
 				injury_target.droplimb()
 				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! Oh god something's missing!</span>")
@@ -512,7 +519,7 @@
 			else if(isslimeperson(M))
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 				if(!injury_target)
-					do_damage = TRUE
+					default_damage(M)
 					return
 				injury_target.cause_internal_bleeding()
 
@@ -520,18 +527,15 @@
 				injury_target.cause_internal_bleeding()
 				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like your inner membrane has been punctured!</span>")
 
-			else if(prob(10))
+			if(prob(25))
 				injury_target = M.get_organ(BODY_ZONE_CHEST)
 				injury_target.fracture()
 			else
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_LEG, BODY_ZONE_R_LEG))
 				if(!injury_target)
-					do_damage = TRUE
+					default_damage(M)
 					return
 				injury_target.fracture()
-		if(do_damage)//if no limb is found, damage them..
-			M.adjustBruteLoss(40)
-			M.adjustBrainLoss(25)
 
 /**
   * Handles the target's return to station.

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -524,19 +524,25 @@
 		var/obj/item/souvenir = pick(souvenirs)
 		new souvenir(closet)
 	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
+		var/obj/item/organ/external/injury_target
 		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
 		if(prob(20)) //remove a limb
 			if(prob(50))
-				M.get_organ(BODY_ZONE_R_ARM).droplimb()
+				injury_target = M.get_organ(BODY_ZONE_R_ARM)
+				injury_target.droplimb()
 			else
-				M.get_organ(BODY_ZONE_L_LEG).droplimb()
+				injury_target = M.get_organ(BODY_ZONE_L_LEG)
+				injury_target.droplimb()
 		else
 			if(prob(10))
-				M.get_organ(BODY_ZONE_CHEST).fracture()
+				injury_target = M.get_organ(BODY_ZONE_CHEST)
+				injury_target.fracture()
 			else if(prob(25))
-				M.get_organ(LEG_RIGHT).fracture()
+				injury_target = M.get_organ(LEG_RIGHT)
+				injury_target.fracture()
 			else
-				M.get_organ(HAND_LEFT).fracture()
+				injury_target = M.get_organ(HAND_LEFT)
+				injury_target.fracture()
 
 	// Return them a bit confused.
 	M.visible_message("<span class='notice'>[M] vanishes...</span>")

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -507,7 +507,7 @@
 			if(ismachineperson(M))
 				M.emp_act(EMP_HEAVY)
 				M.adjustBrainLoss(30)
-				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your componenets are loose!</span>")
+				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your components are loose!</span>")
 
 			else if(isslimeperson(M))
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -535,7 +535,8 @@
 				injury_target = M.get_organ(BODY_ZONE_CHEST)
 				injury_target.fracture()
 			else
-			injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND,BODY_ZONE_PRECISE_L_HAND,BODY_ZONE_R_LEG,BODY_ZONE_R_LEG))
+				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND,BODY_ZONE_PRECISE_L_HAND,BODY_ZONE_R_LEG,BODY_ZONE_R_LEG))
+				injury_target.fracture()
 
 	// Return them a bit confused.
 	M.visible_message("<span class='notice'>[M] vanishes...</span>")

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -531,8 +531,18 @@
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 				injury_target.droplimb()
 		else //fracture
-			if(ismachineperson(M) || isslime(M)) //They dont have bones, will need something here
-				return //TEMP
+			if(ismachineperson(M))
+				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like some of your componenets are loose!</span>")
+				M.emp_act(1)
+				M.adjustBrainLoss(30)
+
+			if(isslimeperson(M))
+				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like your inner membrane has been punctured!</span>")
+				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
+				injury_target.cause_internal_bleeding()
+
+				injury_target = M.get_organ(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST))
+				injury_target.cause_internal_bleeding()
 
 			else if(prob(10))
 				injury_target = M.get_organ(BODY_ZONE_CHEST)

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -534,12 +534,8 @@
 			if(prob(10))
 				injury_target = M.get_organ(BODY_ZONE_CHEST)
 				injury_target.fracture()
-			else if(prob(25))
-				injury_target = M.get_organ(LEG_RIGHT)
-				injury_target.fracture()
 			else
-				injury_target = M.get_organ(HAND_LEFT)
-				injury_target.fracture()
+			injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND,BODY_ZONE_PRECISE_L_HAND,BODY_ZONE_R_LEG,BODY_ZONE_R_LEG))
 
 	// Return them a bit confused.
 	M.visible_message("<span class='notice'>[M] vanishes...</span>")

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -525,10 +525,14 @@
 		new souvenir(closet)
 	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
 		var/obj/item/organ/external/injury_target
+		var/nolimb = FALSE
 		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
 		if(prob(20)) //remove a limb
 			if(prob(50))
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
+				if(!injury_target)
+					nolimb = TRUE
+					return
 				injury_target.droplimb()
 		else //fracture
 			if(ismachineperson(M))
@@ -539,9 +543,15 @@
 			if(isslimeperson(M))
 				to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back! You feel like your inner membrane has been punctured!</span>")
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
+				if(!injury_target)
+					nolimb = TRUE
+					return
 				injury_target.cause_internal_bleeding()
 
 				injury_target = M.get_organ(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST))
+				if(!injury_target)
+					nolimb = TRUE
+					return
 				injury_target.cause_internal_bleeding()
 
 			else if(prob(10))
@@ -549,6 +559,9 @@
 				injury_target.fracture()
 			else
 				injury_target = M.get_organ(pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_LEG, BODY_ZONE_R_LEG))
+				if(!injury_target)
+					nolimb = TRUE
+					return
 				injury_target.fracture()
 
 	// Return them a bit confused.

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -3,7 +3,7 @@
 #define EXTRACTION_PHASE_PREPARE 5 SECONDS
 #define EXTRACTION_PHASE_PORTAL 5 SECONDS
 #define COMPLETION_NOTIFY_DELAY 5 SECONDS
-#define RETURN_BRUISE_CHANCE 50
+#define RETURN_INJURY_CHANCE 80
 #define RETURN_BRUISE_DAMAGE 20
 #define RETURN_SOUVENIR_CHANCE 10
 
@@ -518,14 +518,30 @@
 
 	QDEL_LIST(temp_objs)
 
-	// Chance for souvenir or bruises
+	// Injuries due to questioning and souvenirs
 	if(prob(RETURN_SOUVENIR_CHANCE))
 		to_chat(M, "<span class='notice'>Your captors left you a souvenir for your troubles!</span>")
 		var/obj/item/souvenir = pick(souvenirs)
 		new souvenir(closet)
-	else if(prob(RETURN_BRUISE_CHANCE) && M.health >= 50)
-		to_chat(M, "<span class='warning'>You were roughed up a little by your captors before being sent back!</span>")
-		M.adjustBruteLoss(RETURN_BRUISE_DAMAGE)
+	if(prob(RETURN_INJURY_CHANCE) && M.health >= 50)
+		var/item/organ/external/injurytarget = NULL
+		to_chat(M, "<span class='warning'>You were interrogated by your captors before being sent back!</span>")
+		if(prob(10)) //remove a limb
+			if(prob(50))
+				injurytarget = M.get_organ(FOOT_RIGHT)
+				injurytarget.droplimb()
+			else
+				injurytarget = M.get_organ(HAND_LEFT)
+				injurytarget.droplimb()
+
+		else if(prob(50))//steal an organ
+			if(prob(50))
+
+			else
+
+
+		else//break a bone
+
 
 	// Return them a bit confused.
 	M.visible_message("<span class='notice'>[M] vanishes...</span>")
@@ -590,6 +606,6 @@
 #undef EXTRACTION_PHASE_PREPARE
 #undef EXTRACTION_PHASE_PORTAL
 #undef COMPLETION_NOTIFY_DELAY
-#undef RETURN_BRUISE_CHANCE
+#undef RETURN_INJURY_CHANCE
 #undef RETURN_BRUISE_DAMAGE
 #undef RETURN_SOUVENIR_CHANCE


### PR DESCRIPTION
## What Does This PR Do
Increases the punishment for being Contracted. At the moment, this includes:

- Breaking Bones
- Removing Extremities
- Maybe Nothing!

Note: I am willing to change values/add more possibilities, though I'll need to figure out some of the code for it.

**TODO**
- [x] Randomize Limbs Selected
- [x] Proper Species/RoboLimb Checking
NOTE: I'm unsure on the checks here and will need to keep taking a peek at em.

## Why It's Good For The Game
At the moment too many people simply go along with Contractors and take a "quick trip to Space Brazil" due to the WORST injury being a small amount of brute. This PR aims to make getting Contracted a REALLY BAD TIME that you should no way go along with willingly. Now you may need serious medical treatment if you get sent to the funny red portal. This should also dissuade other Antagonists from freely going along with "friends" to get them free TC.

## Testing
1. Loaded in and contracted targets over and over again.
2. Edited prob values to ensure each step works and actually injures you.
3. Repeat.

## Changelog
:cl:
tweak: changes Contracted injuries to be more meaningful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
