### PR TITLE
Carbon mobs get proper species-based names for mob spawners

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -214,8 +214,8 @@
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)
 		H.set_species(mob_species)
-		if(random)
-			H.real_name = random_name(H.gender, H.dna.species)
+	if(random)
+		H.real_name = random_name(H.gender, H.dna.species)
 
 	if(husk)
 		H.Drain()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -214,6 +214,8 @@
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)
 		H.set_species(mob_species)
+		if(random)
+			H.real_name = random_name(H.gender, H.dna.species)
 
 	if(husk)
 		H.Drain()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes mob spawners generate a random name based on the species. Currently they default to human names as it is done on the mob living level, while setting species is done later on the carbon level.

## Why It's Good For The Game
Fixes #19450. Random dead bodies also get the proper names.

## Images of changes
![Spawner](https://user-images.githubusercontent.com/80771500/196962268-a63393d3-d882-4839-8c63-f87e331fba7a.PNG)

## Testing
Used a mob spawner and set a species. Human spawners were set to have the custom option available for all for ease of testing.

## Changelog
:cl:
fix: Mob spawners have properly set names based on species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
