### PR TITLE
[GBP no update] Adds cooldown to pointing verb

### DIFF
--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -98,9 +98,13 @@
 	set name = "Point To"
 	set category = "Object"
 
+	if(next_move >= world.time)
+		return
+
 	if(istype(A, /obj/effect/temp_visual/point) || istype(A, /atom/movable/emissive_blocker))
 		return FALSE
 
+	changeNext_move(CLICK_CD_POINT)
 	if(A.loc in src) // Object is inside a container on the mob. It's not part of the verb's list since it's not in view and requires middle clicking.
 		point_at(A)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the click cooldown to the pointing verb that was missing from the pointing to inside things PR

## Why It's Good For The Game
Chat spam is pretty bad

## Testing
Hopped on an instance and spammed the middle-click

## Changelog
:cl:
fix: Pointing to things has a cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
