### PR TITLE
Riot shields no longer block projectiles that pass through windows

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -25,6 +25,11 @@
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
+/obj/item/shield/riot/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, checkpass = PASSTABLE)
+	if(hitby.checkpass(PASSGLASS))
+		final_block_chance = 0
+	return ..()
+
 /obj/item/shield/riot/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/melee/baton))
 		if(cooldown < world.time - 25)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR changes riot shields and their subtypes so that they no longer block any projectiles that can pass through windows.

## Why It's Good For The Game
Currently, riot shields and their subtypes are generally seen as overpowered, as holding one in your hand gives you a 50% chance to block all incoming range and melee attacks. While riot shields were arguably balanced when our combat system was centered around one-hit stuns, they are certainly less balanced now, as being able to effectively take twice as many hits means it usually takes 8 disabler shots instead of 4 to stam-crit, 10 instead of 5 laser shots to soft-crit and 20 instead of 10 laser shots to deep-crit. This is an unreasonably strong passive buff from an item that is fairly common and has a very small downside of having to use one hand to hold a shield.

This change will also help balance the power imbalance between lethal laser and lethal ballistic weaponry a bit, as ballistic weapons currently outshine laser weaponry in almost all situations, due to ballistic weaponry causing internal damage, meanwhile, laser weaponry does not.

Riot shields not blocking projectiles that pass through glass also make sense IC, as a shield that is mostly made of glass, logically, should not stop lasers and disablers that are able to pass through windows made of glass.

## Testing
Tested on private server:

Shot riot shield user a few times with laser gun, they didn't block any shots.
Shot riot shield user a few times with shotgun using rubber shot, they blocked some and got hit by some.
Punched riot shield user a few times, they blocked my punches a few times.
     
## Changelog
:cl:
tweak: Riot and telescopic shields no longer block laser weaponry and disablers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
