### PR TITLE
CQC Balancing Tweaks/Buffs

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -886,7 +886,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/cqc
 	name = "CQC Manual"
-	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. Does not restrict weapon usage, but cannot be used alongside Gloves of the North Star."
+	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. \
+			Changes your unarmed damage to deal non-lethal stamina damage. \
+			Does not restrict weapon usage, but cannot be used alongside Gloves of the North Star."
 	reference = "CQC"
 	item = /obj/item/CQC_manual
 	cost = 13

--- a/code/modules/martial_arts/combos/cqc/consecutive.dm
+++ b/code/modules/martial_arts/combos/cqc/consecutive.dm
@@ -8,7 +8,7 @@
 		target.visible_message("<span class='warning'>[user] strikes [target]'s abdomen, neck and back consecutively</span>", \
 							"<span class='userdanger'>[user] strikes your abdomen, neck and back consecutively!</span>")
 		playsound(get_turf(target), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
-		target.adjustStaminaLoss(60)
+		target.adjustStaminaLoss(70)
 		target.apply_damage(20, BRUTE)
 		add_attack_logs(user, target, "Melee attacked with martial-art [src] : Consecutive", ATKLOG_ALL)
 		return MARTIAL_COMBO_DONE

--- a/code/modules/martial_arts/combos/cqc/kick.dm
+++ b/code/modules/martial_arts/combos/cqc/kick.dm
@@ -8,7 +8,7 @@
 	if(!IS_HORIZONTAL(target) && user != target)
 		target.visible_message("<span class='warning'>[user] kicks [target] back!</span>", \
 							"<span class='userdanger'>[user] kicks you back!</span>")
-		playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
+		playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 25, 1, -1)
 		var/atom/throw_target = get_edge_target_turf(target, user.dir)
 		target.throw_at(throw_target, 1, 14, user)
 		target.apply_damage(30, STAMINA)
@@ -18,7 +18,7 @@
 	else if(IS_HORIZONTAL(target) && user != target)
 		target.visible_message("<span class='warning'>[user] kicks [target]'s head, disorienting [target.p_them()]!</span>", \
 					  		"<span class='userdanger'>[user] kicks your head, disorienting you!</span>")
-		playsound(get_turf(user), 'sound/weapons/genhit1.ogg', 50, 1, -1)
+		playsound(get_turf(user), 'sound/weapons/genhit1.ogg', 25, 1, -1)
 		var/atom/throw_target = get_edge_target_turf(target, user.dir)
 		target.throw_at(throw_target, 1, 8, user)
 		target.adjustStaminaLoss(40)

--- a/code/modules/martial_arts/combos/cqc/kick.dm
+++ b/code/modules/martial_arts/combos/cqc/kick.dm
@@ -11,7 +11,7 @@
 		playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
 		var/atom/throw_target = get_edge_target_turf(target, user.dir)
 		target.throw_at(throw_target, 1, 14, user)
-		target.apply_damage(15, STAMINA)
+		target.apply_damage(30, STAMINA)
 		target.Slowed(5 SECONDS)
 		add_attack_logs(user, target, "Melee attacked with martial-art [src] : Kick", ATKLOG_ALL)
 		. = MARTIAL_COMBO_DONE

--- a/code/modules/martial_arts/combos/cqc/kick.dm
+++ b/code/modules/martial_arts/combos/cqc/kick.dm
@@ -11,7 +11,7 @@
 		playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 25, 1, -1)
 		var/atom/throw_target = get_edge_target_turf(target, user.dir)
 		target.throw_at(throw_target, 1, 14, user)
-		target.apply_damage(30, STAMINA)
+		target.apply_damage(25, STAMINA)
 		target.Slowed(5 SECONDS)
 		add_attack_logs(user, target, "Melee attacked with martial-art [src] : Kick", ATKLOG_ALL)
 		. = MARTIAL_COMBO_DONE

--- a/code/modules/martial_arts/combos/cqc/pressure.dm
+++ b/code/modules/martial_arts/combos/cqc/pressure.dm
@@ -9,6 +9,6 @@
 	if(I && target.drop_item())
 		user.put_in_hands(I)
 	target.adjustStaminaLoss(40)
-	playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
+	playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 5, 1, -1)
 	add_attack_logs(user, target, "Melee attacked with martial-art [src] : Pressure", ATKLOG_ALL)
 	return MARTIAL_COMBO_DONE

--- a/code/modules/martial_arts/combos/cqc/restrain.dm
+++ b/code/modules/martial_arts/combos/cqc/restrain.dm
@@ -15,7 +15,7 @@
 		target.visible_message("<span class='warning'>[user] locks [target] into a restraining position!</span>", \
 							"<span class='userdanger'>[user] locks you into a restraining position!</span>")
 		var/stam_damage = target.getStaminaLoss()
-		switch (stam_damage)
+		switch(stam_damage)
 			if(0 to 40)
 				target.Immobilize(4 SECONDS)
 				target.adjustStaminaLoss(35)

--- a/code/modules/martial_arts/combos/cqc/restrain.dm
+++ b/code/modules/martial_arts/combos/cqc/restrain.dm
@@ -23,7 +23,6 @@
 				target.Stun(6 SECONDS)
 			if(81 to 120)
 				target.adjustStaminaLoss(40)
-				target.Silence(6 SECONDS)
 
 		CQC.restraining = TRUE
 		addtimer(CALLBACK(CQC, /datum/martial_art/cqc/.proc/drop_restraining), 5 SECONDS, TIMER_UNIQUE)

--- a/code/modules/martial_arts/combos/cqc/restrain.dm
+++ b/code/modules/martial_arts/combos/cqc/restrain.dm
@@ -1,7 +1,8 @@
 /datum/martial_combo/cqc/restrain
 	name = "Restrain"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_GRAB)
-	explaination_text = "Locks opponents into a restraining position, disarm to begin a chokehold that will knock them out."
+	explaination_text = "Locks opponents into a restraining position that is more effective the more stamina damage the target has taken, \
+						 disarm to begin a chokehold that will knock them out."
 	combo_text_override = "Grab, switch hands, Grab"
 
 /datum/martial_combo/cqc/restrain/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
@@ -13,8 +14,17 @@
 	if(!target.stat)
 		target.visible_message("<span class='warning'>[user] locks [target] into a restraining position!</span>", \
 							"<span class='userdanger'>[user] locks you into a restraining position!</span>")
-		target.adjustStaminaLoss(20)
-		target.Stun(3 SECONDS)
+		var/stam_damage = target.getStaminaLoss()
+		switch (stam_damage)
+			if(0 to 40)
+				target.Immobilize(4 SECONDS)
+				target.adjustStaminaLoss(35)
+			if(41 to 80)
+				target.Stun(6 SECONDS)
+			if(81 to 120)
+				target.adjustStaminaLoss(40)
+				target.Silence(6 SECONDS)
+
 		CQC.restraining = TRUE
 		addtimer(CALLBACK(CQC, /datum/martial_art/cqc/.proc/drop_restraining), 5 SECONDS, TIMER_UNIQUE)
 		add_attack_logs(user, target, "Melee attacked with martial-art [src] : Restrain", ATKLOG_ALL)

--- a/code/modules/martial_arts/combos/cqc/slam.dm
+++ b/code/modules/martial_arts/combos/cqc/slam.dm
@@ -10,7 +10,7 @@
 	target.visible_message("<span class='warning'>[user] slams [target] into the ground!</span>", \
 						"<span class='userdanger'>[user] slams you into the ground!</span>")
 	playsound(get_turf(user), 'sound/weapons/slam.ogg', 50, 1, -1)
-	target.apply_damage(20, STAMINA)
+	target.apply_damage(50, STAMINA)
 	target.KnockDown(7 SECONDS)
 	target.SetConfused(12 SECONDS)
 	add_attack_logs(user, target, "Melee attacked with martial-art [src] :  Slam", ATKLOG_ALL)

--- a/code/modules/martial_arts/combos/cqc/slam.dm
+++ b/code/modules/martial_arts/combos/cqc/slam.dm
@@ -9,7 +9,7 @@
 		return MARTIAL_COMBO_FAIL
 	target.visible_message("<span class='warning'>[user] slams [target] into the ground!</span>", \
 						"<span class='userdanger'>[user] slams you into the ground!</span>")
-	playsound(get_turf(user), 'sound/weapons/slam.ogg', 50, 1, -1)
+	playsound(get_turf(user), 'sound/weapons/slam.ogg', 40, 1, -1)
 	target.apply_damage(50, STAMINA)
 	target.KnockDown(7 SECONDS)
 	target.SetConfused(12 SECONDS)

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -60,16 +60,16 @@
 		picked_hit_type = "stomps on"
 	D.apply_damage(bonus_damage, STAMINA)
 	if(picked_hit_type == "kicks" || picked_hit_type == "stomps on")
-		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
+		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 10, 1, -1)
 	else
-		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
+		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 10, 1, -1)
 	D.visible_message("<span class='danger'>[A] [picked_hit_type] [D]!</span>", \
 					  "<span class='userdanger'>[A] [picked_hit_type] you!</span>")
 	add_attack_logs(A, D, "Melee attacked with martial-art [src] : [picked_hit_type]", ATKLOG_ALL)
 	if(IS_HORIZONTAL(A) && !IS_HORIZONTAL(D))
 		D.visible_message("<span class='warning'>[A] leg sweeps [D]!", \
 							"<span class='userdanger'>[A] leg sweeps you!</span>")
-		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
+		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 10, 1, -1)
 		D.KnockDown(5 SECONDS)
 		A.SetKnockDown(0 SECONDS)
 		A.resting = FALSE
@@ -89,12 +89,12 @@
 	if(!IS_HORIZONTAL(D) || !restraining)
 		D.visible_message("<span class='warning'>[A] strikes [D]'s jaw with their hand!</span>", \
 							"<span class='userdanger'>[A] strikes your jaw, disorienting you!</span>")
-		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 5, TRUE, -1)
 		D.SetSlur(4 SECONDS)
 		D.apply_damage(15, STAMINA)
 	else
 		D.visible_message("<span class='danger'>[A] attempted to disarm [D]!</span>", "<span class='userdanger'>[A] attempted to disarm [D]!</span>")
-		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+		playsound(D, 'sound/weapons/punchmiss.ogg', 5, 1, -1)
 
 	add_attack_logs(A, D, "Disarmed with martial-art [src]", ATKLOG_ALL)
 	return TRUE

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -70,8 +70,9 @@
 		D.visible_message("<span class='warning'>[A] leg sweeps [D]!", \
 							"<span class='userdanger'>[A] leg sweeps you!</span>")
 		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
-		D.KnockDown(3 SECONDS)
+		D.KnockDown(5 SECONDS)
 		A.SetKnockDown(0 SECONDS)
+		A.resting = FALSE
 		A.stand_up() //Quickly get up like the cool dude you are.
 		add_attack_logs(A, D, "Melee attacked with martial-art [src] : Leg sweep", ATKLOG_ALL)
 	return TRUE

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -54,9 +54,9 @@
 	add_attack_logs(A, D, "Melee attacked with martial-art [src]", ATKLOG_ALL)
 	A.do_attack_animation(D)
 	var/picked_hit_type = pick("CQC'd", "neck chopped", "gut punched", "Big Bossed")
-	var/bonus_damage = 13
+	var/bonus_damage = 25
 	if(IS_HORIZONTAL(D))
-		bonus_damage += 9 //Being stomped on doesn't feel good.
+		bonus_damage += 10 //Being stomped on doesn't feel good.
 		picked_hit_type = "stomps on"
 	D.apply_damage(bonus_damage, STAMINA)
 	if(picked_hit_type == "kicks" || picked_hit_type == "stomps on")
@@ -91,7 +91,7 @@
 							"<span class='userdanger'>[A] strikes your jaw, disorienting you!</span>")
 		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
 		D.SetSlur(4 SECONDS)
-		D.apply_damage(8, STAMINA)
+		D.apply_damage(15, STAMINA)
 	else
 		D.visible_message("<span class='danger'>[A] attempted to disarm [D]!</span>", "<span class='userdanger'>[A] attempted to disarm [D]!</span>")
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -31,6 +31,7 @@
 	var/damage_multiplier = 1 + A.getStaminaLoss() / 100 //The chokehold is more effective the more tired the target is.
 	while(do_mob(A, D, 2 SECONDS) && chokehold_active)
 		D.apply_damage(10 * damage_multiplier, OXY)
+		D.SetLoseBreath(3 SECONDS)
 		if(D.getOxyLoss() >= 50 || D.health <= 20)
 			D.visible_message("<span class ='danger>[A] puts [D] to sleep!</span>", \
 						"<span class='userdanger'>[A] knocks you out cold!</span>")
@@ -44,7 +45,7 @@
 	MARTIAL_ARTS_ACT_CHECK
 	var/obj/item/grab/G = D.grabbedby(A, 1)
 	if(G)
-		D.Stun(1 SECONDS) //Catch them off guard, but not long enough to do too much nonsense
+		D.Immobilize(1 SECONDS) //Catch them off guard, but not long enough to do too much nonsense
 		add_attack_logs(A, D, "Melee attacked with martial-art [src] : grabbed", ATKLOG_ALL)
 
 	return TRUE
@@ -80,7 +81,7 @@
 /datum/martial_art/cqc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	MARTIAL_ARTS_ACT_CHECK
 	var/obj/item/grab/G = A.get_inactive_hand()
-	if(restraining && istype(G) && G.affecting == D)
+	if(restraining && istype(G) && G.affecting == D && !chokehold_active)
 		start_chokehold(A, D)
 		return TRUE
 	else

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -54,7 +54,7 @@
 	add_attack_logs(A, D, "Melee attacked with martial-art [src]", ATKLOG_ALL)
 	A.do_attack_animation(D)
 	var/picked_hit_type = pick("CQC'd", "neck chopped", "gut punched", "Big Bossed")
-	var/bonus_damage = 25
+	var/bonus_damage = 20
 	if(IS_HORIZONTAL(D))
 		bonus_damage += 10 //Being stomped on doesn't feel good.
 		picked_hit_type = "stomps on"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR addresses a number of community concerns/suggestions that were brought up in response to trying out the new, reworked CQC, particularly the comments about the low power level when compared to the TC cost. Here were the most common ones.

* Stamcrit in 5 hits, compared to being stamcritted by a baton in two.
* CQC is too loud for a stealthy martial art.
* The restrain combo didn't work very well, and people could just walk out of the grab.
* Legsweeping should get the user up from resting on their own.
* The description should better match what CQC does now.

<details><summary>Specific Details of Changes:</summary>


Consecutive CQC: 60 -> 70 Stamina Damage

Standing Kick: 15 -> 25 Stamina Damage, Half as loud

Horizontal Kick: Half as loud

Pressure: 1/10th as loud, nearly silent

Restrain: At 0 to 40 stamina damage, deals 35 stamina damage and immobilizes for 4 seconds, at 41 to 80 stamina damage, 
stuns for 6 seconds, at 81 to 120 stamina damage, deals 40 stamina damage to fully stamcrit them.

Slam: 20 -> 50 Stamina Damage, 20% quieter

Chokehold: Now also applies lose breath

Legsweep: Will pick you up even if you're manually resting, 3 -> 5 second knockdown, 1/5 as loud

Grab Intent: Immobilizes for a second, instead of stunning for a second

Harm Intent: 13 -> 20 Stamina damage, 1/5 as loud

Disarm Intent: 8 -> 15 Stamina damage, 1/10 as loud
</details>

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
At a first impression, the reception to the CQC rework was very good. People seemed to enjoy it, but had issues with the power level. They and myself felt like if it's going to cost as much as a chainsaw, it should have a higher power level as well. These changes bring the number of hits to put someone in staminacrit from 5 to 3 using combos, or by smacking them with harm intent 5 times.

Restrain is a defining feature of CQC, and the fact that it was very simple to just walk out was unintended, and made that aspect of the martial art much less useful. Now, it has a different effects based on how much stamina damage the target has taken, scaling from some stamina damage and an immobilize, to a stun, and finally to stamcrit. This rewards players for setting up their restrain combos, but doesn't punish people too hard if they don't.

CQC being a less than lethal option means that it's often going to be used in stealth takedowns, especially since using it makes you feel like agent 47, CQCs basic hits, and some of the comboes being much quieter reflect this ascept of gameplay, and add to the secret agent feeling.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned myself in, gave myself CQC and beat up a bunch of skrells. I also transferred myself into said skrells to make sure that the status effects were working properly too.

## Changelog
:cl:
tweak: Buffs CQC, fixes community complaints
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
