### PR TITLE
Reconnecting to a ventcrawler applies the piping overlay

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipe.dm
@@ -38,6 +38,11 @@
 		qdel(parent)
 	parent = null
 
+/obj/machinery/atmospherics/pipe/returnPipenet(obj/machinery/atmospherics/A)
+	if(A)
+		return // It's called by a moving mob that's already in the pipenet
+	return parent
+
 /obj/machinery/atmospherics/pipe/detailed_examine()
 	return "This pipe, and all other pipes, can be connected or disconnected by a wrench. The internal pressure of the pipe must \
 			be below 300 kPa to do this. More pipes can be obtained from the pipe dispenser.<br> \

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -548,7 +548,10 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	return
 
 /mob/living/update_pipe_vision(obj/machinery/atmospherics/target_move)
-	if(pipes_shown.len && !(target_move))
+	if(!client) 
+		pipes_shown.Cut()
+		return
+	if(length(pipes_shown) && !target_move)
 		if(!is_ventcrawling(src))
 			remove_ventcrawl()
 	else

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -3,6 +3,7 @@
 	if(ranged_ability && client)
 		ranged_ability.remove_mousepointer(client)
 	..()
+	update_pipe_vision()
 	if(mind)
 		if(!key) //key and mind have become seperated. I believe this is for when a staff member aghosts.
 			mind.active = FALSE	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Goes over how disconnecting and reconnecting is handling ventcrawling. Pipes weren't cleared properly from the mob, and would result in the reconnect assuming there's nothing new to show. Regular pipes also return their pipenet if needed, as otherwise reconnecting while in a pipe still wouldn't show the overlay.

## Why It's Good For The Game
Fixes #19427

## Images of changes
https://user-images.githubusercontent.com/80771500/196823128-978ddf5c-908f-4921-b2f7-479aabfde941.mp4

## Testing
Spawned as a mouse, ventcrawled, DCed and reconnected. Also messed around with atmos a bit to see if nothing broke.

## Changelog
:cl:
fix: Reconnecting into a mob that was ventcrawling will show the pipes properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
