### PR TITLE
Nerfs Beepsky Smash

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -534,11 +534,6 @@
 	drink_desc = "Heavy, hot and strong. Just like the Iron fist of the LAW."
 	taste_description = "THE LAW"
 
-/datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
-	var/update_flag = STATUS_UPDATE_NONE
-	M.Stun(2 SECONDS)
-	return ..() | update_flag
-
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"
 	id = "irishcream"


### PR DESCRIPTION

## What Does This PR Do
Removes the three silly lines of code that makes Beepsky Smash the best stunning Chem in the game. It no longer has any special effects and is now a normal drink.

## Why It's Good For The Game
Beepsky Smash is very available, extremely easy to make, and instantly hardstuns your target for as long as its in their system. It can be put in Smoke Powder Grenades to instantly hardstun people, even through hardsuits and regardless of internals. It can be loaded into Emagged Hypos, Syringe Guns, Dart Pistols, making it a better tranquilizer than actual tranquilizers. 

## Testing
I removed the three lines of code and booted up the game to test it. I then proceeded to shamble to the bar and down as much Beepsky Smash as I could and walked around completely fine. I make Beepsky Smash Gas Grenades, I injected myself with it, and was still able to move.

## Changelog
:cl:
del: Removed Beepsky Smash's paralyzing ability
/:cl:
