### PR TITLE
Moves paper from layer 4 to layer 3

### DIFF
--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -8,7 +8,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_range = 1
 	throw_speed = 1
-	layer = 4
 	pressure_resistance = 2
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -10,7 +10,7 @@ LINEN BINS
 	icon = 'icons/obj/items.dmi'
 	icon_state = "sheet"
 	item_state = "bedsheet"
-	layer = 4.0
+	layer = 4
 	throwforce = 1
 	throw_speed = 1
 	throw_range = 2

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -13,7 +13,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_range = 1
 	throw_speed = 1
-	layer = 4
 	pressure_resistance = 0
 	slot_flags = SLOT_HEAD
 	body_parts_covered = HEAD

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -7,7 +7,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_range = 2
 	throw_speed = 1
-	layer = 4
 	pressure_resistance = 2
 	attack_verb = list("bapped")
 	var/amount = 0 //Amount of total items clipped to the paper. Note: If you have 2 paper, this should be 1


### PR DESCRIPTION
## What Does This PR Do
Moves paper from layer 4 to layer 3 (Unrelated but also just removes a .0 from bedsheets for readability) 

## Why It's Good For The Game
There is no good reason to have paper on layer 4 rather than layer 3. It's an object, it should be on the object layer. People should not be able to hide under paper. 

## Testing
Compiled, did stuff with paper

## Changelog
:cl:
tweak: Moves paper from layer 4 to layer 3
/:cl:
