### PR TITLE
Fixes wall deconstruction runtimes with power tools

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -424,7 +424,7 @@
 			to_chat(user, "<span class='notice'>Your [I.name] tears though the last of the reinforced plating.</span>")
 			dismantle_wall()
 			visible_message("<span class='warning'>[user] drills through [src]!</span>", "<span class='warning'>You hear the grinding of metal.</span>")
-			return TRUE
+		return TRUE
 
 	else if(istype(I, /obj/item/pickaxe/drill/jackhammer))
 		to_chat(user, "<span class='notice'>You begin to disintegrates the wall.</span>")
@@ -433,7 +433,7 @@
 			to_chat(user, "<span class='notice'>Your [I.name] disintegrates the reinforced plating.</span>")
 			dismantle_wall()
 			visible_message("<span class='warning'>[user] disintegrates [src]!</span>","<span class='warning'>You hear the grinding of metal.</span>")
-			return TRUE
+		return TRUE
 
 	else if(istype(I, /obj/item/twohanded/required/pyro_claws))
 		to_chat(user, "<span class='notice'>You begin to melt the wall.</span>")
@@ -442,7 +442,7 @@
 			to_chat(user, "<span class='notice'>Your [I.name] melts the reinforced plating.</span>")
 			dismantle_wall()
 			visible_message("<span class='warning'>[user] melts [src]!</span>","<span class='warning'>You hear the hissing of steam.</span>")
-			return TRUE
+		return TRUE
 	return FALSE
 
 /turf/simulated/wall/proc/try_wallmount(obj/item/I, mob/user, params)


### PR DESCRIPTION
## What Does This PR Do
Fixes some wall deconstruction runtimes through the attackby proc
specifically just unindents three `return TRUE`s down a level
Fixes #19586

Tbh, the way this is coded is bad and could really just use with a refactor
## Why It's Good For The Game
Runtimes are bad

## Testing
Tested issue and reproduced runtimes
Unindented the three return TRUEs
Compiled and ran and tried reproduction and no runtimes were produced

no player-facing changes, no CL