### PR TITLE
Removes gibbing animation

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -1,7 +1,6 @@
 /mob/living/carbon/human/gib()
 	if(!death(TRUE) && stat != DEAD)
 		return FALSE
-	var/atom/movable/overlay/animation = null
 	notransform = TRUE
 	icon = null
 	invisibility = 101
@@ -35,7 +34,6 @@
 	else
 		new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
 		do_sparks(3, 1, src)
-	QDEL_IN(animation, 15)
 	QDEL_IN(src, 0)
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -6,11 +6,6 @@
 	icon = null
 	invisibility = 101
 	if(!ismachineperson(src))
-		animation = new(loc)
-		animation.icon_state = "blank"
-		animation.icon = 'icons/mob/mob.dmi'
-		animation.master = src
-
 		playsound(src.loc, 'sound/goonstation/effects/gib.ogg', 50, 1)
 	else
 		playsound(src.loc, 'sound/goonstation/effects/robogib.ogg', 50, 1)
@@ -36,7 +31,6 @@
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
 
 	if(!ismachineperson(src))
-		flick("gibbed-h", animation)
 		hgibs(loc, dna)
 	else
 		new /obj/effect/decal/cleanable/blood/gibs/robot(loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes the outdated gibbing animation from triggering upon the gibbing of a subject (mob/living/carbon/human).

## Why It's Good For The Game
The gibbing animation was not compatible with our many species, gibbing someone looks cleaner and is more consistent without the animation, and I encountered a rare runtime exception when punching the gibbing animation model, which could impact stability of the live server if someone were able to do so, and entirely removing it also eliminated that from happening.

## Images of changes
https://youtu.be/xY95vOJX1hE

## Testing
I removed the animation from the code that triggers upon the death via gibbing of any mob/living/carbon/human, ran the local server, gibbed a human, tajaran, and nian, did not run into any runtime exceptions, and observed no gibbing animation.

## Changelog
:cl:LynxSolstice
del: Removed the old gibbing animation as it was incompatible with our current playable species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
