### PR TITLE
Plant data disks can now be cmagged

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -517,6 +517,9 @@
 /atom/proc/cmag_act()
 	return
 
+/atom/proc/uncmag()
+	return
+
 /**
  * Respond to a radioactive wave hitting this atom
  *

--- a/code/game/objects/cleaning.dm
+++ b/code/game/objects/cleaning.dm
@@ -38,6 +38,7 @@
 
 	if(is_cmagged) //If we've cleaned a cmagged object
 		REMOVE_TRAIT(src, TRAIT_CMAGGED, "clown_emag")
+		uncmag()
 		return TRUE
 	else
 		//Generic cleaning functionality

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -480,19 +480,54 @@
 
 /obj/item/disk/plantgene/update_name()
 	. = ..()
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		name = "nuclear authentication disk"
+		return
 	if(gene)
 		name = "[gene.get_name()] (Plant Data Disk)"
 	else
 		name = "plant data disk"
 
+/obj/item/disk/plantgene/update_desc()
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		desc = "Better keep this safe."
+	else
+		desc = "A disk for storing plant genetic data."
+
+/obj/item/disk/plantgene/update_icon()
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		icon_state = "nucleardisk"
+	else
+		icon_state = "datadisk_hydro"
+
 /obj/item/disk/plantgene/attack_self(mob/user)
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		return
 	read_only = !read_only
 	to_chat(user, "<span class='notice'>You flip the write-protect tab to [read_only ? "protected" : "unprotected"].</span>")
 
+/obj/item/disk/plantgene/cmag_act()
+	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
+		to_chat(usr, "<span class='warning'>The bananium ooze flips a couple bits on the plant disk's display, making it look just like the..!</span>")
+		ADD_TRAIT(src, TRAIT_CMAGGED, "clown_emag")
+		update_name()
+		update_desc()
+		update_icon()
+
+/obj/item/disk/plantgene/uncmag()
+	update_name()
+	update_desc()
+	update_icon()
+
 /obj/item/disk/plantgene/examine(mob/user)
 	. = ..()
-	. += "The write-protect tab is set to [read_only ? "protected" : "unprotected"]."
-
+	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
+		. += "The write-protect tab is set to [read_only ? "protected" : "unprotected"]."
+		return
+	if((user.mind.assigned_role == "Captain" || user.mind.special_role == SPECIAL_ROLE_NUKEOPS) && (user.Adjacent(src)))
+		. += "<span class='warning'>... Wait. This isn't the nuclear authentication disk! It's a clever forgery!</span>"
 
 /*
  *  Plant DNA Disks Box

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -495,7 +495,7 @@
 	else
 		desc = "A disk for storing plant genetic data."
 
-/obj/item/disk/plantgene/update_icon()
+/obj/item/disk/plantgene/update_icon_state()
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_CMAGGED))
 		icon_state = "nucleardisk"
@@ -512,14 +512,10 @@
 	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
 		to_chat(user, "<span class='warning'>The bananium ooze flips a couple bits on the plant disk's display, making it look just like the..!</span>")
 		ADD_TRAIT(src, TRAIT_CMAGGED, "clown_emag")
-		update_name()
-		update_desc()
-		update_icon()
+		update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_ICON)
 
 /obj/item/disk/plantgene/uncmag()
-	update_name()
-	update_desc()
-	update_icon()
+	update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_ICON)
 
 /obj/item/disk/plantgene/examine(mob/user)
 	. = ..()

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -508,9 +508,9 @@
 	read_only = !read_only
 	to_chat(user, "<span class='notice'>You flip the write-protect tab to [read_only ? "protected" : "unprotected"].</span>")
 
-/obj/item/disk/plantgene/cmag_act()
+/obj/item/disk/plantgene/cmag_act(mob/user)
 	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
-		to_chat(usr, "<span class='warning'>The bananium ooze flips a couple bits on the plant disk's display, making it look just like the..!</span>")
+		to_chat(user, "<span class='warning'>The bananium ooze flips a couple bits on the plant disk's display, making it look just like the..!</span>")
 		ADD_TRAIT(src, TRAIT_CMAGGED, "clown_emag")
 		update_name()
 		update_desc()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Jestographic Sequencer, or cmag, (see #18933) can now be used on plant data disks.

Once cmagged, the plant disk's name, description, and icon change to that of the nuclear authentication disk, making it nigh-indistinguishable from the real thing to casual observers.

![image](https://user-images.githubusercontent.com/3611705/193704381-24ded109-f751-4544-807b-7d2581c7120b.png)

The average joe won't be able to tell the difference between a cmagged plant disk and the real NAD, but seasoned veterans can: if a Captain or Nuclear Operative closely examines the disk, they'll see right through the clown's charade!
![image](https://user-images.githubusercontent.com/3611705/193704868-31c1ae0c-d66b-4316-b5fd-40b9f5f8e099.png)
![image](https://user-images.githubusercontent.com/3611705/193704806-8c89c636-e308-4463-863e-17be99cd3e15.png)

It probably doesn't need to be said, but the cmagged plant disk does **not** inherit any of the NAD's functionality. You will not be blowing up the station with this.

This PR also adds a new proc, `uncmag()`, which handles any behavior that needs to be done after a cmagged object is cleaned.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Past its ability to invert airlock access, I envisioned the Jestographic Sequencer as eventually becoming a potent mischief-making tool for the clown, distinct from the emag but every bit as fun. This PR is is the first step towards that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server. Everything seems to work fine.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: The Jestographic Sequencer can now affect plant data disks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
