### PR TITLE
[GBP NO UPDATE][READY FOR TM] Simplemob GC improvement 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -59,6 +59,8 @@
 	wanted_objects = typecacheof(wanted_objects)
 
 /mob/living/simple_animal/hostile/Destroy()
+	/// We need to clear the reference to where we're walking to properly GC
+	walk_to(src, 0)
 	if(lose_patience_timer_id)
 		deltimer(lose_patience_timer_id)
 	targets_from = null

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -59,8 +59,6 @@
 	wanted_objects = typecacheof(wanted_objects)
 
 /mob/living/simple_animal/hostile/Destroy()
-	/// We need to clear the reference to where we're walking to properly GC
-	walk_to(src, 0)
 	if(lose_patience_timer_id)
 		deltimer(lose_patience_timer_id)
 	targets_from = null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -129,6 +129,8 @@
 		AddComponent(/datum/component/footstep, footstep_type)
 
 /mob/living/simple_animal/Destroy()
+	/// We need to clear the reference to where we're walking to properly GC
+	walk_to(src, 0)
 	QDEL_NULL(pcollar)
 	master_commander = null
 	GLOB.simple_animals[AIStatus] -= src


### PR DESCRIPTION
## What Does This PR Do
Basically, a continuation of what #19171 is doing, extended to (now) all simplemobs. Sadly, many of these animals still fail to GC for other reasons (such as status effects and hud issues)
This fixes false positives due to walk_to not getting reset on a significant amount of mobs
GBP NO UPDATE due to warriorstar doing the majority of the actual work to find and solve these issues, not me!
## Why It's Good For The Game
GCing good, failing to GC bad
Failing to GC at a mass scale is incredibly bad

## Testing
Local testing went well
Testing on the testserver went well, didn't notice any behavior differences.
Compiled, ran, screwed around with space carp and other simplemobs, more GCing than before on being deleted/killed.
## Changelog
:cl:
fix: Simplemobs GC more consistantly 
/:cl:
