### PR TITLE
Fixes issue with tooltips/blockhair flag conflict

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -92,7 +92,7 @@
 #define SUIT_SENSOR_TRACKING 3
 
 #define BLOCKHEADHAIR 			4		// temporarily removes the user's hair overlay. Leaves facial hair.
-#define BLOCKHAIR				32768	// temporarily removes the user's hair, facial and otherwise.
+#define BLOCKHAIR				32	// temporarily removes the user's hair, facial and otherwise.
 
 //flags for muzzle speech blocking
 #define MUZZLE_MUTE_NONE 0 // Does not mute you.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes an issue with tooltips not displaying for hats using the "BLOCKHAIR" flag, Caused by a conflict another flag.
https://github.com/ParadiseSS13/Paradise/pull/19468
## Testing
<!-- How did you test the PR, if at all? -->
![image](https://user-images.githubusercontent.com/28615254/197344860-f0a4d565-f1dd-4965-b71e-ba3e0eaceb84.png)
I tested to make sure it didn't break anything, now tooltips display, and the hats still hide hair. 
## DISCLAIMER
I am very new to this project, and this is an issue that went way deeper than my expertise. It seems solid though
I tested quite thoroughly. 



