### PR TITLE
Reduces the Disabler's Fire Rate

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -164,6 +164,7 @@
 	e_cost = 50
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
+	delay = 0.6 SECONDS
 
 /obj/item/ammo_casing/energy/disabler/cyborg //seperate balancing for cyborg, again
 	e_cost = 250


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reduces the disabler rate of fire by 0.6 seconds.

From full charge to depletion, 20 shots.
8.5 seconds to 13.4 seconds.

## Why It's Good For The Game
Disablers are a bit cracked right now, fire rate is too good and easy to spam with its giant capacity. This should make missing shots more punishing as well as giving people time to close the gap.

## Testing
Made a server and stopwatched, time is an interesting thing... speaking of time... did you know-

## Changelog
:cl: OctusGit
tweak: Added disabler delay and reduced its fire rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
