### PR TITLE
Fix RPD making pipes on the turf when failing to be put in storage

### DIFF
--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -249,6 +249,10 @@
 
 /obj/item/rpd/afterattack(atom/target, mob/user, proximity)
 	..()
+	if(isstorage(target))
+		var/obj/item/storage/S = target
+		if(!S.can_be_inserted(src, stop_messages = TRUE))
+			return
 	if(loc != user)
 		return
 	if(!proximity && !ranged)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check on RPD to not trigger the afterattack if it's a failed attempt at being put into storage.

## Why It's Good For The Game
Fixes #19085

## Images of changes
![rpd](https://user-images.githubusercontent.com/80771500/193692232-b2116dc4-7124-4f15-a00b-791f8df04c14.png)

## Testing
Stuffed an RPD into a bag, took it out and stuffed it full with other stuff, then tried to stick it in.

## Changelog
:cl:
fix: Failing to put a rapid pipe dispenser into storage won't trigger the device on your feet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
