### PR TITLE
Fix Meta issues caught by automated map tests.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3334,9 +3334,9 @@
 	},
 /area/engine/gravitygenerator)
 "asT" = (
-/obj/structure/lattice,
-/turf/space,
-/area/space)
+/obj/structure/sign/security,
+/turf/simulated/wall/r_wall,
+/area/security/processing)
 "asU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -4865,15 +4865,16 @@
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "axQ" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "axR" = (
@@ -4896,10 +4897,6 @@
 /area/maintenance/fore)
 "axU" = (
 /obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -4908,6 +4905,7 @@
 /obj/structure/sign/electricshock{
 	pixel_x = 32
 	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "axV" = (
@@ -7069,11 +7067,6 @@
 	name = "\improper Mining Office"
 	})
 "aFG" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -7084,25 +7077,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/dorms)
-"aFJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -7826,11 +7800,6 @@
 	name = "\improper Storage Wing"
 	})
 "aHV" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
 	pixel_x = -27
@@ -7858,14 +7827,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aHZ" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -7873,6 +7834,10 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7974,11 +7939,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aIk" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -8592,11 +8552,6 @@
 	})
 "aJC" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -8899,10 +8854,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "hop";
@@ -9116,6 +9067,11 @@
 	c_tag = "Dormitories - Aft";
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -9134,6 +9090,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -9148,6 +9109,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -9161,9 +9127,14 @@
 	},
 /obj/effect/landmark/start/clown,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -11336,6 +11307,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -14907,19 +14883,16 @@
 /turf/simulated/wall/r_wall,
 /area/engine/chiefs_office)
 "ban" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/effect/spawner/window/reinforced,
+/obj/structure/sign/electricshock{
+	pixel_x = -32
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/spawner/window/reinforced,
-/obj/structure/sign/electricshock{
-	pixel_x = -32
-	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bao" = (
@@ -30983,12 +30956,13 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "RD"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
@@ -63258,11 +63232,9 @@
 	},
 /area/engine/break_room)
 "ieA" = (
-/obj/structure/sign/electricshock{
-	pixel_y = -32
-	},
-/turf/space,
-/area/space)
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
+/area/security/prisonlockers)
 "ieT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -64643,11 +64615,6 @@
 	},
 /area/medical/paramedic)
 "iKF" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/newscaster{
 	name = "west bump";
 	pixel_x = -32
@@ -67527,12 +67494,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"knm" = (
-/obj/structure/sign/electricshock{
-	pixel_x = 32
-	},
-/turf/space,
-/area/space)
 "knB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74309,11 +74270,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "nsJ" = (
-/obj/structure/sign/security{
-	pixel_y = 32
-	},
-/turf/space,
-/area/space)
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
+/area/security/range)
 "ntO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -74744,6 +74703,21 @@
 	icon_state = "red"
 	},
 /area/security/warden)
+"nEw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "nEJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -79809,6 +79783,18 @@
 	icon_state = "white"
 	},
 /area/toxins/lab)
+"qpw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/crew_quarters/dorms)
 "qpy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -108594,7 +108580,7 @@ aaa
 cIl
 aaa
 aaa
-asT
+abq
 aaa
 aaa
 aaa
@@ -117491,7 +117477,7 @@ pte
 ivD
 qIB
 abW
-knm
+aaa
 aaa
 aaa
 aOB
@@ -117748,7 +117734,7 @@ tfl
 tfl
 tfl
 tfl
-tfl
+ieA
 amE
 ufj
 aky
@@ -118534,8 +118520,8 @@ lGL
 dBT
 axN
 hvR
-aHI
-nsJ
+asT
+aaa
 nKT
 hOu
 xJy
@@ -126222,8 +126208,8 @@ aaa
 aaa
 aaa
 aaa
-ieA
-esA
+aaa
+nsJ
 fcT
 esA
 fcT
@@ -130359,7 +130345,7 @@ aFG
 aJE
 aIl
 aJD
-aJE
+aFI
 aJE
 aJE
 aCm
@@ -131126,7 +131112,7 @@ awR
 cEe
 aCW
 aEo
-aFI
+qpw
 aGQ
 aJF
 fUI
@@ -131383,7 +131369,7 @@ azj
 aBO
 hYV
 aEp
-aFJ
+nEw
 aGR
 aJG
 law


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR addresses what I believe to be issues with Meta surfaced by the unit tests in https://github.com/ParadiseSS13/Paradise/pull/19204.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If these are all legit issues, then fixing them is good, and it makes it more likely that https://github.com/ParadiseSS13/Paradise/pull/19204 can get in alongside the tests it adds.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

### Multiple center cable nodes
130,94

![paradise dme  MetaStation dmm  - StrongDMM-13_06_01](https://user-images.githubusercontent.com/59303604/193102874-a75f29b7-6b32-498c-84ab-97695b3108f1.png)

90,135

![paradise dme  MetaStation dmm  - StrongDMM-13_07_15](https://user-images.githubusercontent.com/59303604/193102910-68ed8493-e3f2-4f58-a339-d89b97c62669.png)

Dorms Before (clown and mime spawns hidden for clarity):
![paradise dme  MetaStation dmm  - StrongDMM-13_17_55](https://user-images.githubusercontent.com/59303604/193103164-e52eae48-8326-4dbe-af43-b244c8c14618.png)
After:

![paradise dme  MetaStation dmm  - StrongDMM-13_59_40](https://user-images.githubusercontent.com/59303604/193107482-3d14349a-1f1a-4e5e-9be6-2e4d286cb522.png)


84,167 and 85,167

Before:
![paradise dme  MetaStation dmm  - StrongDMM-13_22_06](https://user-images.githubusercontent.com/59303604/193103270-4a3d39c3-5b02-45fe-a01c-3a98fdb2dc0a.png)
After:
![paradise dme  MetaStation dmm  - StrongDMM-13_23_11](https://user-images.githubusercontent.com/59303604/193103286-50f4f82c-5fa3-4016-bae8-7eade9220041.png)

### Structures on non-near space areas

Lattice fix at 53,78

![paradise dme  MetaStation dmm  - StrongDMM-13_41_42](https://user-images.githubusercontent.com/59303604/193104021-5fc61a54-f8f9-4e9b-869f-ecb8a96ba3ed.png)

Signs that were placed in space and pixel pushed to a wall were moved directly on top of the wall in these instances:

92,160

![paradise dme  MetaStation dmm  - StrongDMM-13_25_44](https://user-images.githubusercontent.com/59303604/193103731-9e319c8a-b3d1-4403-8a3e-4a10c042ca7f.png)

88,176

![paradise dme  MetaStation dmm  - StrongDMM-13_26_29](https://user-images.githubusercontent.com/59303604/193104316-9dfe8032-63ff-454d-a3f0-990e78ecfd9b.png)

122,183

![paradise dme  MetaStation dmm  - StrongDMM-13_43_50](https://user-images.githubusercontent.com/59303604/193104491-96416314-655b-43aa-a535-c7283eec4c6b.png)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Small Meta fixes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
