### PR TITLE
Removes the Ablative from the Theft Pool

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -130,12 +130,6 @@
 	protected_jobs = list("Chief Medical Officer")
 	location_override = "the Chief Medical Officer's Office"
 
-/datum/theft_objective/ablative
-	name = "an ablative trenchcoat"
-	typepath = /obj/item/clothing/suit/hooded/ablative
-	protected_jobs = list("Head of Security", "Warden")
-	location_override = "the Armory"
-
 /datum/theft_objective/krav
 	name = "the warden's krav maga martial arts gloves"
 	typepath = /obj/item/clothing/gloves/color/black/krav_maga/sec


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes the Ablative Trenchcoat from the theft pool.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As of now, you cannot steal the Ablative Trenchcoat from the Armory for use as an antagonist unless you take it OFF of a dead Officer. See: [the Advanced Rules](https://www.paradisestation.org/wiki/index.php/Advanced_Rules#Rule_6:_Play_Antagonists_Responsibly). 

As such, this removal will allow antagonists to freely snag it if Security starts breaking out Immolators/Pulse Slugs instead of catching a bwoink. This will also mean a smaller pool of theft objectives, meaning more antagonists may have to fight one another, creating inter-antagonistic conflict, something we truly have very little of in my experience.

Another option that could be taken is to add two Ablative Armor sets to the Brig's loadout to bring to total energy weapon armors up to three, mirroring that of the other specialty armors.


## Changelog
:cl:
tweak: removes the Ablative Trenchcoat from the antagonist theft pool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
