### PR TITLE
Magistrate deskside office door button

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -42862,12 +42862,6 @@
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "bYP" = (
-/obj/machinery/door/airlock{
-	name = "Magistrate's Office";
-	req_access_txt = "74";
-	id_tag = "magistrateofficedoor";
-	glass = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42879,6 +42873,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "Magistrate"
+	},
+/obj/machinery/door/airlock/glass{
+	id_tag = "magistrateofficedoor";
+	name = "Magistrate's Office";
+	req_access_txt = "74"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -42864,7 +42864,9 @@
 "bYP" = (
 /obj/machinery/door/airlock{
 	name = "Magistrate's Office";
-	req_access_txt = "74"
+	req_access_txt = "74";
+	id_tag = "magistrateofficedoor";
+	glass = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -42874,6 +42876,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -46022,6 +46027,20 @@
 /obj/item/taperecorder,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/machinery/button/windowtint{
+	id = "Magistrate";
+	pixel_y = -24;
+	dir = 1;
+	pixel_x = -6
+	},
+/obj/machinery/door_control{
+	id = "magistrateofficedoor";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	req_access_txt = "74";
+	pixel_y = -25
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -90354,10 +90373,6 @@
 /obj/machinery/computer/secure_data/laptop,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/button/windowtint{
-	id = "Magistrate";
-	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54882,10 +54882,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/item/radio/intercom{
+	name = "custom placement";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/item/radio/intercom/department/security{
+	pixel_x = -28;
+	pixel_y = -11
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -67067,21 +67071,20 @@
 "jXj" = (
 /obj/item/taperecorder,
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	name = "custom placement";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/item/radio/intercom/department/security{
-	pixel_x = -28;
-	pixel_y = -11
-	},
 /obj/machinery/button/windowtint{
 	dir = 4;
 	id = "Magistrate";
 	pixel_x = -24;
-	pixel_y = 9;
+	pixel_y = 6;
 	req_access_txt = "74"
+	},
+/obj/machinery/door_control{
+	id = "magistrateofficedoor";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	req_access_txt = "74";
+	pixel_y = -6
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -71872,9 +71875,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock{
+	glass = 1;
+	id_tag = "magistrateofficedoor"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -77216,6 +77225,11 @@
 /obj/machinery/camera{
 	c_tag = "Magistrate's Office";
 	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "west bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67084,7 +67084,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -25;
 	req_access_txt = "74";
-	pixel_y = -6
+	pixel_y = -4
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -71875,14 +71875,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock{
-	glass = 1;
-	id_tag = "magistrateofficedoor"
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "Magistrate"
+	},
+/obj/machinery/door/airlock/glass{
+	id_tag = "magistrateofficedoor"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -9931,12 +9931,13 @@
 	c_tag = "Magistrate's Office";
 	dir = 4
 	},
-/obj/machinery/button/windowtint{
-	dir = 4;
-	id = "Magistrate";
-	pixel_x = -24;
-	pixel_y = 6;
-	req_access_txt = "74"
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = -28
+	},
+/obj/item/radio/intercom/department/security{
+	pixel_x = -28;
+	pixel_y = -7
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -9944,13 +9945,20 @@
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /obj/item/megaphone,
-/obj/item/radio/intercom/department/security{
-	pixel_x = 28;
-	pixel_y = -7
+/obj/machinery/button/windowtint{
+	dir = 8;
+	id = "Magistrate";
+	pixel_x = 24;
+	pixel_y = 6;
+	req_access_txt = "74"
 	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/door_control{
+	id = "magistrateofficedoor";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	req_access_txt = "74";
+	pixel_y = -4
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -13940,7 +13948,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Magistrate's Office";
-	req_access_txt = "74"
+	req_access_txt = "74";
+	id_tag = "magistrateofficedoor"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It adds convenience for the magistrate. Now, his front doors have a deskside door button and a window tint button. front doors are also glassed and tinted.

## Why It's Good For The Game
All other Heads and VIPs get this, Magistrate should too.

## Images of changes
Box:
![1](https://user-images.githubusercontent.com/46283583/193686592-46003f68-9dc5-4864-b97c-2ea9a02cafd7.PNG)
Delta:
![2](https://user-images.githubusercontent.com/46283583/193686787-5a0480f5-321c-436e-b844-be7c2a2b2919.PNG)
Meta:
![3](https://user-images.githubusercontent.com/46283583/193686830-87a4f089-7e0a-4aa1-8272-2dd3e32d2631.PNG)

## Testing
Launched every map through test server, joined as Magi, went to the office and tested the buttons.

## Changelog
:cl:
add: Added an office button to the magistrate's office, front doors are now glassed and tinted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
