### PR TITLE
Fix empty map vote runtime

### DIFF
--- a/code/modules/vote/vote_presets.dm
+++ b/code/modules/vote/vote_presets.dm
@@ -34,6 +34,8 @@
 
 /datum/vote/map/handle_result(result)
 	// Find target map.
+	if(!result)
+		return
 	var/datum/map/top_voted_map
 	for(var/x in subtypesof(/datum/map))
 		var/datum/map/M = x


### PR DESCRIPTION
Check the return value for any null values before doing anything with it to avoid a runtime.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an extra check to the map vote, making sure there was like...*actually* a map selected before proceeding, to fix #18699
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bumping the map vote option and ignoring it on an empty test server should no longer produce a runtime.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I loaded up a test server, ran, then ignored a few votes to make sure there were no runtimes.
<!-- How did you test the PR, if at all? -->