### PR TITLE
[GBP NO UPDATE] Hands don't overlay above jumpsuits on which the hands are covered

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -409,6 +409,9 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 /mob/living/carbon/human/proc/update_hands_layer()
 	remove_overlay(HANDS_LAYER)
 
+	if(w_uniform.body_parts_covered & HANDS)
+		return
+
 	var/mutable_appearance/hands_appearance = new()
 	hands_appearance.layer = -HANDS_LAYER
 
@@ -632,6 +635,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 					thing.layer = initial(thing.layer)
 					thing.plane = initial(thing.plane)
 	apply_overlay(UNIFORM_LAYER)
+	update_hands_layer()
 
 /mob/living/carbon/human/update_inv_wear_id()
 	remove_overlay(ID_LAYER)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -409,7 +409,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 /mob/living/carbon/human/proc/update_hands_layer()
 	remove_overlay(HANDS_LAYER)
 
-	if(w_uniform.body_parts_covered & HANDS)
+	if(w_uniform?.body_parts_covered & HANDS)
 		return
 
 	var/mutable_appearance/hands_appearance = new()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
if the title is confusing, imagine plasmaman envirosuits, they have gloves _built_ into them.
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Small followup to my oversight in https://github.com/ParadiseSS13/Paradise/pull/19058
Only jumpsuits that this will concern realistically is plasmaman envirosuits, kinda forgot that we have plasmamen as a species 💀 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hands being ontop of some jumpsuits might be a bit too _jarring_, fixes that

## Testing
<!-- How did you test the PR, if at all? -->
Spawned as plasmaman, my purple bones weren't ontop of my envirosuit.

## Changelog
:cl:
fix: Fixed hands overlaying ontop of plasma envirosuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
