### PR TITLE
Adminwho topic tweak + Graphics fix verb

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1230,6 +1230,13 @@
 		src << link(GLOB.configuration.system.region_map[choice])
 
 
+/client/verb/reload_graphics()
+	set category = "Special Verbs"
+	set name = "Reload Graphics"
+
+	winset(src, null, "command=\".configure graphics-hwmode off\"")
+	winset(src, null, "command=\".configure graphics-hwmode on\"")
+
 #undef LIMITER_SIZE
 #undef CURRENT_SECOND
 #undef SECOND_COUNT

--- a/code/modules/world_topic/adminwho.dm
+++ b/code/modules/world_topic/adminwho.dm
@@ -1,0 +1,30 @@
+/datum/world_topic_handler/adminwho
+	topic_key = "adminwho"
+	requires_commskey = TRUE
+
+/datum/world_topic_handler/adminwho/execute(list/input, key_valid)
+	var/list/out_data = list()
+
+	for(var/client/C in GLOB.admins)
+		var/list/this_entry = list()
+		// Send both incase we want special formatting
+		this_entry["ckey"] = C.ckey
+		this_entry["key"] = C.key
+		this_entry["rank"] = C.holder.rank
+		// is_afk() returns an int of inactivity, we can use this to determine AFK for how long
+		// This info will not be shown in public channels
+		this_entry["afk"] = C.is_afk()
+		this_entry["stealth"] = "NONE"
+		this_entry["skey"] = "NONE"
+		if(C.holder.fakekey)
+			this_entry["stealth"] = "STEALTH"
+			this_entry["skey"] = C.holder.fakekey
+
+		if(C.holder.big_brother)
+			// While this may seem counter intuitive, only the host has the commskey, and this info wont be broadcasted to chats
+			this_entry["stealth"] = "BB"
+			this_entry["skey"] = C.holder.fakekey
+
+		out_data += list(this_entry)
+
+	return json_encode(out_data)

--- a/code/modules/world_topic/status.dm
+++ b/code/modules/world_topic/status.dm
@@ -3,7 +3,6 @@
 
 /datum/world_topic_handler/status/execute(list/input, key_valid)
 	var/list/status_info = list()
-	var/list/admins = list()
 	status_info["version"] = GLOB.revision_info.commit_hash
 	status_info["mode"] = GLOB.master_mode
 	status_info["respawn"] = GLOB.configuration.general.respawn_enabled
@@ -25,7 +24,6 @@
 			if(C.holder.fakekey)
 				continue	//so stealthmins aren't revealed by the hub
 			admin_count++
-			admins += list(list(C.key, C.holder.rank))
 		player_count++
 	status_info["players"] = player_count
 	status_info["admins"] = admin_count
@@ -34,20 +32,15 @@
 
 	// Add more info if we are authed
 	if(key_valid)
-		if(SSticker && SSticker.mode)
+		if(SSticker.mode)
 			status_info["real_mode"] = SSticker.mode.name
 			status_info["security_level"] = get_security_level()
 			status_info["ticker_state"] = SSticker.current_state
 
-		if(SSshuttle && SSshuttle.emergency)
+		if(SSshuttle.emergency)
 			// Shuttle status, see /__DEFINES/stat.dm
 			status_info["shuttle_mode"] = SSshuttle.emergency.mode
 			// Shuttle timer, in seconds
 			status_info["shuttle_timer"] = SSshuttle.emergency.timeLeft()
-
-		for(var/i in 1 to admins.len)
-			var/list/A = admins[i]
-			status_info["admin[i - 1]"] = A[1]
-			status_info["adminrank[i - 1]"] = A[2]
 
 	return json_encode(status_info)

--- a/paradise.dme
+++ b/paradise.dme
@@ -2590,6 +2590,7 @@
 #include "code\modules\world_topic\_spam_prevention_handler.dm"
 #include "code\modules\world_topic\_topic_base.dm"
 #include "code\modules\world_topic\adminmsg.dm"
+#include "code\modules\world_topic\adminwho.dm"
 #include "code\modules\world_topic\announce.dm"
 #include "code\modules\world_topic\manifest.dm"
 #include "code\modules\world_topic\ping.dm"


### PR DESCRIPTION
## What Does This PR Do
*Please ignore the fact this isn't atomic. If I don't do one I'll forget the other. Do as I say not as I do.*

This PR adds a new `adminwho` topic call (requires auth, you'll see why in a minute) to better display adminwho info out of game. It will now include an actual JSON schema instead of splitting a list for keys starting with `admin` and ending with a count, and will actually consider AFK state, stealth state, etc.

The other thing this PR does is add a verb to reload your graphics. This can happen sometimes with BYOND if you have other apps open that want to use your GPU to do work (yes BYOND is actually GPU accelerated), and can result in bugged overlays. This verb disables and re-enables hardware acceleration ingame without a restart, which should fix these issues.

## Why It's Good For The Game
- Better info in discord on if staff are AFK or not
- Not having to reload the game to fix GPU issues is nice

## Testing

Adminwho topic
![image](https://user-images.githubusercontent.com/25063394/193448667-0bc042c8-2449-4a2e-afe4-24f3ce9152fc.png)

The reload graphics verb works as expected

## Changelog
:cl:
add: Added a verb to reload your graphics if your overlays break. Its located under special verbs.
/:cl:
