### PR TITLE
Fixes a runtime with IV drips

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -40,7 +40,7 @@
 
 /obj/machinery/iv_drip/MouseDrop(mob/living/target)
 	var/mob/user = usr
-	if(user.incapacitated())
+	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 
 	if(!ishuman(user) || !iscarbon(target))

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -39,13 +39,17 @@
 			. += filling
 
 /obj/machinery/iv_drip/MouseDrop(mob/living/target)
-	if(usr.incapacitated())
+	var/mob/user = usr
+	if(user.incapacitated())
 		return
 
-	if(!ishuman(usr) || !iscarbon(target))
+	if(!ishuman(user) || !iscarbon(target))
 		return
 
-	if(Adjacent(target) && usr.Adjacent(target))
+	if(Adjacent(target) && user.Adjacent(target))
+		if(!bag)
+			to_chat(user, "<span class='notice'>There's no IV bag connected to [src]!</span>")
+			return
 		bag.afterattack(target, usr, TRUE)
 		START_PROCESSING(SSmachines, src)
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -48,7 +48,7 @@
 
 	if(Adjacent(target) && user.Adjacent(target))
 		if(!bag)
-			to_chat(user, "<span class='notice'>There's no IV bag connected to [src]!</span>")
+			to_chat(user, "<span class='warning'>There's no IV bag connected to [src]!</span>")
 			return
 		bag.afterattack(target, usr, TRUE)
 		START_PROCESSING(SSmachines, src)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -42,8 +42,7 @@
 	var/mob/user = usr
 	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
-
-	if(!ishuman(user) || !iscarbon(target))
+	if(!ishuman(user))
 		return
 
 	if(Adjacent(target) && user.Adjacent(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Adds a check to see if there is a bag when trying to apply an IV drip to someone

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Fixes this runtime:
```
[2022-10-04T14:49:06] Runtime in iv_drip.dm,49: Cannot execute null.afterattack().
[2022-10-04T14:49:06]   proc name: MouseDrop (/obj/machinery/iv_drip/MouseDrop)
[2022-10-04T14:49:06]   usr: *REDACTED USER*
[2022-10-04T14:49:06]   usr.loc: The floor (25,222,1) (/turf/simulated/floor/plasteel)
[2022-10-04T14:49:06]   src: the IV drip (/obj/machinery/iv_drip)
[2022-10-04T14:49:06]   src.loc: the floor (25,223,1) (/turf/simulated/floor/plasteel)
[2022-10-04T14:49:06]   call stack:
[2022-10-04T14:49:06]   the IV drip (/obj/machinery/iv_drip): MouseDrop(Gustavo Laborde (/mob/living/carbon/human), the floor (25,223,1) (/turf/simulated/floor/plasteel), the floor (25,222,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "mapwindow.map", "icon-x=17;icon-y=17;vis-x=16;v...")
```

## Testing
<!-- How did you test the PR, if at all? -->
Testing on local server, get IC error message instead of runtime

## Changelog
Nothing player facing, just fixes a runtime

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
