### PR TITLE
Cleans up some disease data

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -230,10 +230,8 @@ GLOBAL_LIST_INIT(advance_cures, list(
 // Assign the spread type and give it the correct description.
 /datum/disease/advance/proc/SetSpread(spread_id)
 	switch(spread_id)
-		if(NON_CONTAGIOUS)
-			spread_text = "None"
-		if(SPECIAL)
-			spread_text = "None"
+		if(NON_CONTAGIOUS, SPECIAL)
+			spread_text = "Non-contagious"
 		if(CONTACT_GENERAL, CONTACT_HANDS, CONTACT_FEET)
 			spread_text = "On contact"
 		if(AIRBORNE)

--- a/code/datums/diseases/appendicitis.dm
+++ b/code/datums/diseases/appendicitis.dm
@@ -2,6 +2,8 @@
 	form = "Condition"
 	name = "Appendicitis"
 	max_stages = 3
+	spread_text = "Non-contagious"
+	spread_flags = NON_CONTAGIOUS
 	cure_text = "Surgery"
 	agent = "Shitty Appendix"
 	viable_mobtypes = list(/mob/living/carbon/human)
@@ -9,7 +11,6 @@
 	desc = "If left untreated the subject will become very weak, and may vomit often."
 	severity = "Dangerous!"
 	disease_flags = CAN_CARRY|CAN_RESIST
-	spread_flags = NON_CONTAGIOUS
 	visibility_flags = HIDDEN_PANDEMIC
 	required_organs = list(/obj/item/organ/internal/appendix)
 	bypasses_immunity = TRUE

--- a/code/datums/diseases/berserker.dm
+++ b/code/datums/diseases/berserker.dm
@@ -3,7 +3,7 @@
 	max_stages = 2
 	stage_prob = 5
 	spread_text = "Non-Contagious"
-	spread_flags = SPECIAL
+	spread_flags = NON_CONTAGIOUS
 	cure_text = "Anti-Psychotics"
 	cures = list("haloperidol")
 	agent = "Jagged Crystals"
@@ -12,7 +12,6 @@
 	desc = "Swearing, shouting, attacking nearby crew members uncontrollably."
 	severity = DANGEROUS
 	disease_flags = CURABLE
-	spread_flags = NON_CONTAGIOUS
 
 /datum/disease/berserker/stage_act()
 	..()

--- a/code/datums/diseases/berserker.dm
+++ b/code/datums/diseases/berserker.dm
@@ -2,7 +2,7 @@
 	name = "Berserker"
 	max_stages = 2
 	stage_prob = 5
-	spread_text = "Non-Contagious"
+	spread_text = "Non-contagious"
 	spread_flags = NON_CONTAGIOUS
 	cure_text = "Anti-Psychotics"
 	cures = list("haloperidol")

--- a/code/datums/diseases/cold.dm
+++ b/code/datums/diseases/cold.dm
@@ -1,6 +1,7 @@
 /datum/disease/cold
 	name = "The Cold"
 	max_stages = 3
+	spread_text = "Airborne"
 	spread_flags = AIRBORNE
 	cure_text = "Rest & Spaceacillin"
 	cures = list("spaceacillin")

--- a/code/datums/diseases/food_poisoning.dm
+++ b/code/datums/diseases/food_poisoning.dm
@@ -2,7 +2,7 @@
 	name = "Food Poisoning"
 	max_stages = 3
 	stage_prob = 5
-	spread_text = "Non-Contagious"
+	spread_text = "Non-contagious"
 	spread_flags = NON_CONTAGIOUS
 	cure_text = "Sleep"
 	agent = "Salmonella"

--- a/code/datums/diseases/food_poisoning.dm
+++ b/code/datums/diseases/food_poisoning.dm
@@ -3,7 +3,7 @@
 	max_stages = 3
 	stage_prob = 5
 	spread_text = "Non-Contagious"
-	spread_flags = SPECIAL
+	spread_flags = NON_CONTAGIOUS
 	cure_text = "Sleep"
 	agent = "Salmonella"
 	cures = list("chicken_soup")
@@ -12,7 +12,6 @@
 	desc = "Nausea, sickness, and vomitting."
 	severity = MINOR
 	disease_flags = CURABLE
-	spread_flags = NON_CONTAGIOUS
 	virus_heal_resistant = TRUE
 
 /datum/disease/food_poisoning/stage_act()

--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -41,7 +41,7 @@
 /datum/disease/gbs/curable
 	name = "Non-Contagious GBS"
 	stage_prob = 5
-	spread_text = "Non-Contagious"
+	spread_text = "Non-contagious"
 	spread_flags = NON_CONTAGIOUS
 	cure_text = "Cryoxadone"
 	cures = list("cryoxadone")

--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -42,10 +42,9 @@
 	name = "Non-Contagious GBS"
 	stage_prob = 5
 	spread_text = "Non-Contagious"
-	spread_flags = SPECIAL
+	spread_flags = NON_CONTAGIOUS
 	cure_text = "Cryoxadone"
 	cures = list("cryoxadone")
 	cure_chance = 10
 	agent = "gibbis"
-	spread_flags = NON_CONTAGIOUS
 	disease_flags = CURABLE

--- a/code/datums/diseases/kuru.dm
+++ b/code/datums/diseases/kuru.dm
@@ -3,7 +3,7 @@
 	name = "Space Kuru"
 	max_stages = 4
 	stage_prob = 5
-	spread_text = "Non-Contagious"
+	spread_text = "Non-contagious"
 	spread_flags = NON_CONTAGIOUS
 	cure_text = "Incurable"
 	agent = "Prions"

--- a/code/datums/diseases/kuru.dm
+++ b/code/datums/diseases/kuru.dm
@@ -4,13 +4,12 @@
 	max_stages = 4
 	stage_prob = 5
 	spread_text = "Non-Contagious"
-	spread_flags = SPECIAL
+	spread_flags = NON_CONTAGIOUS
 	cure_text = "Incurable"
 	agent = "Prions"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	desc = "Uncontrollable laughing."
 	severity = BIOHAZARD
-	spread_flags = NON_CONTAGIOUS
 	disease_flags = CAN_CARRY
 	bypasses_immunity = TRUE //Kuru is a prion disorder, not a virus
 	virus_heal_resistant = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Fixes the Cold and Appendicitis not having proper `spread_text`, rendering as `Type: .` in-game
- Standardizes spread type text across diseases, making the terms and capitalization consistent
- Fixes some diseases having their `spread_flags` defined twice, once as `SPECIAL` and once as `NON_CONTAGIOUS`
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Buggy health analyzer output bad, consistent terminology good, values being weirdly assigned twice for the same disease type bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/100448493/195104684-d8b07dce-cf68-4840-b61a-ee00ec78f87d.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Fed a unathi some Cold-infected blood, as well as surgically extracted its appendix and inserted it back after VV'ing it to be inflamed; observed both conditions to now have proper spread type text when analyzed.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: The Cold and Appendicitis now have proper spread type text output when analyzed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
