### PR TITLE
Nerfs Cult Juggernaut. Removed reflection

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -145,7 +145,7 @@
 			adjustBruteLoss(P.damage * 0.6) // 21 hit with security laser gun
 			P.on_hit(src)
 			return FALSE
-	return(..())
+	return ..()
 
 ////////////////////////Wraith/////////////////////////////////////////////
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -139,21 +139,6 @@
 	AIStatus = AI_ON
 	environment_smash = 1 //only token destruction, don't smash the cult wall NO STOP
 
-/mob/living/simple_animal/hostile/construct/armoured/bullet_act(obj/item/projectile/P)
-	if(P.is_reflectable(REFLECTABILITY_ENERGY))
-		var/reflectchance = 80 - round(P.damage/3)
-		if(prob(reflectchance))
-			if((P.damage_type == BRUTE || P.damage_type == BURN))
-				adjustBruteLoss(P.damage * 0.5)
-			visible_message("<span class='danger'>[P] gets reflected by [src]'s shell!</span>", \
-							"<span class='userdanger'>[P] gets reflected by [src]'s shell!</span>")
-
-			P.reflect_back(src, list(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3))
-
-			return -1 // complete projectile permutation
-
-	return (..(P))
-
 
 
 ////////////////////////Wraith/////////////////////////////////////////////

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -133,7 +133,7 @@
 	construct_spells = list(/obj/effect/proc_holder/spell/night_vision, /obj/effect/proc_holder/spell/aoe_turf/conjure/build/lesserforcewall)
 	force_threshold = 11
 	playstyle_string = "<b>You are a Juggernaut. Though slow, your shell can withstand extreme punishment, \
-						create shield walls, rip apart enemies and walls alike, and even deflect energy weapons.</b>"
+						create shield walls, rip apart enemies and walls.</b>"
 
 /mob/living/simple_animal/hostile/construct/armoured/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON
@@ -142,7 +142,7 @@
 /mob/living/simple_animal/hostile/construct/armoured/bullet_act(obj/item/projectile/P)
 	if(P.is_reflectable(REFLECTABILITY_ENERGY))
 		if(P.damage_type == BRUTE || P.damage_type == BURN)
-			adjustBruteLoss(P.damage * 0.6) // 21 hit with laser gun
+			adjustBruteLoss(P.damage * 0.6) // 21 hit with security laser gun
 			P.on_hit(src)
 			return FALSE
 	return(..())

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -139,7 +139,13 @@
 	AIStatus = AI_ON
 	environment_smash = 1 //only token destruction, don't smash the cult wall NO STOP
 
-
+/mob/living/simple_animal/hostile/construct/armoured/bullet_act(obj/item/projectile/P)
+	if(P.is_reflectable(REFLECTABILITY_ENERGY))
+		if(P.damage_type == BRUTE || P.damage_type == BURN)
+			adjustBruteLoss(P.damage * 0.6) // 21 hit with laser gun
+			P.on_hit(src)
+			return FALSE
+	return(..())
 
 ////////////////////////Wraith/////////////////////////////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR removes Cult Construct Juggernaut ability to reflect lasers

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
In default cult round its VERY VERY easy to get juggernaut. You kill one cyborg or  one officer or any other mindshielded person and sacrifice it, then put it in shell. 
To play against it security will ALWAYS order WT auto rifles to have a chance to play against it. Without this nerf cult juggernaut has 76 fucking percent to reflect default security lasers. 
Security does NOT have any weapons to fight juggernaut and they NEED order WT rifles. 

In other side, WT rifles is kinda OVERKILL against default cultists. You can easily get cultist using disabler, rubber shotgun and other guns, same as they can easily fight you. When security get WT rifles, game balance dies. Cult need to fix fractures and IBs, cult dies very easily and all that shit.

And the reason of all that shit is fucking Juggernaut that can just push and do nothing. They have 250 health and 76% to reflect laser and get only 0.5 damage. So it means we need 20 in middle successful laser hits to kill it and not die. Add that this shitter will reflect lasers right in your face, it will dance to avoid hits, it will place his wall spell and it will get healed by other cultists and pylons. 

After that PR Juggernaut will not reflect lasers. It will still take 20+ lasers to die. 
After that PR security maybe will not start cult round with ";Cargo, order auto rifles".

## Testing
<!-- How did you test the PR, if at all? -->
compiled and runned, shoot jugger

## Changelog
:cl:
del: Removed Juggernaut's laser reflect chance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
