### PR TITLE
Improves Metastation's solar arrays

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -62,7 +62,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxport)
 "abU" = (
 /obj/machinery/power/apc{
@@ -160,7 +161,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxstarboard)
 "acI" = (
 /obj/item/seeds/wheat/rice,
@@ -207,7 +209,8 @@
 /area/security/permabrig)
 "adj" = (
 /obj/structure/cable,
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxstarboard)
 "adu" = (
 /obj/structure/closet,
@@ -494,10 +497,14 @@
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "afq" = (
-/obj/effect/spawner/window/reinforced,
-/obj/effect/spawner/airlock/long,
-/turf/simulated/floor/plating,
-/area/maintenance/starboardsolar)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/space,
+/area/solar/auxport)
 "afw" = (
 /obj/machinery/light{
 	dir = 1
@@ -734,8 +741,24 @@
 	name = "\improper Recreation Area"
 	})
 "agH" = (
-/turf/simulated/floor/plating/airless,
-/area/solar/auxstarboard)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/space,
+/area/solar/starboard)
 "agM" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -991,7 +1014,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxport)
 "aiR" = (
 /obj/structure/cable{
@@ -999,7 +1023,8 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxport)
 "aiY" = (
 /turf/simulated/wall,
@@ -1170,16 +1195,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/space,
 /area/solar/auxport)
@@ -3428,13 +3443,9 @@
 	},
 /area/medical/medbreak)
 "atj" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
 /area/solar/port)
 "atk" = (
 /obj/structure/cable/yellow{
@@ -3828,7 +3839,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxstarboard)
 "auw" = (
 /obj/machinery/light/small{
@@ -5404,13 +5416,10 @@
 	name = "\improper Departure Lounge"
 	})
 "azB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/airless,
-/area/maintenance/starboardsolar)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
+/area/solar/starboard)
 "azC" = (
 /obj/item/radio/intercom/department/security{
 	pixel_y = 28
@@ -5778,13 +5787,8 @@
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
 "aBr" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/starboard)
 "aBs" = (
 /obj/structure/lattice/catwalk,
@@ -22086,7 +22090,8 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxport)
 "brp" = (
 /obj/machinery/light,
@@ -26314,8 +26319,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bAC" = (
-/turf/simulated/floor/plating/airless,
-/area/solar/auxport)
+/obj/structure/marker_beacon/dock_marker/collision,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "bAE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28915,13 +28922,10 @@
 	},
 /area/crew_quarters/bar)
 "bHJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area/solar/auxport)
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/airlock/e_to_w,
+/turf/simulated/floor/plating,
+/area/maintenance/portsolar)
 "bHK" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -30929,6 +30933,9 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/solar{
+	name = "Aft Starboard Solar Panel"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -34552,24 +34559,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bXI" = (
-/obj/structure/closet/crate/engineering,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/sheet/glass/fifty,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -38170,12 +38159,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medmaint)
 "chx" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area/solar/port)
+/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/airlock,
+/turf/simulated/floor/plating,
+/area/maintenance/starboardsolar)
 "chy" = (
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -39080,7 +39067,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/starboard)
 "cjZ" = (
 /obj/machinery/alarm{
@@ -39369,17 +39357,12 @@
 /turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "ckL" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/airless,
+/turf/space,
 /area/solar/port)
 "ckN" = (
 /obj/structure/rack,
@@ -40873,25 +40856,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/brig)
 "cpL" = (
-/obj/structure/closet/crate/engineering,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/cable_coil,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -42070,14 +42034,19 @@
 	},
 /area/medical/cmostore)
 "ctJ" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	name = "Aft-Port Solar Array"
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/solar/port)
+/turf/space,
+/area/solar/starboard)
 "ctK" = (
 /obj/structure/filingcabinet/chestdrawer/autopsy,
 /obj/structure/window/reinforced{
@@ -42312,6 +42281,9 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/power/solar{
+	name = "Aft Starboard Solar Panel"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -42595,14 +42567,19 @@
 	},
 /area/medical/surgery1)
 "cuX" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/area/solar/port)
+/turf/space,
+/area/solar/starboard)
 "cva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -42922,8 +42899,8 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -42931,9 +42908,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/space,
 /area/solar/port)
@@ -43399,7 +43375,8 @@
 	},
 /area/medical/cmo)
 "cxB" = (
-/turf/simulated/floor/plating/airless,
+/obj/item/wirecutters,
+/turf/space,
 /area/space)
 "cxC" = (
 /obj/structure/rack,
@@ -43578,7 +43555,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxstarboard)
 "cyd" = (
 /obj/structure/table,
@@ -44135,7 +44113,8 @@
 "czV" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/starboard)
 "czX" = (
 /obj/machinery/light/small,
@@ -45922,10 +45901,18 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
 "cFj" = (
-/obj/structure/cable,
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/space,
 /area/solar/port)
 "cFm" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
@@ -46285,8 +46272,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cGt" = (
-/obj/structure/cable,
-/turf/simulated/floor/plating/airless,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	name = "Aft Starboard Solar Panel"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
+	},
 /area/solar/starboard)
 "cGv" = (
 /obj/structure/lattice/catwalk,
@@ -47359,10 +47364,19 @@
 /turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "cJP" = (
-/obj/effect/spawner/airlock/e_to_w/long,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/portsolar)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/space,
+/area/solar/starboard)
 "cJR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -48553,7 +48567,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/starboard)
 "cNR" = (
 /obj/structure/cable/yellow{
@@ -49833,24 +49848,6 @@
 	},
 /area/medical/morgue)
 "cSx" = (
-/obj/structure/closet/crate/engineering,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/sheet/glass/fifty,
 /obj/item/radio/intercom{
 	name = "east bump";
 	pixel_x = 28
@@ -50741,18 +50738,6 @@
 /turf/space,
 /area/solar/starboard)
 "cVr" = (
-/obj/structure/closet/crate/engineering,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/cable_coil,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -51719,6 +51704,9 @@
 /area/toxins/test_area)
 "cZc" = (
 /obj/structure/cable,
+/obj/machinery/power/solar{
+	name = "Aft Starboard Solar Panel"
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -55362,7 +55350,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/port)
 "emO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -55706,6 +55695,14 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
+"euv" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/space,
+/area/solar/port)
 "euy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57189,12 +57186,8 @@
 /area/security/processing)
 "fhk" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/item/stack/rods/ten,
+/obj/structure/cable,
 /turf/space,
 /area/solar/auxport)
 "fho" = (
@@ -57761,13 +57754,16 @@
 /area/atmos)
 "fts" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	name = "Aft Starboard Solar Panel"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/solar/port)
+/area/solar/starboard)
 "ftQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58215,24 +58211,6 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "fFW" = (
-/obj/structure/closet/crate/engineering,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/sheet/glass/fifty,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
@@ -61666,7 +61644,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/auxport)
 "hrf" = (
 /obj/machinery/newscaster{
@@ -63082,11 +63061,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/space,
 /area/solar/port)
@@ -69637,7 +69611,8 @@
 	name = "\improper Storage Wing"
 	})
 "lio" = (
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/port)
 "liS" = (
 /obj/machinery/light/small,
@@ -72466,7 +72441,12 @@
 	},
 /area/engine/break_room)
 "mBn" = (
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/space,
 /area/solar/starboard)
 "mBr" = (
 /obj/item/radio/intercom{
@@ -84458,7 +84438,8 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/port)
 "sHK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -87718,22 +87699,22 @@
 "upW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/space,
-/area/solar/auxport)
+/area/solar/starboard)
 "uqN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/medical,
@@ -94942,11 +94923,12 @@
 /turf/simulated/floor/wood,
 /area/assembly/showroom)
 "yhM" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/space,
 /area/solar/auxport)
 "yhT" = (
 /obj/structure/sign/poster/random{
@@ -106429,9 +106411,9 @@ ovM
 eoP
 eoP
 eoP
-hDj
+arI
 aaa
-bAC
+agM
 aaa
 abq
 aaa
@@ -106688,7 +106670,7 @@ mzB
 mzB
 ajJ
 arI
-bAC
+agM
 aef
 aef
 aef
@@ -106943,9 +106925,9 @@ eor
 aBs
 aBs
 aBs
-vHW
+arI
 aaa
-bAC
+agM
 aaa
 abq
 aaa
@@ -107202,7 +107184,7 @@ aGj
 aGj
 agM
 abq
-yhM
+agM
 aaa
 abq
 aaa
@@ -107459,7 +107441,7 @@ aaa
 aaa
 abq
 aaa
-aiQ
+agM
 aaa
 itg
 aaa
@@ -107716,7 +107698,7 @@ aaa
 aaa
 abq
 aaa
-aiQ
+agM
 aaa
 abq
 aaa
@@ -107973,7 +107955,7 @@ aEC
 aEC
 agM
 abq
-hpJ
+agM
 abq
 agM
 aEC
@@ -108087,16 +108069,16 @@ jLY
 aaa
 abq
 aaa
-aaa
 nia
+aaa
 lio
 nia
 nia
 nia
+aaa
 nia
 nia
 nia
-abq
 abq
 abq
 abq
@@ -108228,11 +108210,11 @@ ovM
 eoP
 eoP
 eoP
-hDj
+arI
 aaa
-bAC
+agM
 aaa
-eor
+jSA
 kKz
 kKz
 kKz
@@ -108343,18 +108325,18 @@ abq
 abq
 abq
 abq
-abq
 caJ
 bSw
+atj
 ckL
-hZX
-hZX
-hZX
-hZX
-hZX
 cwf
-ctJ
-aaa
+cwf
+hZX
+ckL
+cwf
+cwf
+cFj
+abq
 arA
 bqS
 arA
@@ -108487,9 +108469,9 @@ mzB
 mzB
 ajJ
 arI
-bAC
+agM
 jSA
-upW
+ajJ
 aok
 aok
 aok
@@ -108600,17 +108582,17 @@ asT
 aaa
 aaa
 aaa
+asT
+oji
 aaa
-abq
-oji
-emm
+lio
 oji
 oji
 oji
+aaa
 oji
 oji
 oji
-abq
 abq
 abq
 abq
@@ -108744,9 +108726,9 @@ aBs
 aBs
 fhk
 aaa
-bAC
+agM
 aaa
-ovM
+jSA
 aSH
 aSH
 aSH
@@ -109001,7 +108983,7 @@ aGj
 aGj
 agM
 abq
-bAC
+agM
 pau
 agM
 aGj
@@ -109114,17 +109096,17 @@ dtE
 aaa
 aaa
 aaa
-aaa
-abq
+asT
 nia
+aaa
 lio
 nia
 nia
 nia
+aaa
 nia
 nia
 nia
-abq
 abq
 abq
 aaa
@@ -109258,7 +109240,7 @@ aaa
 aaa
 abq
 aaa
-bAC
+agM
 aaa
 pau
 aaa
@@ -109371,18 +109353,18 @@ dtE
 abq
 abq
 abq
-abq
 caJ
 bSw
+atj
 ckL
-hZX
-hZX
-hZX
-hZX
-hZX
 cwf
-ctJ
-aaa
+cwf
+hZX
+ckL
+cwf
+cwf
+cFj
+abq
 abq
 aaa
 jLY
@@ -109628,17 +109610,17 @@ dtE
 dtE
 aaa
 aaa
+asT
+oji
 aaa
-abq
-oji
-emm
+lio
 oji
 oji
 oji
+aaa
 oji
 oji
 oji
-abq
 abq
 abq
 abq
@@ -110142,17 +110124,17 @@ cFa
 bxo
 cDm
 aaa
+asT
+nia
 aaa
-abq
-fts
 lio
-fts
-fts
-fts
-fts
-fts
-fts
-abq
+nia
+nia
+nia
+aaa
+nia
+nia
+nia
 abq
 abq
 abq
@@ -110399,18 +110381,18 @@ crj
 cFv
 abq
 abq
-abq
-cuX
+caJ
 bSw
+atj
 ckL
+cwf
+cwf
 hZX
-hZX
-hZX
-hZX
-hZX
+ckL
+cwf
 cwf
 cFj
-aaa
+abq
 abq
 aaa
 jLY
@@ -110656,17 +110638,17 @@ dtE
 dtE
 aaa
 aaa
+asT
+oji
 aaa
-abq
-atj
-emm
-atj
-atj
-atj
-atj
-atj
-atj
-abq
+lio
+oji
+oji
+oji
+aaa
+oji
+oji
+oji
 abq
 abq
 aaa
@@ -110800,7 +110782,7 @@ hWO
 aaa
 vqD
 aaa
-yhM
+agM
 aaa
 abq
 aaa
@@ -111057,7 +111039,7 @@ aEC
 aEC
 agM
 aaa
-hpJ
+agM
 aaa
 ccS
 aEC
@@ -111170,17 +111152,17 @@ cYK
 ccx
 aaa
 aaa
+asT
+nia
 aaa
-abq
-fts
 lio
-fts
-fts
-fts
-fts
-fts
-fts
-abq
+nia
+nia
+nia
+aaa
+nia
+nia
+nia
 abq
 abq
 abq
@@ -111312,11 +111294,11 @@ ovM
 eoP
 eoP
 eoP
-hDj
+arI
 aaa
-bAC
+agM
 aaa
-eor
+jSA
 kKz
 kKz
 kKz
@@ -111427,20 +111409,20 @@ yib
 cSA
 abq
 abq
-abq
-cuX
+caJ
 bSw
+atj
 ckL
+cwf
+cwf
 hZX
-hZX
-hZX
-hZX
-hZX
+ckL
+cwf
 cwf
 cFj
-aaa
-cxB
-cxB
+abq
+arA
+arA
 arA
 abq
 iju
@@ -111571,9 +111553,9 @@ mzB
 mzB
 ajJ
 arI
-bAC
+agM
 jSA
-upW
+ajJ
 aok
 aok
 aok
@@ -111685,16 +111667,16 @@ dtE
 aaa
 aaa
 aaa
+oji
 aaa
-atj
-emm
-atj
-atj
-atj
-atj
-atj
-atj
-abq
+lio
+oji
+oji
+oji
+aaa
+oji
+oji
+oji
 abq
 abq
 abq
@@ -111826,11 +111808,11 @@ eor
 aBs
 aBs
 aBs
-vHW
+arI
 aaa
-bAC
+agM
 aaa
-ovM
+jSA
 aSH
 aSH
 aSH
@@ -111944,7 +111926,7 @@ aaa
 aaa
 aaa
 aaa
-chx
+lio
 aaa
 aaa
 aaa
@@ -112200,9 +112182,8 @@ aaa
 aaa
 aaa
 aaa
-cbo
-sFP
-cJP
+aaa
+euv
 aaa
 aaa
 aaa
@@ -112210,7 +112191,8 @@ aaa
 aaa
 aaa
 aaa
-abq
+aaa
+itg
 aaa
 jLY
 aaa
@@ -112342,7 +112324,7 @@ aaa
 aaa
 abq
 aaa
-aiQ
+afq
 aaa
 abq
 aaa
@@ -112458,8 +112440,8 @@ aaa
 aaa
 aaa
 cbo
-cpd
-cbo
+sFP
+bHJ
 aaa
 aaa
 aaa
@@ -112590,7 +112572,7 @@ aaa
 aaa
 jLY
 aaa
-abq
+itg
 aaa
 aaa
 aaa
@@ -112599,9 +112581,9 @@ aaa
 aaa
 abq
 aaa
-aiR
-abA
-bHJ
+ovM
+ajJ
+hDj
 aaa
 aaa
 aaa
@@ -112715,7 +112697,7 @@ aaa
 aaa
 aaa
 cbo
-sFP
+cpd
 cbo
 aaa
 aaa
@@ -112858,7 +112840,7 @@ abq
 aaa
 abq
 aaa
-aiQ
+afq
 aaa
 aaa
 aaa
@@ -113115,7 +113097,7 @@ oET
 aaa
 abq
 aaa
-aiQ
+afq
 aaa
 aaa
 aaa
@@ -131223,7 +131205,7 @@ aaa
 aaa
 aaa
 aaa
-abq
+itg
 aef
 abq
 aaa
@@ -132761,8 +132743,8 @@ fFW
 cuq
 rPy
 rPy
-rPy
-afq
+chx
+aaa
 aaa
 aaa
 aaa
@@ -133020,18 +133002,18 @@ pqP
 pqP
 cmJ
 azB
-cGt
-mBn
-mBn
-mBn
-mBn
-mBn
-cNQ
-cjX
-cGt
-mBn
-mBn
-mBn
+aBr
+aBr
+aBr
+aBr
+aBr
+aBr
+aBr
+aBr
+aBr
+aBr
+aBr
+aBr
 cNQ
 cjX
 czV
@@ -133276,7 +133258,7 @@ cFJ
 rPy
 rPy
 rPy
-rPy
+aaa
 aaa
 aaa
 aaa
@@ -133541,7 +133523,7 @@ cVp
 cZc
 aaa
 bNI
-cVp
+dcq
 cZc
 aaa
 bNI
@@ -133798,7 +133780,7 @@ cVp
 cZc
 aaa
 bNI
-cVp
+dcq
 cZc
 aaa
 bNI
@@ -134055,7 +134037,7 @@ cVp
 cZc
 aaa
 bNI
-cVp
+ctJ
 cZc
 aaa
 bNI
@@ -134308,7 +134290,7 @@ aaa
 aaa
 aaa
 aaa
-aBr
+fts
 aaa
 aaa
 aaa
@@ -134316,7 +134298,7 @@ aBr
 aaa
 aaa
 aaa
-aBr
+fts
 aaa
 aaa
 aaa
@@ -134558,7 +134540,7 @@ aaa
 aaa
 aaa
 aaa
-abq
+jLY
 aaa
 aaa
 aaa
@@ -134569,7 +134551,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aBr
 aaa
 aaa
 aaa
@@ -134820,19 +134802,19 @@ aaa
 aaa
 aaa
 aaa
+cur
+cur
+cur
 aaa
 aaa
 aaa
+aBr
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cur
+cur
+cur
 aaa
 aaa
 aaa
@@ -135075,23 +135057,23 @@ aaa
 jLY
 jLY
 jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
-jLY
+abq
+abq
+cJP
+upW
+upW
+azB
+abq
+abq
+aBr
+abq
+abq
+mBn
+agH
+agH
+cuX
+abq
+abq
 jLY
 jLY
 jLY
@@ -135331,25 +135313,25 @@ aaa
 aaa
 aaa
 aaa
+abq
+aaa
+aaa
+fts
+fts
+fts
 aaa
 aaa
 aaa
+aBr
 aaa
 aaa
 aaa
+fts
+fts
+fts
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abq
 aaa
 aaa
 aaa
@@ -135588,6 +135570,7 @@ aaa
 aaa
 aaa
 aaa
+abq
 aaa
 aaa
 aaa
@@ -135596,6 +135579,7 @@ aaa
 aaa
 aaa
 aaa
+aAW
 aaa
 aaa
 aaa
@@ -135604,9 +135588,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+abq
 aaa
 aaa
 aaa
@@ -135845,25 +135827,25 @@ aaa
 aaa
 aaa
 aaa
+bAC
+abq
+jLY
+jLY
+jLY
+jLY
+jLY
 aaa
+bNI
+cGt
+cZc
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jLY
+jLY
+jLY
+jLY
+jLY
+abq
+bAC
 aaa
 aaa
 aaa
@@ -136108,13 +136090,13 @@ aaa
 aaa
 aaa
 aaa
+abq
 aaa
 aaa
 aaa
+cxB
 aaa
-aaa
-aaa
-aaa
+abq
 aaa
 aaa
 aaa
@@ -136365,13 +136347,13 @@ aaa
 aaa
 aaa
 aaa
-aaD
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bAC
+jLY
+jLY
+jLY
+jLY
+jLY
+bAC
 aaa
 aaa
 aaa
@@ -136880,7 +136862,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaD
 aaa
 aaa
 aaa
@@ -139324,20 +139306,20 @@ cya
 acx
 acx
 adj
-agH
-agH
-agH
-agH
-agH
-agH
-agH
-auv
-acx
-adj
-agH
-agH
-agH
-agH
+aee
+aee
+aee
+aee
+aee
+aee
+aee
+aee
+aee
+aee
+aee
+aee
+aee
+aee
 auv
 arC
 mVu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Changes Metastation's solar arrays to be more user/player friendly by turning space plating into catwalks and having solars already built. Now, Metastation's solars are still different, you still need to build catwalks occassionally and wire in non-traditional ways (see aft-port solars).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Metastation is never voted for, because people have a lot of issues with it that they don't like. This is one of mine and a few others that bothers me about this map. Solars take about twice to three times as long to do on this map, because you need to construct several solars, all while walking on slow space plating.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
(Fore-starboard solars, requires 66 cables, 30 are spawned nearby, has 64 solars)
![image](https://user-images.githubusercontent.com/91113370/192152806-b956e8db-5408-4c56-a6fe-fda87e87d9eb.png)
(Aft-starboard solars, requires 71 cables, 30 are spawned nearby, has 56 solars)
![image](https://user-images.githubusercontent.com/91113370/192152875-83d90194-0b87-43ed-b196-293ef6a3b9ef.png)
(Aft-port solars, requires 80 cables, 30 are spawned nearby, has 60 solars)
![image](https://user-images.githubusercontent.com/91113370/192153015-9bdbcbfe-42cb-42fb-8ef1-7b2e2ab5e3a7.png)
(Fore-port solars, requires 90 cables, 60 are spawned nearby, has 60 solars)
![image](https://user-images.githubusercontent.com/91113370/192153041-63eebfaf-0d94-4873-8a9e-9057a08c6505.png)


## Testing
<!-- How did you test the PR, if at all? -->
Went around to all the solars, wired them, made sure they worked, counted the required wire count, and how many solars there were.

## Changelog
:cl:
tweak: Metastation's solars have been updated to be more player friendly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
