### PR TITLE
Makes cult spear not an instant stun.

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -595,25 +595,24 @@
 			else
 				L.visible_message("<span class='warning'>[src] bounces off of [L], as if repelled by an unseen force!</span>")
 		else if(!..())
-			if(!L.null_rod_check())
-				var/datum/status_effect/cult_stun_mark/S = L.has_status_effect(STATUS_EFFECT_CULT_STUN)
-				if(S)
-					S.trigger()
-				else
-					L.KnockDown(10 SECONDS)
-					L.adjustStaminaLoss(60)
-					L.apply_status_effect(STATUS_EFFECT_CULT_STUN)
-					L.flash_eyes(1, TRUE)
-					if(issilicon(L))
-						var/mob/living/silicon/B = L
-						B.emp_act(EMP_HEAVY)
-					else if(iscarbon(L))
-						var/mob/living/carbon/C = L
-						C.Silence(6 SECONDS)
-						C.Stuttering(16 SECONDS)
-						C.CultSlur(20 SECONDS)
-						C.Jitter(16 SECONDS)
-			break_spear(T)
+			if(L.null_rod_check())
+				return
+			var/datum/status_effect/cult_stun_mark/S = L.has_status_effect(STATUS_EFFECT_CULT_STUN)
+			if(S)
+				S.trigger()
+			else
+				L.KnockDown(10 SECONDS)
+				L.adjustStaminaLoss(60)
+				L.apply_status_effect(STATUS_EFFECT_CULT_STUN)
+				L.flash_eyes(1, TRUE)
+				if(issilicon(L))
+					L.emp_act(EMP_HEAVY)
+				else if(iscarbon(L))
+					L.Silence(6 SECONDS)
+					L.Stuttering(16 SECONDS)
+					L.CultSlur(20 SECONDS)
+					L.Jitter(16 SECONDS)
+		break_spear(T)
 	else
 		..()
 

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -604,10 +604,10 @@
 					L.adjustStaminaLoss(60)
 					L.apply_status_effect(STATUS_EFFECT_CULT_STUN)
 					L.flash_eyes(1, TRUE)
-					if(issilicon(hit_atom))
+					if(issilicon(L))
 						var/mob/living/silicon/B = L
 						B.emp_act(EMP_HEAVY)
-					else if(iscarbon(hit_atom))
+					else if(iscarbon(L))
 						var/mob/living/carbon/C = L
 						C.Silence(6 SECONDS)
 						C.Stuttering(16 SECONDS)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -565,7 +565,7 @@
 	force = 17
 	force_unwielded = 17
 	force_wielded = 24
-	throwforce = 40
+	throwforce = 30
 	throw_speed = 2
 	armour_penetration_percentage = 50
 	block_chance = 30
@@ -596,7 +596,23 @@
 				L.visible_message("<span class='warning'>[src] bounces off of [L], as if repelled by an unseen force!</span>")
 		else if(!..())
 			if(!L.null_rod_check())
-				L.Weaken(6 SECONDS)
+				var/datum/status_effect/cult_stun_mark/S = L.has_status_effect(STATUS_EFFECT_CULT_STUN)
+				if(S)
+					S.trigger()
+				else
+					L.KnockDown(10 SECONDS)
+					L.adjustStaminaLoss(60)
+					L.apply_status_effect(STATUS_EFFECT_CULT_STUN)
+					L.flash_eyes(1, TRUE)
+					if(issilicon(hit_atom))
+						var/mob/living/silicon/B = L
+						B.emp_act(EMP_HEAVY)
+					else if(iscarbon(hit_atom))
+						var/mob/living/carbon/C = L
+						C.Silence(6 SECONDS)
+						C.Stuttering(16 SECONDS)
+						C.CultSlur(20 SECONDS)
+						C.Jitter(16 SECONDS)
 			break_spear(T)
 	else
 		..()
@@ -656,7 +672,7 @@
 			var/mob/living/L = spear.loc
 			L.unEquip(spear)
 			L.visible_message("<span class='warning'>An unseen force pulls the blood spear from [L]'s hands!</span>")
-		spear.throw_at(owner, 10, 2, null)
+		spear.throw_at(owner, 10, 2, null, dodgeable = FALSE)
 
 /obj/item/gun/projectile/shotgun/boltaction/enchanted/arcane_barrage/blood
 	name = "blood bolt barrage"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Cult spear no longer instant stuns and does 40 damage.

It now does 30 damage, and marks a person similar to cult spell. If it hits a person who was cult marked, it will trigger the stun.

Recall of the spear has been improved, and will hit threats on the way back that are lying down, or go into a knocked down cultist hand.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A 6 second instant stun is not great. A cult knockdown spell / mark trigger is much better, 

Recall is good if you miss a throw, or as a trap, but could use a bit of help. Adding undodgeable to the throw flag on recall means it will go into the hand more consistently, or can be used to trigger marks, if you want to give up the 150 blood spear.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned in.
Confirmed damage was correct
Confirmed it marked on hit.
Confirmed recall worked on user if lying down.
Confirmed recall worked on knocked down victims.
Confirm it triggered mark.

## Changelog
:cl:
tweak: Cult spear now marks or applies the cult stun effect to a person on hit, instead of weakening them for 6 seconds. Also does less damage on throw, and recall action is more reliable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
