### PR TITLE
Fix human appearance randomness in spawners.

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -237,15 +237,13 @@
 			D.f_style = random_facial_hair_style(gender, D.dna.species.name)
 		D.facial_colour = rand_hex_color()
 	if(skin_tone)
-		H.change_skin_tone(skin_tone)
+		H.s_tone = skin_tone
 	else
-		H.change_skin_tone(random_skin_tone())
-		H.change_skin_color(rand_hex_color())
-	H.update_hair()
-	H.update_fhair()
-	H.update_body()
-	H.update_dna()
-	H.regenerate_icons()
+		H.s_tone = random_skin_tone()
+		H.skin_colour = rand_hex_color()
+
+	H.update_body(rebuild_base = TRUE)
+
 	if(outfit)
 		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id", "neck", "backpack_contents", "suit_store")
 		for(var/slot in slots)

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -172,7 +172,6 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 	M.age = rand(23,35)
 	M.regenerate_icons()
 	M.update_body()
-	M.update_dna()
 
 	//Creates mind stuff.
 	M.mind = new

--- a/code/modules/ruins/syndicate_space_base.dm
+++ b/code/modules/ruins/syndicate_space_base.dm
@@ -35,6 +35,7 @@
 	assignedrole = "Syndicate Researcher"
 	del_types = list() // Necessary to prevent del_types from removing radio!
 	allow_species_pick = TRUE
+	skin_tone = 255
 
 /obj/effect/mob_spawn/human/spacebase_syndicate/Destroy()
 	var/obj/structure/fluff/empty_sleeper/syndicate/S = new /obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes #17891.

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR slightly modifies how human spawners work, so that spawned humans have their appearance properly randomized.

Sets skin tone for Syndicate Base human spawners to remain albinos for that creepy sci-fi bio-engineering vibe. You know, like Dark City.

I'm not going to pretend I understand DNA code, but update_dna seems to be the wrong thing to do if you create the human first, and make appearance/head appearance changes after.

Other species don't have their properties randomized yet in spawners so this doesn't affect any other species.

The ERT issue was a slightly different one. These aren't the same kind of spawner. An unnecessary update_dna call is removed. This lines up the code with the same spawner used for nukies, which we know works because we don't have issues with albino nukies, because it would be a very noticeable issue if four albinos attempted stealth.

You'll notice e.g. eyes are always black, because that's not one of the things the character spawner randomizes. The ideal scenario would be pulling /datum/character_save#randomize out of the realm of character saves and into a more general utility for randomizing species traits in a reliable way.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This helps human spawners look slightly more realistic.

## Images of changes

<details><summary><h3>Before</h3></summary>

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Before:
![Paradise Station 13-01_41_01](https://user-images.githubusercontent.com/59303604/198945173-fe67629e-1920-4736-b568-c31153f633fd.png)

![Paradise Station 13-02_18_39](https://user-images.githubusercontent.com/59303604/198945189-62e20442-5013-448a-ae0a-c8980c619414.png)

![Paradise Station 13-01_38_25](https://user-images.githubusercontent.com/59303604/198945201-4da5c8eb-12b2-4049-86a8-c8f2b9941c97.png)

![Paradise Station 13-01_30_08](https://user-images.githubusercontent.com/59303604/198945251-70e38651-607b-4db8-92d2-b0cdc821707c.png)

![Paradise Station 13-02_38_08](https://user-images.githubusercontent.com/59303604/198946629-9ea9f026-e6c2-4510-b930-f4815015c398.png)

</details>

<details><summary><h3>After</h3></summary>

![Paradise Station 13-02_04_50](https://user-images.githubusercontent.com/59303604/198945444-d98668fe-9789-4eba-adab-7813c84036d5.png)

![Paradise Station 13-02_15_37](https://user-images.githubusercontent.com/59303604/198945451-42331a41-18e6-453e-97da-e22016250b91.png)

![Paradise Station 13-01_43_48](https://user-images.githubusercontent.com/59303604/198945461-02f3cdc9-a1ed-43a5-a396-d6e624bc8687.png)

![Paradise Station 13-01_44_26](https://user-images.githubusercontent.com/59303604/198945484-c65f99f8-a233-4f2d-8089-59a944aaaa27.png)

![Paradise Station 13-02_34_15](https://user-images.githubusercontent.com/59303604/198946091-d8b4d90e-e692-4ccf-9d59-6c67d190137c.png)


</details>

## Testing
<!-- How did you test the PR, if at all? -->

1. Ensure lavaland/space ruins for syndie space base, beach dome, and survivor ruin are enabled.
2. Spawn/aghost into each mob spawner as available.
3. Trigger an ERT and spawn into an available slot.

## Changelog
:cl:
fix: Human spawner appearances are better randomized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
