### PR TITLE
Removes the deathgasp sound if one is muffled

### DIFF
--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -71,6 +71,7 @@
 	cooldown = 10 SECONDS
 	volume = 40
 	unintentional_stat_allowed = DEAD
+	muzzle_ignore = TRUE
 	bypass_unintentional_cooldown = TRUE  // again, this absolutely MUST play when a user dies, if it can.
 	message = "seizes up and falls limp, their eyes dead and lifeless..."
 	message_alien = "seizes up and falls limp, their eyes dead and lifeless..."
@@ -98,7 +99,10 @@
 		var/mob/living/carbon/human/H = user
 		if(H.dna.species)
 			message = H.dna.species.death_message
-			return pick(H.dna.species.death_sounds)
+			if(H.is_muzzled())
+				return
+			else
+				return pick(H.dna.species.death_sounds)
 
 	if(isalien(user))
 		var/mob/living/carbon/alien/A = user

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -11,6 +11,10 @@
 	. = ..()
 	if(user.mind?.miming)
 		return FALSE  // shh
+	if(user.is_muzzled())
+		if(intentional == FALSE)
+			return TRUE
+		return FALSE
 	return .
 
 /datum/emote/living/blush
@@ -99,10 +103,7 @@
 		var/mob/living/carbon/human/H = user
 		if(H.dna.species)
 			message = H.dna.species.death_message
-			if(H.is_muzzled())
-				return
-			else
-				return pick(H.dna.species.death_sounds)
+			return pick(H.dna.species.death_sounds)
 
 	if(isalien(user))
 		var/mob/living/carbon/alien/A = user

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -71,7 +71,7 @@
 	cooldown = 10 SECONDS
 	volume = 40
 	unintentional_stat_allowed = DEAD
-	muzzle_ignore = TRUE
+	muzzle_ignore = TRUE // makes sure that sound is played upon death
 	bypass_unintentional_cooldown = TRUE  // again, this absolutely MUST play when a user dies, if it can.
 	message = "seizes up and falls limp, their eyes dead and lifeless..."
 	message_alien = "seizes up and falls limp, their eyes dead and lifeless..."

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -11,10 +11,6 @@
 	. = ..()
 	if(user.mind?.miming)
 		return FALSE  // shh
-	if(user.is_muzzled())
-		if(intentional == FALSE)
-			return TRUE
-		return FALSE
 	return .
 
 /datum/emote/living/blush
@@ -89,6 +85,11 @@
 	mob_type_blacklist_typecache = list(
 		/mob/living/carbon/brain,
 	)
+
+/datum/emote/living/deathgasp/should_play_sound(mob/user, intentional)
+	. = ..()
+	if(user.is_muzzled() && intentional)
+		return FALSE
 
 /datum/emote/living/deathgasp/get_sound(mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

This makes it so that if one is muffled, the deathgasp sound effect does not play.

Instead, it simply shows the normal message that comes with deathgasping.

Upon actual death, the message AND sound play.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It does not really make sense how one can audibly deathgasp while being muffled if normal gasping is muted.

Also prevents deathgasp being used to game being muffled to still audibly alert nearby players when in reality you should be muffled!

## Testing
<!-- How did you test the PR, if at all? -->

1. spawn in
2. deathgasp
3. see message and hear sound
4. apply tape to mouth
5. deathgasp
6. see message but hear no sound
7. commit die while muffled
8. see message still pop up and hear the deathgasp sound

## Changelog
:cl:
fix: Fixed deathgasp sound playing despite being muffled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
