### PR TITLE
Fix #19520 Adds a check for SSD players so they don't get harvested by revenants

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -23,7 +23,7 @@
 		return
 	A.attack_ghost(src)
 	if(ishuman(A) && in_range(src, A))
-		if(isLivingSSD(A) && client?.send_ssd_warning(A)) //Do NOT Harvest SSD people unless you accept the warning
+		if(isLivingSSD(A) && client.send_ssd_warning(A)) //Do NOT Harvest SSD people unless you accept the warning
 			return
 		Harvest(A)
 

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -26,8 +26,8 @@
 		if(isLivingSSD(A))
 			if(client && client.send_ssd_warning(A)) //Do NOT Harvest(SSD people)
 				return
-			else
-				Harvest(A)
+		else
+			Harvest(A)
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
 

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -30,7 +30,6 @@
 			Harvest(A)
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
-
 	if(!castcheck(0))
 		return
 	if(draining)

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -23,11 +23,9 @@
 		return
 	A.attack_ghost(src)
 	if(ishuman(A) && in_range(src, A))
-		if(isLivingSSD(A))
-			if(client && client.send_ssd_warning(A)) //Do NOT Harvest(SSD people)
-				return
-		else
-			Harvest(A)
+		if(isLivingSSD(A) && client?.send_ssd_warning(A)) //Do NOT Harvest SSD people unless you accept the warning
+			return
+		Harvest(A)
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
 	if(!castcheck(0))

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -23,9 +23,14 @@
 		return
 	A.attack_ghost(src)
 	if(ishuman(A) && in_range(src, A))
-		Harvest(A)
+		if(isLivingSSD(A))
+			if(client && client.send_ssd_warning(A)) //Do NOT Harvest(SSD people)
+				return
+			else
+				Harvest(A)
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
+
 	if(!castcheck(0))
 		return
 	if(draining)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix #19520 If the target of a revenant harvest is alive but SSD, it sends a warning and returns, otherwise they Harvest(target)
I've copied the code from OnClick() that triggers the SSD alert and adapted it to the local code. Enclosed Harvest() inside an else.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
SSD people being harvested by revenants is bad for the game.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
![image](https://user-images.githubusercontent.com/10063083/198892927-c0b13d34-048f-4a32-a072-bb51fba47441.png)
Posessed a revenant with a guest account and tried to Harvest() an SSD corpse left by my actual account. The SSD warning message takes a while to show up after the player has gone SSD, but when it does it s consistent.
<!-- How did you test the PR, if at all? -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
