### PR TITLE
Bump DreamAnnotate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python3 tools/ci/check_line_endings.py
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
-        uses: yogstation13/DreamAnnotate@v1
+        uses: yogstation13/DreamAnnotate@v2
         if: always()
         with:
           outputFile: output-annotations.txt


### PR DESCRIPTION
## What Does This PR Do
Bumps `yogstation13/DreamAnnotate@v1` to `yogstation13/DreamAnnotate@v2` 

No codebase change, this is just the CI "plugin" that makes annotations show up when you fail dreamchecker, and it puts the line markings down.

## Why It's Good For The Repo
Something something old version is being deprecated and we need to keep stuff going
