### PR TITLE
Fixes a runtime with telekinesis and closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -282,8 +282,7 @@
 // tk grab then use on self
 /obj/structure/closet/attack_self_tk(mob/user)
 	add_fingerprint(user)
-	if(!toggle())
-		to_chat(usr, "<span class='notice'>It won't budge!</span>")
+	toggle(user)
 
 /obj/structure/closet/verb/verb_toggleopen()
 	set src in oview(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! --> Removes a line that would never send because theres no usr, which caused this runtime. toggle() didnt even return true or false, so that line would always try to be sent but it would ever show up because usr.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Fixes this runtime:
```
[2022-10-04T12:48:59] Runtime in browserOutput.dm,303: DEBUG: to_chat called with invalid message/target. Message: '<span class='notice'>It won't budge!</span>'. Target: ''.
[2022-10-04T12:48:59]   proc name: to chat (/proc/to_chat)
[2022-10-04T12:48:59]   usr: *REDACTED USER*
[2022-10-04T12:48:59]   usr.loc: The plating (49,70,4) (/turf/simulated/floor/plating)
[2022-10-04T12:48:59]   src: null
[2022-10-04T12:48:59]   call stack:
[2022-10-04T12:48:59]   to chat(null, "<span class=\'notice\'>It won\...", null)
[2022-10-04T12:48:59]   the welding supplies locker (/obj/structure/closet/secure_closet/engineering_welding): toggle(null)
[2022-10-04T12:48:59]   the welding supplies locker (/obj/structure/closet/secure_closet/engineering_welding): attack self tk(Baldric Merryman (/mob/living/carbon/human))
[2022-10-04T12:48:59]   Telekinetic Grab (/obj/item/tk_grab): afterattack(the welding supplies locker (/obj/structure/closet/secure_closet/engineering_welding), Baldric Merryman (/mob/living/carbon/human), 0, "icon-x=20;icon-y=17;left=1;scr...")
[2022-10-04T12:48:59]   Baldric Merryman (/mob/living/carbon/human): ClickOn(the welding supplies locker (/obj/structure/closet/secure_closet/engineering_welding), "icon-x=20;icon-y=17;left=1;scr...")
[2022-10-04T12:48:59]   the welding supplies locker (/obj/structure/closet/secure_closet/engineering_welding): Click(the plating (51,71,4) (/turf/simulated/floor/plating), "mapwindow.map", "icon-x=20;icon-y=17;left=1;scr...")
```

## Testing
<!-- How did you test the PR, if at all? -->
Get runtime before the change
No runtime after the change

## Changelog
Nothing player-facing.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
