### PR TITLE
Power controle module is dead. Long live APC module!

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -157,7 +157,7 @@
 	cell.charge = 0
 
 /obj/item/apc_electronics
-	name = "power control module"
+	name = "APC Module"
 	desc = "Heavy-duty switching circuits for power control."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "power_mod"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Since time immemorial, APC machine board was called "power control module", although, in the Autolathe, the name to print the board was different - "APC module". This inconsistency, at least to me, caused oft confusion trying to get more APC boards in the past.

## Why It's Good For The Game
Board having a single name everywhere is good for consistency and for new players to avoid confusion.

## Images of changes
![1](https://user-images.githubusercontent.com/46283583/193384413-3db0df82-4d65-4e21-9e79-6b07b99eed8f.PNG)
![2](https://user-images.githubusercontent.com/46283583/193384415-b633f625-1e89-4f85-93b0-6fa896c1b691.PNG)
![3](https://user-images.githubusercontent.com/46283583/193384416-320a02e1-1036-47ba-804a-19ff8f56209c.PNG)

## Testing
launched debugging / went to cargo, printed myself an APC Module board, checked the engi vendor in engineering.

## Changelog
:cl:
tweak: renames the "power control module" to "APC Module"
/:cl:
