### PR TITLE
Buffs the Radio Jammer

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -386,7 +386,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/jobname // the mob's "job"
 
 	if(jammed)
-		Gibberish_all(message_pieces, 100)
+		return
 
 	// --- Human: use their actual job ---
 	if(ishuman(M))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -385,8 +385,8 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/voicemask = 0 // the speaker is wearing a voice mask
 	var/jobname // the mob's "job"
 
-	if(jammed)
-		return
+	if(jammed && !syndiekey)
+		return //All radio is jammed, meaning everything in the jammer radius will be muted.
 
 	// --- Human: use their actual job ---
 	if(ishuman(M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## Original PR's

- https://github.com/tgstation/tgstation/pull/44313
- https://github.com/tgstation/tgstation/pull/68578


## What Does This PR Do
Buffs the radio jammer, it now mutes all radio within its range and has a synergy with the syndicate encryption key. Protecting the headset while the jammer is active.

![dreamseeker_nBqjyvDCcP](https://user-images.githubusercontent.com/62493359/193428554-88c4a1e8-7ffb-4ff8-b983-60eba934c168.gif)


## Why It's Good For The Game
Imma be real with you chief, the radio jammer is an inconsistent and majority of the time piece of shit tool. 

Its less an actual jammer and more a **scrambler** then anything. And even when it does scramble radio lines it still sucks as a tool because it alerts people about its presence. If you scream for help on radio and your message gets scrambled, you've still alerted people that you are in peril. Insult to injury is that sometimes the message is readable enough to the point where people can figure out where you are if you cry loud enough.

The point of this change is to make it an actual good tool. An item ideal for stealth antags who want to abduct people without the fear of getting security on high alert, like what a _real_ jammer should do. Ive also added syndiekey protection for traitors and nuke ops to allow item synergy and viability, you wouldn't want a nukeops buddy to kill all comms with this on.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
booted a server and tested the jammer, worked

## Changelog
:cl:
tweak: The radio jammer now mutes all radio communication, syndicate key's are immune.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
