### PR TITLE
Grenade GC improvement

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -108,3 +108,7 @@
 /obj/item/grenade/attack_hand()
 	walk(src, null, null)
 	..()
+
+/obj/item/grenade/Destroy()
+	walk_to(src, 0)
+	. = ..()

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -113,4 +113,4 @@
 /obj/item/grenade/Destroy()
 	///We need to clear the walk_to on destroy to allow a grenade which uses walk_to or related to properly GC
 	walk_to(src, 0)
-	. = ..()
+	return ..()

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -106,9 +106,11 @@
 	return TRUE
 
 /obj/item/grenade/attack_hand()
+	///We need to clear the walk_to on grabbing a moving grenade to have it not leap straight out of your hand
 	walk(src, null, null)
 	..()
 
 /obj/item/grenade/Destroy()
+	///We need to clear the walk_to on destroy to allow a grenade which uses walk_to or related to properly GC
 	walk_to(src, 0)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Improves the GCing on grenades

## Why It's Good For The Game
They use walk(), walk is not reset, ref is kept, the grenades will always fail to GC due to this. GCing is good.
This needs to be done for a boatload of other items as well 


## Testing
compiled, grenades GCed properly. 
## Changelog
NPFC

