### PR TITLE
Add an additional camera to meta xenobio so it fully reaches every pen fully

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48904,7 +48904,7 @@
 /area/maintenance/starboard)
 "cPe" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Starboard";
+	c_tag = "Xenobiology Lab - Central Fore Port";
 	dir = 1;
 	network = list("Research","SS13")
 	},
@@ -66159,6 +66159,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Central Aft Starboard";
+	dir = 4;
+	network = list("Research","SS13")
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -67710,7 +67715,7 @@
 /area/toxins/xenobiology)
 "ktd" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Aft";
+	c_tag = "Xenobiology Lab - Central Fore Starboard";
 	dir = 4;
 	network = list("Research","SS13")
 	},
@@ -91772,7 +91777,7 @@
 /area/security/prison/cell_block/A)
 "wyX" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Port";
+	c_tag = "Xenobiology Lab - Central Aft Port";
 	dir = 6;
 	network = list("Research","SS13")
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48904,7 +48904,7 @@
 /area/maintenance/starboard)
 "cPe" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Fore Port";
+	c_tag = "Xenobiology Lab - Central Port";
 	dir = 1;
 	network = list("Research","SS13")
 	},
@@ -67715,7 +67715,7 @@
 /area/toxins/xenobiology)
 "ktd" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Fore Starboard";
+	c_tag = "Xenobiology Lab - Central Aft Port";
 	dir = 4;
 	network = list("Research","SS13")
 	},
@@ -91777,7 +91777,7 @@
 /area/security/prison/cell_block/A)
 "wyX" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Aft Port";
+	c_tag = "Xenobiology Lab - Central Starboard";
 	dir = 6;
 	network = list("Research","SS13")
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48445,7 +48445,7 @@
 	req_access_txt = "55"
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Fore";
+	c_tag = "Xenobiology Lab - Central Port";
 	dir = 8;
 	network = list("Research","SS13")
 	},
@@ -48904,7 +48904,7 @@
 /area/maintenance/starboard)
 "cPe" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Port";
+	c_tag = "Xenobiology Lab - Central Fore";
 	dir = 1;
 	network = list("Research","SS13")
 	},
@@ -67715,7 +67715,7 @@
 /area/toxins/xenobiology)
 "ktd" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Aft Port";
+	c_tag = "Xenobiology Lab - Central Fore Starboard";
 	dir = 4;
 	network = list("Research","SS13")
 	},
@@ -91777,7 +91777,7 @@
 /area/security/prison/cell_block/A)
 "wyX" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central Starboard";
+	c_tag = "Xenobiology Lab - Central Aft";
 	dir = 6;
 	network = list("Research","SS13")
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Fixes #19308
Adds one extra camera so the bottom right slime pen can be fully reached.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Allows xenobio players to not be irritated by a minor oversight.

## Testing
<!-- How did you test the PR, if at all? -->

Load Meta.
Use the xenobio console.
Can see the previously unreachable corner.
Put a slime in said corner and took our lad back out using the console.

## Changelog
:cl:
fix: Fixed unreachable slime pen corner with the xenobio console in meta xenobio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
