### PR TITLE
Removes .357 Speed Loaders from Autolathe, replaces with .357 Ammo Boxes

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -452,8 +452,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate .357 Revolver"
 	reference = "SR"
-	desc = "A brutally simple syndicate revolver that fires .357 Magnum cartridges and has 7 chambers."
-	item = /obj/item/gun/projectile/revolver
+	desc = "A brutally simple syndicate revolver that fires .357 Magnum cartridges and has 7 chambers. Comes with a spare speed loader."
+	item = /obj/item/storage/box/syndie_kit/revolver
 	cost = 13
 	surplus = 50
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -351,3 +351,10 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 	new /obj/item/retractor/supermatter(src)
 	new /obj/item/nuke_core_container/supermatter(src)
 	new /obj/item/paper/guides/antag/supermatter_sliver(src)
+
+/obj/item/storage/box/syndie_kit/revolver
+	name = "\improper .357 revolver kit"
+
+/obj/item/storage/box/syndie_kit/revolver/populate_contents()
+	new /obj/item/gun/projectile/revolver(src)
+	new /obj/item/ammo_box/a357(src)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -187,7 +187,7 @@
 	var/num_loaded = 0
 	if(!can_load(user))
 		return
-	if(istype(A, /obj/item/ammo_box))
+	if(istype(A, /obj/item/ammo_box) && !istype(A, /obj/item/ammo_box/b357))
 		var/obj/item/ammo_box/AM = A
 		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
 			var/did_load = give_round(AC, replace_spent)

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -7,6 +7,15 @@
 	multi_sprite_step = 1 // see: /obj/item/ammo_box/update_icon()
 	icon_state = "357"
 
+/obj/item/ammo_box/b357
+	name = "ammo box (.357)"
+	desc = "Contains up to seven .357 bullets, intended to either be inserted into a speed loader or into the gun manually."
+	w_class = WEIGHT_CLASS_NORMAL
+	ammo_type = /obj/item/ammo_casing/a357
+	max_ammo = 7
+	multi_sprite_step = 1
+	icon_state = "357OLD"
+
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"
 	icon_state = "9mmbox"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -1,6 +1,7 @@
 /obj/item/ammo_box/a357
 	name = "speed loader (.357)"
 	desc = "Designed to quickly reload revolvers."
+	materials = list()
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
 	multi_sprite_step = 1 // see: /obj/item/ammo_box/update_icon()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -1,6 +1,7 @@
 /obj/item/gun/projectile/revolver
 	name = "\improper .357 revolver"
 	desc = "A suspicious revolver. Uses .357 ammo."
+	materials = list()
 	icon_state = "revolver"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder
 	origin_tech = "combat=3;materials=2"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -28,6 +28,8 @@
 
 /obj/item/gun/projectile/revolver/attackby(obj/item/A, mob/user, params)
 	. = ..()
+	if(istype(A, /obj/item/ammo_box/b357))
+		return
 	if(.)
 		return
 	var/num_loaded = magazine.attackby(A, user, params, 1)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -788,7 +788,7 @@
 	name = "\improper .357 bullet"
 	id = "a357"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000)
+	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/a357
 	category = list("hacked", "Security")
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -785,11 +785,11 @@
 	category = list("hacked", "Security")
 
 /datum/design/a357
-	name = "Ammo Box (.357)"
+	name = "\improper .357 bullet"
 	id = "a357"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/a357
+	materials = list(MAT_METAL = 5000)
+	build_path = /obj/item/ammo_casing/a357
 	category = list("hacked", "Security")
 
 /datum/design/c10mm

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -784,12 +784,12 @@
 	build_path = /obj/item/ammo_box/foambox/sniper/riot
 	category = list("hacked", "Security")
 
-/datum/design/a357
-	name = "\improper .357 bullet"
-	id = "a357"
+/datum/design/b357
+	name = "Ammo Box (.357)"
+	id = "b357"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/a357
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/b357
 	category = list("hacked", "Security")
 
 /datum/design/c10mm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR removes the recipe for the .357 revolver speed loader from the hacked autolathe and instead replaces it with an ammo-box of .357 ammo for the same price. The ammo-box contains the same amount of .357 ammo (seven shots) but cannot be directly loaded into the gun or speed loader. This means you have to either individually load bullets from the ammo box to the gun or speed loader or dump all the bullets on the ground and scoop them up into the speed loader. Lastly, this ammo box is bigger than most (the speed loader remains tiny) and cannot fit into boxes, so you can't just carry a million ammo boxes and invalidate the point of this PR.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The Syndicate .357 revolver is in a really powerful position right now. It can deliver 60 damage per bullet, 7 bullets per clip, very rapidly, which is capable of nearly instantly dropping anyone hit by it into hardcrit regardless of armor. Now, it seems this was originally balanced around the rather steep price of .357 bullets - 3 TC per Speed Loader from the uplink... except they can just be printed from the Autolathe. As a result, this gun far eclipses the Stetchkin, offering a massively increased damage output _and_ far easier to obtain ammunition, as if you want extra clips of the Stetchkin you need to buy them individually - you can print boxes of the ammo, but this has to be individually loaded into the clips which requires inventory fiddling, and somewhat helps to limit how much you can fire at once - buying more clips means you can reload quickly until you need to refill your clips. The .357 revolver does not suffer from this. With this change, you will still be able to obtain more ammo on-station, but you will be limited on how much revolver-based death you can distribute in each killing spree, being forced to take some time to disengage and either reload your speed loaders from the boxes or acquire more boxes from a lathe.
Do note that you can click a stack of loose .357 bullets on the ground/autolathe with an empty/semi-filled Speed Loader to instantly fill the speed loader, so you're not entirely forced to sit there pulling bullets out of the ammo box and slapping them into the speed loader one at a time - you can dump them all and pick them all up at once.
Lastly, the revolver comes with the spare speed loader so that it's not useless on its own, and you always have at least one loader to help you refill.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
**In a fully upgraded autolathe**
![image](https://user-images.githubusercontent.com/71326864/198951125-4712bd85-6c77-4e69-8aca-f6a27d5783c3.png)

**In an un-upgraded autolathe**
![image](https://user-images.githubusercontent.com/71326864/198951358-77f93a35-b9cf-476f-9e0d-8495a4ceba7f.png)

**Thank you Syndie Cat**
![image](https://user-images.githubusercontent.com/71326864/198869919-bb2d401b-8b0a-4959-898a-2974584109ed.png)

**It's like Christmas came early**
![image](https://user-images.githubusercontent.com/71326864/198869969-834e35d1-cce9-46ea-ab2d-6758e028c2fb.png)

**Misclicks be damned.**
![image](https://user-images.githubusercontent.com/71326864/198870003-e1d1d7c3-fdc6-4abf-8527-f71e5151dd52.png)

## Testing
<!-- How did you test the PR, if at all? -->
See above. Confirmed everything worked as intended.
## Changelog
:cl:
tweak: The Autolathe can no longer print whole .357 speed loaders, and instead now prints .357 ammo boxes which must be individually loaded into speed loaders or the revolver
tweak: The Syndicate Revolver now comes in a box with a spare speed loader
tweak: The .357 revolver and its speed loader can no longer be recycled in an Autolathe, so you don't accidentally recycle it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
