### PR TITLE
Fix failing main surgery during abstract steps getting surgeries stuck

### DIFF
--- a/code/modules/surgery/abstract_steps.dm
+++ b/code/modules/surgery/abstract_steps.dm
@@ -174,7 +174,7 @@
 
 	if(overridden_tool || next_surgery == surgery || !next_surgery)
 		// Continue along with the original surgery.
-		return try_next_step(user, target, target_zone, tool, surgery, null, TRUE)
+		return try_next_step(user, target, target_zone, tool, surgery, null, TRUE, TRUE)
 
 	if(!target.can_run_surgery(next_surgery, user))
 		// Make sure the target can support the surgery.
@@ -199,10 +199,11 @@
  *
  * Arguments:
  * * next_surgery_steps - the steps for the branching surgery to add to the current surgery. If there's no branching surgery (or this would continue the main surgery) ignore this.
- * * override_adding_self - If true, then regardless of the value of insert_self_after, we won't add ourselves in as another step.
+ * * override_adding_self - If true, then on a successful surgery, regardless of the value of insert_self_after, we won't add ourselves in as another step.
+ * * readd_step_on_fail - If true, when we fail a step we'll add the failed step again after the proxy surgery. This is necessary for main surgeries.
  * (for other arguments, see try_op())
  */
-/datum/surgery_step/proxy/proc/try_next_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/running_surgery, list/next_surgery_steps, override_adding_self)
+/datum/surgery_step/proxy/proc/try_next_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/running_surgery, list/next_surgery_steps, override_adding_self, readd_step_on_fail)
 
 	var/list/following_steps = list()
 
@@ -224,6 +225,12 @@
 	if(step_status != SURGERY_INITIATE_SUCCESS)
 		// always add ourselves after a failure so someone can make a different choice.
 		running_surgery.steps.Insert(running_surgery.step_number + 1, type)
+
+		// Since we've already bumped up the step count, if we tried the main branch in the surgery and failed it, we need to add both
+		// the proxy step and the main step to keep them both as options.
+		if(readd_step_on_fail)
+			running_surgery.steps.Insert(running_surgery.step_number + 2, next_step.type)
+
 		running_surgery.step_number++
 
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug that was introduced in #19108 where failing the main "next" surgery step would get you stuck in a weird limbo state. This would most often pop up at the end of organ manipulation, where failing the cautery step would leave you with an open incision and a stuck surgery step.

Fixes #19243

Thanks to meow and matt for letting me know this was an issue.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to finish surgeries is good, actually.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Dropped a vulp on an operating table
- Mashed organ manipulation steps with debug IMS until just before cautery step, then use welder to easily fail the step.
- Before PR, note that this leaves us with a proxy step tacked onto the end of the surgery, with nothing after it.
- After PR, note that this leaves us with the proxy step followed by the cautery step, letting us actually run the cautery step and finish the surgery.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes surgeries getting stuck in inoperable/unfinishable states.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
