### PR TITLE
Tooltips have BYOND macros stripped from the item names

### DIFF
--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -105,6 +105,9 @@ Notes:
 				theme = lowertext(user.client.prefs.UI_style)
 			if(!theme)
 				theme = "default"
+			// Strip macros from item names
+			title = replacetext(title, "\proper", "")
+			title = replacetext(title, "\improper", "")
 			user.client.tooltips.show(tip_src, params, title, content, theme)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
BYOND text macros are stripped from the names when they're fed to the tooltips, as it gets confused and displays a ? in a diamond when they're present.

## Why It's Good For The Game
Fixes that oddity with tooltips and macros.

## Images of changes
![Strip](https://user-images.githubusercontent.com/80771500/198329550-4858a41e-dd1b-4ec3-a00b-feb429c6f251.png)

## Testing
Hovered over several items, spawned items with text macros in their names.

## Changelog
:cl:
fix: Tooltips do not occasionally show a gargabe symbol before the item name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
