### PR TITLE
Sentience Potions now violently explode if overused

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -192,14 +192,19 @@
 
 /obj/item/slimepotion/sentience/examine(mob/user)
 	. = ..()
-	if(user.Adjacent(src))
-		switch(heat_stage)
-			if(0)
-				return
-			if(1)
-				. += "<span class='warning'>The vial is hot to the touch.</span>"
-			if(2)
-				. += "<span class='warning'>The vial is scalding hot! Is it really a good idea to use this..?</span>"
+	if(!user.Adjacent(src))
+		return
+
+	switch(heat_stage)
+		if(0)
+			return
+		if(1)
+			. += "<span class='warning'>The vial is hot to the touch.</span>"
+		if(2)
+			. += "<span class='warning'>The vial is scalding hot! Is it really a good idea to use this..?</span>"
+
+/obj/item/slimepotion/sentience/attack()
+	return
 
 /obj/item/slimepotion/sentience/afterattack(mob/living/M, mob/user, proximity_flag)
 	if(!proximity_flag)
@@ -263,8 +268,10 @@
 		..()
 
 /obj/item/slimepotion/sentience/proc/heat_cooldown()
-	if(heat_stage)
-		addtimer(VARSET_CALLBACK(src, heat_stage, (heat_stage - 1)), 60 SECONDS)
+	if(!heat_stage)
+		return
+
+	addtimer(VARSET_CALLBACK(src, heat_stage, (heat_stage - 1)), 60 SECONDS)
 
 /obj/item/slimepotion/sentience/proc/after_success(mob/living/user, mob/living/simple_animal/SM)
 	return

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -196,8 +196,6 @@
 		return
 
 	switch(heat_stage)
-		if(0)
-			return
 		if(1)
 			. += "<span class='warning'>The vial is hot to the touch.</span>"
 		if(2)
@@ -257,7 +255,7 @@
 	else
 		to_chat(user, "<span class='notice'>[M] looks interested for a moment, but then looks back down. Maybe you should try again later.</span>")
 		heat_stage += 1
-		heat_cooldown()
+		cooldown_timer()
 		if(user.Adjacent(src))
 			switch(heat_stage)
 				if(1)
@@ -267,11 +265,14 @@
 		being_used = FALSE
 		..()
 
-/obj/item/slimepotion/sentience/proc/heat_cooldown()
+/obj/item/slimepotion/sentience/proc/cooldown_timer()
+	addtimer(CALLBACK(src, .proc/cooldown_potion), 60 SECONDS)
+
+/obj/item/slimepotion/sentience/proc/cooldown_potion()
 	if(!heat_stage)
 		return
 
-	addtimer(VARSET_CALLBACK(src, heat_stage, (heat_stage - 1)), 60 SECONDS)
+	heat_stage -= 1
 
 /obj/item/slimepotion/sentience/proc/after_success(mob/living/user, mob/living/simple_animal/SM)
 	return

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -255,7 +255,7 @@
 	else
 		to_chat(user, "<span class='notice'>[M] looks interested for a moment, but then looks back down. Maybe you should try again later.</span>")
 		heat_stage += 1
-		cooldown_timer()
+		addtimer(CALLBACK(src, .proc/cooldown_potion), 60 SECONDS)
 		if(user.Adjacent(src))
 			switch(heat_stage)
 				if(1)
@@ -264,9 +264,6 @@
 					to_chat(user, "<span class='warning'>[src] is boiling hot! You shudder to think what would happen if you used it again...</span>")
 		being_used = FALSE
 		..()
-
-/obj/item/slimepotion/sentience/proc/cooldown_timer()
-	addtimer(CALLBACK(src, .proc/cooldown_potion), 60 SECONDS)
 
 /obj/item/slimepotion/sentience/proc/cooldown_potion()
 	if(!heat_stage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When used more than twice in a one-minute period, Sentience Potions will violently explode, moderately injuring the user with an explosion equivalent to a PDA bomb.

Each time a sentience potion is unsuccessfully used, it "heats up" in stages (starting from 0), and explodes if you try to use it at stage 2. The potion "cools off" a stage every 60 seconds. The user receives warning notifications with every attempt, and can check the state of the sentience potion by examining it.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/3611705/194980863-2376dbd2-a002-4fd4-8729-0b29a37621d8.png)

Xenobiology loves spamming sentience potions on mobs that dchat has zero interest in possessing, resulting in annoying spam that makes lots of people disable sentient mobs in their role preferences entirely. Now, it'll be more difficult to casually pester dchat with sentience requests.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/3611705/194981368-ce17c711-0160-4a54-9c78-78c926d714e9.png)
![image](https://user-images.githubusercontent.com/3611705/194981380-577a019c-dbd7-4a51-81ce-5a4fa5cfe71c.png)
![image](https://user-images.githubusercontent.com/3611705/194981409-79d57f52-63b1-4413-90ed-abfb7bc6ac93.png)
![image](https://user-images.githubusercontent.com/3611705/194981425-1ab12485-ea19-42ad-8568-cfa408e9cae9.png)
![image](https://user-images.githubusercontent.com/3611705/194981445-5c412bc2-ea9d-4e39-b376-3ccdeb0d6afe.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled and tested on local debug server. Sentience potions will blow you up if you use them 3 times in rapid succession, but cool down over time as intended.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Sentience Potions now violently explode with overuse. Be careful!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
