### PR TITLE
makes CQC not theoretically heal losebreath

### DIFF
--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -31,7 +31,7 @@
 	var/damage_multiplier = 1 + A.getStaminaLoss() / 100 //The chokehold is more effective the more tired the target is.
 	while(do_mob(A, D, 2 SECONDS) && chokehold_active)
 		D.apply_damage(10 * damage_multiplier, OXY)
-		D.SetLoseBreath(3 SECONDS)
+		D.AdjustLoseBreath(3 SECONDS)
 		if(D.getOxyLoss() >= 50 || D.health <= 20)
 			D.visible_message("<span class ='danger>[A] puts [D] to sleep!</span>", \
 						"<span class='userdanger'>[A] knocks you out cold!</span>")

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -31,7 +31,7 @@
 	var/damage_multiplier = 1 + A.getStaminaLoss() / 100 //The chokehold is more effective the more tired the target is.
 	while(do_mob(A, D, 2 SECONDS) && chokehold_active)
 		D.apply_damage(10 * damage_multiplier, OXY)
-		D.AdjustLoseBreath(3 SECONDS)
+		D.LoseBreath(3 SECONDS)
 		if(D.getOxyLoss() >= 50 || D.health <= 20)
 			D.visible_message("<span class ='danger>[A] puts [D] to sleep!</span>", \
 						"<span class='userdanger'>[A] knocks you out cold!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

Changes SetLoseBreath to AdjustLoseBreath in the cqc move.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Set and adjust does 2 different things. Set sets a value to X. Adjust adds or subtracts from a value by X.

Let us say someone had 30 seconds of lose breath, and was hit by this move. They would currently, not increase to 33 seconds of losebreath, instead, it would lower it to 3 seconds. This is bad / doesn't make sense, so will fix that up.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed it didn't subtract from the value


## Changelog
:cl:
fix: CQC no longer can make people choke less when choking them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
