### PR TITLE
Prevents Players from circumventing attack cooldown with Wooden Barricades

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -100,7 +100,7 @@
 				var/turf/T = get_turf(src)
 				T.ChangeTurf(/turf/simulated/wall/mineral/wood/nonmetal)
 				qdel(src)
-				return
+			return //return is need to prevent people from exploiting zero-hit cooldowns with the do_after here
 	return ..()
 
 /obj/structure/barricade/wooden/crude


### PR DESCRIPTION
## What Does This PR Do
Fixes #19475

moves a return down so the attackby always returns null instead of returning the parent function when a wooden barricade is attacked with wood. This prevents players from abusing the zero cooldown (because the attack didn't go through yet) caused by the do_after in the attackby proc.

## Why It's Good For The Game
This is an exploit, a funny and inconsequential one at that.


## Testing
Loaded in game, repeated steps offered for reproduction of issue in the report in #19475
Was unable to circumvent the attack cooldown again

## Changelog
:cl:
fix: Players can no long circumvent the attack cooldown with Wooden Barricades
/:cl:
