### PR TITLE
Fix #19259 Desk bell cannot be picked up when anchored anymore

### DIFF
--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -30,7 +30,7 @@
 
 /obj/item/desk_bell/MouseDrop(atom/over_object)
 	var/mob/M = usr
-	if(HAS_TRAIT(M, TRAIT_HANDS_BLOCKED) || !Adjacent(M))
+	if(HAS_TRAIT(M, TRAIT_HANDS_BLOCKED) || !Adjacent(M) || anchored)
 		return
 	if(!ishuman(M))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Doesnt allow the desk bell to be picked up when its anchored.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/19259

## Testing
<!-- How did you test the PR, if at all? -->
- Tried to pick up a desk bell while anchored and failed
- Tested all other desk bell functions, all look good.
## Changelog
:cl:
tweak: Desk bell cannot be picked up when anchored
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
