### PR TITLE
Remove unused newscast ability from announcements.

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -1,48 +1,48 @@
 GLOBAL_DATUM_INIT(minor_announcement, /datum/announcement/minor, new())
-GLOBAL_DATUM_INIT(priority_announcement, /datum/announcement/priority, new(do_log = 0))
-GLOBAL_DATUM_INIT(command_announcement, /datum/announcement/priority/command, new(do_log = 0))
-GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event, new(do_log = 0))
+GLOBAL_DATUM_INIT(priority_announcement, /datum/announcement/priority, new(do_log = FALSE))
+GLOBAL_DATUM_INIT(command_announcement, /datum/announcement/priority/command, new(do_log = FALSE))
+GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event, new(do_log = FALSE))
 
 /datum/announcement
 	var/title = "Attention"
 	var/announcer = ""
-	var/log = 0
+	var/log = FALSE
 	var/sound
 	var/channel_name = "Station Announcements"
 	var/announcement_type = "Announcement"
-	var/admin_announcement = 0 // Admin announcements are received regardless of being in range of a radio, unless you're in the lobby to prevent metagaming
+	var/admin_announcement = FALSE // Admin announcements are received regardless of being in range of a radio, unless you're in the lobby to prevent metagaming
 	var/language = "Galactic Common"
 
-/datum/announcement/New(do_log = 0, new_sound = null)
+/datum/announcement/New(do_log = FALSE, new_sound = null)
 	sound = new_sound
 	log = do_log
 
-/datum/announcement/minor/New(do_log = 0, new_sound = sound('sound/misc/notice2.ogg'))
+/datum/announcement/minor/New(do_log = FALSE, new_sound = sound('sound/misc/notice2.ogg'))
 	..(do_log, new_sound)
 	title = "Attention"
 	announcement_type = "Minor Announcement"
 
-/datum/announcement/priority/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+/datum/announcement/priority/New(do_log = TRUE, new_sound = sound('sound/misc/notice2.ogg'))
 	..(do_log, new_sound)
 	title = "Priority Announcement"
 	announcement_type = "Priority Announcement"
 
-/datum/announcement/priority/command/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+/datum/announcement/priority/command/New(do_log = TRUE, new_sound = sound('sound/misc/notice2.ogg'))
 	..(do_log, new_sound)
-	admin_announcement = 1
+	admin_announcement = TRUE
 	title = "NAS Trurl Update"
 	announcement_type = "NAS Trurl Update"
 
-/datum/announcement/priority/command/event/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+/datum/announcement/priority/command/event/New(do_log = TRUE, new_sound = sound('sound/misc/notice2.ogg'))
 	..(do_log, new_sound)
-	admin_announcement = 0
+	admin_announcement = FALSE
 
-/datum/announcement/priority/security/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+/datum/announcement/priority/security/New(do_log = TRUE, new_sound = sound('sound/misc/notice2.ogg'))
 	..(do_log, new_sound)
 	title = "Security Announcement"
 	announcement_type = "Security Announcement"
 
-/datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, msg_sanitized = 0, from, msg_language, new_sound2 = null)
+/datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, msg_sanitized = FALSE, from, msg_language, new_sound2 = null)
 	if(!message)
 		return
 
@@ -51,7 +51,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 	var/message_sound2 = new_sound2 ? sound(new_sound2) : sound
 
 	if(!msg_sanitized)
-		message = trim_strip_html_properly(message, allow_lines = 1)
+		message = trim_strip_html_properly(message, allow_lines = TRUE)
 	message_title = html_encode(message_title)
 
 	var/message_announcer = null

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -1,50 +1,48 @@
 GLOBAL_DATUM_INIT(minor_announcement, /datum/announcement/minor, new())
 GLOBAL_DATUM_INIT(priority_announcement, /datum/announcement/priority, new(do_log = 0))
-GLOBAL_DATUM_INIT(command_announcement, /datum/announcement/priority/command, new(do_log = 0, do_newscast = 0))
-GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event, new(do_log = 0, do_newscast = 0))
+GLOBAL_DATUM_INIT(command_announcement, /datum/announcement/priority/command, new(do_log = 0))
+GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event, new(do_log = 0))
 
 /datum/announcement
 	var/title = "Attention"
 	var/announcer = ""
 	var/log = 0
 	var/sound
-	var/newscast = 0
 	var/channel_name = "Station Announcements"
 	var/announcement_type = "Announcement"
 	var/admin_announcement = 0 // Admin announcements are received regardless of being in range of a radio, unless you're in the lobby to prevent metagaming
 	var/language = "Galactic Common"
 
-/datum/announcement/New(do_log = 0, new_sound = null, do_newscast = 0)
+/datum/announcement/New(do_log = 0, new_sound = null)
 	sound = new_sound
 	log = do_log
-	newscast = do_newscast
 
-/datum/announcement/minor/New(do_log = 0, new_sound = sound('sound/misc/notice2.ogg'), do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/minor/New(do_log = 0, new_sound = sound('sound/misc/notice2.ogg'))
+	..(do_log, new_sound)
 	title = "Attention"
 	announcement_type = "Minor Announcement"
 
-/datum/announcement/priority/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'), do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/priority/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+	..(do_log, new_sound)
 	title = "Priority Announcement"
 	announcement_type = "Priority Announcement"
 
-/datum/announcement/priority/command/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'), do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/priority/command/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+	..(do_log, new_sound)
 	admin_announcement = 1
 	title = "NAS Trurl Update"
 	announcement_type = "NAS Trurl Update"
 
-/datum/announcement/priority/command/event/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'), do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/priority/command/event/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+	..(do_log, new_sound)
 	admin_announcement = 0
 
-/datum/announcement/priority/security/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'), do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/priority/security/New(do_log = 1, new_sound = sound('sound/misc/notice2.ogg'))
+	..(do_log, new_sound)
 	title = "Security Announcement"
 	announcement_type = "Security Announcement"
 
-/datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, do_newscast = newscast, msg_sanitized = 0, from, msg_language, new_sound2 = null)
+/datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, msg_sanitized = 0, from, msg_language, new_sound2 = null)
 	if(!message)
 		return
 
@@ -70,9 +68,6 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 	var/garbled_formatted_message = Format_Message(message_language.scramble(message), message_language.scramble(message_title), message_language.scramble(message_announcer), message_language.scramble(from))
 
 	Message(formatted_message, garbled_formatted_message, receivers, garbled_receivers)
-
-	if(do_newscast)
-		NewsCast(message, message_title)
 
 	Sound(message_sound, combined_receivers[1] + combined_receivers[2])
 	Sound(message_sound2, combined_receivers[1] + combined_receivers[2])
@@ -150,18 +145,6 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 	formatted_message += "<br><font color='red'>[message]</font>"
 
 	return formatted_message
-
-/datum/announcement/proc/NewsCast(message as text, message_title as text)
-	if(!newscast)
-		return
-
-	var/datum/news_announcement/news = new
-	news.channel_name = channel_name
-	news.author = announcer
-	news.message = message
-	news.message_type = announcement_type
-	news.can_be_redacted = 0
-	announce_newscaster_news(news)
 
 /datum/announcement/proc/Sound(message_sound, receivers)
 	if(!message_sound)

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -1,4 +1,4 @@
-GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newscast = 0)) // Why the hell are captain announcements minor
+GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new()) // Why the hell are captain announcements minor
 /datum/job/captain
 	title = "Captain"
 	flag = JOB_CAPTAIN

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -46,7 +46,6 @@
 
 /obj/machinery/computer/communications/Initialize(mapload)
 	. = ..()
-	crew_announcement.newscast = 0
 
 /obj/machinery/computer/communications/proc/is_authenticated(mob/user, message = 1)
 	if(user.can_admin_interact())

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -107,7 +107,6 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 	. = ..()
 
 	announcement.title = "[department] announcement"
-	announcement.newscast = FALSE
 
 	name = "[department] Requests Console"
 	GLOB.allRequestConsoles += src

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -130,7 +130,6 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	announcement.title = "A.I. Announcement"
 	announcement.announcement_type = "A.I. Announcement"
 	announcement.announcer = name
-	announcement.newscast = 0
 
 	var/list/possibleNames = GLOB.ai_names
 

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -7,8 +7,8 @@ GLOBAL_VAR_INIT(security_level, 0)
 //5 = code delta
 
 //config.alert_desc_blue_downto
-GLOBAL_DATUM_INIT(security_announcement_up, /datum/announcement/priority/security, new(do_log = 0, do_newscast = 0, new_sound = sound('sound/misc/notice1.ogg')))
-GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/security, new(do_log = 0, do_newscast = 0))
+GLOBAL_DATUM_INIT(security_announcement_up, /datum/announcement/priority/security, new(do_log = 0, new_sound = sound('sound/misc/notice1.ogg')))
+GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/security, new(do_log = 0))
 
 /proc/set_security_level(level)
 	switch(level)

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -7,8 +7,8 @@ GLOBAL_VAR_INIT(security_level, 0)
 //5 = code delta
 
 //config.alert_desc_blue_downto
-GLOBAL_DATUM_INIT(security_announcement_up, /datum/announcement/priority/security, new(do_log = 0, new_sound = sound('sound/misc/notice1.ogg')))
-GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/security, new(do_log = 0))
+GLOBAL_DATUM_INIT(security_announcement_up, /datum/announcement/priority/security, new(do_log = FALSE, new_sound = sound('sound/misc/notice1.ogg')))
+GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/security, new(do_log = FALSE))
 
 /proc/set_security_level(level)
 	switch(level)


### PR DESCRIPTION
## What Does This PR Do
Removes the state and implementation for producing newscasts from announcments.

## Why It's Good For The Game
This behavior isn't used anywhere, and it's not even exposed in any admin interfaces. We have several announcement subtypes that aren't really all that different from each other, and removing unneeded state makes it easier to refactor them.

## Testing

Ran unit tests.
<!-- How did you test the PR, if at all? -->