### PR TITLE
Fix VV restore to default and add additional info to logs

### DIFF
--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -116,8 +116,7 @@
 				if(!thing)
 					continue
 				var/datum/D = thing
-				// This originally did initial(D.vars[variable]) but initial() doesn't work on a list index
-				if(D.vv_edit_var(variable, D.vars[variable]) != FALSE)
+				if(D.vv_edit_var(variable, initial(D.vars[variable])) != FALSE)
 					accepted++
 				else
 					rejected++
@@ -207,8 +206,8 @@
 		to_chat(src, "[rejected] out of [count] objects rejected your edit")
 
 	log_world("### MassVarEdit by [src]: [O.type] (A/R [accepted]/[rejected]) [variable]=[html_encode("[O.vars[variable]]")]([list2params(value)])")
-	log_admin("[key_name(src)] mass modified [original_name]'s [variable] to [O.vars[variable]] ([accepted] objects modified)")
-	message_admins("[key_name_admin(src)] mass modified [original_name]'s [variable] to [html_encode("[O.vars[variable]]")] ([accepted] objects modified)")
+	log_admin("[key_name(src)] mass modified [original_name]'s [variable] to [O.vars[variable]] (Type: [class]) ([accepted] objects modified)")
+	message_admins("[key_name_admin(src)] mass modified [original_name]'s [variable] to [html_encode("[O.vars[variable]]")] (Type: [class]) ([accepted] objects modified)")
 
 /proc/get_all_of_type(T, subtypes = TRUE)
 	var/list/typecache = list()

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -632,8 +632,7 @@ GLOBAL_PROTECT(VVmaint_only)
 			return
 
 		if(VV_RESTORE_DEFAULT)
-			// This originally did initial(O.vars[variable]) but initial() doesn't work on a list index
-			var_new = O.vars[variable]
+			var_new = initial(O.vars[variable])
 
 		if(VV_TEXT)
 			var/list/varsvars = vv_parse_text(O, var_new)
@@ -644,7 +643,7 @@ GLOBAL_PROTECT(VVmaint_only)
 		to_chat(src, "Your edit was rejected by the object.")
 		return
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_VAR_EDIT, args)
-	log_world("### VarEdit by [src]: [O.type] [variable]=[html_encode("[var_new]")]")
-	log_admin("[key_name(src)] modified [original_name]'s [variable] to [var_new]")
-	var/msg = "[key_name_admin(src)] modified [original_name]'s [variable] to [html_encode("[var_new]")]"
+	log_world("### VarEdit by [src]: [O.type] [variable]=[html_encode("[var_new]")] (Type: [class])")
+	log_admin("[key_name(src)] modified [original_name]'s [variable] to [var_new] (Type: [class])")
+	var/msg = "[key_name_admin(src)] modified [original_name]'s [variable] to [html_encode("[var_new]")] (Type: [class])"
 	message_admins(msg)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cleans up the last part of the `initial()` removal on list indexes, which was on VV.

At the same time, adds the picked type to logging. Most of it falls into captain obvious if you look at the new var, but it doesn't hurt and Restore to Default does need to be distinct.

## Why It's Good For The Game
Tools that actually work.

## Images of changes
![VV](https://user-images.githubusercontent.com/80771500/194065968-0325c8d6-cc0a-4f87-af24-200680ccc0ad.PNG)

## Testing
VV'ing things.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
