### PR TITLE
Cloning pods can now be cmagged

### DIFF
--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -243,6 +243,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRANSFORMING_TRAIT "transforming"
 #define BUCKLING_TRAIT "buckled"
 #define TRAIT_WAS_BATONNED "batonged"
+#define CLOWN_EMAG "clown_emag"
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -434,10 +434,11 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	malfunction()
 
 /obj/machinery/clonepod/cmag_act(mob/user)
-	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
-		playsound(src, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		to_chat(user, "<span class='warning'>A droplet of bananium ooze seeps into the synthmeat storage chamber...</span>")
-		ADD_TRAIT(src, TRAIT_CMAGGED, "clown_emag")
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		return
+	playsound(src, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	to_chat(user, "<span class='warning'>A droplet of bananium ooze seeps into the synthmeat storage chamber...</span>")
+	ADD_TRAIT(src, TRAIT_CMAGGED, CLOWN_EMAG)
 
 /obj/machinery/clonepod/proc/update_clone_antag(mob/living/carbon/human/H)
 	// Check to see if the clone's mind is an antagonist of any kind and handle them accordingly to make sure they get their spells, HUD/whatever else back.
@@ -492,8 +493,8 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 			<i>You feel like a new being.</i></span>")
 		if(HAS_TRAIT(src, TRAIT_CMAGGED))
 			playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)
-			occupant.dna.SetSEState(GLOB.clumsyblock, TRUE, TRUE)
-			occupant.dna.SetSEState(GLOB.comicblock, TRUE, TRUE)
+			occupant.dna.SetSEState(GLOB.clumsyblock, TRUE, FALSE)
+			occupant.dna.SetSEState(GLOB.comicblock, TRUE, FALSE)
 			singlemutcheck(occupant, GLOB.clumsyblock, MUTCHK_FORCED)
 			singlemutcheck(occupant, GLOB.comicblock, MUTCHK_FORCED)
 			occupant.dna.default_blocks.Add(GLOB.clumsyblock) //Until Genetics fixes you, this is your life now

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -188,6 +188,8 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	. = ..()
 	if(mess)
 		. += "It's filled with blood and viscera. You swear you can see it moving..."
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		. += "<span class='warning'>Yellow ooze is dripping out of the synthmeat storage chamber...</span>"
 	if(!occupant || stat & (NOPOWER|BROKEN))
 		return
 	if(occupant && occupant.stat != DEAD)
@@ -431,6 +433,12 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 /obj/machinery/clonepod/emag_act(user)
 	malfunction()
 
+/obj/machinery/clonepod/cmag_act(mob/user)
+	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
+		playsound(src, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		to_chat(user, "<span class='warning'>A droplet of bananium ooze seeps into the synthmeat storage chamber...</span>")
+		ADD_TRAIT(src, TRAIT_CMAGGED, "clown_emag")
+
 /obj/machinery/clonepod/proc/update_clone_antag(mob/living/carbon/human/H)
 	// Check to see if the clone's mind is an antagonist of any kind and handle them accordingly to make sure they get their spells, HUD/whatever else back.
 	if((H.mind in SSticker.mode:revolutionaries) || (H.mind in SSticker.mode:head_revolutionaries))
@@ -482,6 +490,14 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 		to_chat(occupant, "<span class='userdanger'>You remember nothing from the time that you were dead!</span>")
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br>\
 			<i>You feel like a new being.</i></span>")
+		if(HAS_TRAIT(src, TRAIT_CMAGGED))
+			playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)
+			occupant.dna.SetSEState(GLOB.clumsyblock, TRUE, TRUE)
+			occupant.dna.SetSEState(GLOB.comicblock, TRUE, TRUE)
+			singlemutcheck(occupant, GLOB.clumsyblock, MUTCHK_FORCED)
+			singlemutcheck(occupant, GLOB.comicblock, MUTCHK_FORCED)
+			occupant.dna.default_blocks.Add(GLOB.clumsyblock) //Until Genetics fixes you, this is your life now
+			occupant.dna.default_blocks.Add(GLOB.comicblock)
 		occupant.flash_eyes(visual = 1)
 		clonemind = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Jestographic Sequencer (cmag) can now be used on the cloning pod. Doing so taints the pod's synthmeat storage chamber, causing all people who emerge from the cloning pod to have the comic and clumsy disabilities.

![image](https://user-images.githubusercontent.com/3611705/194738435-d08703a3-07dc-447a-b074-205ccedb6265.png)

As with cmagged doors, it's plainly obvious upon examination that the cloning pod has been tampered with, and the pod can be returned to normal functionality by scrubbing it down with soap or a mop.

![image](https://user-images.githubusercontent.com/3611705/194738480-ef4d05ee-f7a3-41fd-85de-6c587526c5af.png)

The genetic disabilities brought on by bananium exposure are quite persistent, and can't be cured with mutadone alone. You'll have to get a Clean S.E. from Genetics to remove your disabilities... or otherwise accept your new life as a honking abomination.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A traitorous clown can now make the crew see the world from his perspective *and* inconvenience security, all without ever reaching for the esword.

Also will occasionally give Genetics something to do other than spending an uninterrupted 45 minutes looking for hulk block.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server. Everything works as described above.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Added Jestographic Sequencer interaction for cloning pod
/:cl:
