### PR TITLE
Held items no longer prevent Xenomorph disarm knockdown + stamina damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -636,23 +636,20 @@ emp_act
 			add_attack_logs(M, src, "Alien attacked")
 			updatehealth("alien attack")
 
-		if(M.a_intent == INTENT_DISARM) //If not absorbed, always drop item in hand, if no item, get stun instead.
+		if(M.a_intent == INTENT_DISARM) //If not absorbed, you get disarmed, knocked down, and hit with 30 stamina damage.
 			if(absorb_stun(0))
 				visible_message("<span class='warning'>[src] is not affected by [M]'s disarm attempt!</span>")
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 				return FALSE
 			var/obj/item/I = get_active_hand()
-			if(I && unEquip(I))
-				playsound(loc, 'sound/weapons/slash.ogg', 25, TRUE, -1)
-				visible_message("<span class='danger'>[M] disarms [src]!</span>", "<span class='userdanger'>[M] disarms you!</span>", "<span class='hear'>You hear aggressive shuffling!</span>")
-				to_chat(M, "<span class='danger'>You disarm [src]!</span>")
-			else
-				var/obj/item/organ/external/affecting = get_organ(ran_zone(M.zone_selected))
-				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-				apply_effect(10 SECONDS, KNOCKDOWN, run_armor_check(affecting, MELEE))
-				adjustStaminaLoss(M.alien_disarm_damage)
-				add_attack_logs(M, src, "Alien tackled")
-				visible_message("<span class='danger'>[M] has tackled down [src]!</span>")
+			if(I)
+				unEquip(I)
+			var/obj/item/organ/external/affecting = get_organ(ran_zone(M.zone_selected))
+			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
+			apply_effect(10 SECONDS, KNOCKDOWN, run_armor_check(affecting, MELEE))
+			adjustStaminaLoss(M.alien_disarm_damage)
+			add_attack_logs(M, src, "Alien tackled")
+			visible_message("<span class='danger'>[M] has tackled down [src]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>")
 
 /mob/living/carbon/human/attack_animal(mob/living/simple_animal/M)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -636,7 +636,7 @@ emp_act
 			add_attack_logs(M, src, "Alien attacked")
 			updatehealth("alien attack")
 
-		if(M.a_intent == INTENT_DISARM) //If not absorbed, you get disarmed, knocked down, and hit with 30 stamina damage.
+		if(M.a_intent == INTENT_DISARM) //If not absorbed, you get disarmed, knocked down, and hit with stamina damage.
 			if(absorb_stun(0))
 				visible_message("<span class='warning'>[src] is not affected by [M]'s disarm attempt!</span>")
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Advances #18888

Holding an item in your active hand no longer prevents you from being knocked down or taking stamina damage from xenomorph disarm. If you don't have stun absorption (i.e. riot shield), getting disarmed by a Xenomorph will now disarm you, knock you down, and apply 30 stamina damage no matter what.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When I made #18450 a couple months ago, it was with the expectation that it would always take _four_ disarms to put a xenomorph's victim into stamcrit. Unfortunately, I was new, and didn't notice that the code I tinkered with only ran if the victim wasn't holding an item in their hands. This means that a stubborn victim can repeatedly pick up their disarmed item to prevent knockdown + stamina damage from happening, which is both unintentional and a little obnoxious. Also, an unscrupulous player could carry around a notepad and rip sheets of paper out of it to tank 50 disarm attempts, so I'm nipping this in the bud now.

Since heads were looking to have the new Xenomorph disarm buffed a little, I think a conservative first step would be to tweak it to reflect intended behavior.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server. You now get knocked down instantly even if holding an item, riot shield still works, etc.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Holding an item no longer prevents Xenomorph disarm from knocking you down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
