### PR TITLE
Fixes a DNA scanner stacktrace runtime

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -258,7 +258,7 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(flags & NODECONSTRUCT)
+	if(flags & NODECONSTRUCT)//We need to check for this early or the contents could be moved before it checks for the flag normally
 		return
 	for(var/obj/thing in contents) // in case there is something in the scanner
 		thing.forceMove(loc)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -258,6 +258,8 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
+	if(flags & NODECONSTRUCT)
+		return
 	for(var/obj/thing in contents) // in case there is something in the scanner
 		thing.forceMove(loc)
 	default_deconstruction_crowbar(user, I)	

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -253,9 +253,14 @@
 	return ..()
 
 /obj/machinery/dna_scannernew/crowbar_act(mob/user, obj/item/I)
-	if(default_deconstruction_crowbar(user, I))
-		for(var/obj/thing in contents) // in case there is something in the scanner
-			thing.forceMove(loc)
+	if(!panel_open)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	for(var/obj/thing in contents) // in case there is something in the scanner
+		thing.forceMove(loc)
+	default_deconstruction_crowbar(user, I)	
 
 /obj/machinery/dna_scannernew/screwdriver_act(mob/user, obj/item/I)
 	if(occupant)


### PR DESCRIPTION
## What Does This PR Do
Fixes this runtime

```
[2022-11-01T01:00:11] Runtime in stacktrace.dm,14: The �DNA modifier taking damage after deletion
[2022-11-01T01:00:11]   proc name: stack trace (/datum/proc/stack_trace)
[2022-11-01T01:00:11]   usr: *REDACTED USER*
[2022-11-01T01:00:11]   usr.loc: The floor (144,112,2) (/turf/simulated/floor/plasteel)
[2022-11-01T01:00:11]   src: the DNA modifier (/obj/machinery/dna_scannernew)
[2022-11-01T01:00:11]   src.loc: null
[2022-11-01T01:00:11]   call stack:
[2022-11-01T01:00:11]   the DNA modifier (/obj/machinery/dna_scannernew): stack trace("The DNA modifier taking damage...")
[2022-11-01T01:00:11]   the DNA modifier (/obj/machinery/dna_scannernew): take damage(8, "brute", "melee", 1, null, 0, 0)
[2022-11-01T01:00:11]   the DNA modifier (/obj/machinery/dna_scannernew): attacked by(the pocket crowbar (/obj/item/crowbar/red), P.L.A.T.I.N.U.M (/mob/living/carbon/human))
[2022-11-01T01:00:11]   the pocket crowbar (/obj/item/crowbar/red): attack obj(the DNA modifier (/obj/machinery/dna_scannernew), P.L.A.T.I.N.U.M (/mob/living/carbon/human), "icon-x=15;icon-y=30;left=1;but...")
[2022-11-01T01:00:11]   the DNA modifier (/obj/machinery/dna_scannernew): attackby(the pocket crowbar (/obj/item/crowbar/red), P.L.A.T.I.N.U.M (/mob/living/carbon/human), "icon-x=15;icon-y=30;left=1;but...")
[2022-11-01T01:00:11]   the DNA modifier (/obj/machinery/dna_scannernew): attackby(the pocket crowbar (/obj/item/crowbar/red), P.L.A.T.I.N.U.M (/mob/living/carbon/human), "icon-x=15;icon-y=30;left=1;but...")
[2022-11-01T01:00:11]   the DNA modifier (/obj/machinery/dna_scannernew): attackby(the pocket crowbar (/obj/item/crowbar/red), P.L.A.T.I.N.U.M (/mob/living/carbon/human), "icon-x=15;icon-y=30;left=1;but...")
[2022-11-01T01:00:11]   the pocket crowbar (/obj/item/crowbar/red): melee attack chain(P.L.A.T.I.N.U.M (/mob/living/carbon/human), the DNA modifier (/obj/machinery/dna_scannernew), "icon-x=15;icon-y=30;left=1;but...")
[2022-11-01T01:00:11]   P.L.A.T.I.N.U.M (/mob/living/carbon/human): ClickOn(the DNA modifier (/obj/machinery/dna_scannernew), "icon-x=15;icon-y=30;left=1;but...")
[2022-11-01T01:00:11]   the DNA modifier (/obj/machinery/dna_scannernew): Click(the floor (143,111,2) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=15;icon-y=30;left=1;but...")
```

## Testing
Compiled, ran, deconstructed

## Changelog
:cl:
fix: People no longer do an attack animation when deconstructing a DNA scanner
/🆑 