### PR TITLE
Box: Fix tile with simultaneous floor and wall turfs in brig.

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -1868,12 +1868,6 @@
 	},
 /turf/space,
 /area/security/securearmoury)
-"aix" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/turf/simulated/wall,
-/area/security/brig)
 "aiz" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -117743,7 +117737,7 @@ aqI
 auy
 aeF
 wsT
-aix
+auc
 auc
 ahX
 qkA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes a floor turf from a tile which is only meant to be a wall.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One turf per tile is the rule.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![paradise dme  cyberiad dmm  - StrongDMM-12_59_04](https://user-images.githubusercontent.com/59303604/194918130-780c0ccc-367e-4b85-9b18-5260fcc463a6.png)

## Testing
<!-- How did you test the PR, if at all? -->
Ran unit tests.
## Changelog
:cl:
fix: Fixed incorrect floor turf assignment in brig.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
