### PR TITLE
Add support for sharing overlays for energy guns

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -21,6 +21,8 @@
 	/// Do you want the gun to fit into a turret, defaults to true, used for if a energy gun is too strong to be in a turret, or does not make sense to be in one.
 	var/can_fit_in_turrets = TRUE
 	var/new_icon_state
+	/// If the item uses a shared set of overlays instead of being based on icon_state
+	var/overlay_set
 	/// Used when updating icon and overlays to determine the energy pips
 	var/ratio
 
@@ -174,17 +176,18 @@
 
 /obj/item/gun/energy/update_overlays()
 	. = ..()
+	var/overlay_name = overlay_set ? overlay_set : icon_state
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	if(modifystate)
-		. += "[icon_state]_[shot.select_name]"
+		. += "[overlay_name]_[shot.select_name]"
 	if(cell.charge < shot.e_cost)
-		. += "[icon_state]_empty"
+		. += "[overlay_name]_empty"
 	else
 		if(!shaded_charge)
 			for(var/i = ratio, i >= 1, i--)
 				. += image(icon = icon, icon_state = new_icon_state, pixel_x = ammo_x_offset * (i -1))
 		else
-			. += image(icon = icon, icon_state = "[icon_state]_[modifystate ? "[shot.select_name]_" : ""]charge[ratio]")
+			. += image(icon = icon, icon_state = "[overlay_name]_[modifystate ? "[shot.select_name]_" : ""]charge[ratio]")
 	if(gun_light && can_flashlight)
 		var/iconF = "flight"
 		if(gun_light.on)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -772,6 +772,7 @@
 	unique_reskin = TRUE
 	charge_sections = 5
 	inhand_charge_sections = 3
+	overlay_set = "handgun" // Reskins are a different icon_state
 
 /obj/item/gun/energy/detective/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Current overlay code for energy guns do not take into account the possibility of them being reskinned, or at least, not while creating extra overlays due to being based on `icon_state`. This adds a var so energy guns can use a shared set of overlays. It doesn't necessarily have to use it, in case someone makes a skin that uses its own unique overlays.

## Why It's Good For The Game
Fixes #19270

## Images of changes
https://user-images.githubusercontent.com/80771500/193698379-c7218bad-984f-41e8-82c4-5720e6025c53.mp4

## Testing
Spawned a few detective guns and reskinned them, checking their charge displays. Also spawned a different energy gun to see if those were working properly as well.

## Changelog
:cl:
fix: Charge display works properly when using a reskinned detective gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
