### PR TITLE
Improve airlock and windoor assembly examine cases

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -45,7 +45,7 @@
 		if(AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER)
 			. += "<span class='notice'>The circuit is <b>connected loosely</b> to its slot, but the maintenance panel is <i>unscrewed and open</i>.</span>"
 			if(glass)
-				. += "<span class='notice'>The assembly has its electrochromic windows <b>[polarized_glass ? "enabled" : "disabled"]<b> and can be <i>configured</i>.</span>"
+				. += "<span class='notice'>The assembly has its electrochromic windows <b>[polarized_glass ? "enabled" : "disabled"]</b> and can be <i>configured</i>.</span>"
 	if(!mineral && !glass && !noglass)
 		. += "<span class='notice'>There is a small <i>paper</i> placard on the assembly[doorname]. There are <i>empty</i> slots for glass windows and mineral covers.</span>"
 	else if(!mineral && glass && !noglass)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -44,6 +44,8 @@
 			. += "<span class='notice'>The maintenance panel is <b>wired</b>, but the circuit slot is <i>empty</i>.</span>"
 		if(AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER)
 			. += "<span class='notice'>The circuit is <b>connected loosely</b> to its slot, but the maintenance panel is <i>unscrewed and open</i>.</span>"
+			if(glass)
+				. += "<span class='notice'>The assembly has its electrochromic windows <b>[polarized_glass ? "enabled" : "disabled"]<b> and can be <i>configured</i>.</span>"
 	if(!mineral && !glass && !noglass)
 		. += "<span class='notice'>There is a small <i>paper</i> placard on the assembly[doorname]. There are <i>empty</i> slots for glass windows and mineral covers.</span>"
 	else if(!mineral && glass && !noglass)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -32,6 +32,21 @@
 
 /obj/structure/windoor_assembly/examine(mob/user)
 	. = ..()
+	switch(state)
+		if(EMPTY_ASSEMBLY)
+			if(anchored)
+				. += "<span class='notice'>The anchoring bolts are <b>wrenched</b> in place, but the maintenance panel lacks <i>wiring</i>.</span>"
+			else
+				. += "<span class='notice'>The assembly is <b>welded together</b>, but the anchoring bolts are <i>unwrenched</i>.</span>"
+			if(!secure)
+				. += "<span class='notice'>The frame has <i>empty</i> slots for <i>plasteel reinforcements</i>.</span>"
+		if(WIRED_ASSEMBLY)
+			if(electronics)
+				. += "<span class='notice'>The circuit is <b>connected</b> to its slot, but the windoor is not <i>lifted into the frame</i>.</span>"
+				. += "<span class='notice'>The assembly has its electrochromic panel <b>[polarized_glass ? "enabled" : "disabled"]</b> and can be <i>configured</i>.</span>"
+			else
+				. += "<span class='notice'>The maintenance panel is <b>wired</b>, but the circuit slot is <i>empty</i>.</span>"
+
 	. += "<span class='notice'>Alt-click to rotate it clockwise.</span>"
 
 /obj/structure/windoor_assembly/Initialize(mapload, set_dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds an examine case for airlock assemblies to hint at the electrochromic window capability.

Windoor assemblies as a whole were lacking in examines unlike their airlock counterpart, so this adds them, adjusted for the different construction steps.

## Why It's Good For The Game
Makes the construction of windoors a bit less trial and error. The notion of electrochromic windows for those assemblies is communicated better.

## Images of changes
![Assemblies](https://user-images.githubusercontent.com/80771500/191863755-6a60d044-abb5-4547-9a3b-6bebfd95b49e.png)

## Testing
Built airlocks and windoors by hand.

## Changelog
:cl:
add: Examining a windoor assembly will give a description of its current construction status.
tweak: Examining an airlock assembly will tell if the electrochromic windows can be toggled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
