### PR TITLE
Tweaks mass hallucination midround message

### DIFF
--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -15,4 +15,4 @@
 		H.AdjustHallucinate(rand(50, 100))
 
 /datum/event/mass_hallucination/announce()
-	GLOB.event_announcement.Announce("It seems that station [station_name()] is passing through a minor radiation field, this may cause some hallucination, but no further damage")
+	GLOB.event_announcement.Announce("The [station_name()] is passing through a minor radiation field. Be advised that acute exposure to space radiation can induce hallucinogenic episodes.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR changes the "mass hallucination" announcement message to have proper punctuation and read more formally.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Proper punctuation good. Making NAS Trurl advisories read more formally is also good.

I removed the "no further damage" part because that seems like a weird judgment call for CC to make considering that most of the crew is tripping balls and acting irrationally.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before:
![image](https://user-images.githubusercontent.com/3611705/194328554-fbc882c6-2ee7-405c-ae47-05daeeffeeea.png)

After:
![image](https://user-images.githubusercontent.com/3611705/194328612-74fc50a2-e32c-4179-beb8-fba16865d270.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled and tested on local debug server.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
spellcheck: Fixed punctuation and altered wording on mass hallucination midround event announcement
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
