### PR TITLE
Elite buffs / Highlander mode for arena

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -117,6 +117,7 @@
 	locate(min(CENTER.x+(RADIUS),world.maxx), min(CENTER.y+(RADIUS),world.maxy), CENTER.z) \
   )
 
+///This define will take the radius, and center source, and produce a list of turfs in the shape of a square. If used near the edge of the map, will still work fine.
 #define RANGE_EDGE_TURFS(RADIUS, CENTER)\
 	(CENTER.y + RADIUS < world.maxy ? block(locate(max(CENTER.x - RADIUS, 1), min(CENTER.y + RADIUS, world.maxy), CENTER.z), locate(min(CENTER.x + RADIUS, world.maxx), min(CENTER.y + RADIUS, world.maxy), CENTER.z)) : list()) +\
 	(CENTER.y - RADIUS > 1 ? block(locate(max(CENTER.x - RADIUS, 1), max(CENTER.y - RADIUS, 1), CENTER.z), locate(min(CENTER.x + RADIUS, world.maxx), max(CENTER.y - RADIUS, 1), CENTER.z)) : list()) +\

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -117,6 +117,13 @@
 	locate(min(CENTER.x+(RADIUS),world.maxx), min(CENTER.y+(RADIUS),world.maxy), CENTER.z) \
   )
 
+#define RANGE_EDGE_TURFS(RADIUS, CENTER)\
+	(CENTER.y + RADIUS < world.maxy ? block(locate(max(CENTER.x - RADIUS, 1), min(CENTER.y + RADIUS, world.maxy), CENTER.z), locate(min(CENTER.x + RADIUS, world.maxx), min(CENTER.y + RADIUS, world.maxy), CENTER.z)) : list()) +\
+	(CENTER.y - RADIUS > 1 ? block(locate(max(CENTER.x - RADIUS, 1), max(CENTER.y - RADIUS, 1), CENTER.z), locate(min(CENTER.x + RADIUS, world.maxx), max(CENTER.y - RADIUS, 1), CENTER.z)) : list()) +\
+	(CENTER.x - RADIUS > 1 ? block(locate(max(CENTER.x - RADIUS, 1), min(CENTER.y + RADIUS - 1, world.maxy), CENTER.z), locate(max(CENTER.x - RADIUS, 1), max(CENTER.y - RADIUS + 1, 1), CENTER.z)) : list()) +\
+	(CENTER.x + RADIUS < world.maxx ? block(locate(min(CENTER.x + RADIUS, world.maxx), min(CENTER.y + RADIUS - 1, world.maxy), CENTER.z), locate(min(CENTER.x + RADIUS, world.maxx), max(CENTER.y - RADIUS + 1, 1), CENTER.z)) : list())
+
+
 #define FOR_DVIEW(type, range, center, invis_flags) \
 	GLOB.dview_mob.loc = center; \
 	GLOB.dview_mob.see_invisible = invis_flags; \

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -14,7 +14,7 @@
 /obj/item/antag_spawner/nuke_ops
 	name = "syndicate operative teleporter"
 	desc = "A single-use teleporter designed to quickly reinforce operatives in the field."
-	icon = 'icons/obj/device.dmi'
+	icon = 'icons/obj/implants.dmi'
 	icon_state = "locator"
 	var/borg_to_spawn
 	var/checking = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -297,10 +297,9 @@ Difficulty: Hard
 	arena_cooldown = world.time + initial(arena_cooldown)
 	for(var/d in GLOB.cardinal)
 		INVOKE_ASYNC(src, .proc/arena_squares, T, d)
-	for(var/t in RANGE_TURFS(11, T))
-		if(t && get_dist(t, T) == 11)
-			new /obj/effect/temp_visual/hierophant/wall(t, src)
-			new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
+	for(var/t in RANGE_EDGE_TURFS(11, T))
+		new /obj/effect/temp_visual/hierophant/wall(t, src)
+		new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
 	if(get_dist(src, T) >= 11) //hey you're out of range I need to get closer to you!
 		INVOKE_ASYNC(src, .proc/blink, T)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -259,7 +259,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(gps)
 	invaders.Cut()
-	invaders = null
 	if(activator)
 		clear_activator(activator)
 	if(mychild)
@@ -352,7 +351,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		if(M == activator)
 			continue
 		if(M in invaders)
-			to_chat(M, "<span class='colossus'><b>You dare to try to break the sanctity of our arena? SUFFER...</span></b>")
+			to_chat(M, "<span class='colossus'><b>You dare to try to break the sanctity of our arena? SUFFER...</b></span>")
 			var/i = 0
 			while(i <= 3)
 				M.apply_status_effect(STATUS_EFFECT_VOID_PRICE) /// Hey kids, want 60 brute damage, increased by 40 each time you do it? Well, here you go!

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -1,6 +1,7 @@
 #define TUMOR_INACTIVE 0
 #define TUMOR_ACTIVE 1
 #define TUMOR_PASSIVE 2
+#define ARENA_RADIUS 12
 
 //Elite mining mobs
 /mob/living/simple_animal/hostile/asteroid/elite
@@ -237,7 +238,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	icon_state = "tumor_popped"
 	RegisterSignal(mychild, COMSIG_PARENT_QDELETING, .proc/onEliteLoss)
 	INVOKE_ASYNC(src, .proc/arena_checks)
-	AddComponent(/datum/component/proximity_monitor, 12) //Boots out humanoid invaders. Minebots / random fauna / that colossus you forgot to clear away allowed.
+	AddComponent(/datum/component/proximity_monitor, ARENA_RADIUS) //Boots out humanoid invaders. Minebots / random fauna / that colossus you forgot to clear away allowed.
 
 /obj/structure/elite_tumor/proc/return_elite()
 	mychild.forceMove(loc)
@@ -250,7 +251,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.grab_ghost()
 		notify_ghosts("\A [mychild] has been challenged in \the [get_area(src)]!", enter_link="<a href=?src=[UID()];follow=1>(Click to help)</a>", source = mychild, action = NOTIFY_FOLLOW)
 	INVOKE_ASYNC(src, .proc/arena_checks)
-	AddComponent(/datum/component/proximity_monitor, 12)
+	AddComponent(/datum/component/proximity_monitor, ARENA_RADIUS)
 
 /obj/structure/elite_tumor/Initialize(mapload)
 	. = ..()
@@ -328,18 +329,18 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	var/turf/tumor_turf = get_turf(src)
 	if(loc == null)
 		return
-	for(var/tumor_range_turfs in RANGE_EDGE_TURFS(12, tumor_turf))
+	for(var/tumor_range_turfs in RANGE_EDGE_TURFS(ARENA_RADIUS, tumor_turf))
 		var/obj/effect/temp_visual/elite_tumor_wall/newwall
 		newwall = new /obj/effect/temp_visual/elite_tumor_wall(tumor_range_turfs, src)
 		newwall.activator = activator
 		newwall.ourelite = mychild
 
 /obj/structure/elite_tumor/proc/border_check()
-	if(activator != null && get_dist(src, activator) >= 12)
+	if(activator != null && get_dist(src, activator) >= ARENA_RADIUS)
 		activator.forceMove(loc)
 		visible_message("<span class='warning'>[activator] suddenly reappears above [src]!</span>")
 		playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
-	if(mychild != null && get_dist(src, mychild) >= 12)
+	if(mychild != null && get_dist(src, mychild) >= ARENA_RADIUS)
 		mychild.forceMove(loc)
 		visible_message("<span class='warning'>[mychild] suddenly reappears above [src]!</span>")
 		playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
@@ -361,7 +362,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 			to_chat(M, "<span class='userdanger'>Only spectators are allowed, while the arena is in combat...</span>")
 			invaders += M
 		var/list/valid_turfs = list()
-		for(var/turf/T in RANGE_EDGE_TURFS(13, src))
+		for(var/turf/T in RANGE_EDGE_TURFS(ARENA_RADIUS + 1, src))
 			valid_turfs += T
 		M.forceMove(pick(valid_turfs)) //Doesn't check for lava. Don't cheese it.
 		playsound(M, 'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
@@ -487,3 +488,5 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	gpstag = "Cancerous Signal"
 	desc = "Ghosts in a fauna? That's cancerous!"
 	invisibility = 100
+
+#undef ARENA_RADIUS

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -430,7 +430,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		E.revive()
 		user.visible_message("<span class='notice'>[user] stabs [E] with [src], reviving it.</span>")
 		SEND_SOUND(E, 'sound/magic/cult_spell.ogg')
-		to_chat(E, "<span class='userdanger'>You have been revived by [user], amd you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk.</span>")
+		to_chat(E, "<span class='userdanger'>You have been revived by [user], and you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk.</span>")
 		to_chat(E, "<span class='big bold'>Note that you now share the loyalties of [user].  You are expected not to intentionally sabotage their faction unless commanded to!</span>")
 		if(user.mind.special_role)
 			E.maxHealth = 300

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -348,22 +348,21 @@ While using this makes the system rely on OnFire, it still gives options for tim
 /obj/structure/elite_tumor/HasProximity(atom/movable/AM)
 	if(!isliving(AM))
 		return
+	var/mob/living/M = AM
+	if(!ishuman(M) && !isrobot(M))
+		return
+	if(M == activator)
+		return
+	if(M in invaders)
+		to_chat(M, "<span class='colossus'><b>You dare to try to break the sanctity of our arena? SUFFER...</b></span>")
+		for(var/i in 1 to 4)
+			M.apply_status_effect(STATUS_EFFECT_VOID_PRICE) /// Hey kids, want 60 brute damage, increased by 40 each time you do it? Well, here you go!
 	else
-		var/mob/living/M = AM
-		if(!ishuman(M) && !isrobot(M))
-			return
-		if(M == activator)
-			return
-		if(M in invaders)
-			to_chat(M, "<span class='colossus'><b>You dare to try to break the sanctity of our arena? SUFFER...</b></span>")
-			for(var/i in 1 to 4)
-				M.apply_status_effect(STATUS_EFFECT_VOID_PRICE) /// Hey kids, want 60 brute damage, increased by 40 each time you do it? Well, here you go!
-		else
-			to_chat(M, "<span class='userdanger'>Only spectators are allowed, while the arena is in combat...</span>")
-			invaders += M
-		var/list/valid_turfs = RANGE_EDGE_TURFS(13, src)
-		M.forceMove(pick(valid_turfs)) //Doesn't check for lava. Don't cheese it.
-		playsound(M, 'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
+		to_chat(M, "<span class='userdanger'>Only spectators are allowed, while the arena is in combat...</span>")
+		invaders += M
+	var/list/valid_turfs = RANGE_EDGE_TURFS(13, src)
+	M.forceMove(pick(valid_turfs)) //Doesn't check for lava. Don't cheese it.
+	playsound(M, 'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 
 
 /obj/structure/elite_tumor/proc/onEliteLoss()

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -346,11 +346,9 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 
 /obj/structure/elite_tumor/HasProximity(atom/movable/AM)
-	if(!isliving(AM))
+	if(!ishuman(AM) && !isrobot(AM))
 		return
 	var/mob/living/M = AM
-	if(!ishuman(M) && !isrobot(M))
-		return
 	if(M == activator)
 		return
 	if(M in invaders)
@@ -360,7 +358,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	else
 		to_chat(M, "<span class='userdanger'>Only spectators are allowed, while the arena is in combat...</span>")
 		invaders += M
-	var/list/valid_turfs = RANGE_EDGE_TURFS(13, src)
+	var/list/valid_turfs = RANGE_EDGE_TURFS(ARENA_RADIUS + 1, src)
 	M.forceMove(pick(valid_turfs)) //Doesn't check for lava. Don't cheese it.
 	playsound(M, 'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 
@@ -486,4 +484,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	desc = "Ghosts in a fauna? That's cancerous!"
 	invisibility = 100
 
+#undef TUMOR_INACTIVE
+#undef TUMOR_ACTIVE
+#undef TUMOR_PASSIVE
 #undef ARENA_RADIUS

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/goliath_broodmother.dm
@@ -159,7 +159,7 @@
 		var/turf/T = get_step(src, spawndir)
 		if(T)
 			child.forceMove(T)
-			child.revive() // at most this is a 29 hp heal.
+			child.revive() // at most this is a 49 hp heal.
 			playsound(src, 'sound/effects/bamf.ogg', 100, 1)
 
 //The goliath's children.  Pretty weak, simple mobs which are able to put a single tentacle under their target when at range.
@@ -222,7 +222,7 @@
 			continue
 		visible_message("<span class='danger'>[src] grabs hold of [L]!</span>")
 		L.Stun(1 SECONDS)
-		L.KnockDown(3 SECONDS)
+		L.KnockDown(2.5 SECONDS)
 		L.adjustBruteLoss(rand(20,25))
 		latched = TRUE
 	if(!latched)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/goliath_broodmother.dm
@@ -143,7 +143,7 @@
 	color = "#FF0000"
 	speed = 0
 	move_to_delay = 3
-	addtimer(CALLBACK(src, .proc/reset_rage), 65)
+	addtimer(CALLBACK(src, .proc/reset_rage), 5 SECONDS)
 
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/reset_rage()
 	color = "#FFFFFF"
@@ -172,10 +172,11 @@
 	icon_aggro = "goliath_baby"
 	icon_dead = "goliath_baby_dead"
 	icon_gib = "syndicate_gib"
-	maxHealth = 30
-	health = 30
-	melee_damage_lower = 5
-	melee_damage_upper = 5
+	maxHealth = 50
+	health = 50
+	melee_damage_lower = 12.5
+	melee_damage_upper = 12.5
+	armour_penetration_percentage = 50
 	attacktext = "bashes against"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	throw_message = "does nothing to the rocky hide of the"
@@ -221,6 +222,7 @@
 			continue
 		visible_message("<span class='danger'>[src] grabs hold of [L]!</span>")
 		L.Stun(1 SECONDS)
+		L.KnockDown(3 SECONDS)
 		L.adjustBruteLoss(rand(20,25))
 		latched = TRUE
 	if(!latched)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/herald.dm
@@ -28,6 +28,7 @@
 	health = 1000
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	armour_penetration_percentage = 50
 	light_power = 5
 	light_range = 2
 	light_color = "#FF0000"
@@ -151,7 +152,7 @@
 	var/target_turf = get_turf(target)
 	var/angle_to_target = get_angle(src, target_turf)
 	say("Pray")
-	SLEEP_CHECK_DEATH(0.75 SECONDS)// no point blank instant shotgun.
+	SLEEP_CHECK_DEATH(0.5 SECONDS)// no point blank instant shotgun.
 	shoot_projectile(target_turf, angle_to_target, FALSE, TRUE)
 	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 0.2 SECONDS)
 	if(health < maxHealth * 0.5 && !is_mirror)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
@@ -156,9 +156,8 @@
 		return
 	forceMove(T)
 	playsound(src,'sound/effects/bang.ogg', 200, 1)
-	var/list/hit_things = list()
 	var/throwtarget = get_edge_target_turf(src, move_dir)
-	for(var/mob/living/L in T.contents - hit_things - src)
+	for(var/mob/living/L in T.contents - src)
 		if(faction_check_mob(L))
 			charging = FALSE
 			return
@@ -171,7 +170,6 @@
 		else
 			hit_targets += L
 			L.adjustBruteLoss(25)
-		hit_things += L
 
 	addtimer(CALLBACK(src, .proc/legionnaire_charge_to, move_dir, (times_ran + 1), hit_targets), 0.7)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
@@ -28,6 +28,7 @@
 	health = 1000
 	melee_damage_lower = 35
 	melee_damage_upper = 35
+	armour_penetration_percentage = 50
 	attacktext = "slashes its arms at"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	throw_message = "doesn't affect the sturdiness of"
@@ -66,7 +67,7 @@
 /datum/action/innate/elite_attack/bonfire_teleport
 	name = "Bonfire Teleport"
 	button_icon_state = "bonfire_teleport"
-	chosen_message = "<span class='boldwarning'>You will leave a bonfire.  Second use will let you swap positions with it indefintiely.  Using this move on the same tile as your active bonfire removes it.</span>"
+	chosen_message = "<span class='boldwarning'>You will leave a bonfire. Second use will let you swap positions with it indefintiely. Using this move on the same tile as your active bonfire removes it.</span>"
 	chosen_attack_num = BONFIRE_TELEPORT
 
 /datum/action/innate/elite_attack/spew_smoke
@@ -129,7 +130,7 @@
 	visible_message("<span class='danger'>[src] prepares to charge!</span>")
 	addtimer(CALLBACK(src, .proc/legionnaire_charge_to, dir_to_target, 0), 4)
 
-/mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/legionnaire_charge_to(move_dir, times_ran)
+/mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/legionnaire_charge_to(move_dir, times_ran, list/hit_targets = list())
 	if(times_ran >= 6)
 		charging = FALSE
 		return
@@ -147,6 +148,12 @@
 		if(D.density)
 			charging = FALSE
 			return
+	if(T.x > world.maxx-2 || T.x < 2) //Keep them from runtiming
+		charging = FALSE
+		return
+	if(T.y > world.maxy-2 || T.y < 2)
+		charging = FALSE
+		return
 	forceMove(T)
 	playsound(src,'sound/effects/bang.ogg', 200, 1)
 	var/list/hit_things = list()
@@ -155,13 +162,18 @@
 		if(faction_check_mob(L))
 			charging = FALSE
 			return
-		hit_things += L
 		visible_message("<span class='danger'>[src] tramples and kicks [L]!</span>")
 		to_chat(L, "<span class='userdanger'>[src] tramples you and kicks you away!</span>")
 		L.throw_at(throwtarget, 10, 1, src)
-		L.KnockDown(1 SECONDS)
-		L.adjustBruteLoss(25)
-	addtimer(CALLBACK(src, .proc/legionnaire_charge_to, move_dir, (times_ran + 1)), 0.7)
+		L.Weaken(1 SECONDS) //Pain Train has no breaks.
+		if(L in hit_targets)
+			L.adjustBruteLoss(15)
+		else
+			hit_targets += L
+			L.adjustBruteLoss(25)
+		hit_things += L
+
+	addtimer(CALLBACK(src, .proc/legionnaire_charge_to, move_dir, (times_ran + 1), hit_targets), 0.7)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/head_detach(target)
 	ranged_cooldown = world.time + 1 SECONDS * revive_multiplier()
@@ -222,7 +234,7 @@
 		mypile.forceMove(legionturf)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/spew_smoke()
-	ranged_cooldown = world.time + 3 SECONDS * revive_multiplier()
+	ranged_cooldown = world.time + 2.5 SECONDS * revive_multiplier()
 	var/smoke_location = null
 	if(isnull(myhead))
 		smoke_location = src

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
@@ -148,10 +148,10 @@
 		if(D.density)
 			charging = FALSE
 			return
-	if(T.x > world.maxx-2 || T.x < 2) //Keep them from runtiming
+	if(T.x > world.maxx - 2 || T.x < 2) //Keep them from runtiming
 		charging = FALSE
 		return
-	if(T.y > world.maxy-2 || T.y < 2)
+	if(T.y > world.maxy - 2 || T.y < 2)
 		charging = FALSE
 		return
 	forceMove(T)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
@@ -30,6 +30,7 @@
 	health = 1000
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	armour_penetration_percentage = 50
 	attacktext = "smashes into the side of"
 	attack_sound = 'sound/weapons/sonic_jackhammer.ogg'
 	throw_message = "merely dinks off of the"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Elite tumors now kick out humans / cyborgs in the arena not summoner.
First kick out is warning, second damages them over time, worse each time they try it. (Think blue cube red cube teleportation, or hiero teleportation, or bluespace crystals.)


Elite changes

All elites have 50% armor pen in melee. Similar to megafauna, the only real fauna impacted by this is legionnaire, the only other one you melee with, bar broodmother. 

Legionare: Smoke cooldown from 3 -> 2.5 seconds.

Charge now weakens vs knockdown, multiple hits does less damage.

Broodmother:
Tenticals knockdown for 2.5 seconds in addition to stun.

Children now deal 12.5 brute instead of 5, and have 50 hp vs 40. 

Herald:
Shotgun activates after 0.5 seconds instead of 0.75

Bug fixes (Should be own pr got to it in this one sorry)
Legionnaire no longer runtimes charging into world border.
Broodmother dash no longer gets funky due to duration being different than cooldown.

adds RANGE_EDGE_TURFS, a more efficient way to get a radius of turfs

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Teamwork is great. I think lavaland should have more teamwork. However, a 3v1 vs an elite is fun for no one, as the elite gets steamrolled.

This pr should make elites stand a better chance vs late game miners.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed legion charge adaptive damage worked.
Confirmed arena barrier worked as expected.
Confirmed it teleported out unwanted guests.
Confirmed it kicked peoples shit in who tried it multiple times.

## Changelog
:cl:
tweak: Elite tumors kick out humans / cyborgs that are not the activator.
tweak: Various elite buffs. Elites have 50% armor pen on melee, legionnaire charge stuns but deals less damage on multi hit, broodmother tentacles and children are stronger
fix: Broodmother no longer bugs out with dash
fix: Legionnaire no longer runtimes at world edge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
