### PR TITLE
Ensures the gibber "feed" animation does not block the calling code

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -147,7 +147,7 @@
 		occupant = victim
 
 		update_icon(UPDATE_OVERLAYS)
-		feedinTopanim()
+		INVOKE_ASYNC(src, .proc/feedinTopanim)
 
 /obj/machinery/gibber/verb/eject()
 	set category = "Object"


### PR DESCRIPTION
## What Does This PR Do
Fixes #18736
The gibber feed animation was causing the grab to not be deleted when the mob was put into the gibber. Thus making it possible to quickly move away and thus teleport the mob out of the gibber again.

## Why It's Good For The Game
No more tele-gibs using the gibber

## Testing
Spawn as a chef (makes grabs faster)
Spawn a willing humanoid subject
Grab them and click on the gibber
Walk away just after the `do_after` finishes.
See they don't teleport to you (before they did)

## Changelog
:cl:
fix: You can no longer grab teleport people out of the gibber and tele-gib them later.
/:cl: