### PR TITLE
Vent crawling antagonists spawn in vents directly

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -32,6 +32,8 @@
 		if(C)
 			C.remove_from_respawnable_list()
 			var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
+			new_xeno.forceMove(vent)
+			new_xeno.add_ventcrawl(vent)
 			new_xeno.amount_grown += (0.75 * new_xeno.max_grown)	//event spawned larva start off almost ready to evolve.
 			new_xeno.key = C.key
 			if(SSticker && SSticker.mode)

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -32,10 +32,10 @@
 		if(C)
 			C.remove_from_respawnable_list()
 			var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
-			new_xeno.forceMove(vent)
-			new_xeno.add_ventcrawl(vent)
 			new_xeno.amount_grown += (0.75 * new_xeno.max_grown)	//event spawned larva start off almost ready to evolve.
 			new_xeno.key = C.key
+			new_xeno.forceMove(vent)
+			new_xeno.add_ventcrawl(vent)
 			if(SSticker && SSticker.mode)
 				SSticker.mode.xenos += new_xeno.mind
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -27,6 +27,8 @@
 	B.key = M.key
 	B.mind.special_role = SPECIAL_ROLE_BLOB
 	SSticker.mode.update_blob_icons_added(B.mind)
+	B.forceMove(vent)
+	B.add_ventcrawl(vent)
 
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
 	to_chat(B, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Blob)</span>")

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -73,3 +73,8 @@
 		successSpawn = TRUE
 
 #undef TS_HIGHPOP_TRIGGER
+#undef GREEN_SPIDER
+#undef PRINCE_SPIDER
+#undef WHITE_SPIDER
+#undef PRINCESS_SPIDER
+#undef QUEEN_SPIDER

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -1,4 +1,9 @@
 #define TS_HIGHPOP_TRIGGER 80
+#define GREEN_SPIDER 1
+#define PRINCE_SPIDER 2
+#define WHITE_SPIDER 3
+#define PRINCESS_SPIDER 4
+#define QUEEN_SPIDER 5
 
 /datum/event/spider_terror
 	announceWhen = 240
@@ -23,27 +28,27 @@
 	var/spider_type
 	var/infestation_type
 	if((length(GLOB.clients)) < TS_HIGHPOP_TRIGGER)
-		infestation_type = pick(1, 2, 3, 4)
+		infestation_type = pick(GREEN_SPIDER, PRINCE_SPIDER, WHITE_SPIDER, PRINCESS_SPIDER)
 	else
-		infestation_type = pick(2, 3, 4, 5)
+		infestation_type = pick(PRINCE_SPIDER, WHITE_SPIDER, PRINCESS_SPIDER, QUEEN_SPIDER)
 	switch(infestation_type)
-		if(1)
+		if(GREEN_SPIDER)
 			// Weakest, only used during lowpop.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/green
 			spawncount = 5
-		if(2)
+		if(PRINCE_SPIDER)
 			// Fairly weak. Dangerous in single combat but has little staying power. Always gets whittled down.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/prince
 			spawncount = 1
-		if(3)
+		if(WHITE_SPIDER)
 			// Variable. Depends how many they infect.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/white
 			spawncount = 2
-		if(4)
+		if(PRINCESS_SPIDER)
 			// Pretty strong.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess
 			spawncount = 3
-		if(5)
+		if(QUEEN_SPIDER)
 			// Strongest, only used during highpop.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen
 			spawncount = 1
@@ -59,6 +64,9 @@
 		var/mob/living/simple_animal/hostile/poison/terror_spider/S = new spider_type(vent.loc)
 		var/mob/M = pick_n_take(candidates)
 		S.key = M.key
+		if(infestation_type != PRINCE_SPIDER)
+			S.forceMove(vent)
+			S.add_ventcrawl(vent)
 		SEND_SOUND(S, sound('sound/ambience/antag/terrorspider.ogg'))
 		to_chat(S, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Terror_Spider)</span>")
 		spawncount--


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This makes the blob mouse, spiders and xeno larvas spawn in vents instead of directly on top of them. Except Prince. Prince is too big.

Some defines were made for spiders since that code was a mess.

## Why It's Good For The Game
Gives a chance to spawning vent crawlers. Except Prince.

## Images of changes
https://user-images.githubusercontent.com/80771500/195956450-0558a854-59ff-4f01-bc9f-814a7ba7e63b.mp4

## Testing
Spawned using the various event procs. Mouse was the first attempt.

## Changelog
:cl:
tweak: Blob mouse, xeno larva and spiders spawn in vents instead of on top (Except Prince)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
