### PR TITLE
[GBP NO UPDATE] Fix runtimes caused by proc signature change.

### DIFF
--- a/code/datums/spells/knock.dm
+++ b/code/datums/spells/knock.dm
@@ -62,7 +62,12 @@
 			if(is_station_level(A.z))
 				A.req_access = list()
 				A.req_one_access = list()
-		GLOB.command_announcement.Announce("We have removed all access requirements on your station's airlocks. You can thank us later!", "Greetings!", 'sound/misc/notice2.ogg', , , "Space Wizard Federation Message")
+		GLOB.command_announcement.Announce(
+			message = "We have removed all access requirements on your station's airlocks. You can thank us later!",
+			new_title = "Greetings!",
+			new_sound = 'sound/misc/notice2.ogg',
+			from = "Space Wizard Federation Message"
+		)
 	else
 		..()
 	return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -640,7 +640,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if("Yes")
 			var/beepsound = input(usr, "What sound should the announcement make?", "Announcement Sound", "") as anything in MsgSound
 
-			GLOB.command_announcement.Announce(input, customname, MsgSound[beepsound], , , type)
+			GLOB.command_announcement.Announce(
+				message = input,
+				new_title = customname,
+				new_sound = MsgSound[beepsound],
+				from = type
+			)
 			print_command_report(input, customname)
 		if("No")
 			//same thing as the blob stuff - it's not public, so it's classified, dammit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/19463, which was my own dumb mistake
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Changes like this shouldn't introduce new runtimes.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
<!-- How did you test the PR, if at all? -->

Tested admin verb and greater knock spell. Confirmed no runtimes.

**How do I know this fixes all remaining runtimes?** The thing these two call sites have in common is the use of the positional commas syntax in the Announce call. No other calls that I can find do this, or skip parameters without naming the following ones.