### PR TITLE
Fixes disposals not inheriting the proper icon state when welded

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -759,10 +759,11 @@
 	return P
 
 
-// update the icon_state to reflect hidden status
+// update the icon_state to reflect hidden status and change icon when welded
 /obj/structure/disposalpipe/proc/update()
 	var/turf/T = get_turf(src)
 	hide(T.intact && !isspaceturf(T) && !T.transparent_floor)	// space and transparent floors never hide pipes
+	update_icon(UPDATE_ICON_STATE)
 
 // hide called by levelupdate if turf intact status changes
 // change visibility status
@@ -773,6 +774,10 @@
 		return
 	invisibility = INVISIBILITY_MINIMUM
 	alpha = 255
+
+// makes sure we are using the right icon state when we secure the disposals
+/obj/structure/disposalpipe/update_icon_state()
+	icon_state = base_icon_state
 
 // expel the held objects into a turf
 // called when there is a break in the pipe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
I accidentally removed a line of code that was important to making sure disposals didn't end up looking like this

![image](https://user-images.githubusercontent.com/12197162/198630108-aeefa840-c899-4547-b634-f006bd3bc237.png)

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While it works fine despite the pipes, it looks jank as hell currently
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
welded some pipes
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed disposals pipes not getting the right icon when welded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
