### PR TITLE
Dusts dead mobs too when the nuke goes off

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -329,14 +329,18 @@ SUBSYSTEM_DEF(ticker)
 				M.client.screen += cinematic	//show every client the cinematic
 	else	//nuke kills everyone on z-level 1 to prevent "hurr-durr I survived"
 		for(var/mob/M in GLOB.mob_list)
-			if(M.stat != DEAD)
-				var/turf/T = get_turf(M)
-				if(T && is_station_level(T.z) && !istype(M.loc, /obj/structure/closet/secure_closet/freezer) && !(issilicon(M) && override == "AI malfunction"))
+			var/turf/T = get_turf(M)
+			if(T && is_station_level(T.z) && !istype(M.loc, /obj/structure/closet/secure_closet/freezer) && !(issilicon(M) && override == "AI malfunction"))
+				if(M.stat != DEAD)
 					to_chat(M, "<span class='danger'><B>The blast wave from the explosion tears you atom from atom!</B></span>")
 					var/mob/ghost = M.ghostize()
 					M.dust() //no mercy
 					if(ghost && ghost.client) //Play the victims an uninterrupted cinematic.
 						ghost.client.screen += cinematic
+					CHECK_TICK
+				else //Dust dead mobs too
+					if(!isobserver(M)) //except observers
+						M.dust()
 					CHECK_TICK
 			if(M && M.client) //Play the survivors a cinematic.
 				M.client.screen += cinematic


### PR DESCRIPTION
Fixes #19408 by implemeting dusting for non-alive mobs. The "should this mob be dusted" check has been extracted one level up in the condition hierarchy to avoid duplicating it (moved it one line up).

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Dead mobs are now dusted too when in range of a nuke going off at station zlevel, fixing issue #19408.

Instead of filtering if the mobs are dead, first I check if they should be dusted (are they in the right zlevel for that? are they inside a fridge? etc.) and then, from the ones that satisfy those checks, if they are alive, they get ghostized and dusted but if they are not alive and are not observers, they get dusted.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds consistency to the nuke explosion.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before nuke onboard station:
![image](https://user-images.githubusercontent.com/53869326/196055730-07f6ed39-3867-4fd9-8cd9-600966b3243c.png)

After nuke onboard station:
![image](https://user-images.githubusercontent.com/53869326/196055755-14853d65-37f0-4f7b-b0b9-95bfbcb35357.png)

Before nuke at Lavaland:
![image](https://user-images.githubusercontent.com/53869326/196055882-ee994bca-53c3-4714-8eb2-ac9539261b50.png)

After nuke at Lavaland:
![image](https://user-images.githubusercontent.com/53869326/196055923-3f06c4a2-4ed6-431d-927e-6a44a6004a80.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
I spawned multiple corpses from the game panel and set off the nuke, they dusted.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Nazsgull
fix: Dead corpses now get dusted too (fixes issue #19408)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
