### PR TITLE
Magistrate now gets his own tableside door button

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -42818,7 +42818,8 @@
 "bYP" = (
 /obj/machinery/door/airlock{
 	name = "Magistrate's Office";
-	req_access_txt = "74"
+	req_access_txt = "74";
+	id_tag = "magistrateofficedoor"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -45947,6 +45948,20 @@
 /obj/item/taperecorder,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/machinery/button/windowtint{
+	id = "Magistrate";
+	pixel_y = -24;
+	dir = 1;
+	pixel_x = -6
+	},
+/obj/machinery/door_control{
+	id = "magistrateofficedoor";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = -24;
+	req_access_txt = "74"
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -90258,10 +90273,6 @@
 /obj/machinery/computer/secure_data/laptop,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/button/windowtint{
-	id = "Magistrate";
-	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54902,10 +54902,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/item/radio/intercom{
+	name = "custom placement";
+	pixel_x = -28;
+	pixel_y = 2
+	},
+/obj/item/radio/intercom/department/security{
+	pixel_x = -28;
+	pixel_y = -5
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -67061,21 +67065,19 @@
 "jXj" = (
 /obj/item/taperecorder,
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	name = "custom placement";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/item/radio/intercom/department/security{
-	pixel_x = -28;
-	pixel_y = -11
-	},
 /obj/machinery/button/windowtint{
 	dir = 4;
 	id = "Magistrate";
 	pixel_x = -24;
 	pixel_y = 9;
 	req_access_txt = "74"
+	},
+/obj/machinery/door_control{
+	id = "magistrateofficedoor";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	req_access_txt = "74";
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -71866,7 +71868,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock{
+	id_tag = "magistrateofficedoor"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
 /turf/simulated/floor/plasteel{
@@ -77185,6 +77189,11 @@
 /obj/machinery/camera{
 	c_tag = "Magistrate's Office";
 	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "west bump";
+	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -9704,12 +9704,13 @@
 	c_tag = "Magistrate's Office";
 	dir = 4
 	},
-/obj/machinery/button/windowtint{
-	dir = 4;
-	id = "Magistrate";
-	pixel_x = -24;
-	pixel_y = 6;
-	req_access_txt = "74"
+/obj/item/radio/intercom/department/security{
+	pixel_x = -28;
+	pixel_y = -7
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = -28
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -9717,13 +9718,21 @@
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /obj/item/megaphone,
-/obj/item/radio/intercom/department/security{
-	pixel_x = 28;
-	pixel_y = -7
+/obj/machinery/button/windowtint{
+	dir = 8;
+	id = "Magistrate";
+	pixel_x = 24;
+	pixel_y = 6;
+	req_access_txt = "74"
 	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/door_control{
+	id = "magistrateofficedoors";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	req_access_txt = "74";
+	dir = 1;
+	pixel_x = 24;
+	pixel_y = -4
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -13676,7 +13685,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Magistrate's Office";
-	req_access_txt = "74"
+	req_access_txt = "74";
+	id_tag = "magistrateofficedoors"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Map edits to all three maps (Box, Delta, Meta), adding a simple convenience for the magistrate office, the **front** door button. also moved some stuff around so the window tint button is right next to the door button, and shuffled other stuff like light buttons or intercoms that were in the way to other walls (check screenshots)

## Why It's Good For The Game
All of the VIP and Head offices get this, why not Magistrate?

## Images of changes
Box:
![cyberiad](https://user-images.githubusercontent.com/46283583/193383936-4f70b693-1e04-4c3d-a1b4-9f5e1c4e51f1.PNG)
Delta:
![delta](https://user-images.githubusercontent.com/46283583/193383938-c82455dc-02fb-4003-8bfe-7298587541cc.PNG)
Meta:
![meta](https://user-images.githubusercontent.com/46283583/193383945-ca867ff4-8d0a-478e-bd01-c68cd87f5558.PNG)

## Testing
Launched up each of the stations in debug; joined as the magistrate, went to the office, tested the button with and without ID.

## Changelog
:cl:
add: Added an office button to the magistrate's office
/:cl: