### PR TITLE
Inhand small mobs now detail if they're dead/asleep when examined

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -74,6 +74,10 @@
 		H.icon_state = icon_state
 	if(desc)
 		H.desc = desc
+		if(stat == DEAD)
+			H.desc += "<span class='deadsay'> Upon closer examination, [p_they()] appear[p_s()] to be dead.</span>"
+		if(IsSleeping())
+			H.desc += "<span class='notice'> Upon closer examination, [p_they()] appear[p_s()] to be asleep.</span>"
 	H.attack_hand(grabber)
 
 	to_chat(grabber, "<span class='notice'>You scoop up \the [src].")

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -41,6 +41,10 @@
 	for(var/mob/living/M in contents)
 		M.ex_act(intensity)
 
+/obj/item/holder/examine(mob/user)
+	for(var/mob/living/M in contents)
+		. += M.examine(user)
+
 /obj/item/holder/container_resist(mob/living/L)
 	var/mob/M = src.loc                      //Get our mob holder (if any).
 
@@ -74,10 +78,6 @@
 		H.icon_state = icon_state
 	if(desc)
 		H.desc = desc
-		if(stat == DEAD)
-			H.desc += "<span class='deadsay'> Upon closer examination, [p_they()] appear[p_s()] to be dead.</span>"
-		if(IsSleeping())
-			H.desc += "<span class='notice'> Upon closer examination, [p_they()] appear[p_s()] to be asleep.</span>"
 	H.attack_hand(grabber)
 
 	to_chat(grabber, "<span class='notice'>You scoop up \the [src].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #19097 - Issue was caused by the holders.dm for small mobs not having the same additions to examine text as the simple mob itself. Now the holder calls the examine text of the mob itself to retrieve its status.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an examine inconsistency.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/44248086/191582220-b79fb737-b313-490b-b6c8-64ff31cb1317.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in, killed mouse, examined both before and after pick up.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Small mobs now state if they dead or asleep while held in-hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
