### PR TITLE
Implement map tests for catching common errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     name: Unit Tests + SQL Validation
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false # Let all map tests run to completion
       matrix:
         maptype: ['/datum/map/cyberiad', '/datum/map/delta', '/datum/map/metastation']
         byondtype: ['STABLE', 'BETA']

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -329,7 +329,10 @@ SUBSYSTEM_DEF(ticker)
 	SSnightshift.check_nightshift(TRUE)
 
 	#ifdef UNIT_TESTS
-	RunUnitTests()
+	// Run map tests first in case unit tests futz with map state
+	GLOB.test_runner.RunMap()
+	GLOB.test_runner.Run()
+	SSticker.reboot_helper("Unit Test Reboot", "tests ended", 0)
 	#endif
 
 	// Do this 10 second after roundstart because of roundstart lag, and make it more visible

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -332,7 +332,6 @@ SUBSYSTEM_DEF(ticker)
 	// Run map tests first in case unit tests futz with map state
 	GLOB.test_runner.RunMap()
 	GLOB.test_runner.Run()
-	SSticker.reboot_helper("Unit Test Reboot", "tests ended", 0)
 	#endif
 
 	// Do this 10 second after roundstart because of roundstart lag, and make it more visible

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,5 +1,9 @@
 GLOBAL_LIST_INIT(map_transition_config, list(CC_TRANSITION_CONFIG))
 
+#ifdef UNIT_TESTS
+GLOBAL_DATUM(test_runner, /datum/test_runner)
+#endif
+
 /world/New()
 	// IMPORTANT
 	// If you do any SQL operations inside this proc, they must ***NOT*** be ran async. Otherwise players can join mid query
@@ -66,7 +70,8 @@ GLOBAL_LIST_INIT(map_transition_config, list(CC_TRANSITION_CONFIG))
 
 
 	#ifdef UNIT_TESTS
-	HandleTestRun()
+	GLOB.test_runner = new
+	GLOB.test_runner.Start()
 	#endif
 
 
@@ -140,7 +145,7 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 
 	// If we were running unit tests, finish that run
 	#ifdef UNIT_TESTS
-	FinishTestRun()
+	GLOB.test_runner.Finalize()
 	return
 	#endif
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -2,8 +2,8 @@
 //Keep this sorted alphabetically
 
 #ifdef UNIT_TESTS
-#include "announcements.dm"
 #include "aicard_icons.dm"
+#include "announcements.dm"
 #include "component_tests.dm"
 #include "config_sanity.dm"
 #include "crafting_lists.dm"

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -3,12 +3,14 @@
 
 #ifdef UNIT_TESTS
 #include "announcements.dm"
+#include "aicard_icons.dm"
 #include "component_tests.dm"
 #include "config_sanity.dm"
 #include "crafting_lists.dm"
 #include "emotes.dm"
 #include "log_format.dm"
 #include "map_templates.dm"
+#include "map_tests.dm"
 #include "purchase_reference_test.dm"
 #include "reagent_id_typos.dm"
 #include "rustg_version.dm"
@@ -17,7 +19,7 @@
 #include "sql.dm"
 #include "subsystem_init.dm"
 #include "subsystem_metric_sanity.dm"
+#include "test_runner.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"
-#include "aicard_icons.dm"
 #endif

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -67,8 +67,7 @@
 
 /datum/map_per_tile_test/invalid_objs_over_space_checker
 	var/list/invalid_types = list(
-		/obj/machinery/door/airlock,
-		/obj/structure/window
+		/obj/machinery/door/airlock
 	)
 
 /datum/map_per_tile_test/invalid_objs_over_space_checker/CheckTile(turf/T)

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -64,3 +64,20 @@
 	if(disposal)
 		if(!locate(/obj/structure/disposalpipe/trunk) in T.contents)
 			Fail(T, "tile has disposal unit/chute but no pipe trunk")
+
+/datum/map_per_tile_test/invalid_objs_over_space_checker
+	var/list/invalid_types = list(
+		/obj/machinery/door/airlock,
+		/obj/structure/window
+	)
+
+/datum/map_per_tile_test/invalid_objs_over_space_checker/CheckTile(turf/T)
+	for(var/invalid_type in invalid_types)
+		if(isspaceturf(T) && locate(invalid_type) in T.contents)
+			Fail(T, "space turf contains at least one invalid object of type [invalid_type]")
+
+/datum/map_per_tile_test/structures_in_farspace_checker
+
+/datum/map_per_tile_test/structures_in_farspace_checker/CheckTile(turf/T)
+	if(T.loc.type == /area/space && locate(/obj/structure) in T.contents)
+		Fail(T, "tile contains at least one structure found in non-near space area")

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -7,7 +7,7 @@
 
 /datum/map_per_tile_test/proc/Fail(turf/T, reason)
 	succeeded = FALSE
-	LAZYADD(fail_reasons, "[T.x],[T.y],[T.x]: [reason]")
+	LAZYADD(fail_reasons, "[T.x],[T.y],[T.z]: [reason]")
 
 /datum/map_per_tile_test/pipe_vent_checker
 	var/list/pipe_roots = list(

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -1,0 +1,60 @@
+/datum/map_per_tile_test
+	var/succeeded = TRUE
+	var/list/fail_reasons
+
+/datum/map_per_tile_test/proc/CheckTile(turf/T)
+	Fail("CheckTile() called parent or not implemented")
+
+/datum/map_per_tile_test/proc/Fail(reason = "No reason")
+	succeeded = FALSE
+
+	if(!istext(reason))
+		reason = "FORMATTED: [reason != null ? reason : "NULL"]"
+
+	LAZYADD(fail_reasons, reason)
+
+/datum/map_per_tile_test/pipe_vent_checker
+	var/list/pipe_roots = list(
+		/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+		/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers
+	)
+	var/list/unary_roots = list(
+		/obj/machinery/atmospherics/unary
+	)
+
+/datum/map_per_tile_test/pipe_vent_checker/CheckTile(turf/T)
+	var/turf/t = T
+	var/has_pipe = FALSE
+	var/has_unary = FALSE
+
+	if(t)
+		for(var/pipe_root in pipe_roots)
+			if(locate(pipe_root) in t.contents)
+				has_pipe = TRUE
+
+		if(locate(/obj/machinery/atmospherics/unary) in t.contents)
+			has_unary = TRUE
+
+		if(has_pipe && has_unary)
+			succeeded = FALSE
+			LAZYADD(fail_reasons, "[t.x],[t.y],[t.z]: pipe on same tile as vent or scrubber")
+
+	else
+		succeeded = FALSE
+		LAZYADD(fail_reasons, "No turf at [t.x],[t.y],[t.z]!")
+
+/datum/map_per_tile_test/cable_node_checker
+
+/datum/map_per_tile_test/cable_node_checker/CheckTile(turf/T)
+	var/turf/t = T
+	var/center_nodes = 0
+
+	if(t)
+		for(var/obj/structure/cable/cable in t.contents)
+			if(cable.d1 == 0 || cable.d2 == 0)
+				center_nodes++
+
+		if(center_nodes > 1)
+			succeeded = FALSE
+			LAZYADD(fail_reasons, "[t.x],[t.y],[t.z]: tile has multiple center cable nodes")
+

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -1,3 +1,11 @@
+/**
+  * Map per-tile test.
+  *
+  * Per-tile map tests iterate over each tile of a map to perform a check, and
+  * fails the test if a tile does not pass the check. A new test can be
+  * written by extending /datum/map_per_tile_test, and implementing the check
+  * in CheckTile.
+  */
 /datum/map_per_tile_test
 	var/succeeded = TRUE
 	var/list/fail_reasons
@@ -11,6 +19,10 @@
 	LAZYADD(fail_reasons, "[T.x],[T.y],[T.z]: [reason]")
 	failure_count++
 
+/**
+  * Check atmos pipes are not routed under unary devices such as vents and
+  * scrubbers.
+  */
 /datum/map_per_tile_test/pipe_vent_checker
 	var/list/pipe_roots = list(
 		/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -34,6 +46,9 @@
 	if(has_pipe && has_unary)
 		Fail(T, "pipe on same tile as vent or scrubber")
 
+/**
+  * Check that only one cable node exists on a tile.
+  */
 /datum/map_per_tile_test/cable_node_checker
 
 /datum/map_per_tile_test/cable_node_checker/CheckTile(turf/T)
@@ -46,6 +61,9 @@
 	if(center_nodes > 1)
 		Fail(T, "tile has multiple center cable nodes")
 
+/**
+  * Check to ensure that APCs have a cable node on their tile.
+  */
 /datum/map_per_tile_test/apc_cable_node_checker
 
 /datum/map_per_tile_test/apc_cable_node_checker/CheckTile(turf/T)
@@ -59,6 +77,9 @@
 		if(missing_node)
 			Fail(T, "tile has an APC bump but no center cable node")
 
+/**
+  * Check to ensure pipe trunks exist under disposals devices.
+  */
 /datum/map_per_tile_test/disposal_with_trunk_checker
 
 /datum/map_per_tile_test/disposal_with_trunk_checker/CheckTile(turf/T)
@@ -67,6 +88,9 @@
 		if(!locate(/obj/structure/disposalpipe/trunk) in T.contents)
 			Fail(T, "tile has disposal unit/chute but no pipe trunk")
 
+/**
+  * Check for certain objects that should never be over space turfs.
+  */
 /datum/map_per_tile_test/invalid_objs_over_space_checker
 	var/list/invalid_types = list(
 		/obj/machinery/door/airlock
@@ -77,6 +101,9 @@
 		if(isspaceturf(T) && locate(invalid_type) in T.contents)
 			Fail(T, "space turf contains at least one invalid object of type [invalid_type]")
 
+/**
+  * Check that structures in space are always in near-station space.
+  */
 /datum/map_per_tile_test/structures_in_farspace_checker
 
 /datum/map_per_tile_test/structures_in_farspace_checker/CheckTile(turf/T)

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -5,13 +5,9 @@
 /datum/map_per_tile_test/proc/CheckTile(turf/T)
 	Fail("CheckTile() called parent or not implemented")
 
-/datum/map_per_tile_test/proc/Fail(reason = "No reason")
+/datum/map_per_tile_test/proc/Fail(turf/T, reason)
 	succeeded = FALSE
-
-	if(!istext(reason))
-		reason = "FORMATTED: [reason != null ? reason : "NULL"]"
-
-	LAZYADD(fail_reasons, reason)
+	LAZYADD(fail_reasons, "[T.x],[T.y],[T.x]: [reason]")
 
 /datum/map_per_tile_test/pipe_vent_checker
 	var/list/pipe_roots = list(
@@ -23,38 +19,28 @@
 	)
 
 /datum/map_per_tile_test/pipe_vent_checker/CheckTile(turf/T)
-	var/turf/t = T
 	var/has_pipe = FALSE
 	var/has_unary = FALSE
 
-	if(t)
-		for(var/pipe_root in pipe_roots)
-			if(locate(pipe_root) in t.contents)
-				has_pipe = TRUE
+	for(var/pipe_root in pipe_roots)
+		if(locate(pipe_root) in T.contents)
+			has_pipe = TRUE
 
-		if(locate(/obj/machinery/atmospherics/unary) in t.contents)
-			has_unary = TRUE
+	if(locate(/obj/machinery/atmospherics/unary) in T.contents)
+		has_unary = TRUE
 
-		if(has_pipe && has_unary)
-			succeeded = FALSE
-			LAZYADD(fail_reasons, "[t.x],[t.y],[t.z]: pipe on same tile as vent or scrubber")
-
-	else
-		succeeded = FALSE
-		LAZYADD(fail_reasons, "No turf at [t.x],[t.y],[t.z]!")
+	if(has_pipe && has_unary)
+		Fail(T, "pipe on same tile as vent or scrubber")
 
 /datum/map_per_tile_test/cable_node_checker
 
 /datum/map_per_tile_test/cable_node_checker/CheckTile(turf/T)
-	var/turf/t = T
 	var/center_nodes = 0
 
-	if(t)
-		for(var/obj/structure/cable/cable in t.contents)
-			if(cable.d1 == 0 || cable.d2 == 0)
-				center_nodes++
+	for(var/obj/structure/cable/cable in T.contents)
+		if(cable.d1 == 0 || cable.d2 == 0)
+			center_nodes++
 
-		if(center_nodes > 1)
-			succeeded = FALSE
-			LAZYADD(fail_reasons, "[t.x],[t.y],[t.z]: tile has multiple center cable nodes")
+	if(center_nodes > 1)
+		Fail(T, "tile has multiple center cable nodes")
 

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -1,6 +1,7 @@
 /datum/map_per_tile_test
 	var/succeeded = TRUE
 	var/list/fail_reasons
+	var/failure_count = 0
 
 /datum/map_per_tile_test/proc/CheckTile(turf/T)
 	Fail("CheckTile() called parent or not implemented")
@@ -8,6 +9,7 @@
 /datum/map_per_tile_test/proc/Fail(turf/T, reason)
 	succeeded = FALSE
 	LAZYADD(fail_reasons, "[T.x],[T.y],[T.z]: [reason]")
+	failure_count++
 
 /datum/map_per_tile_test/pipe_vent_checker
 	var/list/pipe_roots = list(

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -44,3 +44,23 @@
 	if(center_nodes > 1)
 		Fail(T, "tile has multiple center cable nodes")
 
+/datum/map_per_tile_test/apc_cable_node_checker
+
+/datum/map_per_tile_test/apc_cable_node_checker/CheckTile(turf/T)
+	var/missing_node = TRUE
+	var/obj/machinery/power/apc/apc = locate(/obj/machinery/power/apc) in T.contents
+	if(apc)
+		for(var/obj/structure/cable/cable in T.contents)
+			if(cable.d1 == 0 || cable.d2 == 0)
+				missing_node = FALSE
+
+		if(missing_node)
+			Fail(T, "tile has an APC bump but no center cable node")
+
+/datum/map_per_tile_test/disposal_with_trunk_checker
+
+/datum/map_per_tile_test/disposal_with_trunk_checker/CheckTile(turf/T)
+	var/obj/machinery/disposal/disposal = locate(/obj/machinery/disposal) in T.contents
+	if(disposal)
+		if(!locate(/obj/structure/disposalpipe/trunk) in T.contents)
+			Fail(T, "tile has disposal unit/chute but no pipe trunk")

--- a/code/modules/unit_tests/test_runner.dm
+++ b/code/modules/unit_tests/test_runner.dm
@@ -1,0 +1,105 @@
+/datum/test_runner
+	var/datum/unit_test/current_test
+	var/failed_any_test = FALSE
+	var/list/test_logs = list()
+	var/list/durations = list()
+
+/datum/test_runner/proc/Start()
+	//trigger things to run the whole process
+	Master.sleep_offline_after_initializations = FALSE
+	// This will have the ticker set the game up
+	// Running the tests is part of the ticker's start function, because I cant think of any better place to put it
+	SSticker.force_start = TRUE
+
+
+/datum/test_runner/proc/RunMap(z_level = 2)
+	CHECK_TICK
+
+	var/list/tests = list()
+
+	for(var/I in subtypesof(/datum/map_per_tile_test))
+		tests += new I
+		test_logs[I] = list()
+		durations[I] = 0
+
+	for(var/X in 1 to world.maxx)
+		for(var/Y in 1 to world.maxy)
+			var/loc = locate(X, Y, z_level)
+			for(var/datum/map_per_tile_test/t in tests)
+				var/duration = REALTIMEOFDAY
+				t.CheckTile(loc)
+				durations[t.type] += REALTIMEOFDAY - duration
+
+	for(var/datum/map_per_tile_test/test in tests)
+		if(!test.succeeded)
+			failed_any_test = TRUE
+			test_logs[test.type] += test.fail_reasons
+
+	QDEL_LIST(tests)
+
+
+/datum/test_runner/proc/Run()
+	CHECK_TICK
+
+	for(var/I in subtypesof(/datum/unit_test))
+		test_logs[I] = list()
+		var/datum/unit_test/test = new I
+
+		current_test = test
+		var/duration = REALTIMEOFDAY
+
+		test.Run()
+
+		duration = REALTIMEOFDAY - duration
+		current_test = null
+
+		if(!test.succeeded)
+			failed_any_test = TRUE
+			test_logs[I] += test.fail_reasons
+
+		qdel(test)
+
+		CHECK_TICK
+
+	SSticker.reboot_helper("Unit Test Reboot", "tests ended", 0)
+
+
+/datum/test_runner/proc/Finalize(emit_failures = FALSE)
+	var/time = world.timeofday
+	set waitfor = FALSE
+	var/list/fail_reasons
+	if(GLOB)
+		if(GLOB.total_runtimes != 0)
+			fail_reasons = list("Total runtimes: [GLOB.total_runtimes]")
+		if(!GLOB.log_directory)
+			LAZYADD(fail_reasons, "Missing GLOB.log_directory!")
+		if(failed_any_test)
+			LAZYADD(fail_reasons, "Unit Tests failed!")
+	else
+		fail_reasons = list("Missing GLOB!")
+
+	if(!fail_reasons)
+		text2file("Success!", "data/clean_run.lk")
+
+	var/list/result = list()
+	result += "RUN  [time2text(time, "YYYY-MM-DD")]T[time2text(time, "hh:mm:ss")]"
+
+	for(var/reason in fail_reasons)
+		result += "FAIL [reason]"
+
+	for(var/test in test_logs)
+		if(length(test_logs[test]) == 0)
+			result += "PASS [test] [durations[test] / 10]s"
+		else
+			result += "FAIL [test] [durations[test] / 10]s"
+			result += "\t" + test_logs[test].Join("\n\t")
+
+	for(var/entry in result)
+		log_world(entry)
+
+	if(emit_failures)
+		var/filename = "data/test_run-[time2text(time, "YYYY-MM-DD")]T[time2text(time, "hh_mm_ss")].lk"
+		text2file(result.Join("\n"), filename)
+
+	sleep(0)	//yes, 0, this'll let Reboot finish and prevent byond memes
+	del(world)	//shut it down

--- a/code/modules/unit_tests/test_runner.dm
+++ b/code/modules/unit_tests/test_runner.dm
@@ -22,13 +22,11 @@
 		test_logs[I] = list()
 		durations[I] = 0
 
-	for(var/X in 1 to world.maxx)
-		for(var/Y in 1 to world.maxy)
-			var/loc = locate(X, Y, z_level)
-			for(var/datum/map_per_tile_test/t in tests)
-				var/duration = REALTIMEOFDAY
-				t.CheckTile(loc)
-				durations[t.type] += REALTIMEOFDAY - duration
+	for(var/turf/T in block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level)))
+		for(var/datum/map_per_tile_test/test in tests)
+			var/duration = REALTIMEOFDAY
+			test.CheckTile(T)
+			durations[test.type] += REALTIMEOFDAY - duration
 
 	for(var/datum/map_per_tile_test/test in tests)
 		if(!test.succeeded)
@@ -42,15 +40,15 @@
 	CHECK_TICK
 
 	for(var/I in subtypesof(/datum/unit_test))
-		test_logs[I] = list()
 		var/datum/unit_test/test = new I
+		test_logs[I] = list()
 
 		current_test = test
 		var/duration = REALTIMEOFDAY
 
 		test.Run()
 
-		duration = REALTIMEOFDAY - duration
+		durations[I] = REALTIMEOFDAY - duration
 		current_test = null
 
 		if(!test.succeeded)
@@ -98,7 +96,7 @@
 		log_world(entry)
 
 	if(emit_failures)
-		var/filename = "data/test_run-[time2text(time, "YYYY-MM-DD")]T[time2text(time, "hh_mm_ss")].lk"
+		var/filename = "data/test_run-[time2text(time, "YYYY-MM-DD")]T[time2text(time, "hh_mm_ss")].log"
 		text2file(result.Join("\n"), filename)
 
 	sleep(0)	//yes, 0, this'll let Reboot finish and prevent byond memes

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -6,11 +6,6 @@ You may use /New() and /Destroy() for setup/teardown respectively
 You can use the run_loc_bottom_left and run_loc_top_right to get turfs for testing
 */
 
-/// VARS FOR UNIT TESTS
-GLOBAL_DATUM(current_test, /datum/unit_test)
-GLOBAL_VAR_INIT(failed_any_test, FALSE)
-GLOBAL_VAR(test_log)
-
 /datum/unit_test
 	//Bit of metadata for the future maybe
 	var/list/procs_tested
@@ -43,60 +38,3 @@ GLOBAL_VAR(test_log)
 		reason = "FORMATTED: [reason != null ? reason : "NULL"]"
 
 	LAZYADD(fail_reasons, reason)
-
-/proc/RunUnitTests()
-	CHECK_TICK
-
-	for(var/I in subtypesof(/datum/unit_test))
-		var/datum/unit_test/test = new I
-
-		GLOB.current_test = test
-		var/duration = REALTIMEOFDAY
-
-		test.Run()
-
-		duration = REALTIMEOFDAY - duration
-		GLOB.current_test = null
-		GLOB.failed_any_test |= !test.succeeded
-
-		var/list/log_entry = list("[test.succeeded ? "PASS" : "FAIL"]: [I] [duration / 10]s")
-		var/list/fail_reasons = test.fail_reasons
-
-		qdel(test)
-
-		for(var/J in 1 to LAZYLEN(fail_reasons))
-			log_entry += "\tREASON #[J]: [fail_reasons[J]]"
-		log_world(log_entry.Join("\n"))
-
-		CHECK_TICK
-
-	SSticker.reboot_helper("Unit Test Reboot", "tests ended", 0)
-
-
-// OTHER MISC PROCS RELATED TO UNIT TESTS //
-
-/world/proc/HandleTestRun()
-	//trigger things to run the whole process
-	Master.sleep_offline_after_initializations = FALSE
-	// This will have the ticker set the game up
-	// Running the tests is part of the ticker's start function, because I cant think of any better place to put it
-	SSticker.force_start = TRUE
-
-/world/proc/FinishTestRun()
-	set waitfor = FALSE
-	var/list/fail_reasons
-	if(GLOB)
-		if(GLOB.total_runtimes != 0)
-			fail_reasons = list("Total runtimes: [GLOB.total_runtimes]")
-		if(!GLOB.log_directory)
-			LAZYADD(fail_reasons, "Missing GLOB.log_directory!")
-		if(GLOB.failed_any_test)
-			LAZYADD(fail_reasons, "Unit Tests failed!")
-	else
-		fail_reasons = list("Missing GLOB!")
-	if(!fail_reasons)
-		text2file("Success!", "data/clean_run.lk")
-	else
-		log_world("Test run failed!\n[fail_reasons.Join("\n")]")
-	sleep(0)	//yes, 0, this'll let Reboot finish and prevent byond memes
-	del(src)	//shut it down


### PR DESCRIPTION
## What Does This PR Do

- Adds test runner:
	- to make it easier to track things across test types
	- for example to ensure a fully specified log can be emitted

- Adds map tile test type:
	- when writing a test, coders implement CheckTile, which is handed a single turf
	- when the test runner runs these tests, it iterates over all turfs in the specified z-level, and runs each test's CheckTile on each turf in turn.

- Adds several sample map tile tests:
	- check to see if a pipe exists on the same tile as a scrubber or vent
	- check to see if a tile contains two cables, each with a center node
	- check to see if a tile contains an APC bump but no center node cable
	- check to see if a tile is a space turf and contains invalid objects such as airlocks
	- check to see if a tile is a space turf and contains a structure but is not nearspaced

- Adds failure log
	- it was annoying during dev to try and catch errors when they were just logged to the world so here
	- it's not enabled by default because it changes the expectations of the CI runners (`data/clean_run.lk` is not emitted in these circumstances). it can be enabled by passing `emit_failures = TRUE` to the test runner's `Finalize()` proc.

When enabled, the failure log has a filename like `data/test_run-2022-09-28T13_29_18.lk`, and looks like this:

```
RUN  2022-09-28T13:29:18
FAIL Unit Tests failed!
FAIL /datum/map_per_tile_test/pipe_vent_checker
	127,89,2: pipe on same tile as vent or scrubber
	205,106,2: pipe on same tile as vent or scrubber
FAIL /datum/map_per_tile_test/cable_node_checker
	79,152,2: tile has multiple center cable nodes
	80,152,2: tile has multiple center cable nodes
	81,152,2: tile has multiple center cable nodes
	83,152,2: tile has multiple center cable nodes
	84,152,2: tile has multiple center cable nodes
	85,152,2: tile has multiple center cable nodes
	152,56,2: tile has multiple center cable nodes
	171,50,2: tile has multiple center cable nodes
	183,154,2: tile has multiple center cable nodes
PASS /datum/unit_test/aicard_icons
PASS /datum/unit_test/component_duping
PASS /datum/unit_test/config_sanity
PASS /datum/unit_test/crafting_lists
PASS /datum/unit_test/emote
FAIL /datum/unit_test/log_format
	RUSTG log format is not valid 8601 format. Expected '[2022-09-28T13:29:11] Log time format test', got '[2022-09-27T23:21:23] Log time format test'
PASS /datum/unit_test/map_templates
PASS /datum/unit_test/uplink_refs
PASS /datum/unit_test/spellbook_refs
PASS /datum/unit_test/reagent_id_typos
PASS /datum/unit_test/rustg_version
PASS /datum/unit_test/spawn_humans
PASS /datum/unit_test/spell_targeting
FAIL /datum/unit_test/sql_version
	SQL errors occured on startup. Please fix them.
PASS /datum/unit_test/subsystem_init
PASS /datum/unit_test/subsystem_metric_sanity
PASS /datum/unit_test/timer_sanity
```

## Why It's Good For The Game

Automating checks for common map errors reduces cognitive overhead and maintenance burden for mappers and reviewers, and the payoff will extend forever into the future.

## Testing

1. Ran tests locally against all maps, and made fixes to all maps (#19208, #19211, #19213)
3. Ran tests on CI

## Changelog
:cl:
add: Start building test suite specifically for map linting.
/:cl:
