### PR TITLE
Makes wormhole projector portals spawn effects once every 0.5 seconds max

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -6,8 +6,8 @@
  * - destination - Where to teleport the atom to
  * - variance_range - With what precision to do the teleport. 0 means on target. Higher means that many turfs around it
  * - force_teleport - Whether to use forceMove instead of Move to move the atom to the destination
- * - effect_in - The effect started at the starting turf
- * - effect_out - The effect started at the destination turf
+ * - effect_in - The effect started at the starting turf. If set to NONE then no effect is used
+ * - effect_out - The effect started at the destination turf. If set to NONE then no effect is used
  * - sound_in - The sound played at the starting turf
  * - sound_out - The sound played at the destination turf
  * - bypass_area_flag - Whether is_teleport_allowed is skipped or not

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -2,12 +2,27 @@
  * Will teleport the given atom to the given destination using the other parameters
  *
  * Arguments:
- * - atom_to_teleport - List of atoms. Can accept output of view() and range() procs.
- *
+ * - atom_to_teleport - Atom to teleport
+ * - destination - Where to teleport the atom to
+ * - variance_range - With what precision to do the teleport. 0 means on target. Higher means that many turfs around it
+ * - force_teleport - Whether to use forceMove instead of Move to move the atom to the destination
+ * - effect_in - The effect started at the starting turf
+ * - effect_out - The effect started at the destination turf
+ * - sound_in - The sound played at the starting turf
+ * - sound_out - The sound played at the destination turf
+ * - bypass_area_flag - Whether is_teleport_allowed is skipped or not
+ * - safe_turf_pick - Whether the chosen random turf from the variance is prefered to be a safe turf or not
  */
-/proc/do_teleport(atom_to_teleport, destination, precision = 0, force_teleport = 1, effect_in = null, effect_out = null, sound_in = null, sound_out = null, bypass_area_flag = FALSE, safe_turf_pick = FALSE)
+/proc/do_teleport(atom_to_teleport, destination, variance_range = 0, force_teleport = TRUE, datum/effect_system/effect_in = null, datum/effect_system/effect_out = null, sound_in = null, sound_out = null, bypass_area_flag = FALSE, safe_turf_pick = FALSE)
 	var/datum/teleport/instant/science/D = new // default here
-	if(D.start(atom_to_teleport, destination, precision, force_teleport, effect_in, effect_out, sound_in, sound_out, bypass_area_flag, safe_turf_pick))
+	if(isnull(effect_in) || isnull(effect_out)) // Set default effects
+		var/datum/effect_system/spark_spread/effect = new
+		effect.set_up(5, 1, atom_to_teleport)
+		if(isnull(effect_in))
+			effect_in = effect
+		if(isnull(effect_out))
+			effect_out = effect
+	if(D.start(atom_to_teleport, destination, variance_range, force_teleport, effect_in, effect_out, sound_in, sound_out, bypass_area_flag, safe_turf_pick))
 		return 1
 	return 0
 
@@ -173,16 +188,6 @@
 
 
 /datum/teleport/instant/science
-
-/datum/teleport/instant/science/setEffects(datum/effect_system/aeffectin,datum/effect_system/aeffectout)
-	if(aeffectin==null || aeffectout==null) // fuck you
-		var/datum/effect_system/spark_spread/aeffect = new
-		aeffect.set_up(5, 1, teleatom)
-		effectin = effectin || aeffect
-		effectout = effectout || aeffect
-		return 1
-	else
-		return ..()
 
 /datum/teleport/instant/science/setPrecision(aprecision)
 	..()

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -1,7 +1,13 @@
-//wrapper
-/proc/do_teleport(ateleatom, adestination, aprecision = 0, afteleport = 1, aeffectin = null, aeffectout = null, asoundin = null, asoundout = null, bypass_area_flag = FALSE, safe_turf_pick = FALSE)
-	var/datum/teleport/instant/science/D = new
-	if(D.start(arglist(args)))
+/**
+ * Will teleport the given atom to the given destination using the other parameters
+ *
+ * Arguments:
+ * - atom_to_teleport - List of atoms. Can accept output of view() and range() procs.
+ *
+ */
+/proc/do_teleport(atom_to_teleport, destination, precision = 0, force_teleport = 1, effect_in = null, effect_out = null, sound_in = null, sound_out = null, bypass_area_flag = FALSE, safe_turf_pick = FALSE)
+	var/datum/teleport/instant/science/D = new // default here
+	if(D.start(atom_to_teleport, destination, precision, force_teleport, effect_in, effect_out, sound_in, sound_out, bypass_area_flag, safe_turf_pick))
 		return 1
 	return 0
 
@@ -159,7 +165,7 @@
 		return doTeleport()
 	return 0
 
-/datum/teleport/instant/start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
+/datum/teleport/instant/start(ateleatom, adestination, aprecision = 0, afteleport = 1, aeffectin = null, aeffectout = null, asoundin = null, asoundout = null, bypass_area_flag = FALSE, safe_turf_pick = FALSE)
 	if(..())
 		if(teleport())
 			return 1
@@ -169,7 +175,7 @@
 /datum/teleport/instant/science
 
 /datum/teleport/instant/science/setEffects(datum/effect_system/aeffectin,datum/effect_system/aeffectout)
-	if(aeffectin==null || aeffectout==null)
+	if(aeffectin==null || aeffectout==null) // fuck you
 		var/datum/effect_system/spark_spread/aeffect = new
 		aeffect.set_up(5, 1, teleatom)
 		effectin = effectin || aeffect
@@ -190,7 +196,7 @@
 				safe_turf_first = FALSE
 			else
 				precision = max(rand(1, 100) * length(bagholding), 100)
-			
+
 			if(isliving(teleatom))
 				var/mob/living/MM = teleatom
 				to_chat(MM, "<span class='warning'>The bluespace interface on your bag of holding interferes with the teleport!</span>")

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -732,7 +732,7 @@
 		M.Confused(20 SECONDS)
 		M.flash_eyes(override_blindness_check = TRUE)
 		M.EyeBlind(20 SECONDS)
-		do_teleport(M, get_turf(M), 5, asoundin = 'sound/magic/cult_spell.ogg')
+		do_teleport(M, get_turf(M), 5, sound_in = 'sound/magic/cult_spell.ogg')
 		qdel(src)
 		return
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -116,10 +116,10 @@
 		icon_state = fail_icon
 		var/list/target_z = levels_by_trait(SPAWN_RUINS)
 		target_z -= M.z
-		if(!attempt_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), pick(target_z)), 0, FALSE))
+		if(!attempt_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), pick(target_z)), 0, FALSE)) // Try to send them to deep space.
 			return FALSE
 	else
-		if(!attempt_teleport(M, target, precision))
+		if(!attempt_teleport(M, target, precision)) // Try to send them to a turf adjacent to target.
 			return FALSE
 	if(one_use)
 		qdel(src)
@@ -132,7 +132,7 @@
 	if(!use_effects)
 		effect = NONE // No effect
 
-	if(!do_teleport(victim, destination, variance, force_teleport, effect, effect, bypass_area_flag = ignore_tele_proof_area_setting)) // Try to send them to deep space.
+	if(!do_teleport(victim, destination, variance, force_teleport, effect, effect, bypass_area_flag = ignore_tele_proof_area_setting))
 		invalid_teleport()
 		return FALSE
 	effect_cooldown = world.time + EFFECT_COOLDOWN

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -1,3 +1,5 @@
+#define EFFECT_COOLDOWN 0.5 SECONDS
+
 /obj/effect/portal
 	name = "portal"
 	desc = "Looks unstable. Best to test it with the clown."
@@ -17,6 +19,8 @@
 	var/can_multitool_to_remove = FALSE
 	var/ignore_tele_proof_area_setting = FALSE
 	var/one_use = FALSE // Does this portal go away after one teleport?
+	/// The time after which the effects should play again. Too many effects can lag the server
+	var/effect_cooldown = 0
 
 /obj/effect/portal/New(loc, turf/_target, obj/creation_object = null, lifespan = 300, mob/creation_mob = null)
 	..()
@@ -112,15 +116,26 @@
 		icon_state = fail_icon
 		var/list/target_z = levels_by_trait(SPAWN_RUINS)
 		target_z -= M.z
-		if(!do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), pick(target_z)), 0, bypass_area_flag = ignore_tele_proof_area_setting)) // Try to send them to deep space.
-			invalid_teleport()
+		if(!attempt_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), pick(target_z)), 0, FALSE))
 			return FALSE
 	else
-		if(!do_teleport(M, target, precision, bypass_area_flag = ignore_tele_proof_area_setting)) // Try to send them to a turf adjacent to target.
-			invalid_teleport()
+		if(!attempt_teleport(M, target, precision))
 			return FALSE
 	if(one_use)
 		qdel(src)
+
+	return TRUE
+
+/obj/effect/portal/proc/attempt_teleport(atom/movable/victim, turf/destination, variance = 0, force_teleport = TRUE)
+	var/use_effects = world.time >= effect_cooldown
+	var/effect = null // Will result in the default effect being used
+	if(!use_effects)
+		effect = NONE // No effect
+
+	if(!do_teleport(victim, destination, variance, force_teleport, effect, effect, bypass_area_flag = ignore_tele_proof_area_setting)) // Try to send them to deep space.
+		invalid_teleport()
+		return FALSE
+	effect_cooldown = world.time + EFFECT_COOLDOWN
 	return TRUE
 
 /obj/effect/portal/proc/invalid_teleport()
@@ -135,3 +150,5 @@
 	failchance = 0
 	precision = 0
 	ignore_tele_proof_area_setting = TRUE
+
+#undef EFFECT_COOLDOWN

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -204,7 +204,7 @@ Difficulty: Hard
 	if(mode == BLUESPACE)
 		new /obj/effect/temp_visual/bsg_kaboom(get_turf(src))
 		src.visible_message("<span class='danger'>[src] teleports somewhere nearby!</span>")
-		do_teleport(src, target, 7, asoundin = 'sound/effects/phasein.ogg', safe_turf_pick = TRUE) //Teleport within 7 tiles of the target
+		do_teleport(src, target, 7, sound_in = 'sound/effects/phasein.ogg', safe_turf_pick = TRUE) //Teleport within 7 tiles of the target
 		new /obj/effect/temp_visual/bsg_kaboom(get_turf(src))
 
 		TR.health_and_snap_check(FALSE)// We want the legs to instantly teleport with it, without regening

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -722,7 +722,7 @@
 		if(loc == user && is_teleport_allowed(userturf.z)) //Because Nuke Ops bringing this back on their shuttle, then looting the ERT area is 2fun4you!
 			visible_message("<span class='notice'>[src] twists and bends, relocating itself!</span>")
 			throwSmoke(userturf)
-			do_teleport(user, userturf, 8, asoundin = 'sound/effects/phasein.ogg')
+			do_teleport(user, userturf, 8, sound_in = 'sound/effects/phasein.ogg')
 			throwSmoke(get_turf(user))
 			warn_admins(user, "Teleport", 0)
 

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -29,7 +29,7 @@
 		src.visible_message("<span class='warning'>[src]'s fragments begin rapidly vibrating and blink out of existence.</span>")
 		qdel(src)
 		return
-	do_teleport(L, get_turf(L), blink_range, asoundin = 'sound/effects/phasein.ogg')
+	do_teleport(L, get_turf(L), blink_range, sound_in = 'sound/effects/phasein.ogg')
 	L.apply_status_effect(STATUS_EFFECT_TELEPORTSICK)
 
 /obj/item/stack/ore/bluespace_crystal/throw_impact(atom/hit_atom)


### PR DESCRIPTION
## What Does This PR Do
Makes the portals, made from wormhole projectors, only spawn effects once every 0.5 seconds

## Why It's Good For The Game
Effects can harm performance if overdone

## Testing
- Make a wormhole projector
- Make two portals with it
- Walk through it fast enough

## Changelog
:cl:
tweak: Wormhole projector portals now only spawn effects every 0.5 seconds
/:cl:
