### PR TITLE
Nerfs disabler beams

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
@@ -20,7 +20,7 @@
 /area/ruin/unpowered/BMPship/Delta)
 "af" = (
 /obj/machinery/porta_turret{
-	installation = /obj/item/gun/energy/gun;
+	installation = /obj/item/gun/energy/gun/turret/disabler;
 	lethal = 1;
 	name = "ship defense turret"
 	},
@@ -1997,7 +1997,7 @@
 "go" = (
 /obj/machinery/porta_turret{
 	check_synth = 1;
-	installation = /obj/item/gun/energy/gun;
+	installation = /obj/item/gun/energy/gun/turret/disabler;
 	lethal = 1;
 	name = "ship defense turret"
 	},
@@ -2320,7 +2320,7 @@
 "hp" = (
 /obj/machinery/porta_turret{
 	check_synth = 1;
-	installation = /obj/item/gun/energy/gun;
+	installation = /obj/item/gun/energy/gun/turret/disabler;
 	lethal = 1;
 	name = "ship defense turret"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -67375,7 +67375,7 @@
 	},
 /obj/machinery/porta_turret{
 	dir = 4;
-	installation = /obj/item/gun/energy/gun;
+	installation = /obj/item/gun/energy/gun/turret/disabler;
 	name = "hallway turret"
 	},
 /turf/simulated/floor/bluegrid,
@@ -67388,7 +67388,7 @@
 	},
 /obj/machinery/porta_turret{
 	dir = 8;
-	installation = /obj/item/gun/energy/gun;
+	installation = /obj/item/gun/energy/gun/turret/disabler;
 	name = "hallway turret"
 	},
 /turf/simulated/floor/bluegrid,

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -149,7 +149,7 @@
 /area/shuttle/administration)
 "iz" = (
 /obj/machinery/porta_turret{
-	installation = /obj/item/gun/energy/gun
+	installation = /obj/item/gun/energy/gun/turret/disabler
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -415,7 +415,7 @@
 "AH" = (
 /obj/machinery/light/spot,
 /obj/machinery/porta_turret{
-	installation = /obj/item/gun/energy/gun
+	installation = /obj/item/gun/energy/gun/turret/disabler
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -469,7 +469,7 @@
 "BZ" = (
 /obj/machinery/light/spot,
 /obj/machinery/porta_turret{
-	installation = /obj/item/gun/energy/gun
+	installation = /obj/item/gun/energy/gun/turret/disabler
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -602,7 +602,7 @@
 /area/shuttle/administration)
 "Hc" = (
 /obj/machinery/porta_turret{
-	installation = /obj/item/gun/energy/gun
+	installation = /obj/item/gun/energy/gun/turret/disabler
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -846,7 +846,7 @@
 /area/shuttle/administration)
 "Ur" = (
 /obj/machinery/porta_turret{
-	installation = /obj/item/gun/energy/gun
+	installation = /obj/item/gun/energy/gun/turret/disabler
 	},
 /obj/structure/window/reinforced{
 	dir = 1;

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -165,6 +165,14 @@
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 
+/obj/item/ammo_casing/energy/disabler_turret
+	projectile_type = /obj/item/projectile/beam/disabler_turret
+	muzzle_flash_color = LIGHT_COLOR_LIGHTBLUE
+	select_name  = "disable"
+	e_cost = 200 //Costly!
+	fire_sound = 'sound/weapons/taser2.ogg'
+	harmful = FALSE
+
 /obj/item/ammo_casing/energy/disabler/cyborg //seperate balancing for cyborg, again
 	e_cost = 250
 

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -94,6 +94,12 @@
 	ammo_x_offset = 2
 	shaded_charge = FALSE
 
+/obj/item/gun/energy/gun/turret/disabler
+	name = "turret energy gun"
+	desc = "A modification of the E-07 energy gun manufactured by Shellguard Munitions, it looks extremely heavy... The fire selector has 'kill' and 'disable' settings."
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler_turret, /obj/item/ammo_casing/energy/laser)
+	origin_tech = "combat=4;magnets=3"
+
 /obj/item/gun/energy/gun/nuclear
 	name = "advanced energy gun"
 	desc = "An energy gun with an experimental miniaturized nuclear reactor that automatically charges the internal power cell."

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -51,12 +51,17 @@
 	icon_state = "disabler"
 	item_state = null
 	origin_tech = "combat=3"
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/accelerator)
 	ammo_x_offset = 2
 	can_flashlight = TRUE
 	flight_x_offset = 15
 	flight_y_offset = 10
 	can_holster = TRUE
+
+
+/obj/item/ammo_casing/energy/disabler/accelerator
+	projectile_type = /obj/item/projectile/beam/disabler/accelerator
+	select_name = "accelerator"
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -51,17 +51,13 @@
 	icon_state = "disabler"
 	item_state = null
 	origin_tech = "combat=3"
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler/accelerator)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 2
 	can_flashlight = TRUE
 	flight_x_offset = 15
 	flight_y_offset = 10
 	can_holster = TRUE
 
-
-/obj/item/ammo_casing/energy/disabler/accelerator
-	projectile_type = /obj/item/projectile/beam/disabler/accelerator
-	select_name = "accelerator disabler"
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,7 +47,7 @@
 
 /obj/item/gun/energy/disabler
 	name = "disabler"
-	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
+	desc = "A low power self-defense weapon that exhausts and then weakens organic targets, the beams need to travel a short distance until becoming fully effective."
 	icon_state = "disabler"
 	item_state = null
 	origin_tech = "combat=3"
@@ -61,7 +61,7 @@
 
 /obj/item/ammo_casing/energy/disabler/accelerator
 	projectile_type = /obj/item/projectile/beam/disabler/accelerator
-	select_name = "accelerator"
+	select_name = "accelerator disabler"
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -64,9 +64,7 @@
 
 /obj/item/projectile/beam/disabler/accelerator/Range()
 	..()
-	damage = (min(5, 100) + damage)
-	if(damage > 30)
-		damage = 30
+	damage = min(damage + 5, 30)
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -71,7 +71,6 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_CYAN
 
-
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -47,6 +47,22 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
+	damage = 10
+	range = 30
+	damage_type = STAMINA
+	flag = "energy"
+	hitsound = 'sound/weapons/tap.ogg'
+	eyeblur = 0
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
+	light_color = LIGHT_COLOR_CYAN
+
+/obj/item/projectile/beam/disabler/Range()
+	..()
+	damage = min(damage + 5, 30)
+
+/obj/item/projectile/beam/disabler_turret
+	name = "disabler beam"
+	icon_state = "omnilaser"
 	damage = 30
 	damage_type = STAMINA
 	flag = "energy"
@@ -55,16 +71,6 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_CYAN
 
-
-
-/obj/item/projectile/beam/disabler/accelerator
-	name = "accelerator disabler"
-	range = 30
-	damage = 10
-
-/obj/item/projectile/beam/disabler/accelerator/Range()
-	..()
-	damage = min(damage + 5, 30)
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"
@@ -242,7 +248,7 @@
 /obj/item/projectile/beam/silencer
 	name = "energy beam" //Keep it vague? It's not a laser, but it's silenced, does a person know what it is?
 	icon_state = "omnilaser"
-	stamina = 30
+	stamina = 10
 	damage = 15
 	damage_type = OXY
 	flag = "energy"
@@ -250,3 +256,7 @@
 	eyeblur = 0
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_CYAN
+
+/obj/item/projectile/beam/silencer/Range()
+	..()
+	stamina = min(stamina + 5, 30)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -55,6 +55,19 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_CYAN
 
+
+
+/obj/item/projectile/beam/disabler/accelerator
+	name = "accelerator disabler"
+	range = 30
+	damage = 10
+
+/obj/item/projectile/beam/disabler/accelerator/Range()
+	..()
+	damage = (min(5, 100) + damage)
+	if(damage > 30)
+		damage = 30
+
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Nerfs disabler beams
Disabler beams from the basic disabler now deal 10 stamina damage base per shot, and every tile it travels increases the damage it deals by 5, for a maximum of 30 total stamina damage, or an increase of 20 stamina damage.
Disabler beams now have a range of 30 tiles
This PR now effects all disabler projectiles, with the exception of turrets
the disabler description have been updated to reflect this
TODO:
- [ ] stamina sprite for the turret gun
## Why It's Good For The Game
Currently the disabler and other weapons are just straight up better than the baton, either dual wielding or whatever you choose, disabler beams are more consistent.
This PR reduces the effectiveness of the disabler beams close range while still letting it perform well in medium to long range, giving the baton an actual niche. 
I am open to changing this, but a change should be made. 
Talked with balance on this, it should affect all disable beams
## Testing
Compiled, ran, shooty shoot

## Changelog
:cl:
tweak: Disabler beams now need to travel four tiles to become fully effective
tweak: Disable beams now have a maximum range of 30
/:cl:

