### PR TITLE
moves all living var definitions to living_defines.dm

### DIFF
--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -23,15 +23,6 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 	return
 
 ///mob freeze procs
-
-/mob/living
-	/// Used for preventing attacks on admin-frozen mobs.
-	var/frozen = null
-	/// Used for keeping track of previous sleeping value with admin freeze.
-	var/admin_prev_sleeping = 0
-	/// Flag to enable these making trees semi-transparent if behind them
-	flags_2 = CRITICAL_ATOM_2
-
 /mob/living/admin_Freeze(client/admin, skip_overlays = FALSE, mech = null)
 	if(!istype(admin))
 		return

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -60,9 +60,6 @@
 
 	return
 
-//Mob procs and vars for scooping up
-/mob/living/var/holder_type
-
 /mob/living/proc/get_scooped(mob/living/carbon/grabber, has_variant = FALSE)
 	if(!holder_type)
 		return

--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -1,6 +1,3 @@
-/mob/living
-	var/datum/language/default_language
-
 /mob/living/verb/set_default_language(language as null|anything in languages)
 	set name = "Set Default Language"
 	set category = "IC"

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -7,6 +7,9 @@
 	move_force = null
 	pull_force = null
 
+	/// Flag to enable these making trees semi-transparent if behind them
+	flags_2 = CRITICAL_ATOM_2
+
 	//Health and life related vars
 	var/maxHealth = 100 //Maximum health that should be possible.
 	var/health = 100 	//A mob's health
@@ -78,4 +81,15 @@
 	var/resting = FALSE
 	var/body_position = STANDING_UP
 	var/mobility_flags = MOBILITY_FLAGS_DEFAULT
+
+	/// Used for preventing attacks on admin-frozen mobs.
+	var/frozen = null
+	/// Used for keeping track of previous sleeping value with admin freeze.
+	var/admin_prev_sleeping = 0
+
+	/// the type of holder that will be created when a mob gets scooped up
+	var/holder_type
+
+	var/datum/language/default_language
+
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
title

## Why It's Good For The Game
if you go to the definition of mob/living in vsc you will now get shown all of them and not 3 random vars

## Testing
It compiles.
It just moved var definitions around it shouldnt break anything


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
