### PR TITLE
Fix Box issues caught by automated map tests.

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -17337,14 +17337,15 @@
 /area/maintenance/fpmaint)
 "aSv" = (
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aSw" = (
@@ -18072,19 +18073,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aUh" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/computer/monitor{
 	dir = 1;
 	name = "Backup Power Monitoring Console"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aUi" = (
@@ -47772,16 +47775,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "coG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -48301,17 +48298,13 @@
 /turf/simulated/wall,
 /area/medical/cryo)
 "cqp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -51626,9 +51619,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
@@ -54754,9 +54744,6 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cHz" = (
@@ -55626,9 +55613,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -55702,6 +55691,9 @@
 	pixel_x = -24
 	},
 /obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJN" = (
@@ -55925,7 +55917,6 @@
 	name = "Atmospherics Requests Console";
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
@@ -56467,7 +56458,6 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cMd" = (
@@ -56718,8 +56708,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -66114,16 +66104,17 @@
 	name = "\improper AI Satellite Hallway"
 	})
 "dmO" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/structure/cable,
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
 "dmP" = (
@@ -69463,7 +69454,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "eAb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -75016,6 +75012,12 @@
 /obj/machinery/atmospherics/binary/pump{
 	name = "heat exchange to port"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -77462,14 +77464,13 @@
 	},
 /area/medical/cmo)
 "kLc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -77510,6 +77511,12 @@
 "kNW" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -84155,10 +84162,6 @@
 /area/maintenance/asmaint2)
 "qll" = (
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -84166,6 +84169,11 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -88175,6 +88183,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"tJb" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "tJA" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -91828,6 +91849,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"wuZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/mixing)
 "wvD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -92419,6 +92451,22 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/hallway)
+"xag" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/mixing)
 "xbd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -115202,7 +115250,7 @@ aPu
 aYc
 aPi
 aRn
-aSv
+tJb
 aab
 aUE
 aVl
@@ -115459,7 +115507,7 @@ aMA
 aMA
 aMA
 aRn
-aSv
+tJb
 aaa
 aUE
 aVn
@@ -115716,7 +115764,7 @@ aMA
 aaa
 aQg
 aRp
-aSv
+tJb
 aab
 aUE
 aUE
@@ -146858,8 +146906,8 @@ lVB
 vBv
 oGw
 cqe
-cqk
-gZU
+wuZ
+xag
 nhs
 kwP
 frm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR addresses what I believe to be issues with Box surfaced by the unit tests in https://github.com/ParadiseSS13/Paradise/pull/19204.

I'm uncertain about the changes for pipes/vents in atmos/scichem so let me know if they're not great fixes.
I'm also uncertain about which parts of the turbine actually need center nodes, so I kept both.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If these are all legit issues, then fixing them is good, and it makes it more likely that https://github.com/ParadiseSS13/Paradise/pull/19204 can get in alongside the tests it adds.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

Not all of these have before and afters, in the cases where the fix was rote.

### Multiple center cable nodes

171,50 maints rage cage
![paradise dme  cyberiad dmm  - StrongDMM-22_31_46](https://user-images.githubusercontent.com/59303604/193179195-5675b1d5-56e2-4e2b-9a39-f6f5e684e459.png)

152,56 turbine
![paradise dme  cyberiad dmm  - StrongDMM-22_33_38](https://user-images.githubusercontent.com/59303604/193179248-57e10f88-d47e-45b8-bddb-69e895a149c3.png)

79-85,152 vault electrified grilles
![paradise dme  cyberiad dmm  - StrongDMM-22_35_11](https://user-images.githubusercontent.com/59303604/193179325-d069c248-f344-4695-b4b2-569f62d165c4.png)

183,154 eng maintenance 

![paradise dme  cyberiad dmm  - StrongDMM-22_50_56](https://user-images.githubusercontent.com/59303604/193179757-de84e0a7-4fa7-4eba-b087-0f4d1c045831.png)


Before (computer removed for clarity):
![paradise dme  cyberiad dmm  - StrongDMM-22_38_02](https://user-images.githubusercontent.com/59303604/193179461-0848c9d8-f18a-49da-887b-8cb8e36022b8.png)
After:

![paradise dme  cyberiad dmm  - StrongDMM-22_49_57](https://user-images.githubusercontent.com/59303604/193179681-27431095-12cf-42aa-982f-d2fdb4f915d4.png)


### Pipes overlapping vents/scrubbers/ports/injectors

127,89 atmos

Before (lockers removed for clarity):

![paradise dme  cyberiad dmm  - StrongDMM-22_24_52](https://user-images.githubusercontent.com/59303604/193179851-df206847-026a-4d56-bf7e-c3a5ba489cc1.png)
After:
![paradise dme  cyberiad dmm  - StrongDMM-22_26_00](https://user-images.githubusercontent.com/59303604/193179869-872f709b-dd11-4e7c-99be-140915e8899f.png)

205,106 scichem
Before:
![paradise dme  cyberiad dmm  - StrongDMM-22_55_01](https://user-images.githubusercontent.com/59303604/193180572-1f9ebf12-1861-4b1c-9119-69c99eb5d8ec.png)
After:
![paradise dme  cyberiad dmm  - StrongDMM-22_54_17](https://user-images.githubusercontent.com/59303604/193180650-9af7c23a-19e8-450d-a140-9de128e2e930.png)



## Testing

Ran unit tests.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Small Box fixes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
