### PR TITLE
Fixes the immovable rod not despawning

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -89,7 +89,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 			clong.ex_act(EXPLODE_HEAVY)
 
 /obj/effect/immovablerod/event
-	var/tiles_moved = 0
 	// The base chance to "damage" the floor when passing. This is not guaranteed to cause a full on hull breach.
 	// Chance to expose the tile to space is like 60% of this value.
 	var/floor_rip_chance = 40
@@ -97,10 +96,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/event/Move()
 	var/atom/oldloc = loc
 	. = ..()
-	tiles_moved++
 	if(prob(floor_rip_chance))
 		var/turf/simulated/floor/T = get_turf(oldloc)
 		if(istype(T))
 			T.ex_act(EXPLODE_HEAVY)
-	if(get_dist(oldloc, loc) > 2 && tiles_moved > 10) // We went on a journey, commit sudoku
+	if(loc == destination)
 		qdel(src)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -34,14 +34,23 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 /obj/effect/immovablerod/New(atom/start, atom/end, delay)
 	. = ..()
+	// Spawn and go from this place
 	loc = start
 	z_original = z
+	// To this place where we delete ourselves
 	destination = end
-	move_delay = delay
+	new /obj/effect/end_tile(destination)
+
+	// Notify ghosts about something interesting happening
 	if(notify)
 		notify_ghosts("\A [src] is inbound!",
 				enter_link="<a href=?src=[UID()];follow=1>(Click to follow)</a>",
 				source = src, action = NOTIFY_FOLLOW)
+
+	// Setting speed here
+	move_delay = delay
+
+	// Start moving
 	GLOB.poi_list |= src
 	if(end?.z == z_original)
 		walk_towards(src, destination, move_delay)
@@ -100,5 +109,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		var/turf/simulated/floor/T = get_turf(oldloc)
 		if(istype(T))
 			T.ex_act(EXPLODE_HEAVY)
-	if(loc == destination)
+
+// If the rod reaches this, we need to delete it
+/obj/effect/end_tile/Crossed(atom/movable/AM)
+	if(istype(AM, /obj/effect/immovablerod/event))
+		qdel(AM)
 		qdel(src)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -34,23 +34,14 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 /obj/effect/immovablerod/New(atom/start, atom/end, delay)
 	. = ..()
-	// Spawn and go from this place
 	loc = start
 	z_original = z
-	// To this place where we delete ourselves
 	destination = end
-	new /obj/effect/end_tile(destination)
-
-	// Notify ghosts about something interesting happening
+	move_delay = delay
 	if(notify)
 		notify_ghosts("\A [src] is inbound!",
 				enter_link="<a href=?src=[UID()];follow=1>(Click to follow)</a>",
 				source = src, action = NOTIFY_FOLLOW)
-
-	// Setting speed here
-	move_delay = delay
-
-	// Start moving
 	GLOB.poi_list |= src
 	if(end?.z == z_original)
 		walk_towards(src, destination, move_delay)
@@ -109,9 +100,5 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		var/turf/simulated/floor/T = get_turf(oldloc)
 		if(istype(T))
 			T.ex_act(EXPLODE_HEAVY)
-
-// If the rod reaches this, we need to delete it
-/obj/effect/end_tile/Crossed(atom/movable/AM)
-	if(istype(AM, /obj/effect/immovablerod/event))
-		qdel(AM)
+	if(loc == destination)
 		qdel(src)


### PR DESCRIPTION
## What Does This PR Do

Fixes the immovable rod not deleting when it reaches the end tile.

Fixes #19153 

## Why It's Good For The Game

It was designed to despawn after reaching its end tile, it does not do it.

## Images of changes

https://user-images.githubusercontent.com/33333517/192138977-a2ca6718-7210-457c-a8c6-3151a9888a2f.mp4

## Testing

1. Event manager, set medium event to immovable rod
2. Decrease timer to 0
3. Watch immovable rod from start to end

## Changelog
:cl:
fix: Fixed the immovable rod not despawning after it reached its end tile.
/:cl:
