### PR TITLE
Fix surgery steps being performable in invalid states

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -97,6 +97,9 @@
 	if(!self_operable && user == target)
 		return FALSE
 
+	if(lying_required && !on_operable_surface(target))
+		return FALSE
+
 	var/datum/surgery_step/step = get_surgery_step()
 	if(step)
 		var/obj/item/tool = user.get_active_hand()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some unintentional behavior where so long as a surgery was started on a table, it could be continued in any state. This PR ensures that surgery steps must be performed on an operable surface.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Surgery was supposed to be limited to tables (as noted by the fact that you can only start surgeries on tables); this was absolutely an oversight.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Start surgery while someone's lying down
- Stand them up
- Click them with a scalpel and stab them instead of incising
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Surgery steps can now only be completed on operable surfaces.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
