### PR TITLE
The (formal CC) blueshield drip is back in town

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -146,7 +146,7 @@
 	new /obj/item/clothing/accessory/holster(src)
 	new /obj/item/clothing/accessory/blue(src)
 	new /obj/item/clothing/shoes/jackboots/jacksandals(src)
-	new /obj/item/clothing/under/rank/centcom/blueshield(src)
+	new /obj/item/clothing/under/rank/centcom/blueshield/formal(src)
 
 
 /obj/structure/closet/secure_closet/ntrep

--- a/code/modules/clothing/under/centcom.dm
+++ b/code/modules/clothing/under/centcom.dm
@@ -55,15 +55,6 @@
 	name = "\improper Trans-Solar Federation commander's uniform"
 	desc = "Gold trim on space-black cloth, this uniform is worn by generals of the Trans-Solar Federation. It has exotic materials for protection."
 
-/obj/item/clothing/under/rank/centcom/blueshield
-	name = "formal blueshield's uniform"
-	desc = "Gold trim on space-black cloth, this uniform bears \"Close Protection\" on the left shoulder. It's got exotic materials for protection."
-	icon_state = "officer"
-	item_state = "g_suit"
-	item_color = "officer"
-	armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 20, ACID = 20)
-	displays_id = FALSE
-
 /obj/item/clothing/under/rank/centcom/representative
 	name = "formal Nanotrasen Representative's uniform"
 	desc = "Gold trim on space-black cloth, this uniform bears \"N.S.S. Cyberiad\" on the left shoulder."
@@ -117,3 +108,11 @@
 	icon_state = "blueshieldf"
 	item_state = "blueshieldf"
 	item_color = "blueshieldf"
+
+/obj/item/clothing/under/rank/centcom/blueshield/formal
+	name = "formal blueshield's uniform"
+	desc = "Gold trim on space-black cloth, this uniform bears \"Close Protection\" on the left shoulder. It's got exotic materials for protection."
+	icon_state = "officer"
+	item_state = "g_suit"
+	item_color = "officer"
+	displays_id = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/19419

Fixes the lack of the formal CC suit in the blueshield's locker.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Drip.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/71735193/196276606-0a390fca-5bfd-4025-ba7e-c6021dbcf51b.png)


## Testing
<!-- How did you test the PR, if at all? -->
Spawned as blueshield, took a screenshot for `Images of changes`, put the uniform on, had positive drip,

## Changelog
:cl:
fix: The formal blueshield's uniform is back in the blueshield's locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
