### PR TITLE
Fix Buildmode's Edit right-click to reset vars again

### DIFF
--- a/code/modules/buildmode/submodes/variable_edit.dm
+++ b/code/modules/buildmode/submodes/variable_edit.dm
@@ -45,7 +45,7 @@
 			to_chat(user, "<span class='warning'>[initial(object.name)] does not have a var called '[varholder]'</span>")
 	if(right_click)
 		if(object.vars.Find(varholder))
-			var/reset_value = object.vars[varholder] // Can't use initial() on a list index so just hope for the best I guess
+			var/reset_value = initial(object.vars[varholder])
 			if(!object.vv_edit_var(varholder, reset_value))
 				to_chat(user, "<span class='warning'>Your edit was rejected by [object].</span>")
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the Edit mode's right-click reset the selected var again

## Why It's Good For The Game
Fixes #18995

## Images of changes
https://user-images.githubusercontent.com/80771500/193711436-169c1b54-89b9-45be-9c77-e9c7afe58b3d.mp4

## Testing
Messed around in build mode

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
