### PR TITLE
Add CI script for verifying tickedness of files.

### DIFF
--- a/tools/ci/unticked_files.py
+++ b/tools/ci/unticked_files.py
@@ -1,0 +1,48 @@
+# Naive search for unticked files. Has no semantic knowledge, just a lexical
+# search for #include directives against existing file paths.
+#
+# Usage:
+#  python unticked_files.py C:\Path\To\Paradise\
+#
+# Returns 0 if all existing files are considered ticked, 1 otherwise.
+
+from pathlib import Path
+import argparse
+import sys
+
+INCLUDER_FILES = [
+    'paradise.dme',
+    'code/modules/tgs/includes.dm',
+    'code/modules/unit_tests/_unit_tests.dm',
+]
+
+IGNORE_FILES = {
+    # Included directly in the function /datum/tgs_api/v5#ApiVersion
+    'code/modules/tgs/v5/interop_version.dm'
+}
+
+def get_unticked_files(root:Path):
+    ticked_files = set()
+    for includer in INCLUDER_FILES:
+        with open(root / includer, 'r') as f:
+            lines = [line for line in f.readlines() if line.startswith('#include')]
+            included = [line.replace('#include ', '').rstrip('\r\n').strip('"') for line in lines]
+            print(f'Found {len(included)} includes in {root / includer}')
+            ticked_files.update([root / Path(includer).parent / i for i in included])
+
+    all_dm_files = {f for f in root.glob('**/*.dm')}
+    return all_dm_files - ticked_files - {root / f for f in IGNORE_FILES}
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", help="paracode root directory")
+    args = parser.parse_args()
+
+    # Windows quoting behavior for directories adds trailing double-quote
+    unticked_files = get_unticked_files(Path(args.root.strip('"')))
+    if unticked_files:
+        print(f'Found {len(unticked_files)} unticked files:')
+        print('\n'.join(str(x) for x in sorted(unticked_files)))
+        sys.exit(1)
+    else:
+        print(f'Found no unticked files')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

CC @AffectedArc07 

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay 
reviews or even discourage maintainers from merging your PR! -->
Adds a simple script that does a lexical search on `#include` directives and matches them to files on the filesystem, reporting any discrepancies.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Unticked files are dead code and are ticking time bombs. See #19587 and #19588. This script will solve this problem forever into the future.

No CI configuration is actually provided because it would fail instantly; the following unticked files are not part of either of the above PRs and I don't know the status of the ninja module in general, since some of the ninja files _are_ ticked, so I'm not messing with them:
```
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\__ninjaDefines.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\admin_ninja_verbs.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\martial_art.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\ninja_event.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\Ninja_Readme.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\energy_net_nets.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_adrenaline.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_cost_check.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_empulse.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_net.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_smoke.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_stars.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_stealth.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\n_suit_verbs\ninja_teleporting.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\SpiderOS.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\suit_attackby.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\suit_process.dm
D:\ExternalRepos\third_party\Paradise\code\modules\ninja\suit\suit_verbs_handlers.dm
```

While I could also add these files to `IGNORED_FILES`, I want that list to be confirmed things we know we want, or _are_ included, just not in a way the basic search can find them.

## Testing
<!-- How did you test the PR, if at all? -->
Ran command manually, did sanity check on results.
