### PR TITLE
Glowshrooms no longer spread when planted

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -44,7 +44,7 @@
 	},
 /area/ruin/powered)
 "k" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/simulated/floor/plating/asteroid{
 	name = "dirt"
 	},
@@ -78,7 +78,7 @@
 /turf/simulated/floor/plating/asteroid/basalt,
 /area/ruin/powered)
 "q" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/simulated/floor/plating,
 /area/ruin/powered)
 "r" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -98,7 +98,7 @@
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "n" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
 	nitrogen = 23;
@@ -163,7 +163,7 @@
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "u" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/simulated/floor/wood{
 	nitrogen = 23;
 	oxygen = 14;
@@ -204,7 +204,7 @@
 /area/ruin/unpowered/misc_lavaruin)
 "z" = (
 /obj/structure/table/wood,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/item/a_gift,
 /turf/simulated/floor/wood{
 	nitrogen = 23;
@@ -295,7 +295,7 @@
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "J" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
 	nitrogen = 23;

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -387,7 +387,7 @@
 	name = "Space Bar"
 	})
 "bm" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/powered{
 	name = "Space Bar"

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -10,10 +10,8 @@
 	icon_state = "glowshroom" //replaced in New
 	layer = ABOVE_NORMAL_TURF_LAYER
 	max_integrity = 30
-	var/delay = 1200
 	var/floor = 0
 	var/generation = 1
-	var/spreadIntoAdjacentChance = 60
 	var/obj/item/seeds/myseed = /obj/item/seeds/glowshroom
 
 /obj/structure/glowshroom/extinguish_light()
@@ -35,13 +33,6 @@
 /obj/structure/glowshroom/shadowshroom/extinguish_light()
 	return
 
-/obj/structure/glowshroom/single/Spread()
-	return
-
-/obj/structure/glowshroom/examine(mob/user)
-	. = ..()
-	. += "This is a [generation]\th generation [name]!"
-
 /obj/structure/glowshroom/Destroy()
 	QDEL_NULL(myseed)
 	return ..()
@@ -58,7 +49,6 @@
 		myseed.adjust_yield(rand(-1,2))
 		myseed.adjust_production(rand(-3,6))
 		myseed.adjust_endurance(rand(-3,6))
-	delay = delay - myseed.production * 100 //So the delay goes DOWN with better stats instead of up. :I
 	obj_integrity = myseed.endurance
 	max_integrity = myseed.endurance
 	if(myseed.get_gene(/datum/plant_gene/trait/glow))
@@ -79,53 +69,6 @@
 		icon_state = "[base_icon_state][rand(1,3)]"
 	else //if on the floor, glowshroom on-floor sprite
 		icon_state = "[base_icon_state]f"
-
-	addtimer(CALLBACK(src, .proc/Spread), delay)
-
-/obj/structure/glowshroom/proc/Spread()
-	var/turf/ownturf = get_turf(src)
-	var/shrooms_planted = 0
-	for(var/i in 1 to myseed.yield)
-		if(prob(1/(generation * generation) * 100))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
-			var/list/possibleLocs = list()
-			var/spreadsIntoAdjacent = FALSE
-
-			if(prob(spreadIntoAdjacentChance))
-				spreadsIntoAdjacent = TRUE
-
-			for(var/turf/simulated/floor/earth in view(3,src))
-				if(!ownturf.CanAtmosPass(earth))
-					continue
-				if(spreadsIntoAdjacent || !locate(/obj/structure/glowshroom) in view(1,earth))
-					possibleLocs += earth
-				CHECK_TICK
-
-			if(!possibleLocs.len)
-				break
-
-			var/turf/newLoc = pick(possibleLocs)
-
-			var/shroomCount = 0 //hacky
-			var/placeCount = 1
-			for(var/obj/structure/glowshroom/shroom in newLoc)
-				shroomCount++
-			for(var/wallDir in GLOB.cardinal)
-				var/turf/isWall = get_step(newLoc,wallDir)
-				if(isWall.density)
-					placeCount++
-			if(shroomCount >= placeCount)
-				continue
-
-			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE)
-			child.generation = generation + 1
-			shrooms_planted++
-
-			CHECK_TICK
-		else
-			shrooms_planted++ //if we failed due to generation, don't try to plant one later
-	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
-		myseed.yield -= shrooms_planted
-		addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/CalcDir(turf/location = loc)
 	var/direction = 16

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -11,7 +11,6 @@
 	layer = ABOVE_NORMAL_TURF_LAYER
 	max_integrity = 30
 	var/floor = 0
-	var/generation = 1
 	var/obj/item/seeds/myseed = /obj/item/seeds/glowshroom
 
 /obj/structure/glowshroom/extinguish_light()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes glowshrooms, glowcaps, and shadowshroom's ability to spread itself after being planted.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Glowshrooms are notorious for causing a ton of lag due to how the lighting engine works, mostly because of how many sources of light they spawn. This allows the shrooms to still be planted for when someone really wants to create natural lighting, but doesn't want to destroy the server by pressing z a few times.


## Testing
<!-- How did you test the PR, if at all? -->
Spawned in glowshrooms, shadowshrooms, and glowcaps, and went AFK
5 minutes later, none of them had spread.

## Changelog
:cl:
tweak: Glowshrooms and its variants no longer spread when planted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
