### PR TITLE
Fixes human mobs still being able to vomit while dead

### DIFF
--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -86,7 +86,7 @@
 		if(iscarbon(M))
 			var/mob/living/carbon/L = M
 			L.Weaken(12 SECONDS)
-			if(ishuman(L) && L.stat == !DEAD)
+			if(ishuman(L))
 				shake_camera(L, 20, 1)
 				addtimer(CALLBACK(L, /mob/living/carbon.proc/vomit), 20)
 

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -86,7 +86,7 @@
 		if(iscarbon(M))
 			var/mob/living/carbon/L = M
 			L.Weaken(12 SECONDS)
-			if(ishuman(L))
+			if(ishuman(L) && L.stat == !DEAD)
 				shake_camera(L, 20, 1)
 				addtimer(CALLBACK(L, /mob/living/carbon.proc/vomit), 20)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -88,6 +88,8 @@
 
 
 /mob/living/carbon/proc/vomit(lost_nutrition = 10, blood = 0, stun = 1, distance = 0, message = 1)
+	if(stat == DEAD)
+		return FALSE
 	if(ismachineperson(src)) //IPCs do not vomit particulates
 		return FALSE
 	if(is_muzzled())
@@ -548,7 +550,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	return
 
 /mob/living/update_pipe_vision(obj/machinery/atmospherics/target_move)
-	if(!client) 
+	if(!client)
 		pipes_shown.Cut()
 		return
 	if(length(pipes_shown) && !target_move)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If a corpse calls the vomit proc, such as being thrown through a mining jaunter, it will still vomit despite being dead. This PR implements a new check in the proc to make sure they don't starting vomiting successfully when they really shouldn't be.

## Why It's Good For The Game
If the dead don't speak they sure as hell shouldn't be throwing up.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned myself in and threw a corpse through a jaunter - no more vomiting.

## Changelog
:cl:
fix: Corpses can no longer vomit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
