### PR TITLE
[GBP NO UPDATE] Restricts some jumpsuits from appearing with chameleon gear

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -217,7 +217,25 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/under
 	chameleon_action.chameleon_name = "Jumpsuit"
-	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank), only_root_path = TRUE)
+	chameleon_action.chameleon_blacklist = typecacheof(list(
+		/obj/item/clothing/under,
+		/obj/item/clothing/under/misc,
+		/obj/item/clothing/under/dress,
+		/obj/item/clothing/under/pants,
+		/obj/item/clothing/under/color,
+		/obj/item/clothing/under/retro,
+		/obj/item/clothing/under/solgov,
+		/obj/item/clothing/under/suit,
+		/obj/item/clothing/under/costume,
+		/obj/item/clothing/under/rank,
+		/obj/item/clothing/under/rank/captain,
+		/obj/item/clothing/under/rank/cargo,
+		/obj/item/clothing/under/rank/civilian,
+		/obj/item/clothing/under/rank/engineering,
+		/obj/item/clothing/under/rank/medical,
+		/obj/item/clothing/under/rank/rnd,
+		/obj/item/clothing/under/rank/security,
+		), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/under/chameleon/Destroy()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -228,7 +228,6 @@
 		/obj/item/clothing/under/suit,
 		/obj/item/clothing/under/costume,
 		/obj/item/clothing/under/rank,
-		/obj/item/clothing/under/rank/captain,
 		/obj/item/clothing/under/rank/cargo,
 		/obj/item/clothing/under/rank/civilian,
 		/obj/item/clothing/under/rank/engineering,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Restricts some jumpsuits that shouldn't be used ingame... from being used ingame.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Less missing sprites(potentially).

## Testing
<!-- How did you test the PR, if at all? -->
Looked at an EMP'd jumpsuit for some time, less missing sprites.

## Changelog
:cl:
fix: Less broken sprites (should) now appear when using broken chameleon jumpsuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
