### PR TITLE
Adds IPC plastic surgery

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -690,15 +690,15 @@
 	return ..()
 
 /datum/surgery_step/robotics/edit_serial/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	var/old_name = target.real_name
-	var/new_name = copytext(reject_bad_text(input(user, "Choose a name for this machine.", "Set Name", "[old_name]") as null|text), 1, MAX_NAME_LEN)
+
+	var/new_name = copytext(reject_bad_text(input(user, "Choose a name for this machine.", "Set Name", "[target.real_name]") as null|text), 1, MAX_NAME_LEN)
 	if(!new_name)
 		to_chat(user, "<span class='warning'>Invalid name! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
 	else if(!target.Adjacent(user))
 		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
-	var/gender_list = list("Male" = MALE, "Female" = FEMALE, "Genderless" = PLURAL, "Object" = NEUTER)
+	var/static/list/gender_list = list("Male" = MALE, "Female" = FEMALE, "Genderless" = PLURAL, "Object" = NEUTER)
 	var/gender_key = input(user, "Choose a gender for this machine.", "Select Gender", target.gender) as null|anything in gender_list
 	if(!gender_key)
 		to_chat(user, "<span class='warning'>You must choose a gender! Please try again.</span>")
@@ -707,6 +707,7 @@
 		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
 	var/new_gender = gender_list[gender_key]
+	var/old_name = target.real_name
 	target.real_name = new_name
 	target.gender = new_gender
 	user.visible_message(

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -696,7 +696,7 @@
 		to_chat(user, "<span class='warning'>Invalid name! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
 	else if(!target.Adjacent(user))
-		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.")
+		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
 	var/gender_list = list("Male" = MALE, "Female" = FEMALE, "Genderless" = PLURAL, "Object" = NEUTER)
 	var/gender_key = input(user, "Choose a gender for this machine.", "Select Gender", target.gender) as null|anything in gender_list
@@ -704,7 +704,7 @@
 		to_chat(user, "<span class='warning'>You must choose a gender! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
 	else if(!target.Adjacent(user))
-		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.")
+		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
 	var/new_gender = gender_list[gender_key]
 	target.real_name = new_name

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -666,3 +666,37 @@
 	user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to reprogram [target]'s [affected.name].</span>",
 	"<span class='warning'> Your [tool.name] slips, failing to reprogram [target]'s [affected.name].</span>")
 	return SURGERY_STEP_RETRY
+
+/datum/surgery/reconfigure_id
+	name = "Reconfigure Identity"
+	steps = list(
+		/datum/surgery_step/robotics/external/unscrew_hatch,
+		/datum/surgery_step/robotics/external/open_hatch,
+		/datum/surgery_step/robotics/edit_serial,
+		/datum/surgery_step/robotics/external/close_hatch)
+	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
+	requires_organic_bodypart = FALSE
+
+/datum/surgery_step/robotics/edit_serial
+	name = "edit serial number"
+	allowed_tools = list(TOOL_MULTITOOL = 100)
+	time = 4.8 SECONDS
+
+/datum/surgery_step/robotics/edit_serial/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+	user.visible_message("[user] begins to edit [target]'s identity parameters with [tool].",
+	"You begin to alter [target]'s identity parameters with [tool]...</span>")
+	return ..()
+
+/datum/surgery_step/robotics/edit_serial/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+	var/old_name = target.real_name
+	var/new_name = copytext(reject_bad_text(input(user,"Choose a name for this machine.","Set name","[old_name]")),1,MAX_NAME_LEN)
+	if(!new_name || !length(new_name))
+		to_chat(user, "<span_class='notice'> Invalid name! Please try again.")
+		return SURGERY_STEP_RETRY
+	else
+		target.real_name = new_name
+		user.visible_message(
+			"<span_class='notice'> [user] edits [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name] </span>",
+			"<span class='notice'> You alter [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name] </span>"
+			)
+		return SURGERY_STEP_CONTINUE

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -691,13 +691,19 @@
 
 /datum/surgery_step/robotics/edit_serial/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/old_name = target.real_name
-	var/new_name = copytext(reject_bad_text(input(user,"Choose a name for this machine.","Set Name","[old_name]") as null|text),1,MAX_NAME_LEN)
+	var/new_name = copytext(reject_bad_text(input(user, "Choose a name for this machine.", "Set Name", "[old_name]") as null|text), 1, MAX_NAME_LEN)
 	if(!new_name)
 		to_chat(user, "<span class='warning'>Invalid name! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
-	var/new_gender = input(user,"Choose a gender for this machine.","Select Gender",target.gender) as null|anything in list(MALE, FEMALE)
+	else if(!target.Adjacent(user))
+		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.")
+		return SURGERY_STEP_INCOMPLETE
+	var/new_gender = input(user, "Choose a gender for this machine.", "Select Gender", target.gender) as null|anything in list(MALE, FEMALE)
 	if(!new_gender)
 		to_chat(user, "<span class='warning'>You must choose a gender! Please try again.</span>")
+		return SURGERY_STEP_INCOMPLETE
+	else if(!target.Adjacent(user))
+		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.")
 		return SURGERY_STEP_INCOMPLETE
 	target.real_name = new_name
 	target.gender = new_gender

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -675,7 +675,7 @@
 		/datum/surgery_step/robotics/edit_serial,
 		/datum/surgery_step/robotics/external/close_hatch
 	)
-	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
+	possible_locs = list(BODY_ZONE_HEAD)
 
 /datum/surgery_step/robotics/edit_serial
 	name = "edit serial number"
@@ -698,13 +698,15 @@
 	else if(!target.Adjacent(user))
 		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.")
 		return SURGERY_STEP_INCOMPLETE
-	var/new_gender = input(user, "Choose a gender for this machine.", "Select Gender", target.gender) as null|anything in list(MALE, FEMALE)
-	if(!new_gender)
+	var/gender_list = list("Male" = MALE, "Female" = FEMALE, "Genderless" = PLURAL, "Object" = NEUTER)
+	var/gender_key = input(user, "Choose a gender for this machine.", "Select Gender", target.gender) as null|anything in gender_list
+	if(!gender_key)
 		to_chat(user, "<span class='warning'>You must choose a gender! Please try again.</span>")
 		return SURGERY_STEP_INCOMPLETE
 	else if(!target.Adjacent(user))
 		to_chat(user, "<span class='warning'>The multitool is out of range! Please try again.")
 		return SURGERY_STEP_INCOMPLETE
+	var/new_gender = gender_list[gender_key]
 	target.real_name = new_name
 	target.gender = new_gender
 	user.visible_message(

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -684,16 +684,17 @@
 
 /datum/surgery_step/robotics/edit_serial/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	user.visible_message("[user] begins to edit [target]'s identity parameters with [tool].",
-	"You begin to alter [target]'s identity parameters with [tool]...</span>")
+	"You begin to alter [target]'s identity parameters with [tool].")
 	return ..()
 
 /datum/surgery_step/robotics/edit_serial/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/old_name = target.real_name
-	var/new_name = copytext(reject_bad_text(input(user,"Choose a name for this machine.","Set name","[old_name]")),1,MAX_NAME_LEN)
+	var/new_name = copytext(reject_bad_text(input(user,"Choose a name for this machine.","Set Name","[old_name]")),1,MAX_NAME_LEN)
 	if(!new_name || !length(new_name))
 		to_chat(user, "<span_class='notice'> Invalid name! Please try again.")
 		return SURGERY_STEP_RETRY
 	else
+		target.gender = input(user,"Choose a gender for this machine","Select Gender",target.gender) in list(MALE, FEMALE)
 		target.real_name = new_name
 		user.visible_message(
 			"<span_class='notice'> [user] edits [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name] </span>",

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -667,7 +667,7 @@
 	"<span class='warning'> Your [tool.name] slips, failing to reprogram [target]'s [affected.name].</span>")
 	return SURGERY_STEP_RETRY
 
-/datum/surgery/reconfigure_id
+/datum/surgery/robotics/reconfigure_id
 	name = "Reconfigure Identity"
 	steps = list(
 		/datum/surgery_step/robotics/external/unscrew_hatch,
@@ -675,7 +675,6 @@
 		/datum/surgery_step/robotics/edit_serial,
 		/datum/surgery_step/robotics/external/close_hatch)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
-	requires_organic_bodypart = FALSE
 
 /datum/surgery_step/robotics/edit_serial
 	name = "edit serial number"
@@ -683,21 +682,28 @@
 	time = 4.8 SECONDS
 
 /datum/surgery_step/robotics/edit_serial/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	user.visible_message("[user] begins to edit [target]'s identity parameters with [tool].",
-	"You begin to alter [target]'s identity parameters with [tool].")
+	user.visible_message(
+		"[user] begins to edit [target]'s identity parameters with [tool].",
+		"You begin to alter [target]'s identity parameters with [tool]."
+		)
 	return ..()
 
 /datum/surgery_step/robotics/edit_serial/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/old_name = target.real_name
-	var/new_name = copytext(reject_bad_text(input(user,"Choose a name for this machine.","Set Name","[old_name]")),1,MAX_NAME_LEN)
-	if(!new_name || !length(new_name))
-		to_chat(user, "<span_class='notice'> Invalid name! Please try again.")
+	var/new_name = copytext(reject_bad_text(input(user,"Choose a name for this machine.","Set Name","[old_name]") as null|text),1,MAX_NAME_LEN)
+	if(!new_name)
+		to_chat(user, "<span class='warning'> Invalid name! Please try again. </span>")
 		return SURGERY_STEP_RETRY
 	else
-		target.gender = input(user,"Choose a gender for this machine","Select Gender",target.gender) in list(MALE, FEMALE)
-		target.real_name = new_name
-		user.visible_message(
-			"<span_class='notice'> [user] edits [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name] </span>",
-			"<span class='notice'> You alter [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name] </span>"
-			)
-		return SURGERY_STEP_CONTINUE
+		var/new_gender = input(user,"Choose a gender for this machine.","Select Gender",target.gender) as null|anything in list(MALE, FEMALE)
+		if(!new_gender)
+			to_chat(user, "<span class='warning'> You must choose a gender! Please try again. </span>")
+			return SURGERY_STEP_RETRY
+		else
+			target.real_name = new_name
+			target.gender = new_gender
+			user.visible_message(
+				"<span class='notice'> [user] edits [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name]. </span>",
+				"<span class='notice'> You alter [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name]. </span>"
+				)
+			return SURGERY_STEP_CONTINUE

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -668,7 +668,7 @@
 	return SURGERY_STEP_RETRY
 
 /datum/surgery/robotics/reconfigure_id
-	name = "Reconfigure Identity"
+	name = "Identity Reconfiguration"
 	steps = list(
 		/datum/surgery_step/robotics/external/unscrew_hatch,
 		/datum/surgery_step/robotics/external/open_hatch,

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -673,7 +673,8 @@
 		/datum/surgery_step/robotics/external/unscrew_hatch,
 		/datum/surgery_step/robotics/external/open_hatch,
 		/datum/surgery_step/robotics/edit_serial,
-		/datum/surgery_step/robotics/external/close_hatch)
+		/datum/surgery_step/robotics/external/close_hatch
+	)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
 
 /datum/surgery_step/robotics/edit_serial
@@ -681,29 +682,27 @@
 	allowed_tools = list(TOOL_MULTITOOL = 100)
 	time = 4.8 SECONDS
 
-/datum/surgery_step/robotics/edit_serial/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/edit_serial/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message(
 		"[user] begins to edit [target]'s identity parameters with [tool].",
 		"You begin to alter [target]'s identity parameters with [tool]."
-		)
+	)
 	return ..()
 
-/datum/surgery_step/robotics/edit_serial/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/edit_serial/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/old_name = target.real_name
 	var/new_name = copytext(reject_bad_text(input(user,"Choose a name for this machine.","Set Name","[old_name]") as null|text),1,MAX_NAME_LEN)
 	if(!new_name)
-		to_chat(user, "<span class='warning'> Invalid name! Please try again. </span>")
-		return SURGERY_STEP_RETRY
-	else
-		var/new_gender = input(user,"Choose a gender for this machine.","Select Gender",target.gender) as null|anything in list(MALE, FEMALE)
-		if(!new_gender)
-			to_chat(user, "<span class='warning'> You must choose a gender! Please try again. </span>")
-			return SURGERY_STEP_RETRY
-		else
-			target.real_name = new_name
-			target.gender = new_gender
-			user.visible_message(
-				"<span class='notice'> [user] edits [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name]. </span>",
-				"<span class='notice'> You alter [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name]. </span>"
-				)
-			return SURGERY_STEP_CONTINUE
+		to_chat(user, "<span class='warning'>Invalid name! Please try again.</span>")
+		return SURGERY_STEP_INCOMPLETE
+	var/new_gender = input(user,"Choose a gender for this machine.","Select Gender",target.gender) as null|anything in list(MALE, FEMALE)
+	if(!new_gender)
+		to_chat(user, "<span class='warning'>You must choose a gender! Please try again.</span>")
+		return SURGERY_STEP_INCOMPLETE
+	target.real_name = new_name
+	target.gender = new_gender
+	user.visible_message(
+		"<span class='notice'>[user] edits [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name].</span>",
+		"<span class='notice'>You alter [old_name]'s identity parameters with [tool]; [target.p_they()] [target.p_are()] now known as [new_name].</span>"
+		)
+	return SURGERY_STEP_CONTINUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR adds a new surgery option for IPCs and IRCs called "Reconfigure Identity" which allows them to have their names changed, similar to how it's done for organics. The only difference is that this operation allows the surgeon/roboticist to input a fully custom name, which I justify by the fact that they don't have the complexities of organic faces.

The surgery follows the standard steps, and uses a multitool for the renaming step, similar to Cybernetic Appearance Customization. If for whatever reason the player inputs an invalid name, it will tell them and force them to redo the step. Once a name has been chosen, the player then selects a gender which completes the surgery step.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I've played a lot of roboticist and this has always been one of the glaring holes in the functionality of IPCs and IRCs. If a body is unclonable or gibbed, one option is to put the brain in an MMI. From there, if you don't want to enslave someone to the AI, you put them into an IRC, in which case they would be forced to walk around as "Integrated Robotic Chassis (9001) (as John Smith)" That's an eyesore to look at for everyone involved. This change allows John Smith to get back to work with at least his name still intact!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![C1apture](https://user-images.githubusercontent.com/11909245/198873118-3911359c-eb11-472c-95ff-8112b2cf6bca.PNG)
![C2apture](https://user-images.githubusercontent.com/11909245/198873130-7dc09230-0ea4-456b-b560-180b8d78a9d6.PNG)
![C3apture](https://user-images.githubusercontent.com/11909245/198873137-2d52d8f8-8950-42c8-acef-d6731e79fa4c.PNG)
![C4apture](https://user-images.githubusercontent.com/11909245/198873141-cb56d571-33a2-4844-a521-dacf2be41df2.PNG)
![C5apture](https://user-images.githubusercontent.com/11909245/198873144-156945be-930c-4d41-8805-f56b6e5bc478.PNG)

## Testing
<!-- How did you test the PR, if at all? -->
Went into a local test server and changed the names of several IRCs printed fresh from the exosuit fabricators.

## Changelog
:cl:
add: Added IPC name-changing surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
