### PR TITLE
No longer need to have slimes with body parts to remove their cores

### DIFF
--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -2,6 +2,7 @@
 	name = "core removal"
 	steps = list(/datum/surgery_step/slime/cut_flesh, /datum/surgery_step/slime/extract_core)
 	target_mobtypes = list(/mob/living/simple_animal/slime)
+	requires_bodypart = FALSE
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_GROIN)
 
 /datum/surgery/core_removal/can_start(mob/user, mob/living/carbon/target)


### PR DESCRIPTION
## What Does This PR Do
Fixes #19226
Slimes don't have limbs so the surgery should also reflect that.

## Why It's Good For The Game
Slimes can now be hand-harvested again for that biological slime core market

## Testing
Kill a slime using `death` admin command
Throw their lifeless body on a table
Use scalpel on body to remove the core and get the menu as expected

![image](https://user-images.githubusercontent.com/15887760/193418098-262a68db-016c-4ff7-94fc-a88595416d0e.png)


## Changelog
:cl:
fix: Slimes can be hand-harvested again for their cores.
/:cl: