### PR TITLE
Fixes a Barcode Scanner Runtime

### DIFF
--- a/code/modules/library/library_equipment.dm
+++ b/code/modules/library/library_equipment.dm
@@ -345,12 +345,15 @@
 	if(computer == library_computer)
 		return TRUE //we're succesfully connected already, let player know it was a "succesful connection"
 
-	UnregisterSignal(computer, COMSIG_PARENT_QDELETING)
+	disconnect() //clear references to old computer, we have to unregister signals
 	computer = library_computer
 	RegisterSignal(library_computer, COMSIG_PARENT_QDELETING, .proc/disconnect)
 	return TRUE
 
 /obj/item/barcodescanner/proc/disconnect()
+	if(!computer)
+		return //proc will runtime if computer is null
+	UnregisterSignal(computer, COMSIG_PARENT_QDELETING)
 	computer = null
 
 /obj/item/barcodescanner/proc/scanID(obj/item/card/id/ID, mob/user)


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime caused by passing a null value to UnregisterSignal in the barcode scanner code.

```dm
2022-11-02T12:16:10] Runtime in _component.dm,220: Cannot read null.comp_lookup 
[2022-11-02T12:16:10] proc name: UnregisterSignal (/datum/proc/UnregisterSignal) 
[2022-11-02T12:16:10] usr: *REDACTED USER* [2022-11-02T12:16:10] usr.loc: The carpet (172,137,2) (/turf/simulated/floor/carpet) 
[2022-11-02T12:16:10] src: the barcode scanner (/obj/item/barcodescanner) 
[2022-11-02T12:16:10] src.loc: Jason Ford (/mob/living/carbon/human) 
[2022-11-02T12:16:10] call stack: 
[2022-11-02T12:16:10] the barcode scanner (/obj/item/barcodescanner): UnregisterSignal(null, "parent_qdeleting") 
[2022-11-02T12:16:10] the barcode scanner (/obj/item/barcodescanner): connect(Library Computer (/obj/machinery/computer/library)) 
[2022-11-02T12:16:10] Library Computer (/obj/machinery/computer/library): attackby(the barcode scanner (/obj/item/barcodescanner), Jason Ford (/mob/living/carbon/human), "icon-x=16;icon-y=19;left=1;but...") 
[2022-11-02T12:16:10] the barcode scanner (/obj/item/barcodescanner): melee attack chain(Jason Ford (/mob/living/carbon/human), Library Computer (/obj/machinery/computer/library), "icon-x=16;icon-y=19;left=1;but...") 
[2022-11-02T12:16:10] Jason Ford (/mob/living/carbon/human): ClickOn(Library Computer (/obj/machinery/computer/library), "icon-x=16;icon-y=19;left=1;but...") 
[2022-11-02T12:16:10] Library Computer (/obj/machinery/computer/library): Click(the floor (171,136,2) (/turf/simulated/floor/wood), "mapwindow.map", "icon-x=16;icon-y=19;left=1;but...")
```

## Why It's Good For The Game
Runtimes are bad

## Testing
Built, ran on test server, connected barcode scanner with null value for `computer` and no runtime was produced

No Changelog b/c changes are not player facing
