### PR TITLE
Syntiflesh requires more cryoxadone and blood

### DIFF
--- a/code/modules/reagents/chemistry/recipes/food.dm
+++ b/code/modules/reagents/chemistry/recipes/food.dm
@@ -60,7 +60,7 @@
 	name = "Syntiflesh"
 	id = "syntiflesh"
 	result = null
-	required_reagents = list("blood" = 5, "cryoxadone" = 1)
+	required_reagents = list("blood" = 15, "cryoxadone" = 10)
 	result_amount = 1
 
 /datum/chemical_reaction/syntiflesh/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION
## IMPORTANT NOTE
This effects syntiflesh, not synthflesh
Syntiflesh is a meat snack food, and is commonly used for the cloner (Yes, it was referred to as synthflesh on the wiki)
Synthflesh is a chemical used for treating brute/burn

## What Does This PR Do
Syntiflesh requires 15 blood and 10 cryoxadone from 5 blood and 1 cryox to create now

## Why It's Good For The Game
Cloning has been a contentious topic for a long time, and one of its biggest issues is how easy it is to get the materials required to clone someone, previously you would get around~3000 biomass from just 80 units of cryox and a monkey or two. The goal of this PR is to encourage other people to help with the gathering of biomass while still letting medical get enough through medchem... just not enough to heal the station 2-3 times over.

I would like this PR to be testmerged to see if cryox is a necessary evil to prevent... questionable player behavior. 

## Testing
Compiled and ran
It worked yeah (floating points didn't)

## Changelog
:cl:
tweak: More chemicals are required to create Syntiflesh
/:cl:
