### PR TITLE
Safes can now be closed when repaired

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -182,6 +182,7 @@ GLOBAL_LIST_EMPTY(safes)
 			to_chat(user, "<span class='notice'>You replace the broken mechanism.</span>")
 			qdel(I)
 			broken = FALSE
+			locked = FALSE
 			update_icon()
 		else if(I.w_class + space <= maxspace)
 			if(!user.drop_item())
@@ -355,7 +356,7 @@ GLOBAL_LIST_EMPTY(safes)
 	cut_overlay(progress_bar)
 	update_icon()
 	STOP_PROCESSING(SSobj, src)
-	
+
 /**
   * # Floor Safe
   *


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Sets locked status to FALSE when its repaired. With this change the player will be able to close the safe instead of being stuck in a open/locked state.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://user-images.githubusercontent.com/77684085/199308786-31746b23-825c-472b-802c-6ff4ad6c1272.png)
## Testing
<!-- How did you test the PR, if at all? -->
- Used the drill to open the vault safe
- Spawned safe_internals and used to repair the safe (can only repair if its open)
- Managed to interact and close the safe normally
## Changelog
:cl:
fix: Safes can now be closed when repaired
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
