### PR TITLE
Fixes cursed heart overlay remaining active

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -124,6 +124,15 @@
 		RegisterSignal(owner, COMSIG_LIVING_PRE_DEFIB, .proc/just_before_revive)
 		RegisterSignal(owner, COMSIG_LIVING_DEFIBBED, .proc/on_defib_revive)
 
+/obj/item/organ/internal/heart/cursed/remove(mob/living/carbon/M, special)
+	if(owner?.client?.prefs.colourblind_mode == COLOURBLIND_MODE_NONE)
+		owner.client.color = ""
+
+	UnregisterSignal(owner, COMSIG_LIVING_PRE_DEFIB, .proc/just_before_revive)
+	UnregisterSignal(owner, COMSIG_LIVING_DEFIBBED, .proc/on_defib_revive)
+	return ..()
+
+
 /obj/item/organ/internal/heart/cursed/proc/on_defib_revive(mob/living/carbon/shocked, mob/living/carbon/shocker, obj/item/defib, mob/dead/observer/ghost = null)
 	SIGNAL_HANDLER  // COMSIG_LIVING_DEFIBBED
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #19068, where you would be stuck with the red overlay if you had your cursed heart removed while it was active.

Also tags on removing the client's signals that I forgot to do in my last cursed heart PR (oops).
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having you client be blood-red forever seems a little annoying. Also, I can see some possibly unforeseen consequences with these signals not getting properly unregistered, so it's a good thing to do so.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Be vulp
- Use cursed heart
- let it get to red
- delete heart
- red disappears
- I die instantly from cardiac failure
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: The red cursed-heart overlay should now be removed with the heart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
