### PR TITLE
Fix #18913 splashing acid on masks no longer displays "Your [null] melts away!"

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -348,14 +348,14 @@
 					var/melted_something = FALSE
 					if(H.wear_mask && !(H.wear_mask.resistance_flags & ACID_PROOF))
 						to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
-						qdel(H.wear_mask)
+						QDEL_NULL(H.wear_mask)
 						H.update_inv_wear_mask()
 						melted_something = TRUE
 
 					if(H.head && !(H.head.resistance_flags & ACID_PROOF))
-						qdel(H.head)
-						H.update_inv_head()
 						to_chat(H, "<span class='danger'>Your [H.head] melts away!</span>")
+						QDEL_NULL(H.head)
+						H.update_inv_head()
 						melted_something = TRUE
 					if(melted_something)
 						return

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -353,8 +353,7 @@
 
 					if(H.head && !(H.head.resistance_flags & ACID_PROOF))
 						to_chat(H, "<span class='danger'>Your [H.head.name] melts away!</span>")
-						QDEL_NULL(H.head)
-						H.update_inv_head()
+						qdel(H.head)
 						melted_something = TRUE
 					if(melted_something)
 						return

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -347,7 +347,7 @@
 				else
 					var/melted_something = FALSE
 					if(H.wear_mask && !(H.wear_mask.resistance_flags & ACID_PROOF))
-						to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
+						to_chat(H, "<span class='danger'>Your [H.wear_mask.name] melts away!</span>")
 						QDEL_NULL(H.wear_mask)
 						H.update_inv_wear_mask()
 						melted_something = TRUE

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -348,8 +348,7 @@
 					var/melted_something = FALSE
 					if(H.wear_mask && !(H.wear_mask.resistance_flags & ACID_PROOF))
 						to_chat(H, "<span class='danger'>Your [H.wear_mask.name] melts away!</span>")
-						QDEL_NULL(H.wear_mask)
-						H.update_inv_wear_mask()
+						qdel(H.wear_mask)
 						melted_something = TRUE
 
 					if(H.head && !(H.head.resistance_flags & ACID_PROOF))

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -353,7 +353,7 @@
 						melted_something = TRUE
 
 					if(H.head && !(H.head.resistance_flags & ACID_PROOF))
-						to_chat(H, "<span class='danger'>Your [H.head] melts away!</span>")
+						to_chat(H, "<span class='danger'>Your [H.head.name] melts away!</span>")
 						QDEL_NULL(H.head)
 						H.update_inv_head()
 						melted_something = TRUE

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -347,9 +347,9 @@
 				else
 					var/melted_something = FALSE
 					if(H.wear_mask && !(H.wear_mask.resistance_flags & ACID_PROOF))
+						to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
 						qdel(H.wear_mask)
 						H.update_inv_wear_mask()
-						to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
 						melted_something = TRUE
 
 					if(H.head && !(H.head.resistance_flags & ACID_PROOF))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Changes the order in wich the head object is deleted so the H.wear_mask can find it.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/18913
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![meltingmask](https://user-images.githubusercontent.com/77684085/191857309-3f66b23e-ef46-449f-9726-4484e3d21fb0.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Used fluorosulfuric acid on a clown mask and verified the chat.
## Changelog
:cl:
fix: Splashing acid on masks now displays the correct message.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
