### PR TITLE
Fixes overlays on cmagged plant disks

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -502,6 +502,13 @@
 	else
 		icon_state = "datadisk_hydro"
 
+/obj/item/disk/plantgene/update_overlays()
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		overlays -= "datadisk_gene"
+	else
+		overlays += "datadisk_gene"
+
 /obj/item/disk/plantgene/attack_self(mob/user)
 	if(HAS_TRAIT(src, TRAIT_CMAGGED))
 		return
@@ -512,10 +519,11 @@
 	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
 		to_chat(user, "<span class='warning'>The bananium ooze flips a couple bits on the plant disk's display, making it look just like the..!</span>")
 		ADD_TRAIT(src, TRAIT_CMAGGED, "clown_emag")
-		update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_ICON)
+		update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_ICON|UPDATE_OVERLAYS)
+		playsound(src, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 /obj/item/disk/plantgene/uncmag()
-	update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_ICON)
+	update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_ICON|UPDATE_OVERLAYS)
 
 /obj/item/disk/plantgene/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Plant data disks now have their overlay removed when cmagged, making them properly indistinguishable from a real NAD. The overlay returns if the cmagged disk is cleaned.

Also adds a sparking sound effect when plant disks are cmagged, since I meant to add one but forgot.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
To casual observers, cmagged plant data disks are now indistinguishable from the NAD as intended. Embarrassed I didn't notice this in the original PR.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/3611705/198812534-ac3b1b22-9617-4e45-b984-5073dca859bd.png)
Which is which? Can't tell? That's the point.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled and tested on local debug server. Overlay gets added and removed as expected.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Cmagged plant disks now have their overlay properly removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
