### PR TITLE
Removes corgis as a facehugger target, fixes #19157

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -106,8 +106,6 @@
 /obj/item/clothing/mask/facehugger/proc/Attach(mob/living/M)
 	if(!isliving(M))
 		return FALSE
-	if((!iscorgi(M) && !iscarbon(M)) || isalien(M))
-		return FALSE
 	if(attached)
 		return FALSE
 	else
@@ -225,9 +223,6 @@
 		return FALSE
 	if(HAS_TRAIT(M, TRAIT_XENO_IMMUNE))
 		return FALSE
-
-	if(iscorgi(M))
-		return TRUE
 
 	var/mob/living/carbon/C = M
 	if(ishuman(C))


### PR DESCRIPTION
## What Does This PR Do
Removes corgis as a target for facehuggers. Fixes #19157.

## Why It's Good For The Game
For some strange reason, facehuggers will leap at corgis despite not being able to actually plant a larva in them. As no other simplemobs can be implanted, I've elected to simply remove this entirely rather than make corgis implantable.

## Testing
- Spawned group of corgis
- Spawned facehugger
- Facehugger did not attempt to couple with corgis
- Beat group of vox to death
- Success

## Changelog

:cl:
fix: facehuggers no longer target corgis
/:cl:

