### PR TITLE
Admin tools, adds better logging for viruses

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -51,6 +51,7 @@
 		else
 			DD.vars[V] = D.vars[V]
 
+	create_log(MISC_LOG, "has contacted the virus \"[DD]\"")
 	DD.affected_mob.med_hud_set_status()
 
 

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -150,6 +150,7 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 			if(!(type in affected_mob.resistances))
 				affected_mob.resistances += type
 		remove_virus()
+		affected_mob.create_log(MISC_LOG, "has been cured from the virus \"[src]\"")
 	qdel(src)
 
 /datum/disease/proc/IsSame(datum/disease/D)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -64,6 +64,7 @@
 			var/obj/O = affected_mob.loc
 			O.force_eject_occupant(affected_mob)
 		var/mob/living/new_mob = new new_form(affected_mob.loc)
+		affected_mob.create_log(MISC_LOG, "has transformed into [new_mob], due to having the virus \"[src]\"")
 		if(istype(new_mob))
 			new_mob.a_intent = "harm"
 			if(affected_mob.mind)


### PR DESCRIPTION
## What Does This PR Do

Adds logging to the following:

- contacted disease
- cured from disease
- transformed into another mob due to disease

## Why It's Good For The Game

Helps admins with troubleshooting issues like "why did I turn into a cyborg" or finding people force-infecting other people with deadly diseases.

## Images of changes

![image](https://user-images.githubusercontent.com/33333517/191694769-e08fc6dd-4da4-436c-870c-4fb3ca2a8778.png)

![image](https://user-images.githubusercontent.com/33333517/191697144-d18fc3e9-6364-490f-9bcd-8af823f6a8c0.png)

![image](https://user-images.githubusercontent.com/33333517/191696773-36dff0ee-57ad-440b-b982-1660cc1205ba.png)

## Testing

First image:

1. Spawn skrell
2. VV -> Add reagents -> Nanomachines
3. Wait for natural virus progression, then transform
4. Check LOGS

Second image:

1. Join as assistant
2. VV -> Add reagents -> Xenomicrobes
3. Set virus stage to 4
4. Transform on stage 5
5. Check LOGS

Third image:

1. Force Disease Outbreak event
7. Join round
8. Analyze self
9. Spawn cure, consume it
10. Cure self


## Changelog
:cl:
add: Adds better admin logging for virus-related events.
/:cl:
