### PR TITLE
Only play each announcement sound once.

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -50,7 +50,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 
 	var/message_title = new_title ? new_title : title
 	var/message_sound = new_sound ? sound(new_sound) : sound
-	var/message_sound2 = new_sound2 ? sound(new_sound2) : sound
+	var/message_sound2 = new_sound2 ? sound(new_sound2) : null
 
 	if(!msg_sanitized)
 		message = trim_strip_html_properly(message, allow_lines = 1)
@@ -75,7 +75,8 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 		NewsCast(message, message_title)
 
 	Sound(message_sound, combined_receivers[1] + combined_receivers[2])
-	Sound(message_sound2, combined_receivers[1] + combined_receivers[2])
+	if(message_sound2 != null)
+		Sound(message_sound2, combined_receivers[1] + combined_receivers[2])
 	Log(message, message_title)
 
 /datum/announcement/proc/Get_Receivers(datum/language/message_language)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -75,7 +75,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 		NewsCast(message, message_title)
 
 	Sound(message_sound, combined_receivers[1] + combined_receivers[2])
-	if(message_sound2 != null)
+	if(message_sound2)
 		Sound(message_sound2, combined_receivers[1] + combined_receivers[2])
 	Log(message, message_title)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
There are exactly three places in the codebase where an announcement specifies two sounds to play simultaneously: the terror spider announcement, the gamma alert, and the delta alert. However, if a second sound is not specified, it is repurposed as a copy of the first one, and still played. This PR prevents the playing two copies of an announcement's sound simultaneously when a second sound is not specified.

## Why It's Good For The Game

Loud noises bad.

## Testing

1. Disable night shift mode in config so it doesn't do its fucking ding.
2. Disable white noise mode in preferences so it doesn't mess with the recording.
3. Disable ambient noise mode in preferences so it doesn't mess with the recording.
4. Set up audio recording.
5. Ready up as Captain, start the server, record the initial welcome announcement.
6. Wait for the blackbox recorder sound to finish playing because for some reason it doesn't count as ambient noise.
7. Wait an exceptionally long time for the blackbox recorder sound to finish playing.
8. Make a Captain's announcement and record it.

Welcome announcement before and after (that second waveform is "Welcome to the station crew, enjoy your stay" which is not part of the announcement sound):

![bandicam 2022-10-19 18-42-56-235-18_48_53](https://user-images.githubusercontent.com/59303604/196819624-34ada56e-a491-48ce-894b-e4b6eec27e04.png)

Captain announcement before and after:

![bandicam 2022-10-19 18-42-56-235-18_49_11](https://user-images.githubusercontent.com/59303604/196819632-e2e2ca01-f158-4cfd-beb2-84f2e6ea4b0f.png)


## Changelog
:cl:
fix: Announcement sounds no longer play twice at the same time. Nearly all announcements should be quieter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
