### PR TITLE
Fixes waterpacks and friends not GCing. Clears atom reference from reagents

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -45,10 +45,11 @@
 	. += "<span class='notice'>The safety is [safety ? "on" : "off"].</span>"
 
 
-/obj/item/extinguisher/New()
-	..()
-	create_reagents(max_water)
-	reagents.add_reagent("water", max_water)
+/obj/item/extinguisher/Initialize(mapload)
+	. = ..()
+	if(!reagents)
+		create_reagents(max_water)
+		reagents.add_reagent("water", max_water)
 
 /obj/item/extinguisher/attack_self(mob/user as mob)
 	safety = !safety

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -128,16 +128,16 @@
 
 	var/obj/item/watertank/tank
 
-/obj/item/reagent_containers/spray/mister/New(parent_tank)
-	..()
-	if(check_tank_exists(parent_tank, src))
-		tank = parent_tank
-		reagents = tank.reagents	//This mister is really just a proxy for the tank's reagents
-		loc = tank
-	return
+/obj/item/reagent_containers/spray/mister/Initialize(mapload)
+	if(!check_tank_exists(loc, src))
+		return INITIALIZE_HINT_QDEL
+	tank = loc
+	reagents = tank.reagents	//This mister is really just a proxy for the tank's reagents
+	return ..()
 
 /obj/item/reagent_containers/spray/mister/Destroy()
 	tank = null
+	reagents = null // Unset, this is the tanks reagents
 	return ..()
 
 /obj/item/reagent_containers/spray/mister/dropped(mob/user as mob)
@@ -151,11 +151,9 @@
 
 /proc/check_tank_exists(parent_tank, mob/living/carbon/human/M, obj/O)
 	if(!parent_tank || !istype(parent_tank, /obj/item/watertank))	//To avoid weird issues from admin spawns
-		M.unEquip(O)
-		qdel(0)
-		return 0
+		return FALSE
 	else
-		return 1
+		return TRUE
 
 /obj/item/reagent_containers/spray/mister/Move()
 	..()
@@ -239,14 +237,20 @@
 	var/metal_synthesis_cooldown = 0
 	var/nanofrost_cooldown = 0
 
-/obj/item/extinguisher/mini/nozzle/New(parent_tank)
-	. = ..()
-	if(check_tank_exists(parent_tank, src))
-		tank = parent_tank
-		reagents = tank.reagents
-		max_water = tank.volume
-		loc = tank
-	return
+/obj/item/extinguisher/mini/nozzle/Initialize(mapload)
+	if(!check_tank_exists(loc, src))
+		return INITIALIZE_HINT_QDEL
+
+	tank = loc
+	reagents = tank.reagents
+	max_water = tank.volume
+
+	return ..()
+
+/obj/item/extinguisher/mini/nozzle/Destroy()
+	tank = null
+	reagents = null // Unset, this is the tanks reagents
+	return ..()
 
 /obj/item/extinguisher/mini/nozzle/Move()
 	..()

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -864,3 +864,4 @@
 	addiction_list = null
 	if(my_atom && my_atom.reagents == src)
 		my_atom.reagents = null
+	my_atom = null

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -45,7 +45,8 @@
 
 /obj/item/reagent_containers/Initialize(mapload)
 	. = ..()
-	create_reagents(volume, temperature_min, temperature_max)
+	if(!reagents) // Some subtypes create their own reagents
+		create_reagents(volume, temperature_min, temperature_max)
 	if(!possible_transfer_amounts)
 		verbs -= /obj/item/reagent_containers/verb/set_APTFT
 	if(spawned_disease)


### PR DESCRIPTION
## What Does This PR Do
Fixes #19255

- Waterpacks and the nozzles now properly GC.
- Move nozzles to Initialize
- Makes reagents not hold a reference to their atom when they get destroyed

The whole water tank stuff needs a refactor. Why are the tanks not related to each other? Refactoring it all will take a bit more time than I can spare though.

## Why It's Good For The Game
GC Gut ja

## Testing
Spawned both a `/obj/item/watertank` and a `/obj/item/watertank/atmos` and deleted both after using both shortly by putting them on my back and spraying some water around.
Waited long enough for the GC to fully be done.

I've checked all subtypes of `/obj/item/reagent_containers` and `/obj/item/extinguisher` to see if any changes made there would impact the subtypes. None behave as weird as the nozzles.

I in-game tested the fire extinguisher and cleaning spray and they behaved as expected.