### PR TITLE
Admin added contracts generate rewards instead of defaulting to 0 TC

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1233,6 +1233,9 @@
 				var/datum/syndicate_contract/new_contract = new(H, src, list(), target)
 				new_contract.reward_tc = list(0, 0, 0)
 				H.contracts += new_contract
+				for(var/difficulty in EXTRACTION_DIFFICULTY_EASY to EXTRACTION_DIFFICULTY_HARD)
+					var/amount_tc = H.calculate_tc_reward(length(H.contracts), difficulty)
+					new_contract.reward_tc[difficulty] = amount_tc
 				SStgui.update_uis(H)
 				log_admin("[key_name(usr)] has given a new contract to [key_name(current)] with [target.current] as the target")
 				message_admins("[key_name_admin(usr)] has given a new contract to [key_name_admin(current)] with [target.current] as the target")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes contracts added through the traitor panel properly generate rewards based on the difficulty and total amount of contracts.

This doesn't try to mess with preexisting contracts, as I feel like that's a whole different kind of ordeal. Unless a reset is intended.

## Why It's Good For The Game
Fixes #18940

## Images of changes
https://user-images.githubusercontent.com/80771500/194184751-52a59db4-ace8-4571-b09e-4413546dc010.mp4

## Testing
Bought a contractor kit, added contracts through the traitor panel.

## Changelog
:cl:
fix: ahelped contracts have proper rewards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
