### PR TITLE
Fix #19495 Spam clicking with an RCD to build a wall will no longer consume matter for failed attempts

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -378,6 +378,8 @@
 			to_chat(user, "Building Wall...")
 			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			if(do_after(user, 20 * toolspeed, target = A))
+				if(!isfloorturf(A))
+					return FALSE
 				if(!useResource(3, user))
 					return FALSE
 				playsound(loc, usesound, 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Added a check to prevent matter from being consumed if a wall has already been built.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/19495

## Testing
<!-- How did you test the PR, if at all? -->
- Set RCD mode to wall
- Spam click to build a wall
- Noticed that only 3 matter has been consumed
## Changelog
:cl:
fix: Spam clicking with an RCD to build a wall will no longer consume matter for failed attempts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
