### PR TITLE
Fix #18731 Mixing bowl now disposes properly

### DIFF
--- a/code/game/objects/items/mixing_bowl.dm
+++ b/code/game/objects/items/mixing_bowl.dm
@@ -107,7 +107,7 @@
 			dat = {"<B>[src] is empty</B><BR>"}
 		else
 			dat = {"<b>Ingredients:</b><br>[dat]"}
-		dat += {"<HR><BR> <A href='?src=[UID()];action=dispose'>Dispose ingredients!</A><BR>"}
+		dat += {"<hr><br> <a href='?src=[UID()];action=dispose'>Dispose ingredients!</a><br>"}
 
 	var/datum/browser/popup = new(user, name, name, 400, 400)
 	popup.set_content(dat)

--- a/code/game/objects/items/mixing_bowl.dm
+++ b/code/game/objects/items/mixing_bowl.dm
@@ -107,7 +107,7 @@
 			dat = {"<B>[src] is empty</B><BR>"}
 		else
 			dat = {"<b>Ingredients:</b><br>[dat]"}
-		dat += {"<HR><BR> <A href='?src=[UID()];action=dispose'>Eject ingredients!</A><BR>"}
+		dat += {"<HR><BR> <A href='?src=[UID()];action=dispose'>Dispose ingredients!</A><BR>"}
 
 	var/datum/browser/popup = new(user, name, name, 400, 400)
 	popup.set_content(dat)
@@ -118,8 +118,9 @@
 /obj/item/mixing_bowl/Topic(href, href_list)
 	if(..())
 		return
-	if(href_list["dispose"])
-		dispose()
+	switch(href_list["action"])
+		if("dispose")
+			dispose()
 	return
 
 /obj/item/mixing_bowl/proc/dispose()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Changes action description to "Dispose ingredients!" to better reflect the destination of those ingredients.
Dispose action now triggers properly.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/18731
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![mixingbowl](https://user-images.githubusercontent.com/77684085/191964959-d8825e6a-2bdd-4cb3-8099-9bd40bfa8dba.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Added ingredients and disposed them.
## Changelog
:cl:
fix: Mixing bowl now disposes properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
