### PR TITLE
Power gloves deal stamina damage instead of weakening.

### DIFF
--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -73,10 +73,13 @@
 		beam_from.Beam(target_atom, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/effects.dmi', time = 6)
 		if(isliving(target_atom))
 			var/mob/living/L = target_atom
+			var/surplus_power = C.surplus()
 			if(user.a_intent == INTENT_DISARM)
 				add_attack_logs(user, L, "shocked with power gloves.")
 				L.adjustStaminaLoss(60)
 				L.Jitter(10 SECONDS)
+				var/atom/throw_target = get_edge_target_turf(user, get_dir(user, get_step_away(L, user)))
+				L.throw_at(throw_target, surplus_power/100000, surplus_power/100000) //100 kW surplus throws 1 tile, 200 throws 2, etc.
 			else
 				add_attack_logs(user, L, "electrocuted with[P.unlimited_power ? " unlimited" : null] power gloves")
 				if(P.unlimited_power)

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -74,7 +74,7 @@
 		if(isliving(target_atom))
 			var/mob/living/L = target_atom
 			if(user.a_intent == INTENT_DISARM)
-				add_attack_logs(user, L, "shocked and stunned with power gloves.")
+				add_attack_logs(user, L, "shocked with power gloves.")
 				L.adjustStaminaLoss(60)
 				L.Jitter(10 SECONDS)
 			else

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -79,7 +79,7 @@
 				L.adjustStaminaLoss(60)
 				L.Jitter(10 SECONDS)
 				var/atom/throw_target = get_edge_target_turf(user, get_dir(user, get_step_away(L, user)))
-				L.throw_at(throw_target, surplus_power/100000, surplus_power/100000) //100 kW surplus throws 1 tile, 200 throws 2, etc.
+				L.throw_at(throw_target, surplus_power / 100000, surplus_power / 100000) //100 kW surplus throws 1 tile, 200 throws 2, etc.
 			else
 				add_attack_logs(user, L, "electrocuted with[P.unlimited_power ? " unlimited" : null] power gloves")
 				if(P.unlimited_power)

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -74,8 +74,9 @@
 		if(isliving(target_atom))
 			var/mob/living/L = target_atom
 			if(user.a_intent == INTENT_DISARM)
-				add_attack_logs(user, L, "shocked and weakened with power gloves")
-				L.Weaken(6 SECONDS)
+				add_attack_logs(user, L, "shocked and stunned with power gloves.")
+				L.adjustStaminaLoss(60)
+				L.Jitter(10 SECONDS)
 			else
 				add_attack_logs(user, L, "electrocuted with[P.unlimited_power ? " unlimited" : null] power gloves")
 				if(P.unlimited_power)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -344,7 +344,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/powergloves
 	name = "Power Gloves"
-	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. Must be standing on a powered cable to use."
+	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. \
+			Must be standing on a powered cable to use. \
+			Activated by alt-clicking, or pressing the middle mouse button. Disarm intent will deal stamina damage and cause jittering, while harm intent will deal damage based on the power of the cable you're standing on."
 	reference = "PG"
 	item = /obj/item/clothing/gloves/color/yellow/power
 	cost = 10

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -15,7 +15,7 @@
 	var/old_mclick_override
 	var/datum/middleClickOverride/power_gloves/mclick_override = new /datum/middleClickOverride/power_gloves
 	var/last_shocked = 0
-	var/shock_delay = 40
+	var/shock_delay = 3 SECONDS
 	var/unlimited_power = FALSE // Does this really need explanation?
 	var/shock_range = 7
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Progresses #18179 by changing the weaken on power gloves' disarm to deal 60 stamina damage, and cause jittering. Also makes the description in the uplink more descriptive.

Lowered the cooldown from 4 seconds to 3 seconds on request.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Long range, undodgeable stuns are kinda wack. Now at least there's a bit more counterplay, as you get a chance to run, or call for help before getting totally stunned.

There was also very little in-game description on HOW to use the power gloves, and not even the wiki mentions the stun on disarm function of the gloves.


## Testing
<!-- How did you test the PR, if at all? -->
Shocked a bunch of skrells, and had to shock each of them twice to stun them. Also spawned in a tot uplink to make sure it said the right thing.
## Changelog
:cl:
tweak: Power gloves don't instant stun, and do stamina damage instead
tweak: Power gloves uplink description tells you how to use them
tweak: Power gloves cooldown lowered from 4 seconds to 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
