### PR TITLE
Catches all missed implants from #18937 change to bio-chip

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_storage.dm
+++ b/code/game/objects/items/weapons/implants/implant_storage.dm
@@ -64,6 +64,6 @@
 	implant_type = /obj/item/implant/storage
 
 /obj/item/implantcase/storage
-	name = "implant case - 'Storage'"
-	desc = "A glass case containing a storage implant."
+	name = "bio-chip case - 'Storage'"
+	desc = "A glass case containing a storage bio-chip."
 	implant_type = /obj/item/implant/storage

--- a/code/game/objects/items/weapons/implants/implant_traitor.dm
+++ b/code/game/objects/items/weapons/implants/implant_traitor.dm
@@ -48,10 +48,10 @@
 	M.remove_antag_datum(/datum/antagonist/mindslave)
 
 /obj/item/implanter/traitor
-	name = "implanter (Mindslave)"
+	name = "bio-chip implanter (Mindslave)"
 	implant_type = /obj/item/implant/traitor
 
 /obj/item/implantcase/traitor
-	name = "implant case - 'Mindslave'"
-	desc = "A glass case containing a mindslave implant."
+	name = "bio-chip case - 'Mindslave'"
+	desc = "A glass case containing a mindslave bio-chip."
 	implant_type = /obj/item/implant/traitor

--- a/code/game/objects/items/weapons/implants/implant_uplink.dm
+++ b/code/game/objects/items/weapons/implants/implant_uplink.dm
@@ -1,5 +1,5 @@
 /obj/item/implant/uplink
-	name = "uplink implant"
+	name = "uplink bio-chip"
 	desc = "Summon things."
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "radio"
@@ -45,18 +45,18 @@
 		hidden_uplink.check_trigger(imp_in)
 
 /obj/item/implanter/uplink
-	name = "implanter (uplink)"
+	name = "bio-chip implanter (uplink)"
 	implant_type = /obj/item/implant/uplink
 
 /obj/item/implantcase/uplink
-	name = "implant case - 'Syndicate Uplink'"
-	desc = "A glass case containing an uplink implant."
+	name = "bio-chip case - 'Syndicate Uplink'"
+	desc = "A glass case containing an uplink bio-chip."
 	implant_type = /obj/item/implant/uplink
 
 /obj/item/implanter/nuclear
-	name = "implanter (Nuclear Agent Uplink)"
+	name = "bio-chip implanter (Nuclear Agent Uplink)"
 	implant_type = /obj/item/implant/uplink/nuclear
 
 /obj/item/implantcase/nuclear
-	name = "implant case - 'Nuclear Agent Uplink'"
+	name = "bio-chip case - 'Nuclear Agent Uplink'"
 	implant_type = /obj/item/implant/uplink/nuclear

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -1,6 +1,6 @@
 /obj/item/implantpad
 	name = "bio-chip pad"
-	desc = "Used to modify implants."
+	desc = "Used to modify bio-chips."
 	icon = 'icons/obj/implants.dmi'
 	icon_state = "implantpad-off"
 	item_state = "electronic"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Follows up on https://github.com/ParadiseSS13/Paradise/pull/18937 by changing instances of implants to bio-chips.
I apparently missed these in merging the large volume of changes from sirryan's PR. Sorry Mr Maintainer!
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistent naming is good, unfortunately I didn't manage to catch these in the mass of merge changes.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed some bio-chips being called implants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
