### PR TITLE
 Fix #19098, update chassis mod install/uninstall procs.

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -572,15 +572,17 @@
 	var/chassis_name = "super-kinetic accelerator"
 
 /obj/item/borg/upgrade/modkit/chassis_mod/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
-	. = ..()
-	if(.)
-		KA.icon_state = chassis_icon
-		KA.name = chassis_name
+    . = ..()
+    if(.)
+        KA.current_skin = chassis_icon
+        KA.name = chassis_name
+        KA.update_icon()
 
 /obj/item/borg/upgrade/modkit/chassis_mod/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
-	KA.icon_state = initial(KA.icon_state)
-	KA.name = initial(KA.name)
-	..()
+    KA.current_skin = initial(KA.current_skin)
+    KA.name = initial(KA.name)
+    KA.update_icon()
+    ..()
 
 /obj/item/borg/upgrade/modkit/chassis_mod/orange
 	name = "hyper chassis"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug causing the PKAs to lose their chassis mod whenever fired or dropped.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #19098, and ensures that the chassis PKA mods aren't _quite_ so much of a waste of mining points anymore.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/46016730/191160123-a5dfa7f6-da24-4bb1-8b01-3612b74a9eaa.mp4

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Installed some PKA chassis mods on a couple of PKAs, fired them, noted they remained fancy. Stuffed them in my bag and dropped them to similar results.
Uninstalled and reinstalled the mods to ensure that remained functional. Went mining to make sure they still worked otherwise, and made sure to test that the energy crossbow also worked since that was a child of the PKA.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Vi3trice
fix: Fixed a bug causing PKAs with reskin mods to lose the skin on use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
