### PR TITLE
[GBP: No update] Fixes screen alerts sometimes going invisible

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -149,9 +149,10 @@
 /obj/screen/alert/take_item/proc/cancel_give()
 	SIGNAL_HANDLER
 	var/mob/living/giver = locateUID(giver_UID)
+	var/mob/living/receiver = locateUID(receiver_UID)
 	to_chat(giver, "<span class='warning'>You need to keep the item in your active hand if you want to hand it to someone!</span>")
-	to_chat(locateUID(receiver_UID), "<span class='warning'>[giver] seems to have given up on giving you [locateUID(item_UID)].</span>")
-	qdel(src)
+	to_chat(receiver, "<span class='warning'>[giver] seems to have given up on giving you [locateUID(item_UID)].</span>")
+	receiver.clear_alert("take item [item_UID]")
 
 
 /obj/screen/alert/take_item/Click(location, control, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes alerts going invisible and some alert runtimes. Simply qdeling an alert causes it to remain as a null inside of a mob's `alerts` list, and we get runtimes like the one below. It needs to be properly cleared with `clear_alert()`. I should have seen this sooner.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Actually fixes #18886 this time.
```
Runtime in alert.dm,723: Cannot read null.icon_state
[2022-10-14T04:16:25]   proc name: reorganize alerts (/datum/hud/proc/reorganize_alerts)
[2022-10-14T04:16:25]   src: /datum/hud/human (/datum/hud/human)
[2022-10-14T04:16:25]   call stack:
[2022-10-14T04:16:25]   /datum/hud/human (/datum/hud/human): reorganize alerts()
[2022-10-14T04:16:25]   CHAR_NAME (/mob/living/carbon/human): clear alert("pressure", 0)
[2022-10-14T04:16:25]   CHAR_NAME (/mob/living/carbon/human): handle environment(/datum/gas_mixture (/datum/gas_mixture))
[2022-10-14T04:16:25]   CHAR_NAME (/mob/living/carbon/human): Life(2, 2529)
[2022-10-14T04:16:25]   CHAR_NAME (/mob/living/carbon/human): Life(2, 2529)
[2022-10-14T04:16:25]   CHAR_NAME (/mob/living/carbon/human): Life(2, 2529)
[2022-10-14T04:16:25]   Mobs (/datum/controller/subsystem/mobs): fire(1)
[2022-10-14T04:16:25]   Mobs (/datum/controller/subsystem/mobs): ignite(1)
[2022-10-14T04:16:25]   Master (/datum/controller/master): RunQueue()
[2022-10-14T04:16:25]   Master (/datum/controller/master): Loop()
[2022-10-14T04:16:25]   Master (/datum/controller/master): StartProcessing(0)
[2022-10-14T04:16:25]   (This error will now be silenced for 10 minutes)
```
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. Got two accounts
2. Give an item to the other player
3. Fired the `cancel_give()` proc by switching hands and equipping/dropping the item before the other player accepts
4. No runtimes
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes alerts sometimes going invisible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
