### PR TITLE
Having a facehugger on your face muffles your speech

### DIFF
--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -393,7 +393,7 @@
 	..()
 	block = GLOB.swedeblock
 
-/datum/mutation/disability/speech/swedish/on_say(mob/M, message)
+/datum/mutation/disability/speech/swedish/on_say(mob/living/M, message)
 	// svedish
 	message = replacetextEx(message,"W","V")
 	message = replacetextEx(message,"w","v")

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -406,7 +406,7 @@
 	message = replacetextEx(message,"bo","bjo")
 	message = replacetextEx(message,"O",pick("Ö","Ø","O"))
 	message = replacetextEx(message,"o",pick("ö","ø","o"))
-	if(prob(30) && !M.is_muzzled())
+	if(prob(30) && !M.is_muzzled() && !M.is_facehugged())
 		message += " Bork[pick("",", bork",", bork, bork")]!"
 	return message
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -94,6 +94,10 @@
 		if(message)
 			to_chat(src, "<span class='warning'>The muzzle prevents you from vomiting!</span>")
 		return FALSE
+	if(is_facehugged())
+		if(message)
+			to_chat(src, "<span class='warning'>You try to throw up, but the alien's proboscis obstructs your throat!</span>") //Sorry
+		return FALSE
 	if(stun)
 		Stun(8 SECONDS)
 	if(nutrition < 100 && !blood)
@@ -846,6 +850,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 /mob/living/carbon/is_muzzled()
 	return(istype(wear_mask, /obj/item/clothing/mask/muzzle))
+
+/mob/living/carbon/is_facehugged() //The distinction is made because facehuggers will (eventually) be made mobs, and should not be treated as muzzles
+	return(istype(wear_mask, /obj/item/clothing/mask/facehugger))
 
 /mob/living/carbon/resist_buckle()
 	INVOKE_ASYNC(src, .proc/resist_muzzle)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -851,8 +851,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 /mob/living/carbon/is_muzzled()
 	return(istype(wear_mask, /obj/item/clothing/mask/muzzle))
 
-/mob/living/carbon/is_facehugged() //The distinction is made because facehuggers will (eventually) be made mobs, and should not be treated as muzzles
-	return(istype(wear_mask, /obj/item/clothing/mask/facehugger))
+/mob/living/carbon/is_facehugged()
+	return istype(wear_mask, /obj/item/clothing/mask/facehugger)
 
 /mob/living/carbon/resist_buckle()
 	INVOKE_ASYNC(src, .proc/resist_muzzle)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -795,6 +795,9 @@
 /mob/living/proc/get_visible_name()
 	return name
 
+/mob/living/proc/is_facehugged()
+	return FALSE
+
 /mob/living/update_gravity(has_gravity)
 	if(!SSticker)
 		return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -174,6 +174,10 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 			muffledspeech_all(message_pieces)
 			verb = "mumbles"
 
+	if(is_facehugged())
+		muffledspeech_all(message_pieces)
+		verb = "gurgles"
+
 	if(!ignore_speech_problems)
 		var/list/hsp = handle_speech_problems(message_pieces, verb)
 		verb = hsp["verb"]
@@ -326,6 +330,10 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 			to_chat(src, "<span class='danger'>Your mouth is taped and you cannot speak!</span>")
 		else
 			to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
+		return
+
+	if(is_facehugged())
+		to_chat(src, "<span class='danger'>You can't get a word out with this horrible creature on your face!</span>")
 		return
 
 	var/message = multilingual_to_message(message_pieces)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -984,7 +984,10 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	return gender
 
 /mob/proc/is_muzzled()
-	return 0
+	return FALSE
+
+/mob/proc/is_facehugged()
+	return FALSE
 
 /mob/Stat()
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -986,9 +986,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/is_muzzled()
 	return FALSE
 
-/mob/proc/is_facehugged()
-	return FALSE
-
 /mob/Stat()
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Facehuggers muffle (not mute!) the speech of anyone they're attached to, similar to being duct taped.

![image](https://user-images.githubusercontent.com/3611705/191966218-023d0f74-9389-4274-b160-ed96c3078dca.png)
![image](https://user-images.githubusercontent.com/3611705/191966259-e2d44822-061e-4fbf-8712-1dc32a0f4643.png)

Also changes the scoping of the Swede disability's mob param to `mob/living`, since it needs to check facehugged status and ghosts can't be facehugged (or acquire disabilities).
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While #19025 removed an obnoxiously long stun from facehuggers, it also introduced an issue; people with a horrific sci-fi alien violating their face can now effortlessly make callouts. From an IC perspective, this is a bit silly, and from an OOC perspective it hurts hit-and-run facehugger strategies when your victim can call out your location mid-facehug.

By having facehuggers muffle their victims' speech, the victim can alert everyone that something is obviously wrong with them _without_ breaking immersion or immediately blowing the Xenomorph's cover. This also gives Xenomorphs a more "lore-friendly" way to shut their victims up, so they don't have to resort to stripping headsets every abduction.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Facehuggers now muffle their victim's speech
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
