### PR TITLE
Adds a hardened version of the anti-drop implant

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -120,6 +120,12 @@
 		ui_action_click()
 	return ..()
 
+/obj/item/organ/internal/cyberimp/brain/anti_drop/hardened
+	name = "Hardened Anti-drop implant"
+	desc = "A military-grade version of the standard implant, for NT's more elite forces."
+	origin_tech = "materials=6;programming=5;biotech=5"
+	emp_proof = TRUE
+
 /obj/item/organ/internal/cyberimp/brain/anti_stam
 	name = "CNS Rebooter implant"
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when fatigued. Incompatible with the Neural Jumpstarter."


### PR DESCRIPTION
## What Does This PR Do

Adds an adminbus-only version of the anti-drop implant. Hardened implants are exactly like the regular ones, but emp-proof.

Requested by @meow20 

## Why It's Good For The Game

Admins sometimes want emp-proof implants without varediting, especially if they intend to serialize it with json. It was requested, so I coded it.

## Images of changes

![image](https://user-images.githubusercontent.com/33333517/192274680-de7e542e-8010-4dfe-8a81-629c8418dfa4.png)

## Testing

1. Spawn skrell
2. Open VV
3. Add organ
4. Guess the path of this item because the text crops off

## Changelog
:cl:
add: Added a hardened version of the anti-drop implant, only accessible via adminbus.
/:cl:
