### PR TITLE
Fixes monitors having the wrong circuit board when deconstructed

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -15657,10 +15657,7 @@
 	},
 /area/security/permabrig)
 "aTH" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("Prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -23554,10 +23551,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching interrogations.";
-	name = "Interrogation Monitor";
-	network = list("Interrogation");
+/obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = -30
 	},
 /obj/structure/cable{
@@ -31215,10 +31209,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/bridge)
 "bAC" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("Research","Research Outpost","RD");
+/obj/machinery/computer/security/telescreen/rd{
 	pixel_y = 2
 	},
 /turf/simulated/wall,
@@ -69687,10 +69678,7 @@
 	},
 /obj/structure/displaycase/labcage,
 /obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("Research","MiniSat","RD");
+/obj/machinery/computer/security/telescreen/rd{
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4175,10 +4175,8 @@
 /obj/machinery/porta_turret{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 4;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_x = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -13927,10 +13925,8 @@
 /obj/machinery/porta_turret{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_x = 29
 	},
 /turf/simulated/floor/plasteel{
@@ -15638,11 +15634,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the AI Upload.";
+/obj/machinery/computer/security/telescreen/upload{
 	dir = 4;
-	name = "AI Upload Monitor";
-	network = list("AIUpload");
 	pixel_x = -29
 	},
 /obj/machinery/turretid/stun{
@@ -15698,11 +15691,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching areas on the MiniSat.";
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_x = 29
 	},
 /obj/effect/landmark/start/cyborg,
@@ -20818,10 +20808,8 @@
 	},
 /obj/item/storage/secure/briefcase,
 /obj/item/clothing/mask/cigarette/cigar,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -25372,10 +25360,8 @@
 /obj/structure/rack,
 /obj/item/aicard,
 /obj/item/radio/off,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -26359,10 +26345,8 @@
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -28850,10 +28834,8 @@
 /area/medical/medbay)
 "bHC" = (
 /obj/machinery/light,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_y = -30
 	},
 /mob/living/simple_animal/pet/dog/fox/Renault,
@@ -37317,9 +37299,7 @@
 	dir = 1
 	},
 /obj/structure/table/wood,
-/obj/machinery/computer/security/telescreen{
-	name = "vault monitor";
-	network = list("vault");
+/obj/machinery/computer/security/telescreen/vault{
 	pixel_y = 30
 	},
 /obj/item/paper_bin{
@@ -38045,10 +38025,7 @@
 	pixel_y = 34;
 	req_access_txt = "30"
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("Research","MiniSat","RD");
+/obj/machinery/computer/security/telescreen/rd{
 	pixel_x = 31;
 	pixel_y = 30
 	},
@@ -40427,11 +40404,8 @@
 	pixel_x = 8;
 	pixel_y = -36
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
+/obj/machinery/computer/security/telescreen/turbine{
 	dir = 8;
-	name = "turbine vent monitor";
-	network = list("Turbine");
 	pixel_x = 32
 	},
 /obj/machinery/computer/turbine_computer{
@@ -59480,10 +59454,7 @@
 	},
 /area/crew_quarters/courtroom)
 "ghX" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("Prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -62255,10 +62226,8 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 4;
-	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
 	pixel_y = -30
 	},
 /obj/item/folder/blue,
@@ -82003,10 +81972,7 @@
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("Prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = -30
 	},
 /obj/structure/cable/yellow{
@@ -92668,10 +92634,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the horrors within the test chamber.";
-	name = "Research Monitor";
-	network = list("TestChamber");
+/obj/machinery/computer/security/telescreen/research{
 	pixel_y = 30
 	},
 /obj/item/radio/intercom{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10417,14 +10417,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "A telescreen that connects to the engine's camera network.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
 	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
 	pixel_x = 30
-	},
+ 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aOk" = (
@@ -18869,14 +18866,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/computer/security/telescreen{
-	desc = "A telescreen that connects to the engine's camera network.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
 	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
 	pixel_x = 30
-	},
+ 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -46958,14 +46958,11 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "A telescreen that connects to the engine's camera network.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
 	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
 	pixel_y = 30
-	},
+ 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cmk" = (
@@ -61413,14 +61410,11 @@
 /obj/machinery/camera{
 	c_tag = "Engineering East"
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "A telescreen that connects to the engine's camera network.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
 	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
 	pixel_y = 30
-	},
+ 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -46612,10 +46612,7 @@
 	},
 /area/medical/cmostore)
 "clj" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("Research","Research Outpost","RD");
+/obj/machinery/computer/security/telescreen/rd{
 	pixel_y = 2
 	},
 /obj/structure/table/glass,
@@ -55245,10 +55242,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the horrors within the test chamber.";
-	name = "Research Monitor";
-	network = list("TestChamber");
+/obj/machinery/computer/security/telescreen/research{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -63,6 +63,38 @@
 	board_name = "Engine Camera Monitor"
 	build_path = /obj/machinery/computer/security/telescreen/engine
 
+/obj/item/circuitboard/camera/research
+	board_name = "Research Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/research
+
+/obj/item/circuitboard/camera/rd
+	board_name = "Research Director Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/rd
+
+/obj/item/circuitboard/camera/prison
+	board_name = "Prison Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/prison
+
+/obj/item/circuitboard/camera/interrogation
+	board_name = "Interrogation Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/interrogation
+
+/obj/item/circuitboard/camera/minisat
+	board_name = "MiniSat Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/minisat
+
+/obj/item/circuitboard/camera/upload
+	board_name = "AI Upload Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/upload
+
+/obj/item/circuitboard/camera/vault
+	board_name = "Vault Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/vault
+
+/obj/item/circuitboard/camera/turbine
+	board_name = "Turbine Vent Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/turbine
+
 /obj/item/circuitboard/camera/wooden_tv
 	board_name = "Wooden TV"
 	build_path = /obj/machinery/computer/security/wooden_tv

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -59,6 +59,10 @@
 	board_name = "Entertainment Monitor"
 	build_path = /obj/machinery/computer/security/telescreen/entertainment
 
+/obj/item/circuitboard/camera/engine
+	board_name = "Engine Camera Monitor"
+	build_path = /obj/machinery/computer/security/telescreen/engine
+
 /obj/item/circuitboard/camera/wooden_tv
 	board_name = "Wooden TV"
 	build_path = /obj/machinery/computer/security/wooden_tv

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -261,3 +261,9 @@
 	light_color = "#FAC54B"
 	network = list("Power Alarms","Atmosphere Alarms","Fire Alarms")
 	circuit = /obj/item/circuitboard/camera/engineering
+
+/obj/machinery/computer/security/telescreen/engine
+	name = "Engine Monitor"
+	desc = "A telescreen that connects to the engine's camera network.";
+	network = list("engine")
+	circuit = /obj/item/circuitboard/camera/engine

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -263,7 +263,7 @@
 	circuit = /obj/item/circuitboard/camera/engineering
 
 /obj/machinery/computer/security/telescreen/engine
-	name = "Engine Monitor"
+	name = "engine monitor"
 	desc = "A telescreen that connects to the engine's camera network.";
 	network = list("engine")
 	circuit = /obj/item/circuitboard/camera/engine

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -269,49 +269,49 @@
 	circuit = /obj/item/circuitboard/camera/engine
 
 /obj/machinery/computer/security/telescreen/research
-	name = "Research Monitor"
+	name = "research monitor"
 	desc = "Used for watching the horrors within the test chamber.";
 	network = list("TestChamber")
 	circuit = /obj/item/circuitboard/camera/research
 
 /obj/machinery/computer/security/telescreen/rd
-	name = "Research Director Monitor"
+	name = "research director monitor"
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	network = list("Research","Research Outpost","RD","MiniSat")
 	circuit = /obj/item/circuitboard/camera/rd
 
 /obj/machinery/computer/security/telescreen/prison
-	name = "Prison Monitor"
+	name = "prison monitor"
 	desc = "Used for watching Prison Wing holding areas.";
 	network = list("Prison")
 	circuit = /obj/item/circuitboard/camera/prison
 
 /obj/machinery/computer/security/telescreen/interrogation
-	name = "Interrogation Monitor"
+	name = "interrogation monitor"
 	desc = "Used for watching interrogations.";
 	network = list("Interrogation")
 	circuit = /obj/item/circuitboard/camera/interrogation
 
 /obj/machinery/computer/security/telescreen/minisat
-	name = "MiniSat Monitor"
+	name = "minisat monitor"
 	desc = "Used for watching areas on the MiniSat.";
 	network = list("MiniSat","tcomm")
 	circuit = /obj/item/circuitboard/camera/minisat
 
 /obj/machinery/computer/security/telescreen/upload
-	name = "AI Upload Monitor"
+	name = "ai upload monitor"
 	desc = "Used for watching the AI Upload.";
 	network = list("AIUpload")
 	circuit = /obj/item/circuitboard/camera/upload
 
 /obj/machinery/computer/security/telescreen/vault
-	name = "Vault Monitor"
+	name = "vault monitor"
 	desc = "Used for watching the vault.";
 	network = list("vault")
 	circuit = /obj/item/circuitboard/camera/vault
 
 /obj/machinery/computer/security/telescreen/turbine
-	name = "Turbine Vent Monitor"
+	name = "turbine vent monitor"
 	desc = "Used for watching the turbine vent.";
 	network = list("Turbine")
 	circuit = /obj/item/circuitboard/camera/turbine

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -267,3 +267,51 @@
 	desc = "A telescreen that connects to the engine's camera network.";
 	network = list("engine")
 	circuit = /obj/item/circuitboard/camera/engine
+
+/obj/machinery/computer/security/telescreen/research
+	name = "Research Monitor"
+	desc = "Used for watching the horrors within the test chamber.";
+	network = list("TestChamber")
+	circuit = /obj/item/circuitboard/camera/research
+
+/obj/machinery/computer/security/telescreen/rd
+	name = "Research Director Monitor"
+	desc = "Used for watching the RD's goons from the safety of his office.";
+	network = list("Research","Research Outpost","RD","MiniSat")
+	circuit = /obj/item/circuitboard/camera/rd
+
+/obj/machinery/computer/security/telescreen/prison
+	name = "Prison Monitor"
+	desc = "Used for watching Prison Wing holding areas.";
+	network = list("Prison")
+	circuit = /obj/item/circuitboard/camera/prison
+
+/obj/machinery/computer/security/telescreen/interrogation
+	name = "Interrogation Monitor"
+	desc = "Used for watching interrogations.";
+	network = list("Interrogation")
+	circuit = /obj/item/circuitboard/camera/interrogation
+
+/obj/machinery/computer/security/telescreen/minisat
+	name = "MiniSat Monitor"
+	desc = "Used for watching areas on the MiniSat.";
+	network = list("MiniSat","tcomm")
+	circuit = /obj/item/circuitboard/camera/minisat
+
+/obj/machinery/computer/security/telescreen/upload
+	name = "AI Upload Monitor"
+	desc = "Used for watching the AI Upload.";
+	network = list("AIUpload")
+	circuit = /obj/item/circuitboard/camera/upload
+
+/obj/machinery/computer/security/telescreen/vault
+	name = "Vault Monitor"
+	desc = "Used for watching the vault.";
+	network = list("vault")
+	circuit = /obj/item/circuitboard/camera/vault
+
+/obj/machinery/computer/security/telescreen/turbine
+	name = "Turbine Vent Monitor"
+	desc = "Used for watching the turbine vent.";
+	network = list("Turbine")
+	circuit = /obj/item/circuitboard/camera/turbine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Turns multiple monitors into proper items.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
If you deconstruct one of these monitors it will have the telescreen circuit board (wich has all cameras access), it should be the respective circuit board.

## Testing
<!-- How did you test the PR, if at all? -->
- Deconstructed the monitors, it has the correct circuit board now.
## Changelog
:cl:
fix: Fixed monitors having the wrong circuit board when deconstructed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
