### PR TITLE
Slightly optimizes admin surgery room

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -3744,6 +3744,12 @@
 /obj/structure/closet/syndicate/personal,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
+"mJ" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -30
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/admin)
 "mK" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /turf/simulated/floor/plasteel{
@@ -6088,9 +6094,7 @@
 /area/admin)
 "vk" = (
 /obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/rods,
-/obj/item/pen,
+/obj/item/storage/belt/utility/full/multitool,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "vl" = (
@@ -6289,9 +6293,7 @@
 /area/admin)
 "vO" = (
 /obj/structure/table,
-/obj/item/scalpel,
-/obj/item/bonesetter,
-/obj/item/bonegel,
+/obj/item/storage/backpack/duffel/syndie/med/surgery,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "vP" = (
@@ -6299,6 +6301,7 @@
 /obj/item/kitchen/utensil/fork,
 /obj/item/lighter,
 /obj/item/restraints/handcuffs/cable/red,
+/obj/item/kitchen/knife,
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/fancy/cigarettes,
 /obj/item/pen,
@@ -6467,9 +6470,8 @@
 /area/admin)
 "wz" = (
 /obj/structure/table,
-/obj/item/FixOVein,
-/obj/item/retractor,
-/obj/item/cautery,
+/obj/item/scalpel/laser/manager/debug,
+/obj/item/stack/medical/bruise_pack/advanced,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "wA" = (
@@ -6566,14 +6568,19 @@
 /area/admin)
 "wW" = (
 /obj/structure/table,
-/obj/item/surgicaldrill,
-/obj/item/stack/medical/bruise_pack/advanced,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil,
+/obj/item/pen,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "wX" = (
 /obj/structure/table,
-/obj/item/hemostat,
-/obj/item/circular_saw,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/storage/pill_bottle/psychiatrist,
+/obj/item/storage/pill_bottle/psychiatrist,
+/obj/item/storage/pill_bottle/psychiatrist,
+/obj/item/storage/pill_bottle/psychiatrist,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "wY" = (
@@ -11432,6 +11439,10 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/specops)
+"TE" = (
+/obj/machinery/computer/operating,
+/turf/simulated/floor/plasteel/freezer,
+/area/admin)
 "TF" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -70711,7 +70722,7 @@ aN
 wk
 wk
 uk
-nJ
+mJ
 vO
 wz
 wW
@@ -70967,7 +70978,7 @@ aN
 aN
 aN
 lH
-nJ
+TE
 nJ
 nJ
 nJ

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -3744,12 +3744,6 @@
 /obj/structure/closet/syndicate/personal,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"mJ" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = -30
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/admin)
 "mK" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /turf/simulated/floor/plasteel{
@@ -6094,7 +6088,10 @@
 /area/admin)
 "vk" = (
 /obj/structure/table,
-/obj/item/storage/belt/utility/full/multitool,
+/obj/item/storage/belt/utility/full/multitool{
+	pixel_x = -2;
+	pixel_y = 1
+	},
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "vl" = (
@@ -6293,7 +6290,9 @@
 /area/admin)
 "vO" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffel/syndie/med/surgery,
+/obj/item/storage/backpack/duffel/syndie/med/surgery{
+	pixel_y = 8
+	},
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "vP" = (
@@ -6470,8 +6469,13 @@
 /area/admin)
 "wz" = (
 /obj/structure/table,
-/obj/item/scalpel/laser/manager/debug,
-/obj/item/stack/medical/bruise_pack/advanced,
+/obj/item/scalpel/laser/manager/debug{
+	pixel_y = -5
+	},
+/obj/item/stack/medical/bruise_pack/advanced{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "wA" = (
@@ -11439,10 +11443,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/specops)
-"TE" = (
-/obj/machinery/computer/operating,
-/turf/simulated/floor/plasteel/freezer,
-/area/admin)
 "TF" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -11696,6 +11696,10 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
+"UE" = (
+/obj/machinery/computer/operating,
+/turf/simulated/floor/plasteel/freezer,
+/area/admin)
 "UF" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -12912,6 +12916,12 @@
 	icon_state = "white"
 	},
 /area/centcom/control)
+"ZA" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -30
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/admin)
 "ZC" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
@@ -70722,7 +70732,7 @@ aN
 wk
 wk
 uk
-mJ
+ZA
 vO
 wz
 wW
@@ -70978,7 +70988,7 @@ aN
 aN
 aN
 lH
-TE
+UE
 nJ
 nJ
 nJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a few QoL goodies to the admin surgery room such as a suspicious surgery duffelbag, a full toolbelt, an operating computer, a mounted defibrillator, and some anesthetics.

This is my first (real) mapping PR, so please let me know if I've broken anything/could do something better.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While the admin room is kind of a weird mix of IC and OOC, it's really nice for testing, especially when working with the tiny map. Not having to spawn in the operating computer and surgery tools each and every time would be a godsend.

The debug IMS would save a tiny bit of time too, but if it's a little too OOC to have mapped into the game anywhere, I can definitely remove it.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/89928798/196068355-87f66442-1455-412c-a36c-c064f03c2725.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Spawned in
- Everything looks right
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The admin testing room has some new surgical tools.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
