### PR TITLE
Makes RPDs not smash pipes when placing a new pipe

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipe.dm
@@ -48,6 +48,8 @@
 	if(istype(W, /obj/item/analyzer))
 		atmosanalyzer_scan(parent.air, user)
 		return
+	if(istype(W, /obj/item/rpd) && user.a_intent != INTENT_HARM)
+		return
 	return ..()
 
 /obj/machinery/atmospherics/proc/pipeline_expansion()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->When on non-harm intent, placing a pipe by clicking on a pipe will no longer attack the pipe.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Bashing pipes with your RPD doesn't do any damage really but it does make you look like a bit of an idiot, mostly quality of life for atmosians.

## Testing
<!-- How did you test the PR, if at all? -->
On help intent: clicked on pipe with RPD: made new pipe, old pipe not smashed
On harm intent: Old behavior, made new pipe and bashed old pipe.

## Changelog
:cl:
tweak: RPDs will now only attack pipes when on harm intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
