### PR TITLE
Fixes a missing variable on a changeling objective

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -736,6 +736,8 @@
 				new_objective.owner = src
 				new_objective.target = new_target
 				new_objective.explanation_text = "Escape on the shuttle or an escape pod with the identity of [targ.current.real_name], the [targ.assigned_role] while wearing [targ.current.p_their()] identification card."
+				var/datum/objective/escape/escape_with_identity/O = new_objective
+				O.target_real_name = new_objective.target.current.real_name
 			if("custom")
 				var/expl = sanitize(copytext(input("Custom objective:", "Objective", objective ? objective.explanation_text : "") as text|null,1,MAX_MESSAGE_LEN))
 				if(!expl)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -747,6 +747,8 @@
 		if(!new_objective)
 			return
 
+		new_objective.post_admin_creation()
+
 		if(objective)
 			remove_objective(objective)
 			if(objective_pos[2])

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -747,8 +747,6 @@
 		if(!new_objective)
 			return
 
-		new_objective.post_admin_creation()
-
 		if(objective)
 			remove_objective(objective)
 			if(objective_pos[2])

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -89,12 +89,6 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		qdel(src)
 	owner?.announce_objectives()
 
-/**
-  * Called when an admin creates a objective, allowing for variables to be set post-target selection
-  */
-/datum/objective/proc/post_admin_creation()
-	return
-
 /datum/objective/assassinate
 	martyr_compatible = 1
 
@@ -357,9 +351,6 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	else
 		explanation_text = "Free Objective"
 
-/datum/objective/escape/escape_with_identity/post_admin_creation()
-	target_real_name = target.current.real_name
-
 /datum/objective/escape/escape_with_identity/check_completion()
 	if(!target_real_name)
 		return 1
@@ -368,7 +359,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	var/mob/living/carbon/human/H = owner.current
 	if(..())
 		if(H.dna.real_name == target_real_name)
-			if(H.get_id_name() == target_real_name)
+			if(H.get_id_name()== target_real_name)
 				return 1
 	return 0
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -89,6 +89,12 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		qdel(src)
 	owner?.announce_objectives()
 
+/**
+  * Called when an admin creates a objective, allowing for variables to be set post-target selection
+  */
+/datum/objective/proc/post_admin_creation()
+	return
+
 /datum/objective/assassinate
 	martyr_compatible = 1
 
@@ -351,6 +357,9 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	else
 		explanation_text = "Free Objective"
 
+/datum/objective/escape/escape_with_identity/post_admin_creation()
+	target_real_name = target.current.real_name
+
 /datum/objective/escape/escape_with_identity/check_completion()
 	if(!target_real_name)
 		return 1
@@ -359,7 +368,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	var/mob/living/carbon/human/H = owner.current
 	if(..())
 		if(H.dna.real_name == target_real_name)
-			if(H.get_id_name()== target_real_name)
+			if(H.get_id_name() == target_real_name)
 				return 1
 	return 0
 

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -162,7 +162,7 @@
 		if(prob(70))
 			add_objective(/datum/objective/escape)
 		else
-			add_objective(/datum/objective/escape/escape_with_identity)
+			add_objective(/datum/objective/escape/escape_with_identity) // If our kill target has no genes, 30% time pick someone else to steal the identity of
 
 /datum/antagonist/changeling/process()
 	if(!owner || !owner.current)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Adds a missing var to admin creating the escape with identity objective (why the FUCK arent types immutable?, why does this work properly)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #19183

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->Before:
![image](https://user-images.githubusercontent.com/91113370/192329717-6eeffc5c-ba34-4815-9306-ba4f357b4cc4.png)
After:
![image](https://user-images.githubusercontent.com/91113370/192329802-d9ee85ed-806e-4b1d-b8a6-3aff0653bbba.png)
Now failing the objective when objective is admin edited:
![image](https://user-images.githubusercontent.com/91113370/192329881-479ae26b-4e8f-445f-bddb-c9ef0784359b.png)

## Testing
<!-- How did you test the PR, if at all? -->
See above

## Changelog
No player facing changes, just broken admin stuff

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
