### PR TITLE
Penlights are universally pens

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -22,7 +22,7 @@
 
 #define isclothing(A) (istype(A, /obj/item/clothing))
 
-#define is_pen(W) (istype(W, /obj/item/pen)|istype(W, /obj/item/flashlight/pen))
+#define is_pen(W) (istype(W, /obj/item/pen) || istype(W, /obj/item/flashlight/pen))
 
 #define isstorage(A) (istype(A, /obj/item/storage))
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -22,7 +22,7 @@
 
 #define isclothing(A) (istype(A, /obj/item/clothing))
 
-#define is_pen(W) (istype(W, /obj/item/pen))
+#define is_pen(W) (istype(W, /obj/item/pen)|istype(W, /obj/item/flashlight/pen))
 
 #define isstorage(A) (istype(A, /obj/item/storage))
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -89,13 +89,14 @@
 
 /obj/item/flashlight/pen
 	name = "penlight"
-	desc = "A pen-sized light, used by medical staff."
+	desc = "A pen, and a light. Used by medical staff."
 	icon_state = "penlight"
 	item_state = ""
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = SLOT_BELT | SLOT_EARS
 	flags = CONDUCT
 	brightness_on = 2
+	var/colour = "blue" // Ink color
 
 /obj/item/flashlight/seclite
 	name = "seclite"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -297,7 +297,7 @@
 	return ..()
 
 /obj/item/storage/pill_bottle/attackby(obj/item/I, mob/user, params)
-	if(is_pen(I) || istype(I, /obj/item/flashlight/pen))
+	if(is_pen(I))
 		rename_interactive(user, I)
 	else
 		return ..()

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -110,7 +110,7 @@
 			reagents.clear_reagents()
 
 /obj/item/reagent_containers/glass/attackby(obj/item/I, mob/user, params)
-	if(is_pen(I) || istype(I, /obj/item/flashlight/pen))
+	if(is_pen(I))
 		var/t = rename_interactive(user, I)
 		if(!isnull(t))
 			label_text = t

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -149,7 +149,7 @@
 				. += "inject"
 
 /obj/item/reagent_containers/iv_bag/attackby(obj/item/I, mob/user, params)
-	if(is_pen(I) || istype(I, /obj/item/flashlight/pen))
+	if(is_pen(I))
 		rename_interactive(user, I)
 
 // PRE-FILLED IV BAGS BELOW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the color blue to penlights, and makes them part of the `is_pen` check.

Penlights can already write on pill bottles, beakers and iv bags due to a specific check being made for it, what's stopping it from just being seeing as a pen all around?

This removes the listed specific checks above as well since now it's simply a pen check.

## Why It's Good For The Game
A little bit of consistency. Being only capable of writing on pill bottles, beakers and iv bags are a standout.

## Images of changes
![Penlight](https://user-images.githubusercontent.com/80771500/197556813-ee6078a6-966b-4d12-ad31-a5159f7bdd18.PNG)

## Testing
Spawned a pen and a penlight, and messed around with interactions as outside of the color addition, all was done was throw it into the helper check.

## Changelog
:cl:
tweak: Penlights are now pens all around.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
