### PR TITLE
Fixes a runtime with atmos pipes on metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -93766,9 +93766,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/portable/scrubber,
 /obj/machinery/camera{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> Removes a single connector causing a runtime on metastation

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes this runtime, which was posted directly to #coding-chat
```
[2022-09-27T02:56:02] Runtime in stacktrace.dm,14: /obj/machinery/atmospherics/pipe/manifold/hidden/purple [[0x2007ea8]] added to a pipenet while still having one (/datum/pipeline) (pipes leading to the same spot stacking in one turf). Nearby: 156, 133, 2.
   proc name: stack trace (/datum/proc/stack_trace)
   src: /datum/pipeline (/datum/pipeline)
   call stack:
   /datum/pipeline (/datum/pipeline): stack trace("/obj/machinery/atmospherics/pi...")
   /datum/pipeline (/datum/pipeline): build pipeline(the connector port (/obj/machinery/atmospherics/unary/portables_connector))
   the connector port (/obj/machinery/atmospherics/unary/portables_connector): build network(0)
   Atmospherics (/datum/controller/subsystem/air): setup pipenets(/list (/list))
   Atmospherics (/datum/controller/subsystem/air): setup pipenets(/list (/list))
   Atmospherics (/datum/controller/subsystem/air): Initialize(105547)
   Master (/datum/controller/master): Initialize(10, 0, 1)
   ```

## Testing
<!-- How did you test the PR, if at all? -->
Boot up meta, no runtime

## Changelog
They shall not know of the duplicated connector being removed (Nothing player-facing)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
