### PR TITLE
Fix #17543 Genetics UI Block 32 Doesn't Properly Change Gender

### DIFF
--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -5,7 +5,7 @@
 
 /mob/living/carbon/human/proc/change_gender(new_gender, update_dna = 1)
 	var/obj/item/organ/external/head/H = bodyparts_by_name["head"]
-	if(gender == new_gender || (gender == PLURAL && !(dna.species.has_gender)))
+	if(gender == new_gender || (gender == PLURAL && !dna.species.has_gender))
 		return
 
 	gender = new_gender

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -5,7 +5,7 @@
 
 /mob/living/carbon/human/proc/change_gender(new_gender, update_dna = 1)
 	var/obj/item/organ/external/head/H = bodyparts_by_name["head"]
-	if(gender == new_gender || (gender == PLURAL && dna.species.has_gender))
+	if(gender == new_gender || (gender == PLURAL && !(dna.species.has_gender)))
 		return
 
 	gender = new_gender


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
When changing the gender of a species that has_gender it will no longer be stuck at PLURAL because of the triggered `return`
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/17543

## Testing
<!-- How did you test the PR, if at all? -->
- Changed, using UI block 32, the gender multiple times from male, female and plural.
- It didnt get stuck in any of them

## Changelog
:cl:
fix: Genetics UI: properly changes gender now instead of being stuck at plural
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
