### PR TITLE
Diona nymphs eject from dionas if a species change occur

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1278,6 +1278,9 @@
 
 		oldspecies.on_species_loss(src)
 
+	for(var/mob/living/simple_animal/diona/N in contents) // Let nymphs wiggle out
+		N.resist()
+
 	dna.species = new new_species()
 
 	tail = dna.species.tail

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1278,9 +1278,6 @@
 
 		oldspecies.on_species_loss(src)
 
-	for(var/mob/living/simple_animal/diona/N in contents) // Let nymphs wiggle out
-		N.resist()
-
 	dna.species = new new_species()
 
 	tail = dna.species.tail

--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -77,6 +77,9 @@
 	. = ..()
 	H.clear_alert("nolight")
 
+	for(var/mob/living/simple_animal/diona/N in H.contents) // Let nymphs wiggle out
+		N.resist()
+
 /datum/species/diona/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	if(R.id == "glyphosate" || R.id == "atrazine")
 		H.adjustToxLoss(3) //Deal aditional damage

--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -78,7 +78,7 @@
 	H.clear_alert("nolight")
 
 	for(var/mob/living/simple_animal/diona/N in H.contents) // Let nymphs wiggle out
-		N.resist()
+		N.split()
 
 /datum/species/diona/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	if(R.id == "glyphosate" || R.id == "atrazine")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If dionas happen to contain nymphs and change species, those will automatically eject.

This doesn't apply to scooped up nymphs.

## Why It's Good For The Game
Fixes #18138

## Images of changes
https://user-images.githubusercontent.com/80771500/193864860-74cc1935-343a-49d9-a3d8-13eb6ef549a7.mp4

## Testing
Spawned a nymph and diona, and had them merge, then changed the species. Stuffing the nymph into storage or on top of your head won't get affected.

## Changelog
:cl:
fix: Geshalt nymphs automatically get ejected from dionas if they happen to transform into a different species
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
