### PR TITLE
Fixes scuffed RCD airlock image previews

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -135,13 +135,15 @@
  * * airlock_type - an airlock typepath.
  */
 /obj/item/rcd/proc/get_airlock_image(airlock_type)
-	var/obj/machinery/door/airlock/proto = new airlock_type(null)
-	proto.icon_state = "closed"
-	if(!proto.glass)
-		proto.add_overlay("fill_closed")
-	var/icon/I = getFlatIcon(proto)
-	qdel(proto)
-	return "[icon2base64(I)]"
+	var/obj/machinery/door/airlock/airlock = airlock_type
+	var/icon/base = icon(initial(airlock.icon), "closed")
+	if(initial(airlock.glass))
+		var/icon/glass_fill = icon(initial(airlock.overlays_file), "glass_closed")
+		base.Blend(glass_fill, ICON_OVERLAY)
+	else
+		var/icon/solid_fill = icon(initial(airlock.icon), "fill_closed")
+		base.Blend(solid_fill, ICON_OVERLAY)
+	return "[icon2base64(base)]"
 
 /**
  * Runs a series of pre-checks before opening the radial menu to the user.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes scuffed RCD airlock image previews and re-writes the code a bit to not use `getFlatIcon()`.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Images of changes
![dreamseeker_cZT3mkRF7A](https://user-images.githubusercontent.com/42044220/195774511-68cb98aa-43ca-4b2e-a651-5f1dda7e3754.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Loaded into the game. Viewed the RCD airlock image previews.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: RCD airlock image previews appear normally again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
