### PR TITLE
Status/AI display now can be deconstructed with a wrench

### DIFF
--- a/code/game/machinery/ai_display.dm
+++ b/code/game/machinery/ai_display.dm
@@ -110,3 +110,16 @@ GLOBAL_LIST_EMPTY(ai_displays)
 
 	. += new_display
 	underlays += emissive_appearance(icon, "lightmask")
+
+/obj/machinery/ai_status_display/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	TOOL_ATTEMPT_DISMANTLE_MESSAGE
+	if(I.use_tool(src, user, 20, volume = I.tool_volume))
+		TOOL_DISMANTLE_SUCCESS_MESSAGE
+		deconstruct(disassembled = TRUE)
+
+/obj/machinery/ai_status_display/deconstruct(disassembled = FALSE)
+	new /obj/item/stack/sheet/metal(drop_location(), 1)
+	..()

--- a/code/game/machinery/ai_display.dm
+++ b/code/game/machinery/ai_display.dm
@@ -118,8 +118,5 @@ GLOBAL_LIST_EMPTY(ai_displays)
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 20, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-		deconstruct(disassembled = TRUE)
-
-/obj/machinery/ai_status_display/deconstruct(disassembled = FALSE)
-	new /obj/item/stack/sheet/metal(drop_location(), 1)
-	..()
+		new /obj/item/stack/sheet/metal(drop_location(), 1)
+		deconstruct()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -222,8 +222,5 @@ GLOBAL_LIST_EMPTY(status_displays)
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 20, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-		deconstruct(disassembled = TRUE)
-
-/obj/machinery/status_display/deconstruct(disassembled = FALSE)
-	new /obj/item/stack/sheet/metal(drop_location(), 1)
-	..()
+		new /obj/item/stack/sheet/metal(drop_location(), 1)
+		deconstruct()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -214,3 +214,16 @@ GLOBAL_LIST_EMPTY(status_displays)
 				SD.set_picture(data1)
 
 		SD.update()
+
+/obj/machinery/status_display/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	TOOL_ATTEMPT_DISMANTLE_MESSAGE
+	if(I.use_tool(src, user, 20, volume = I.tool_volume))
+		TOOL_DISMANTLE_SUCCESS_MESSAGE
+		deconstruct(disassembled = TRUE)
+
+/obj/machinery/status_display/deconstruct(disassembled = FALSE)
+	new /obj/item/stack/sheet/metal(drop_location(), 1)
+	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Status display and AI display are now deconstructable (wrench, 2 seconds, Drop = 1 metal sheet).
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
At the moment, if you wish to renovate and remove one display from a wall you would have no other option than to attack it with a welder until its destroyed. Adding a proper way for removal instead of going unga unga on it is good.

## Testing
<!-- How did you test the PR, if at all? -->
- Tried to deconstruct displays using different intents, items and wrenchs.
## Changelog
:cl:
tweak: Status/AI display now can be deconstructed with a wrench
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
