### PR TITLE
Adds a container capacity check before pill reagent transfer

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -34,6 +34,10 @@
 /obj/item/reagent_containers/food/pill/afterattack(obj/target, mob/user, proximity)
 	if(!proximity || !target.is_refillable())
 		return
+	if(target.reagents.holder_full())
+		to_chat(user, "<span class='warning'>[target] is full.</span>")
+		return
+
 	to_chat(user, "<span class='notice'>You [!target.reagents.total_volume ? "break open" : "dissolve"] [src] in [target].</span>")
 	for(var/mob/O in oviewers(2, user))
 		O.show_message("<span class='warning'>[user] puts something in [target].</span>", 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes pills not checking if target container is full before allowing the player to dissolve them inside. In the case of a container that isn't completely full and a pill with volume greater than the beaker's remaining capacity, as per current behavior however much fits is transferred and the rest destroyed.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more bluespacing your pills by accidentally clicking on a beaker that's already full
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Spawned in a beaker
- Spawned in a bunch of pills
- Checked that a completely full beaker refuses to accept more pills, but a partially-full beaker still does not
- Checked that patches haven't been made able to dissolve in beakers in some freak accident
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can no longer waste pills by attempting to dissolve them in already-full reagent containers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
