### PR TITLE
Orbiter component now uses lock_in_orbit parameter, allowing for orbiters that always stay with an atom

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -114,7 +114,8 @@
 	orbiter.orbiting_uid = parent.UID()
 	store_orbit_data(orbiter, orbit_flags)
 
-	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
+	if(!(orbit_flags & ORBIT_LOCK_IN))
+		RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
 
 	// Head first!
 	if(pre_rotation)

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -114,7 +114,7 @@
 	orbiter.orbiting_uid = parent.UID()
 	store_orbit_data(orbiter, orbit_flags)
 
-	if(!(orbit_flags & ORBIT_LOCK_IN))
+	if(!lock_in_orbit)
 		RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
 
 	// Head first!

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -247,7 +247,7 @@
 
 		to_chat(user, "<span class='notice'>You release the wisp. It begins to bob around your head.</span>")
 		icon_state = "lantern"
-		wisp.orbit(user, 20)
+		wisp.orbit(user, 20, lock_in_orbit = TRUE)
 		set_light(0)
 
 		user.update_sight()
@@ -292,9 +292,6 @@
 	icon_state = "orb"
 	light_range = 7
 	layer = ABOVE_ALL_MOB_LAYER
-
-/obj/effect/wisp/onShuttleMove()
-	return
 
 //Red/Blue Cubes
 /obj/item/warp_cube

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -293,6 +293,9 @@
 	light_range = 7
 	layer = ABOVE_ALL_MOB_LAYER
 
+/obj/effect/wisp/onShuttleMove()
+	return
+
 //Red/Blue Cubes
 /obj/item/warp_cube
 	name = "blue cube"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the orbiter component so it actually uses the `lock_in_orbit` parameter/bitflag. It sets those up, but didn't make use of it afterwards.

Now, orbiters that use `lock_in_orbit` will not have `COMSIG_MOVABLE_MOVED` registered to them, and always stick with their atom. Ghosts can still break away as they don't use that bitflag.

## Why It's Good For The Game
Fixes #18739

## Images of changes
https://user-images.githubusercontent.com/80771500/193825726-331a6ad2-65ab-482e-aeb7-463edb0e8103.mp4

## Testing
Used a _spooky_ lantern and went back and forth with a shuttle.

## Changelog
:cl:
fix: Spooky lantern wisps keep orbiting the user while in shuttle transit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
