### PR TITLE
Fix #19489, Changes aft maintenance library to aft maint area

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -30100,6 +30100,10 @@
 	icon_state = "caution"
 	},
 /area/atmos)
+"byA" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/maintenance/abandonedlibrary)
 "byB" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -67565,7 +67569,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "ddA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67576,7 +67580,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "ddC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -68061,7 +68065,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "deA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -68301,7 +68305,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "deV" = (
 /obj/structure/sign/examroom,
 /turf/simulated/wall,
@@ -68948,7 +68952,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dgB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -79965,12 +79969,12 @@
 /obj/structure/barricade/wooden,
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFi" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFj" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -79980,7 +79984,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFl" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
@@ -80137,29 +80141,29 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFL" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFM" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFN" = (
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFP" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFQ" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -80167,12 +80171,12 @@
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFS" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dFU" = (
 /obj/structure/chair{
 	dir = 1
@@ -80434,42 +80438,42 @@
 "dGB" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGC" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGD" = (
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGF" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGG" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
 /turf/simulated/floor/carpet,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGH" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGI" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dGJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80825,18 +80829,18 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dHs" = (
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dHt" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dHu" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards,
@@ -80844,13 +80848,13 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dHv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder/red,
 /turf/simulated/floor/carpet,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dHw" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -80861,7 +80865,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dHx" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -81327,15 +81331,15 @@
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dIq" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dIr" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dIt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81343,20 +81347,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dIu" = (
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dIv" = (
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dIw" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dIx" = (
 /turf/simulated/wall,
 /area/chapel/office)
@@ -81624,7 +81628,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81635,7 +81639,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81643,7 +81647,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81651,7 +81655,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81659,14 +81663,14 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJq" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -81675,7 +81679,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -81684,7 +81688,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dJu" = (
 /obj/structure/morgue,
 /turf/simulated/floor/plasteel/dark,
@@ -81914,13 +81918,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dKc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -81933,7 +81937,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dKd" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
@@ -82124,16 +82128,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dKF" = (
 /obj/structure/cult/archives,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dKG" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dKH" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight,
@@ -82409,7 +82413,7 @@
 "dLm" = (
 /obj/effect/landmark/spawner/rev,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dLn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -82715,19 +82719,19 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMe" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMf" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMh" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Backroom";
@@ -83020,12 +83024,12 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMJ" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -83034,17 +83038,17 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMO" = (
 /obj/machinery/door/morgue{
 	name = "Occult Study"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMP" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dMQ" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -83288,13 +83292,13 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNy" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNz" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small,
@@ -83302,40 +83306,40 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNA" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNC" = (
 /obj/machinery/light/small,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dND" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/wood,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNE" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNF" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plating,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNG" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/apmaint)
+/area/maintenance/abandonedlibrary)
 "dNH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90533,6 +90537,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block)
+"iZi" = (
+/obj/effect/spawner/random_spawners/wall_rusted_always,
+/turf/simulated/wall,
+/area/maintenance/abandonedlibrary)
 "iZW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Affairs Maintenance";
@@ -91044,6 +91052,9 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore)
+"kcy" = (
+/turf/simulated/floor/plating,
+/area/maintenance/abandonedlibrary)
 "kdu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -93765,6 +93776,9 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
+"plp" = (
+/turf/simulated/wall,
+/area/maintenance/abandonedlibrary)
 "pnF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -94969,6 +94983,10 @@
 	icon_state = "red"
 	},
 /area/hallway/secondary/exit)
+"rmX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/abandonedlibrary)
 "rnA" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -127695,18 +127713,18 @@ dCC
 dDT
 dEB
 ddy
-ddy
-ddy
-ddy
-ddy
-ddy
-ddy
-ddy
-ddy
-ddy
-ddy
-ddy
-ddy
+plp
+plp
+plp
+plp
+plp
+plp
+plp
+plp
+plp
+plp
+plp
+plp
 abj
 dPq
 dXH
@@ -127963,7 +127981,7 @@ dHt
 dMc
 dMI
 dNx
-ddy
+plp
 ddy
 dPq
 dPq
@@ -128208,7 +128226,7 @@ mGS
 dCE
 gQW
 dEF
-ddy
+plp
 dFL
 dGC
 dHs
@@ -128220,7 +128238,7 @@ dIp
 dHs
 dMJ
 dNy
-ddy
+plp
 dOO
 dPr
 deW
@@ -128475,9 +128493,9 @@ ddz
 dHs
 dIu
 dMd
-dbp
+rmX
 dNz
-ddy
+plp
 dOO
 dPs
 dOO
@@ -128734,7 +128752,7 @@ dFN
 dFN
 dMK
 dNA
-ddy
+plp
 dOP
 dPt
 dbw
@@ -128991,7 +129009,7 @@ dFN
 dFN
 dNy
 dMI
-ddy
+plp
 dOO
 dXo
 dQb
@@ -129493,19 +129511,19 @@ cHA
 dCG
 dDU
 dEG
-ddy
+plp
 dFP
 dGE
 dHs
 dIu
 dIu
 ddB
-dOO
+kcy
 dIu
 dIu
 dHs
 dNC
-ddy
+plp
 dEi
 dPw
 dQe
@@ -129750,7 +129768,7 @@ dbk
 dEy
 dDV
 dEH
-ddy
+plp
 dFN
 dGF
 dGF
@@ -129762,7 +129780,7 @@ dIq
 dMe
 dIu
 dND
-ddy
+plp
 dhx
 dPx
 dQf
@@ -130007,7 +130025,7 @@ cHA
 dCH
 dDW
 dID
-dku
+iZi
 dFQ
 dGG
 dHu
@@ -130019,7 +130037,7 @@ dHt
 dMe
 dHs
 dNE
-ddy
+plp
 dbp
 dPy
 dbw
@@ -130264,19 +130282,19 @@ dkI
 dCI
 dDX
 dOO
-ddy
+plp
 dFR
 dGH
 dHv
 dIw
-dOO
-ddy
-ddy
-dku
-ddy
+kcy
+plp
+plp
+iZi
+plp
 dMO
-ddy
-ddy
+plp
+plp
 dOO
 dPz
 dQg
@@ -130521,19 +130539,19 @@ dkI
 dbo
 dDX
 dbp
-ddy
+plp
 dFS
 dGI
 dHw
 dFN
 dJs
-ddy
+plp
 dKF
 dLm
 dMf
 dMP
 dNF
-ddy
+plp
 dik
 diD
 dQn
@@ -130778,19 +130796,19 @@ dkI
 dEi
 dDX
 dOO
-ddy
-ddy
-ddy
-ddy
-ddy
+plp
+plp
+plp
+plp
+plp
 dJt
-ddy
+plp
 dKG
 dIv
-dbp
+rmX
 dGE
 dNG
-ddy
+plp
 dbp
 dPA
 dQc
@@ -131039,15 +131057,15 @@ dFl
 dcA
 dOO
 dHx
-ddy
-ddy
-dku
-dku
-ddy
-dku
-dku
-ddy
-dlJ
+plp
+plp
+iZi
+iZi
+plp
+iZi
+iZi
+plp
+byA
 dik
 dPB
 dbw

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1963,6 +1963,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 6;
 	icon_state = "bluecorner"
 	},
 /area/hallway/secondary/entry)
@@ -67564,7 +67565,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "ddA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67575,7 +67576,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "ddC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -68060,7 +68061,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "deA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -68300,7 +68301,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "deV" = (
 /obj/structure/sign/examroom,
 /turf/simulated/wall,
@@ -68947,7 +68948,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dgB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -79960,19 +79961,16 @@
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
-"dFg" = (
-/turf/simulated/wall,
-/area/library/abandoned)
 "dFh" = (
 /obj/structure/barricade/wooden,
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFi" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFj" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -79982,11 +79980,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/library/abandoned)
-"dFk" = (
-/obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFl" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
@@ -80143,29 +80137,29 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFL" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFM" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFN" = (
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFP" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFQ" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -80173,12 +80167,12 @@
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFS" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dFU" = (
 /obj/structure/chair{
 	dir = 1
@@ -80440,42 +80434,42 @@
 "dGB" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGC" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGD" = (
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGF" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGG" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
 /turf/simulated/floor/carpet,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGH" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGI" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dGJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80831,18 +80825,18 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dHs" = (
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dHt" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dHu" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards,
@@ -80850,13 +80844,13 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dHv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder/red,
 /turf/simulated/floor/carpet,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dHw" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -80867,7 +80861,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dHx" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -81333,15 +81327,15 @@
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dIq" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dIr" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dIt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81349,20 +81343,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dIu" = (
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dIv" = (
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dIw" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dIx" = (
 /turf/simulated/wall,
 /area/chapel/office)
@@ -81630,7 +81624,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81641,7 +81635,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81649,7 +81643,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81657,7 +81651,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81665,17 +81659,14 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJq" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
-"dJr" = (
-/turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -81684,7 +81675,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -81693,7 +81684,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dJu" = (
 /obj/structure/morgue,
 /turf/simulated/floor/plasteel/dark,
@@ -81923,13 +81914,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dKc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -81942,7 +81933,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dKd" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
@@ -82133,16 +82124,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dKF" = (
 /obj/structure/cult/archives,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dKG" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dKH" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight,
@@ -82418,7 +82409,7 @@
 "dLm" = (
 /obj/effect/landmark/spawner/rev,
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dLn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -82724,23 +82715,19 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMe" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMf" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
-"dMg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMh" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Backroom";
@@ -83033,12 +83020,12 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMJ" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -83047,17 +83034,17 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMO" = (
 /obj/machinery/door/morgue{
 	name = "Occult Study"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMP" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dMQ" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -83301,13 +83288,13 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNy" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNz" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small,
@@ -83315,40 +83302,40 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNA" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNC" = (
 /obj/machinery/light/small,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dND" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNE" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNF" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNG" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /turf/simulated/floor/plasteel/dark,
-/area/library/abandoned)
+/area/maintenance/apmaint)
 "dNH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83643,10 +83630,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"dOm" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/library/abandoned)
 "dOn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -97344,6 +97327,10 @@
 	},
 /turf/simulated/floor/plasteel/grimy,
 /area/crew_quarters/theatre)
+"vHl" = (
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/wall,
+/area/hallway/primary/aft)
 "vId" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/beach/sand,
@@ -127450,7 +127437,7 @@ gQW
 dCB
 gQW
 dEA
-dFg
+ddy
 abj
 abj
 abj
@@ -127707,19 +127694,19 @@ mGS
 dCC
 dDT
 dEB
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
-dFg
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
 abj
 dPq
 dXH
@@ -127964,7 +127951,7 @@ dBA
 dCD
 gQW
 dEE
-dFg
+ddy
 dFK
 dGB
 dHr
@@ -127976,7 +127963,7 @@ dHt
 dMc
 dMI
 dNx
-dFg
+ddy
 ddy
 dPq
 dPq
@@ -128221,7 +128208,7 @@ mGS
 dCE
 gQW
 dEF
-dFg
+ddy
 dFL
 dGC
 dHs
@@ -128233,7 +128220,7 @@ dIp
 dHs
 dMJ
 dNy
-dFg
+ddy
 dOO
 dPr
 deW
@@ -128488,9 +128475,9 @@ ddz
 dHs
 dIu
 dMd
-dMg
+dbp
 dNz
-dFg
+ddy
 dOO
 dPs
 dOO
@@ -128747,7 +128734,7 @@ dFN
 dFN
 dMK
 dNA
-dFg
+ddy
 dOP
 dPt
 dbw
@@ -129004,7 +128991,7 @@ dFN
 dFN
 dNy
 dMI
-dFg
+ddy
 dOO
 dXo
 dQb
@@ -129506,19 +129493,19 @@ cHA
 dCG
 dDU
 dEG
-dFg
+ddy
 dFP
 dGE
 dHs
 dIu
 dIu
 ddB
-dJr
+dOO
 dIu
 dIu
 dHs
 dNC
-dFg
+ddy
 dEi
 dPw
 dQe
@@ -129763,7 +129750,7 @@ dbk
 dEy
 dDV
 dEH
-dFg
+ddy
 dFN
 dGF
 dGF
@@ -129775,7 +129762,7 @@ dIq
 dMe
 dIu
 dND
-dFg
+ddy
 dhx
 dPx
 dQf
@@ -130020,7 +130007,7 @@ cHA
 dCH
 dDW
 dID
-dFk
+dku
 dFQ
 dGG
 dHu
@@ -130032,7 +130019,7 @@ dHt
 dMe
 dHs
 dNE
-dFg
+ddy
 dbp
 dPy
 dbw
@@ -130277,19 +130264,19 @@ dkI
 dCI
 dDX
 dOO
-dFg
+ddy
 dFR
 dGH
 dHv
 dIw
-dJr
-dFg
-dFg
-dFk
-dFg
+dOO
+ddy
+ddy
+dku
+ddy
 dMO
-dFg
-dFg
+ddy
+ddy
 dOO
 dPz
 dQg
@@ -130534,19 +130521,19 @@ dkI
 dbo
 dDX
 dbp
-dFg
+ddy
 dFS
 dGI
 dHw
 dFN
 dJs
-dFg
+ddy
 dKF
 dLm
 dMf
 dMP
 dNF
-dFg
+ddy
 dik
 diD
 dQn
@@ -130791,19 +130778,19 @@ dkI
 dEi
 dDX
 dOO
-dFg
-dFg
-dFg
-dFg
-dFg
+ddy
+ddy
+ddy
+ddy
+ddy
 dJt
-dFg
+ddy
 dKG
 dIv
-dMg
+dbp
 dGE
 dNG
-dFg
+ddy
 dbp
 dPA
 dQc
@@ -131052,15 +131039,15 @@ dFl
 dcA
 dOO
 dHx
-dFg
-dFg
-dFk
-dFk
-dFg
-dFk
-dFk
-dFg
-dOm
+ddy
+ddy
+dku
+dku
+ddy
+dku
+dku
+ddy
+dlJ
 dik
 dPB
 dbw
@@ -136700,7 +136687,7 @@ dHR
 dql
 dGf
 dBT
-dfu
+vHl
 dEU
 dFv
 dGl

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -30103,7 +30103,7 @@
 "byA" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "byB" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -67569,7 +67569,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "ddA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67580,7 +67580,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "ddC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -68065,7 +68065,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "deA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -68305,7 +68305,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "deV" = (
 /obj/structure/sign/examroom,
 /turf/simulated/wall,
@@ -68952,7 +68952,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dgB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -79969,12 +79969,12 @@
 /obj/structure/barricade/wooden,
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFi" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFj" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -79984,7 +79984,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFl" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
@@ -80141,29 +80141,29 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFL" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFM" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFN" = (
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFP" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFQ" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -80171,12 +80171,12 @@
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFS" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dFU" = (
 /obj/structure/chair{
 	dir = 1
@@ -80438,42 +80438,42 @@
 "dGB" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGC" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGD" = (
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGF" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGG" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
 /turf/simulated/floor/carpet,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGH" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGI" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dGJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80829,18 +80829,18 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dHs" = (
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dHt" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dHu" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards,
@@ -80848,13 +80848,13 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dHv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder/red,
 /turf/simulated/floor/carpet,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dHw" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -80865,7 +80865,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dHx" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -81331,15 +81331,15 @@
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dIq" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dIr" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dIt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81347,20 +81347,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dIu" = (
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dIv" = (
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dIw" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dIx" = (
 /turf/simulated/wall,
 /area/chapel/office)
@@ -81628,7 +81628,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81639,7 +81639,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81647,7 +81647,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81655,7 +81655,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81663,14 +81663,14 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJq" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -81679,7 +81679,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -81688,7 +81688,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dJu" = (
 /obj/structure/morgue,
 /turf/simulated/floor/plasteel/dark,
@@ -81918,13 +81918,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dKb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/grimy,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dKc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -81937,7 +81937,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dKd" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
@@ -82128,16 +82128,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dKF" = (
 /obj/structure/cult/archives,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dKG" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dKH" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight,
@@ -82413,7 +82413,7 @@
 "dLm" = (
 /obj/effect/landmark/spawner/rev,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dLn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -82719,19 +82719,19 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMe" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMf" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMh" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Backroom";
@@ -83024,12 +83024,12 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMJ" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -83038,17 +83038,17 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMO" = (
 /obj/machinery/door/morgue{
 	name = "Occult Study"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMP" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dMQ" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -83292,13 +83292,13 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNy" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNz" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small,
@@ -83306,40 +83306,40 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNA" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNC" = (
 /obj/machinery/light/small,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dND" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/wood,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNE" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNF" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNG" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /turf/simulated/floor/plasteel/dark,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "dNH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90540,7 +90540,7 @@
 "iZi" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "iZW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Affairs Maintenance";
@@ -91054,7 +91054,7 @@
 /area/hallway/primary/fore)
 "kcy" = (
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "kdu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -93778,7 +93778,7 @@
 /area/crew_quarters/fitness)
 "plp" = (
 /turf/simulated/wall,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "pnF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -94986,7 +94986,7 @@
 "rmX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/area/maintenance/library)
 "rnA" = (
 /obj/structure/chair/stool{
 	dir = 8

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -965,10 +965,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "library"
 	sound_environment = SOUND_AREA_LARGE_SOFTFLOOR
 
-/area/library/abandoned
-	name = "\improper Abandoned Library"
-	icon_state = "library"
-
 /area/chapel
 	icon_state = "chapel"
 	ambientsounds = HOLY_SOUNDS

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -696,7 +696,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	power_light = 0
 	power_environ = 0
 
-/area/maintenance/abandonedlibrary
+/area/maintenance/library
 	name = "Abandoned Library"
 	icon_state = "library"
 

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -696,6 +696,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	power_light = 0
 	power_environ = 0
 
+/area/maintenance/abandonedlibrary
+	name = "Abandoned Library"
+	icon_state = "library"
+
 /area/maintenance/spacehut
 	name = "Space Hut"
 	icon_state = "spacehut"


### PR DESCRIPTION
Changes the area from `library` area to `apmaints `area, so it responds correctly to radiation storms.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix #19489 by changing the type of area at the aft library zone (Delta) from library to apmaints (the surrounding maintenance area).
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having a maintenance area unshielded breaks the cohesion of "Maintenance is shielded from radiation".
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before
![image](https://user-images.githubusercontent.com/10063083/197569461-4e2adfe3-958a-4632-8600-7e9ab304f3a6.png)
After
![image](https://user-images.githubusercontent.com/10063083/197569556-1825e2cb-1861-49bc-aa02-a8acdce2f9e8.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->
Launched a local server
![image](https://user-images.githubusercontent.com/10063083/197572713-d74e4256-d0ec-4730-830a-16c71e65b2a4.png)

## Changelog
:cl:
tweak: Delta maintenance library is now shielded from radiation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
