### PR TITLE
Ensures status effects can't be added post qdel. Fixing GC issues with mobs caused by status effects

### DIFF
--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -108,6 +108,8 @@
 /// Applies a given status effect to this mob, returning the effect if it was successful or null otherwise
 /mob/living/proc/apply_status_effect(effect, ...)
 	. = null
+	if(QDELETED(src))
+		return
 	var/datum/status_effect/S1 = effect
 	LAZYINITLIST(status_effects)
 	for(var/datum/status_effect/S in status_effects)


### PR DESCRIPTION
## What Does This PR Do
Fixes #19239
The issue was caused by an order of execution thing. Mob gets damaged, gets deleted, and afterwards the effect gets added.
![image](https://user-images.githubusercontent.com/15887760/194137588-0536602b-43b0-4abe-92ad-93e877ebb877.png)
This PR basically ensures no status effect can get added on deleted mobs.

## Why It's Good For The Game
Collect me some garbage please

## Testing
A hivebot, blobspore and venus_human_trap walked into the captains office. All three got shot by a laser and got deleted properly.

Any mob which gets deleted upon getting killed would work.