### PR TITLE
Linen bin and ashtrays tweaks

### DIFF
--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -3,6 +3,7 @@
 	var/max_butts = 0
 	var/icon_half = ""
 	var/icon_full = ""
+	var/material = /obj/item/stack/sheet/metal
 
 /obj/item/ashtray/Initialize(mapload)
 	. = ..()
@@ -51,10 +52,6 @@
 	else
 		desc = initial(desc)
 
-/obj/item/ashtray/deconstruct()
-	empty_tray()
-	qdel(src)
-
 /obj/item/ashtray/proc/empty_tray()
 	for(var/obj/item/I in contents)
 		I.forceMove(loc)
@@ -66,6 +63,15 @@
 	empty_tray()
 	return ..()
 
+/obj/item/ashtray/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	if(I.use_tool(src, user, volume = I.tool_volume))
+		empty_tray()
+		new material(drop_location(), 1)
+		deconstruct()
+
 /obj/item/ashtray/plastic
 	name = "plastic ashtray"
 	desc = "Cheap plastic ashtray."
@@ -74,7 +80,7 @@
 	icon_full  = "ashtray_full_bl"
 	max_butts = 8
 	max_integrity = 8
-	materials = list(MAT_METAL=30, MAT_GLASS=30)
+	material = /obj/item/stack/sheet/plastic
 	throwforce = 3
 
 /obj/item/ashtray/bronze
@@ -85,7 +91,6 @@
 	icon_full  = "ashtray_full_br"
 	max_butts = 16
 	max_integrity = 16
-	materials = list(MAT_METAL=80)
 	throwforce = 10
 
 /obj/item/ashtray/glass
@@ -96,5 +101,5 @@
 	icon_full  = "ashtray_full_gl"
 	max_butts = 12
 	max_integrity = 12
-	materials = list(MAT_GLASS=60)
+	material = /obj/item/stack/sheet/glass
 	throwforce = 6

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -305,6 +305,11 @@ LINEN BINS
 	extinguish()
 	update_icon()
 
+/obj/structure/bedsheetbin/wrench_act(mob/user, obj/item/I)
+	if(user.a_intent == INTENT_HARM)
+		. = TRUE
+		default_unfasten_wrench(user, I, time = 20)
+
 /obj/structure/bedsheetbin/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/bedsheet))
 		if(!user.drop_item())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
All ashtrays are now deconstructable (0 seconds, 1 material received)
You can now unfasten linen bins with a wrench (on harm intent, 2 seconds)
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Now that its possible to build ashtrays it makes sense to add a way to deconstruct them.
Linen bins are currently anchored to the floor and without a way to move/deconstruct them. If a player wishes to renovate a room where this item is in he would have problems (i myself had this problem when renovating mining maints).
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/77684085/192897273-fe8c8456-ceba-4ba8-b743-9d574019c7e3.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Deconstructed multiple ashtrays, all looks fine
- Was capable of unfastening linen bins on harm intent and to hide the wrench on it.
## Changelog
:cl:
tweak: All ashtrays are now deconstructable
tweak: Linen bin can now be unfastened with a wrench on harm intention
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
