### PR TITLE
Remove redundant component tracking.

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -92,6 +92,8 @@
 	//set up the typecache
 	var/our_type = type
 	for(var/I in _GetInverseTypeList(our_type))
+		if (I == /datum/component)
+			continue
 		var/test = dc[I]
 		if(test)	//already another component of this type here
 			var/list/components_of_type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

### ⚠️ **PAY ATTENTION. THIS PR TOUCHES THE COMPONENT SYSTEM. TEST MERGING IS STRONGLY SUGGESTED.** ⚠️

## What Does This PR Do

Fixes #19130.

This PR excludes `/datum/component` from the list of types when checking for duplicate datum components.

This issue manifested itself in the failure to GC of `/obj/structure/spider/spiderlings`, which was traced back to the failure to find a reference to the `/datum/component/spawning` component attached on Initialize. However, this issue has always been present; when inspecting the `datum_components` of any object, the values will look something like this:

![-15_01_28](https://user-images.githubusercontent.com/59303604/192041283-5d329ae6-4ca7-433a-b15b-01f8484a6193.png)

As you can see, Paperwork has two components, but his `datum_components` also includes a list of his components.

This is because the absence of `/datum/component` in the list was considered an absence of each subcomponent respectively. They are added to a list because of how the component system handles 'duplicates', components of the same subtype. Depending on the component's `dupe_mode`, it may attempt to merge the two, clobber one with the other, or allow the presence of both added to a list in the datum_components list, with the key being the component type, and the list values being instances of the component.

What's weird is `/datum/component/proc/_GetInverseTypeList`, which is where the registrar gets the list of subtypes to check. It is reproduced in its entirety below:

```
/datum/component/proc/_GetInverseTypeList(our_type = type)
	//we can do this one simple trick
	var/current_type = parent_type
	. = list(our_type, current_type)
	//and since most components are root level + 1, this won't even have to run
	while (current_type != /datum/component)
		current_type = type2parent(current_type)
		. += current_type
```

I don't really understand the comment; it seems to understand that it would in fact be included `/datum/component` in the results (1: "most components are root level + 1", 2: it adds the parent_type to the list first thing). So it sounds as if the behavior is intended. But I'm confident that the existing behavior is broken. Even more confusing, I can't find any components that _are_ second level children of `/datum/component`, so I don't know why it's looking at all. But if it is indeed the case that a `/datum/component/foo/bar/baz` exists, we can't just remove the assignation of the parent type to the list here. We have to check after the fact.

I also don't know why `/datum/component`'s `dupe_mode` of `COMPONENT_DUPE_HIGHLANDER` (i think it just lets the latest version win) doesn't cause any issues here, instead obediently adding each subcomponent in turn to what it believes is a list of duplicate components.

This also removes an unnecessary list allocation to any object with a component. This may provide a negligible performance boost.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
GC failures are bad

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Spawned 100 spiderlings, waited for them to grow up, inspected del log.

Before:
![-11_01_39](https://user-images.githubusercontent.com/59303604/192041749-17014ec6-4a6c-4035-ae00-2df2f4db423c.png)

After:
<!-- How did you test the PR, if at all? -->
![-15_19_53](https://user-images.githubusercontent.com/59303604/192041801-9117bc5a-4c68-4fe3-8ab3-8df81ca39fdc.png)

![-15_22_43](https://user-images.githubusercontent.com/59303604/192042291-51ddbbde-52df-41e2-9377-b0817dcbfd53.png)


## Changelog
:cl:
fix: Fixed an issue which prevented spiderlings from GC'ing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
