### PR TITLE
Don't track Runtime or Ian in E.X.P.E.R.I-MENTOR state.

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -23,8 +23,6 @@
 	anchored = TRUE
 	use_power = IDLE_POWER_USE
 	var/recentlyExperimented = 0
-	var/mob/trackedIan
-	var/mob/trackedRuntime
 	var/badThingCoeff = 0
 	var/resetTime = 15
 	var/cloneMode = FALSE
@@ -78,13 +76,6 @@
 	SetTypeReactions()
 	RefreshParts()
 	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/r_n_d/experimentor/LateInitialize()
-	..()
-	// GLOB.mob_living_list gets populated in /mob/Initialize()
-	// so we need to delay searching for those until after the Initialize()
-	trackedIan = locate(/mob/living/simple_animal/pet/dog/corgi/Ian) in GLOB.mob_living_list
-	trackedRuntime = locate(/mob/living/simple_animal/pet/cat/Runtime) in GLOB.mob_living_list
 
 /obj/machinery/r_n_d/experimentor/RefreshParts()
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
@@ -500,6 +491,7 @@
 		if(globalMalf > 16 && globalMalf < 35)
 			visible_message("<span class='warning'>[src] melts [exp_on], ian-izing the air around it!</span>")
 			throwSmoke(loc)
+			var/mob/trackedIan = locate(/mob/living/simple_animal/pet/dog/corgi/Ian) in GLOB.mob_living_list
 			if(trackedIan)
 				throwSmoke(trackedIan.loc)
 				trackedIan.loc = loc
@@ -511,6 +503,7 @@
 		if(globalMalf > 36 && globalMalf < 59)
 			visible_message("<span class='warning'>[src] encounters a run-time error!</span>")
 			throwSmoke(loc)
+			var/mob/trackedRuntime = locate(/mob/living/simple_animal/pet/cat/Runtime) in GLOB.mob_living_list
 			if(trackedRuntime)
 				throwSmoke(trackedRuntime.loc)
 				trackedRuntime.loc = loc

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -491,10 +491,10 @@
 		if(globalMalf > 16 && globalMalf < 35)
 			visible_message("<span class='warning'>[src] melts [exp_on], ian-izing the air around it!</span>")
 			throwSmoke(loc)
-			var/mob/trackedIan = locate(/mob/living/simple_animal/pet/dog/corgi/Ian) in GLOB.mob_living_list
-			if(trackedIan)
-				throwSmoke(trackedIan.loc)
-				trackedIan.loc = loc
+			var/mob/tracked_ian = locate(/mob/living/simple_animal/pet/dog/corgi/Ian) in GLOB.mob_living_list
+			if(tracked_ian)
+				throwSmoke(tracked_ian.loc)
+				tracked_ian.loc = loc
 				investigate_log("Experimentor has stolen Ian!", "experimentor") //...if anyone ever fixes it...
 			else
 				new /mob/living/simple_animal/pet/dog/corgi(loc)
@@ -503,10 +503,10 @@
 		if(globalMalf > 36 && globalMalf < 59)
 			visible_message("<span class='warning'>[src] encounters a run-time error!</span>")
 			throwSmoke(loc)
-			var/mob/trackedRuntime = locate(/mob/living/simple_animal/pet/cat/Runtime) in GLOB.mob_living_list
-			if(trackedRuntime)
-				throwSmoke(trackedRuntime.loc)
-				trackedRuntime.loc = loc
+			var/mob/tracked_runtime = locate(/mob/living/simple_animal/pet/cat/Runtime) in GLOB.mob_living_list
+			if(tracked_runtime)
+				throwSmoke(tracked_runtime.loc)
+				tracked_runtime.loc = loc
 				investigate_log("Experimentor has stolen Runtime!", "experimentor")
 			else
 				new /mob/living/simple_animal/pet/cat(loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

When using the E.X.P.E.R.I-MENTOR, two of the random events which may occur are the teleporting of Ian or Runtime to the E.X.P.E.R.I-MENTOR itself. In order to do this, it would find those pets in LateInitialize, and hold onto those references forever. Once Ian and Runtime are killed/deleted, these references aren't cleaned up, but they are completely unnecessary in the first place.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
GC failures bad.

## Testing
<!-- How did you test the PR, if at all? -->

Testing GC reference loss:
1. Enabled GC ref finder debug options in `_compile_options.dm`.
2. Spawned in, jumped to Ian and Runtime and deleted them.
3. Waited for GC logs.

Before:
```
[2022-10-18T02:44:26] Beginning search for references to a /mob/living/simple_animal/pet/cat/Runtime.
[2022-10-18T02:44:26] Finished searching globals
[2022-10-18T02:44:35] Found /mob/living/simple_animal/pet/cat/Runtime [0x3000029] in /obj/machinery/r_n_d/experimentor's [0x2007e09] trackedRuntime var. World -> /obj/machinery/r_n_d/experimentor
[2022-10-18T02:45:24] Finished searching atoms
[2022-10-18T02:45:24] Found /mob/living/simple_animal/pet/cat/Runtime [0x3000029] in list World -> /datum/controller/subsystem/persistent_data [0x21000087] -> registered_atoms (list).
[2022-10-18T02:45:32] Finished searching datums
[2022-10-18T02:45:32] Finished searching clients
[2022-10-18T02:45:32] Completed search for references to a /mob/living/simple_animal/pet/cat/Runtime.
```

After:
```
[2022-10-18T02:38:56] Beginning search for references to a /mob/living/simple_animal/pet/cat/Runtime.
[2022-10-18T02:38:56] Finished searching globals
[2022-10-18T02:39:37] Finished searching atoms
[2022-10-18T02:39:37] Found /mob/living/simple_animal/pet/cat/Runtime [0x3000029] in list World -> /datum/controller/subsystem/persistent_data [0x21000087] -> registered_atoms (list).
[2022-10-18T02:39:42] Finished searching datums
[2022-10-18T02:39:42] Finished searching clients
[2022-10-18T02:39:42] Completed search for references to a /mob/living/simple_animal/pet/cat/Runtime.
[2022-10-18T02:39:42] GC: -- [0x2100000d] | /mob/living/simple_animal/pet/cat/Runtime was unable to be GC'd --
```
(Only the `persistent_data` ref failure is present.)

Testing behavior:
1. Spawned in.
5. Jumped to E.X.P.E.R.I-MENTOR.
6. Spawned 10 `/obj/item/relic`s and fed them into the E.X.P.E.R.I-MENTOR, until Ian and Runtime were teleported as expected.