### PR TITLE
Tweaks the syndicate research base a little

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -973,7 +973,9 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/virology)
 "jO" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3597,7 +3599,9 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
 "LK" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -879,6 +879,7 @@
 /obj/structure/table,
 /obj/item/pen,
 /obj/item/paper_bin,
+/obj/item/stamp/syndicate,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -987,9 +988,7 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "jW" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/beer/upgraded{
-	dir = 1
-	},
+/obj/machinery/chem_dispenser/beer/upgraded,
 /obj/machinery/alarm/syndicate{
 	pixel_y = 24
 	},
@@ -1967,9 +1966,7 @@
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "vv" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/soda/upgraded{
-	dir = 1
-	},
+/obj/machinery/chem_dispenser/soda/upgraded,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -3224,7 +3221,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_space_base/cargo)
 "IA" = (
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3446,7 +3443,9 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "KB" = (
-/mob/living/simple_animal/pig,
+/mob/living/simple_animal/pig{
+	faction = list("neutral", "syndicate")
+	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/bar)
 "KH" = (
@@ -3508,7 +3507,7 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
 "Le" = (
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -4166,14 +4165,18 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/cargo)
 "SW" = (
-/mob/living/simple_animal/cow,
+/mob/living/simple_animal/cow{
+	faction = list("neutral", "syndicate")
+	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/bar)
 "SX" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
-/mob/living/simple_animal/chicken,
+/mob/living/simple_animal/chicken{
+	faction = list("neutral", "syndicate")
+	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/bar)
 "Tc" = (
@@ -4707,7 +4710,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1222;
 	name = "Bomb Mix Monitor";
-	sensors = list("burn_sensor" = "Burn Mix")
+	sensors = list("burn_sensor"="Burn Mix")
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -363,7 +363,6 @@
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "dS" = (
-/obj/structure/closet/crate,
 /obj/item/extinguisher{
 	pixel_x = -5;
 	pixel_y = 5
@@ -387,6 +386,9 @@
 /obj/item/flashlight{
 	pixel_x = 1;
 	pixel_y = -1
+	},
+/obj/structure/rack{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1377,7 +1379,6 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/cargo)
 "oj" = (
-/obj/structure/closet/crate,
 /obj/item/storage/box/donkpockets{
 	pixel_x = -2;
 	pixel_y = 6
@@ -1397,6 +1398,9 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/structure/rack{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2044,7 +2048,6 @@
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "wf" = (
-/obj/structure/closet/crate,
 /obj/item/vending_refill/snack{
 	pixel_x = -3;
 	pixel_y = 3
@@ -2055,6 +2058,9 @@
 	},
 /obj/item/vending_refill/coffee,
 /obj/item/vending_refill/cola,
+/obj/structure/rack{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "brown"
@@ -3159,7 +3165,6 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/chemistry)
 "HL" = (
-/obj/structure/closet/crate,
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/stack/sheet/metal/fifty,
@@ -3167,6 +3172,9 @@
 /obj/item/circuitboard/gibber,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/structure/rack{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3444,7 +3452,7 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "KB" = (
 /mob/living/simple_animal/pig{
-	faction = list("neutral", "syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/bar)
@@ -4166,7 +4174,7 @@
 /area/ruin/unpowered/syndicate_space_base/cargo)
 "SW" = (
 /mob/living/simple_animal/cow{
-	faction = list("neutral", "syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/bar)
@@ -4175,12 +4183,11 @@
 	dir = 4
 	},
 /mob/living/simple_animal/chicken{
-	faction = list("neutral", "syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/bar)
 "Tc" = (
-/obj/structure/closet/crate,
 /obj/item/storage/box/donkpockets{
 	pixel_x = -2;
 	pixel_y = 6
@@ -4193,6 +4200,9 @@
 	},
 /obj/machinery/alarm/syndicate{
 	pixel_y = 24
+	},
+/obj/structure/rack{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -4658,6 +4668,9 @@
 /obj/item/storage/part_replacer,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/rack{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;


### PR DESCRIPTION
## What Does This PR Do

- Adds a syndicate stamp for faxes
- Fixes the soda and beer dispensers facing the wrong way
- Replaces the beer keg with a dinnerware vending machine
- Adds "syndicate" faction to the animals in the pen so syndicate killbots don't murder the entire livestock during patrol
- Replaces crates with racks

## Why It's Good For The Game

- Stamp: practicing proper paperwork
- Dispensers: simply faced the wrong direction
- Dinnerware: candy machine needs it, plus it allows for some Proper RP:tm:
- Faction: sometimes admins spawn the syndicate patrol robot `/mob/living/simple_animal/bot/ed209/syndicate` and it'd annihilate the animals, this fixes it
- Replaces crates with racks: requested by @warriorstar-orion, most of our stuff is put on racks instead of crates everywhere else in the game, rather than crates

## Images of changes

Adds a syndicate stamp for faxes

![image](https://user-images.githubusercontent.com/33333517/192562869-d921a285-557d-41de-b927-66b18599878e.png)

Fixes the soda and beer dispensers facing the wrong way

![image](https://user-images.githubusercontent.com/33333517/192562922-4455eff3-db69-4eaf-856e-7c8bdefe2352.png)

Replaces the beer keg with a dinnerware vending machine

![image](https://user-images.githubusercontent.com/33333517/192562989-0061a8c5-f21b-4d6c-ae56-18282eab9c69.png)

Adds "syndicate" faction to the animals in the pen so syndicate killbots don't murder the entire livestock during patrol

![image](https://user-images.githubusercontent.com/33333517/192562656-32c6412e-4be3-4376-9e59-b7a4d65ac868.png)

Replaces crates with racks

![image](https://user-images.githubusercontent.com/33333517/192574738-ea0ac152-07ac-47a3-8cdc-c477e377b50e.png)

## Testing

Compiled the game, took the screenshots above.

## Changelog
:cl:
add: Syndicate research base - Added a syndicate stamp to it, added a dinnerware vending machine.
tweak: Syndicate research base - The animals in the pen are now in the "syndicate" faction, syndicate patrol bots no longer murder them. Replaced some crates with racks.
fix: Syndicate research base - Fixed the direction of the soda and booze dispensers.
del: Syndicate research base - Removed the beer keg (the dinnerware vending machine needed space).
/:cl:
