### PR TITLE
Fixes an order of operations issue with badmin bombs and spawned mobs

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -402,9 +402,8 @@
 /obj/item/bombcore/badmin/summon/detonate()
 	var/obj/machinery/syndicatebomb/B = src.loc
 	for(var/i = 0; i < amt_summon; i++)
-		var/atom/movable/X = new summon_path
+		var/atom/movable/X = new summon_path(get_turf(src))
 		X.admin_spawned = TRUE
-		X.loc = get_turf(src)
 		if(prob(50))
 			for(var/j = 1, j <= rand(1, 3), j++)
 				step(X, pick(NORTH,SOUTH,EAST,WEST))


### PR DESCRIPTION

## What Does This PR Do
Fixes mobs being initialized in nullspace with badmin bombs
mobs get spawned in nullspace THEN moved into the actual game world, now they spawn in the game world
fixes #19288 
## Why It's Good For The Game
I prefer not to get 100 runtimes (might just be me)

## Testing
set one off no runtimes with the normal one and a varedited one, also passed the GC vibe check
## Changelog
:cl:
fix: Badmin bombs no longer runtime when spawning mobs
/:cl:
