### PR TITLE
Meson eyes prevent supermatter hallucinations

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -538,7 +538,7 @@
 
 	//Makes em go mad and accumulate rads.
 	for(var/mob/living/carbon/human/l in view(src, HALLUCINATION_RANGE(power))) // If they can see it without mesons on.  Bad on them.
-		if(!istype(l.glasses, /obj/item/clothing/glasses/meson) && !HAS_TRAIT(l, TRAIT_MESON_VISION))
+		if(!istype(l.glasses, /obj/item/clothing/glasses/meson) && !HAS_TRAIT(l, TRAIT_MESON_VISION) && !l.get_int_organ(/obj/item/organ/internal/eyes/cybernetic/meson))
 			var/D = sqrt(1 / max(1, get_dist(l, src)))
 			var/hallucination_amount = power * hallucination_power * D
 			l.AdjustHallucinate(hallucination_amount, 0, 200 SECONDS)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -538,7 +538,7 @@
 
 	//Makes em go mad and accumulate rads.
 	for(var/mob/living/carbon/human/l in view(src, HALLUCINATION_RANGE(power))) // If they can see it without mesons on.  Bad on them.
-		if(!istype(l.glasses, /obj/item/clothing/glasses/meson) && !HAS_TRAIT(l, TRAIT_MESON_VISION) && !l.get_int_organ(/obj/item/organ/internal/eyes/cybernetic/meson))
+		if(!istype(l.glasses, /obj/item/clothing/glasses/meson) && !HAS_TRAIT(l, TRAIT_MESON_VISION))
 			var/D = sqrt(1 / max(1, get_dist(l, src)))
 			var/hallucination_amount = power * hallucination_power * D
 			l.AdjustHallucinate(hallucination_amount, 0, 200 SECONDS)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -126,9 +126,16 @@
 	name = "meson eyes"
 	desc = "These cybernetic eyes will allow you to see the structural layout of the station, and, well, everything else."
 	eye_color = "#199900"
-	vision_flags = SEE_TURFS
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	origin_tech = "materials=4;engineering=4;biotech=4;magnets=4"
+
+/obj/item/organ/internal/eyes/cybernetic/meson/insert(mob/living/carbon/human/M, special = FALSE)
+	ADD_TRAIT(M, TRAIT_MESON_VISION, "meson_vision")
+	. = ..()
+
+/obj/item/organ/internal/eyes/cybernetic/meson/remove(mob/living/carbon/human/M, special = FALSE)
+	REMOVE_TRAIT(M, TRAIT_MESON_VISION, "meson_vision")
+	. = ..()
 
 /obj/item/organ/internal/eyes/cybernetic/xray
 	name = "\improper X-ray eyes"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -131,11 +131,11 @@
 
 /obj/item/organ/internal/eyes/cybernetic/meson/insert(mob/living/carbon/human/M, special = FALSE)
 	ADD_TRAIT(M, TRAIT_MESON_VISION, "meson_vision")
-	. = ..()
+	return ..()
 
 /obj/item/organ/internal/eyes/cybernetic/meson/remove(mob/living/carbon/human/M, special = FALSE)
 	REMOVE_TRAIT(M, TRAIT_MESON_VISION, "meson_vision")
-	. = ..()
+	return ..()
 
 /obj/item/organ/internal/eyes/cybernetic/xray
 	name = "\improper X-ray eyes"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -130,11 +130,11 @@
 	origin_tech = "materials=4;engineering=4;biotech=4;magnets=4"
 
 /obj/item/organ/internal/eyes/cybernetic/meson/insert(mob/living/carbon/human/M, special = FALSE)
-	ADD_TRAIT(M, TRAIT_MESON_VISION, "meson_vision")
+	ADD_TRAIT(M, TRAIT_MESON_VISION, "meson_vision[UID()]")
 	return ..()
 
 /obj/item/organ/internal/eyes/cybernetic/meson/remove(mob/living/carbon/human/M, special = FALSE)
-	REMOVE_TRAIT(M, TRAIT_MESON_VISION, "meson_vision")
+	REMOVE_TRAIT(M, TRAIT_MESON_VISION, "meson_vision[UID()]")
 	return ..()
 
 /obj/item/organ/internal/eyes/cybernetic/xray


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR makes the meson eyes implant prevent supermatter hallucinations. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently both meson goggles and engineering goggles will prevent hallucinations; it only makes sense that the robot eyes with the same function function the same.


## Testing
<!-- How did you test the PR, if at all? -->
Tested on a local server. Shoved some swanky new eyeballs into my head and stared into the Magic Dorito(tm) for several minutes. Didn't get attacked by phantom abductors.

## Changelog
:cl:
tweak: Meson eyes now prevent supermatter hallucinations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
