### PR TITLE
Fixes cleanable floor decals shading jank

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -10,7 +10,6 @@ GLOBAL_LIST_EMPTY(splatter_cache)
 	gender = PLURAL
 	density = FALSE
 	layer = TURF_LAYER
-	plane = GAME_PLANE
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "mfloor1"
 	random_icon_states = list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -15,12 +15,14 @@
 	icon_state = "ash"
 	scoop_reagents = list("ash" = 10)
 	mergeable_decal = FALSE
+	plane = GAME_PLANE
 
 /obj/effect/decal/cleanable/glass
 	name = "tiny shards"
 	desc = "Back to sand."
 	icon = 'icons/obj/shards.dmi'
 	icon_state = "tiny"
+	plane = GAME_PLANE
 
 /obj/effect/decal/cleanable/glass/Initialize(mapload)
 	. = ..()
@@ -104,6 +106,7 @@
 	desc = "Somebody should remove that."
 	density = FALSE
 	layer = OBJ_LAYER
+	plane = GAME_PLANE
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb1"
 	resistance_flags = FLAMMABLE
@@ -113,6 +116,7 @@
 	desc = "It looks like a melted... something."
 	density = FALSE
 	layer = OBJ_LAYER
+	plane = GAME_PLANE
 	gender = NEUTER
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "molten"
@@ -127,6 +131,7 @@
 	desc = "Somebody should remove that."
 	density = FALSE
 	layer = OBJ_LAYER
+	plane = GAME_PLANE
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb2"
 
@@ -154,6 +159,7 @@
 	desc = "The shredded remains of what appears to be clothing."
 	icon_state = "shreds"
 	gender = PLURAL
+	plane = GAME_PLANE
 	mergeable_decal = FALSE
 
 /obj/effect/decal/cleanable/shreds/ex_act(severity, target)
@@ -212,6 +218,7 @@
 	name = "confetti"
 	desc = "Party time!"
 	gender = PLURAL
+	plane = GAME_PLANE
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "confetti1"
 	random_icon_states = list("confetti1", "confetti2", "confetti3")

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -2,6 +2,7 @@
 	var/list/random_icon_states = list()
 	var/bloodiness = 0 //0-100, amount of blood in this decal, used for making footprints and affecting the alpha of bloody footprints
 	var/mergeable_decal = TRUE //when two of these are on a same tile or do we need to merge them into just one?
+	plane = FLOOR_PLANE //prevents Ambient Occlusion effects around it ; Set to GAME_PLANE in Initialize() if on a wall
 
 /obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C) // Returns true if we should give up in favor of the pre-existing decal
 	if(mergeable_decal)
@@ -73,6 +74,8 @@
 	if(smoothing_flags)
 		QUEUE_SMOOTH(src)
 		QUEUE_SMOOTH_NEIGHBORS(src)
+	if(loc && iswallturf(loc) && plane == FLOOR_PLANE)
+		plane = GAME_PLANE // so they can be seen above walls
 
 /obj/effect/decal/cleanable/Destroy()
 	if(smoothing_flags)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -74,7 +74,7 @@
 	if(smoothing_flags)
 		QUEUE_SMOOTH(src)
 		QUEUE_SMOOTH_NEIGHBORS(src)
-	if(loc && iswallturf(loc) && plane == FLOOR_PLANE)
+	if(iswallturf(loc) && plane == FLOOR_PLANE)
 		plane = GAME_PLANE // so they can be seen above walls
 
 /obj/effect/decal/cleanable/Destroy()

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/effects/crayondecal.dmi'
 	icon_state = "rune1"
 	layer = MID_TURF_LAYER
-	plane = GAME_PLANE //makes the graffiti visible over a wall.
 	mergeable_decal = FALSE // Allows crayon drawings to overlap one another.
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
For some cleanable floor decals like blood trails or blood splatter they have ambient occlusion effects around them, making them appear floating in the air or to have alot of volume which they shouldnt have. (It looks bad) This PR removes those efffects through plane magic.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Looks better.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_M5nHaDKEsf](https://user-images.githubusercontent.com/16618648/193407305-dfad0b6e-0cc5-44f0-8a26-5f18dd4a965d.png)
_throw up and bug guts never had the weird shading effects, I realized this after making the image... dont look at those ones_

![image](https://user-images.githubusercontent.com/16618648/193470638-cda600be-3fc4-4a92-a865-79894c1e8e69.png)
_Heres a high contrast view as well_

## Testing
<!-- How did you test the PR, if at all? -->
Tested in VSC, before and after. Spawned in and visually checked 
all `/obj/effect/decal/cleanable` objects

## Changelog
:cl:
tweak: Removed the shading effects for various cleanable decals where it looked bad.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
