### PR TITLE
Fixes mulebots not being screwable

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -138,10 +138,11 @@
 
 /mob/living/simple_animal/bot/mulebot/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()
-	if(open)
-		on = FALSE
-	update_controls()
-	update_icon()
+	if(.)
+		if(open)
+			on = FALSE
+		update_controls()
+		update_icon()
 
 /mob/living/simple_animal/bot/mulebot/emag_act(mob/user)
 	if(emagged < 1)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -137,11 +137,11 @@
 	return
 
 /mob/living/simple_animal/bot/mulebot/screwdriver_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(open)
 		on = FALSE
 	update_controls()
 	update_icon()
-	return TRUE
 
 /mob/living/simple_animal/bot/mulebot/emag_act(mob/user)
 	if(emagged < 1)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -138,11 +138,13 @@
 
 /mob/living/simple_animal/bot/mulebot/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()
-	if(.)
-		if(open)
-			on = FALSE
-		update_controls()
-		update_icon()
+	if(!.)
+		return
+
+	if(open)
+		on = FALSE
+	update_controls()
+	update_icon()
 
 /mob/living/simple_animal/bot/mulebot/emag_act(mob/user)
 	if(emagged < 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Corrects a small oversight made on #19024, by removing the . = ..(), it made it not able to screwdriver the mulebots. This occured because of a slight misunderstanding from me of the code during reviewing the old PR, which old me decided it was probably an accident because this is one of those procs that always tries to call . = ..()

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #19346

## Testing
<!-- How did you test the PR, if at all? -->
Screwdrivered a mulebot, worked correctly.

## Changelog
:cl:
fix: Mulebots can be screwdrivered again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
