### PR TITLE
[Meta Station] HoP clothes locker now unmissing

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26841,20 +26841,13 @@
 	pixel_x = 26
 	},
 /obj/structure/table/wood,
-/obj/item/paper_bin/nanotrasen{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/stamp/hop{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "custom placement";
 	pixel_x = 6;
 	pixel_y = -34
 	},
+/obj/machinery/smartfridge/id,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
 "bCd" = (
@@ -37328,13 +37321,17 @@
 	network = list("vault");
 	pixel_y = 30
 	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /obj/item/pen{
 	pixel_x = -3;
 	pixel_y = 5
+	},
+/obj/item/paper_bin/nanotrasen{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stamp/hop{
+	pixel_x = -4;
+	pixel_y = -4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
@@ -51974,8 +51971,7 @@
 	c_tag = "Head of Personnel's Office";
 	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/machinery/smartfridge/id,
+/obj/structure/closet/secure_closet/hop2,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
 "daf" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Restores the HoP's clothes locker on Meta station (it was missing previously). Moved some stuff around to make it fit.

## Why It's Good For The Game
Drip is important. we can't have it missing.

## Images of changes
![1](https://user-images.githubusercontent.com/46283583/194671783-0f56627e-ac16-485c-8616-515b61dd2578.PNG)

## Testing
launched a test server, went to HoP office, took the picture

## Changelog
:cl:
fix: Restores the HoP clothes locker on meta station 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
