### PR TITLE
Admin Maximize Research applies to all tech types

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -160,7 +160,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		files.known_tech[T.id] = T
 	for(var/v in files.known_tech)
 		var/datum/tech/KT = files.known_tech[v]
-		KT.level = 7
+		KT.level = 8
 	files.RefreshResearch()
 
 /obj/machinery/computer/rdconsole/Initialize(mapload)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -160,8 +160,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		files.known_tech[T.id] = T
 	for(var/v in files.known_tech)
 		var/datum/tech/KT = files.known_tech[v]
-		if(KT.level < KT.max_level)
-			KT.level=KT.max_level
+		KT.level = 7
 	files.RefreshResearch()
 
 /obj/machinery/computer/rdconsole/Initialize(mapload)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -235,7 +235,6 @@ research holder datum.
 	var/desc = "description"			//General description of what it does and what it makes.
 	var/id = "id"						//An easily referenced ID. Must be alphanumeric, lower-case, and no symbols.
 	var/level = 1						//A simple number scale of the research level. Level 0 = Secret tech.
-	var/max_level = 1          // Maximum level this can be at (for job objectives)
 	var/rare = 1						//How much CentCom wants to get that tech. Used in supply shuttle tech cost calculation.
 	var/list/req_tech = list()			//List of ids associated values of techs required to research this tech. "id" = #
 
@@ -246,70 +245,59 @@ research holder datum.
 	name = "Materials Research"
 	desc = "Development of new and improved materials."
 	id = "materials"
-	max_level = 7
 
 /datum/tech/engineering
 	name = "Engineering Research"
 	desc = "Development of new and improved engineering parts and methods."
 	id = "engineering"
-	max_level = 7
 
 /datum/tech/plasmatech
 	name = "Plasma Research"
 	desc = "Research into the mysterious substance colloqually known as 'plasma'."
 	id = "plasmatech"
-	max_level = 7
 	rare = 3
 
 /datum/tech/powerstorage
 	name = "Power Manipulation Technology"
 	desc = "The various technologies behind the storage and generation of electicity."
 	id = "powerstorage"
-	max_level = 7
 
 /datum/tech/bluespace
 	name = "'Blue-space' Research"
 	desc = "Research into the sub-reality known as 'blue-space'."
 	id = "bluespace"
-	max_level = 7
 	rare = 2
 
 /datum/tech/biotech
 	name = "Biological Technology"
 	desc = "Research into the deeper mysteries of life and organic substances."
 	id = "biotech"
-	max_level = 7
 
 /datum/tech/combat
 	name = "Combat Systems Research"
 	desc = "The development of offensive and defensive systems."
 	id = "combat"
-	max_level = 7
 
 /datum/tech/magnets
 	name = "Electromagnetic Spectrum Research"
 	desc = "Research into the electromagnetic spectrum. No clue how they actually work, though."
 	id = "magnets"
-	max_level = 7
 
 /datum/tech/programming
 	name = "Data Theory Research"
 	desc = "The development of new computer and artificial intelligence and data storage systems."
 	id = "programming"
-	max_level = 7
 
 /datum/tech/toxins //not meant to be raised by deconstruction, do not give objects toxins as an origin_tech
 	name = "Toxins Research"
 	desc = "Research into plasma based explosive devices. Upgrade through testing explosives in the toxins lab."
 	id = "toxins"
-	max_level = 7
 	rare = 2
 
 /datum/tech/syndicate
 	name = "Illegal Technologies Research"
 	desc = "The study of technologies that violate standard Nanotrasen regulations."
 	id = "syndicate"
-	max_level = 0 // Don't count towards maxed research, since it's illegal.
 	rare = 4
 
 /datum/tech/abductor

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -235,6 +235,7 @@ research holder datum.
 	var/desc = "description"			//General description of what it does and what it makes.
 	var/id = "id"						//An easily referenced ID. Must be alphanumeric, lower-case, and no symbols.
 	var/level = 1						//A simple number scale of the research level. Level 0 = Secret tech.
+	var/max_level = 1          // Maximum level this can be at (for job objectives)
 	var/rare = 1						//How much CentCom wants to get that tech. Used in supply shuttle tech cost calculation.
 	var/list/req_tech = list()			//List of ids associated values of techs required to research this tech. "id" = #
 
@@ -245,59 +246,70 @@ research holder datum.
 	name = "Materials Research"
 	desc = "Development of new and improved materials."
 	id = "materials"
+	max_level = 7
 
 /datum/tech/engineering
 	name = "Engineering Research"
 	desc = "Development of new and improved engineering parts and methods."
 	id = "engineering"
+	max_level = 7
 
 /datum/tech/plasmatech
 	name = "Plasma Research"
 	desc = "Research into the mysterious substance colloqually known as 'plasma'."
 	id = "plasmatech"
+	max_level = 7
 	rare = 3
 
 /datum/tech/powerstorage
 	name = "Power Manipulation Technology"
 	desc = "The various technologies behind the storage and generation of electicity."
 	id = "powerstorage"
+	max_level = 7
 
 /datum/tech/bluespace
 	name = "'Blue-space' Research"
 	desc = "Research into the sub-reality known as 'blue-space'."
 	id = "bluespace"
+	max_level = 7
 	rare = 2
 
 /datum/tech/biotech
 	name = "Biological Technology"
 	desc = "Research into the deeper mysteries of life and organic substances."
 	id = "biotech"
+	max_level = 7
 
 /datum/tech/combat
 	name = "Combat Systems Research"
 	desc = "The development of offensive and defensive systems."
 	id = "combat"
+	max_level = 7
 
 /datum/tech/magnets
 	name = "Electromagnetic Spectrum Research"
 	desc = "Research into the electromagnetic spectrum. No clue how they actually work, though."
 	id = "magnets"
+	max_level = 7
 
 /datum/tech/programming
 	name = "Data Theory Research"
 	desc = "The development of new computer and artificial intelligence and data storage systems."
 	id = "programming"
+	max_level = 7
 
 /datum/tech/toxins //not meant to be raised by deconstruction, do not give objects toxins as an origin_tech
 	name = "Toxins Research"
 	desc = "Research into plasma based explosive devices. Upgrade through testing explosives in the toxins lab."
 	id = "toxins"
+	max_level = 7
 	rare = 2
 
 /datum/tech/syndicate
 	name = "Illegal Technologies Research"
 	desc = "The study of technologies that violate standard Nanotrasen regulations."
 	id = "syndicate"
+	max_level = 0 // Don't count towards maxed research, since it's illegal.
 	rare = 4
 
 /datum/tech/abductor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Technologies had an old var that was probably meant to be used for job objectives. This var was in turn being used by the admin button to maximize research, but that'd result in illegal and alien being untouched as they had a `max_level` of 0 and 1 respectively, and everything else at 7.

This makes the button set tech levels to be a set value of 8 instead, as this is the actual maximum research you can get.

## Why It's Good For The Game
Make the button actually function in full.

## Images of changes
![RD](https://user-images.githubusercontent.com/80771500/194766574-262431e5-29e5-4d47-9611-f8a4b6c2406c.PNG)

## Testing
Went to the RD console, used the Maximize Research button.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
