### PR TITLE
Candles do not repeatedly update their icon on every process

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -1,3 +1,7 @@
+#define TALL_CANDLE 1
+#define MID_CANDLE 2
+#define SHORT_CANDLE 3
+
 /obj/item/candle
 	name = "red candle"
 	desc = "In Greek myth, Prometheus stole fire from the Gods and gave it to humankind. The jewelry he kept for himself."
@@ -6,6 +10,8 @@
 	item_state = "candle1"
 	w_class = WEIGHT_CLASS_TINY
 	var/wax = 200
+	/// Index for the icon state
+	var/wax_index = TALL_CANDLE
 	var/lit = FALSE
 	var/infinite = FALSE
 	var/start_lit = FALSE
@@ -24,9 +30,9 @@
 
 /obj/item/candle/update_icon_state()
 	if(flickering)
-		icon_state = "candle[get_icon_index()]_flicker"
+		icon_state = "candle[wax_index]_flicker"
 	else
-		icon_state = "candle[get_icon_index()][lit ? "_lit" : ""]"
+		icon_state = "candle[wax_index][lit ? "_lit" : ""]"
 
 /obj/item/candle/can_enter_storage(obj/item/storage/S, mob/user)
 	if(lit)
@@ -60,13 +66,19 @@
 		START_PROCESSING(SSobj, src)
 		update_icon(UPDATE_ICON_STATE)
 
-/obj/item/candle/proc/get_icon_index()
+/obj/item/candle/proc/get_wax_index()
+	if(wax_index == SHORT_CANDLE) // It's at its shortest
+		return
+	var/new_wax_index
 	if(wax > 150)
-		. = 1
+		new_wax_index = TALL_CANDLE
 	else if(wax > 80)
-		. = 2
+		new_wax_index = MID_CANDLE
 	else
-		. = 3
+		new_wax_index = SHORT_CANDLE
+	if(wax_index != new_wax_index)
+		wax_index = new_wax_index
+		update_icon(UPDATE_ICON_STATE)
 
 /obj/item/candle/proc/start_flickering()
 	flickering = TRUE
@@ -82,13 +94,13 @@
 		return
 	if(!infinite)
 		wax--
+		get_wax_index()
 	if(!wax)
 		new/obj/item/trash/candle(src.loc)
 		if(istype(src.loc, /mob))
 			var/mob/M = src.loc
 			M.unEquip(src, 1) //src is being deleted anyway
 		qdel(src)
-	update_icon(UPDATE_ICON_STATE)
 	if(isturf(loc)) //start a fire if possible
 		var/turf/T = loc
 		T.hotspot_expose(700, 5)
@@ -112,3 +124,7 @@
 		return TRUE
 
 	return FALSE
+
+#undef TALL_CANDLE
+#undef MID_CANDLE
+#undef SHORT_CANDLE

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -77,6 +77,7 @@
 	if(wax_index != new_wax_index)
 		wax_index = new_wax_index
 		return TRUE
+	return FALSE
 
 /obj/item/candle/proc/start_flickering()
 	flickering = TRUE

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -67,8 +67,6 @@
 		update_icon(UPDATE_ICON_STATE)
 
 /obj/item/candle/proc/get_wax_index()
-	if(wax_index == SHORT_CANDLE) // It's at its shortest
-		return
 	var/new_wax_index
 	if(wax > 150)
 		new_wax_index = TALL_CANDLE
@@ -94,7 +92,8 @@
 		return
 	if(!infinite)
 		wax--
-		get_wax_index()
+		if(wax_index != SHORT_CANDLE) // It's not at its shortest
+			get_wax_index()
 	if(!wax)
 		new/obj/item/trash/candle(src.loc)
 		if(istype(src.loc, /mob))

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -66,7 +66,7 @@
 		START_PROCESSING(SSobj, src)
 		update_icon(UPDATE_ICON_STATE)
 
-/obj/item/candle/proc/get_wax_index()
+/obj/item/candle/proc/update_wax_index()
 	var/new_wax_index
 	if(wax > 150)
 		new_wax_index = TALL_CANDLE
@@ -76,7 +76,7 @@
 		new_wax_index = SHORT_CANDLE
 	if(wax_index != new_wax_index)
 		wax_index = new_wax_index
-		update_icon(UPDATE_ICON_STATE)
+		return TRUE
 
 /obj/item/candle/proc/start_flickering()
 	flickering = TRUE
@@ -93,7 +93,8 @@
 	if(!infinite)
 		wax--
 		if(wax_index != SHORT_CANDLE) // It's not at its shortest
-			get_wax_index()
+			if(update_wax_index())
+				update_icon(UPDATE_ICON_STATE)
 	if(!wax)
 		new/obj/item/trash/candle(src.loc)
 		if(istype(src.loc, /mob))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds a check to see if candles do need to have their icon updated when lit. At the moment, they do so on every `process`, including even eternal candles which do not need to in the first place.

## Why It's Good For The Game
Cutting on unnecessary proc calls or updating icons.

## Images of changes
Nothing playerfacing.

## Testing
Lit various candles at different wax levels and let them burn.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
