### PR TITLE
Fix runtimes with Rev malfunction ability

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -301,13 +301,13 @@
 		new /obj/effect/temp_visual/revenant(loc)
 		locked = FALSE
 		open = TRUE
-		emag_act(null)
+		emag_act(usr)
 
 /obj/rev_malfunction(cause_emp = TRUE)
 	if(prob(20))
 		if(prob(50))
 			new /obj/effect/temp_visual/revenant(loc)
-		emag_act(null)
+		emag_act(usr)
 	else if(cause_emp)
 		emp_act(1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes revenants call emag_act correctly when using the malfunction ability thus preventing runtimes.
Side effects may include some messages about cryptographic sequencers or cards when using it.

## Why It's Good For The Game
Fixes #19027
Runtimes bad

## Testing
Spawned a rev, emagged a few things through malfunction.
Got the expected messages instead of runtimes.

## Changelog
:cl: uc_guy
fix: Rev malfunction ability will now show the correct emagging messages instead of runtiming.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
