### PR TITLE
Fixes parallax being visible in the "fog of war"

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -15,7 +15,13 @@
 	var/client/C = mymob.client
 	if(!apply_parallax_pref())
 		return
-
+	// this is needed so it blends properly with the space plane and blackness plane.
+	var/obj/screen/plane_master/space/S = plane_masters["[PLANE_SPACE]"]
+	S.color = list(1, 1, 1, 1,
+				   1, 1, 1, 1,
+				   1, 1, 1, 1,
+				   1, 1, 1, 1,)
+	S.appearance_flags |= NO_CLIENT_COLOR
 	if(!length(C.parallax_layers_cached))
 		C.parallax_layers_cached = list()
 		C.parallax_layers_cached += new /obj/screen/parallax_layer/layer_1(null, C.view)
@@ -36,12 +42,15 @@
 	var/client/C = mymob.client
 	C.screen -= (C.parallax_layers_cached + C.parallax_static_layers_tail)
 	C.parallax_layers = null
+	var/obj/screen/plane_master/space/S = plane_masters["[PLANE_SPACE]"]
+	S.color = null
+	S.appearance_flags &= ~NO_CLIENT_COLOR
 
 /datum/hud/proc/apply_parallax_pref()
 	var/client/C = mymob.client
 	if(C.prefs)
 		var/pref = C.prefs.parallax
-		if (isnull(pref))
+		if(isnull(pref))
 			pref = PARALLAX_HIGH
 		switch(C.prefs.parallax)
 			if (PARALLAX_INSANE)

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -85,4 +85,12 @@
 	name = "parallax plane master"
 	plane = PLANE_SPACE_PARALLAX
 	appearance_flags = PLANE_MASTER
-	blend_mode = BLEND_OVERLAY
+	blend_mode = BLEND_MULTIPLY
+
+/obj/screen/plane_master/blackness
+	name = "blackness plane master"
+	plane = BLACKNESS_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	color = list(null, null, null, "#0000", "#000f")
+	blend_mode = BLEND_ADD
+	appearance_flags = PLANE_MASTER | NO_CLIENT_COLOR | PIXEL_SCALE

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -28,7 +28,7 @@
 	var/impacted_z_levels // The list of z-levels that this weather is actively affecting
 
 	var/overlay_layer = AREA_LAYER //Since it's above everything else, this is the layer used by default. TURF_LAYER is below mobs and walls if you need to use that.
-	var/overlay_plane = BLACKNESS_PLANE
+	var/overlay_plane = FLOOR_PLANE
 	var/aesthetic = FALSE //If the weather has no purpose other than looks
 	var/immunity_type = "storm" //Used by mobs to prevent them from being affected by the weather
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -148,6 +148,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		MA.icon = initial(icon)
 		MA.icon_state = initial(icon_state)
 	MA.underlays = COPY.underlays
+	MA.layer = GHOST_LAYER
 	MA.plane = GAME_PLANE
 	. = MA
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -11,6 +11,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "ghost"
 	layer = GHOST_LAYER
+	plane = GAME_PLANE
 	stat = DEAD
 	density = FALSE
 	alpha = 127
@@ -90,6 +91,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	toggle_all_huds_on(body)
 	RegisterSignal(src, COMSIG_MOB_HUD_CREATED, .proc/set_ghost_darkness_level) //something something don't call this until we have a HUD
 	..()
+	plane = GAME_PLANE
 
 /mob/dead/observer/Destroy()
 	toggle_all_huds_off()
@@ -146,7 +148,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		MA.icon = initial(icon)
 		MA.icon_state = initial(icon_state)
 	MA.underlays = COPY.underlays
-
+	MA.plane = GAME_PLANE
 	. = MA
 
 /mob/dead/CanPass(atom/movable/mover, turf/target, height=0)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1075,7 +1075,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 			MA.icon = path_image_icon
 			MA.icon_state = path_image_icon_state
 			MA.layer = ABOVE_OPEN_TURF_LAYER
-			MA.plane = 0
+			MA.plane = FLOOR_PLANE
 			MA.appearance_flags = RESET_COLOR|RESET_TRANSFORM
 			MA.color = path_image_color
 			MA.dir = direction


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
prevents seeing parallax when you have night vision and no line of sight to a turf.

## Why It's Good For The Game
seeing space as a t-spider is disorienting 

## Images of changes
before: 
![image](https://user-images.githubusercontent.com/69320440/197353120-91654443-bb8b-4bed-b125-5f6fae643417.png)

after
![image](https://user-images.githubusercontent.com/69320440/197353173-d13a2a12-e219-4cc1-af83-9395865fbca8.png)

## Testing
walked around and changed my NV variables, saw no issues.

## Changelog
:cl:
fix: you wont see parallax instead of fog of war if you have night vision
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
