### PR TITLE
Bug fixes for Meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28549,7 +28549,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mule_bot,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/atmos/control)
 "bGE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1809,6 +1809,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/sign/electricshock{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/security/brig)
 "amI" = (
@@ -3335,10 +3338,6 @@
 	icon_state = "dark"
 	},
 /area/engine/gravitygenerator)
-"asT" = (
-/obj/structure/sign/security,
-/turf/simulated/wall/r_wall,
-/area/security/processing)
 "asU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -10398,7 +10397,7 @@
 	dir = 8;
 	layer = 4;
 	pixel_x = 30
- 	},
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aOk" = (
@@ -18848,7 +18847,7 @@
 	dir = 8;
 	layer = 4;
 	pixel_x = 30
- 	},
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
@@ -30985,7 +30984,7 @@
 	network = list("Turbine")
 	},
 /turf/space,
-/area/maintenance/turbine)
+/area/space/nearstation)
 "bNS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44593,7 +44592,9 @@
 /obj/machinery/door/window/northright,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mule_bot,
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cBx" = (
@@ -60454,6 +60455,9 @@
 "gLH" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
@@ -61124,6 +61128,9 @@
 /area/toxins/test_chamber)
 "hfb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "yellow"
@@ -63260,10 +63267,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"ieA" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
-/area/security/prisonlockers)
 "ieT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -64395,9 +64398,6 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "iEX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -81138,6 +81138,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"rcQ" = (
+/obj/structure/sign/security{
+	pixel_y = 32
+	},
+/turf/space,
+/area/space/nearstation)
 "rcY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -82217,17 +82223,6 @@
 	icon_state = "black"
 	},
 /area/security/permabrig)
-"rBT" = (
-/obj/machinery/atmospherics/unary/thermomachine/freezer{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/engineering)
 "rCq" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -83300,7 +83295,7 @@
 	dir = 1
 	},
 /turf/space,
-/area/security/securearmoury)
+/area/space)
 "saw" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -86619,6 +86614,10 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
+"tHk" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "tHm" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -117785,7 +117784,7 @@ tfl
 tfl
 tfl
 tfl
-ieA
+tfl
 amE
 ufj
 aky
@@ -118571,8 +118570,8 @@ lGL
 dBT
 axN
 hvR
-asT
-aaa
+aHI
+rcQ
 nKT
 hOu
 xJy
@@ -138869,7 +138868,7 @@ ans
 aBZ
 hQX
 tSX
-avA
+tHk
 iLI
 aDi
 gHz
@@ -139387,7 +139386,7 @@ apL
 aBZ
 iJz
 enh
-rBT
+vZU
 aHi
 vIz
 aDL

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12942,8 +12942,12 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "caution"
 	},
 /area/atmos/control)
 "aVk" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a few bugs/nitpicks I have with Meta

opacity on the plastic flaps in medbay has been set to 1

a rogue air vent in the SM room has been removed

very minor fixes to the warning stripes around SM to make it consistent

a few wall mounted signs around brig have had their x/y pixel push fixed

cameras are no longer area'd in space

## Why It's Good For The Game
map upkeep

## Testing
Ran it locally to check the changes

## Changelog
:cl: Bmon
fix: Fixed a few minor mapping errors with Meta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
