### PR TITLE
Dark shards do not get eaten by humans

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -426,6 +426,9 @@
 	status = 0
 	contents = newlist(/obj/item/cursed_katana)
 
+/obj/item/organ/internal/cyberimp/arm/katana/prepare_eat()
+	return // It's a shard
+
 
 /obj/item/organ/internal/cyberimp/arm/katana/attack_self(mob/living/carbon/user, modifiers)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the cursed katana/dark shard not a valid snack organ.

## Why It's Good For The Game
Fixes #19449. Plus, who would eat that?

## Images of changes
https://user-images.githubusercontent.com/80771500/197078396-da38ddea-cd48-48ca-92ee-ad4084c9fe74.mp4

## Testing
Spawned a dark shard, and clicked on self.

## Changelog
:cl:
fix: You don't take a bite out of dark shards if you click on yourself while holding one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
