### PR TITLE
Adds an additional safety check for Buildmode advanced mode to prevent a runtime

### DIFF
--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -47,13 +47,15 @@
 			log_admin("Build Mode: [key_name(user)] modified [T] ([T.x],[T.y],[T.z]) to [objholder]")
 			T.ChangeTurf(objholder)
 		else if(!isnull(objholder))
-			var/obj/A = new objholder (get_turf(object))
-			A.setDir(BM.build_dir)
-			log_admin("Build Mode: [key_name(user)] modified [A]'s ([A.x],[A.y],[A.z]) dir to [BM.build_dir]")
+			//we only want to set the direction of mobs or objects, not turfs or areas.
+			var/atom/movable/A = new objholder(get_turf(object))
+			if(istype(A))
+				A.setDir(BM.build_dir)
+				log_admin("Build Mode: [key_name(user)] modified [A]'s ([A.x],[A.y],[A.z]) dir to [BM.build_dir]")
 		else
 			to_chat(user, "<span class='warning'>Select object type first.</span>")
 	else if(right_click)
 		if(isobj(object))
 			log_admin("Build Mode: [key_name(user)] deleted [object] at ([object.x],[object.y],[object.z])")
 			qdel(object)
-	
+


### PR DESCRIPTION
## What Does This PR Do
Adds a safety check for buildmode advanced mode
Fixes #19527
## Why It's Good For The Game
Runtimes are bad

## Testing
I compiled without errors but did no further testing than that. This doesn't actually change any functionality or affect behavior, only adds in a safety check.

No player facing changes