### PR TITLE
Tweak the cyborg analyzer so it handles cybernetic implants separately

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -333,9 +333,18 @@
 			organ_found = null
 			if(LAZYLEN(H.internal_organs))
 				for(var/obj/item/organ/internal/O in H.internal_organs)
-					if(!O.is_robotic())
+					if(!O.is_robotic() || istype(O, /obj/item/organ/internal/cyberimp))
 						continue
 					organ_found = TRUE
 					to_chat(user, "[capitalize(O.name)]: <font color='red'>[O.damage]</font>")
 			if(!organ_found)
 				to_chat(user, "<span class='warning'>No prosthetics located.</span>")
+			to_chat(user, "<hr>")
+			to_chat(user, "<span class='notice'>Cybernetic implants:</span>")
+			organ_found = null
+			if(LAZYLEN(H.internal_organs))
+				for(var/obj/item/organ/internal/cyberimp/I in H.internal_organs)
+					organ_found = TRUE
+					to_chat(user, "[capitalize(I.name)]: <font color='red'>[I.crit_fail ? "CRITICAL FAILURE" : I.damage]</font>")
+			if(!organ_found)
+				to_chat(user, "<span class='warning'>No implants located.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Due to cyber implants handling critical failure on their own, I split them from the prosthetics section of the cyborg analyzer. If they're failing, they'll show as such.

## Why It's Good For The Game
Fixes #18535. They're also implants, rather than seen as prosthetics or biochips.

## Images of changes
![FAIL](https://user-images.githubusercontent.com/80771500/193844095-34c7e40d-4a0f-4bcf-abff-d755512de0d7.PNG)

## Testing
Spawned as an IPC, and other various customized characters. Had the implant in particular reach critical failure.

## Changelog
:cl:
tweak: Cyborg analyzers treat cyber implants separately, and can detect if they're critically failing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
