### PR TITLE
Announcements Refactor Day 1 Patch.

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -165,3 +165,4 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcer, new(config_type = /datum
 	default_title = ANNOUNCE_KIND_AI
 	add_log = TRUE
 	log_name = ANNOUNCE_KIND_AI
+	sound = sound('sound/misc/notice2.ogg')

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -150,9 +150,8 @@ GLOBAL_VAR_INIT(announcing_vox, 0) // Stores the time of the last announcement
 
 /mob/living/silicon/ai/proc/ai_voice_announcement_to_text(words)
 	var/words_string = jointext(words, " ")
-	var/formatted_message = "<h1 class='alert'>A.I. Announcement</h1>"
-	formatted_message += "<br><span class='alert'>[words_string]</span>"
-	formatted_message += "<br><span class='alert'> -[src]</span>"
+	// Don't go through .Announce because we need to filter by clients which have TTS enabled
+	var/formatted_message = announcer.Format(words_string, "A.I. Announcement")
 
 	var/announce_sound = sound('sound/misc/notice2.ogg')
 	for(var/player in GLOB.player_list)

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -32,7 +32,7 @@ GLOBAL_DATUM_INIT(security_announcement, /datum/announcer, new(config_type = /da
 
 		switch(level)
 			if(SEC_LEVEL_GREEN)
-				GLOB.security_announcement.Announce("All threats to the station have passed. All weapons need to be holstered and privacy laws are once again fully enforced.","Attention! Security level lowered to green.", 'sound/AI/green.ogg')
+				GLOB.security_announcement.Announce("All threats to the station have passed. All weapons need to be holstered and privacy laws are once again fully enforced.","Attention! Security level lowered to green.", new_sound2='sound/AI/green.ogg')
 				GLOB.security_level = SEC_LEVEL_GREEN
 				unset_stationwide_emergency_lighting()
 				post_status(STATUS_DISPLAY_TRANSFER_SHUTTLE_TIME)
@@ -40,9 +40,11 @@ GLOBAL_DATUM_INIT(security_announcement, /datum/announcer, new(config_type = /da
 
 			if(SEC_LEVEL_BLUE)
 				if(GLOB.security_level < SEC_LEVEL_BLUE)
-					GLOB.security_announcement.Announce("The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible and random searches are permitted.","Attention! Security level elevated to blue.", 'sound/AI/blue.ogg')
+					GLOB.security_announcement.Announce("The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible and random searches are permitted.","Attention! Security level elevated to blue.",
+					new_sound='sound/misc/notice1.ogg',
+					new_sound2='sound/AI/blue.ogg')
 				else
-					GLOB.security_announcement.Announce("The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed.","Attention! Security level lowered to blue.", 'sound/AI/blue.ogg')
+					GLOB.security_announcement.Announce("The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed.","Attention! Security level lowered to blue.", new_sound2='sound/AI/blue.ogg')
 				GLOB.security_level = SEC_LEVEL_BLUE
 
 				post_status(STATUS_DISPLAY_TRANSFER_SHUTTLE_TIME)
@@ -51,9 +53,11 @@ GLOBAL_DATUM_INIT(security_announcement, /datum/announcer, new(config_type = /da
 
 			if(SEC_LEVEL_RED)
 				if(GLOB.security_level < SEC_LEVEL_RED)
-					GLOB.security_announcement.Announce("There is an immediate and serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised.","Attention! Code Red!", 'sound/AI/red.ogg')
+					GLOB.security_announcement.Announce("There is an immediate and serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised.","Attention! Code Red!",
+					new_sound='sound/misc/notice1.ogg',
+					new_sound2='sound/AI/red.ogg')
 				else
-					GLOB.security_announcement.Announce("The station's self-destruct mechanism has been deactivated, but there is still an immediate and serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised.","Attention! Code Red!", 'sound/AI/red.ogg')
+					GLOB.security_announcement.Announce("The station's self-destruct mechanism has been deactivated, but there is still an immediate and serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised.","Attention! Code Red!", new_sound2='sound/AI/red.ogg')
 					unset_stationwide_emergency_lighting()
 				GLOB.security_level = SEC_LEVEL_RED
 

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -426,11 +426,8 @@ em				{font-style: normal;font-weight: bold;}
 span.body .codephrases 		{color: #5555FF;}
 span.body .coderesponses 		{color: #FF3333;}
 
-.announcement { font-size: 24pt; }
-.announcement h1, .announcement h2 { color: #fff; }
-.announcement p { color: #d82020; font-size: 12pt; }
-.announcement h1 { font-size: 100%; }
-.announcement h2 { font-size: 90%; }
-.announcement.minor h1 { font-size: 80%; }
-.announcement.minor h2 { font-size: 70%; }
-.announcement.sec h1 { color: #f00; font-size: 80%; font-family: Verdana, sans-serif; }
+.announcement h1, .announcement h2 { color: #fff; margin: 2px 0; }
+.announcement p { color: #d82020; line-height: 1; }
+.announcement.minor h1 { font-size: 180%; }
+.announcement.minor h2 { font-size: 170%; }
+.announcement.sec h1 { color: #f00; font-family: Verdana, sans-serif; }

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -426,11 +426,8 @@ em						{font-style: normal;	font-weight: bold;}
 span.body .codephrases {color: #0000FF;}
 span.body .coderesponses {color: #FF0000;}
 
-.announcement { font-size: 24pt; }
-.announcement h1, .announcement h2 { color: #000; }
-.announcement p { color: #d82020; font-size: 12pt; }
-.announcement h1 { font-size: 100%; }
-.announcement h2 { font-size: 90%; }
-.announcement.minor h1 { font-size: 80%; }
-.announcement.minor h2 { font-size: 70%; }
-.announcement.sec h1 { color: #f00; font-size: 80%; font-family: Verdana, sans-serif; }
+.announcement h1, .announcement h2 { color: #000; margin: 2px 0; }
+.announcement p { color: #d82020; line-height: 1; }
+.announcement.minor h1 { font-size: 180%; }
+.announcement.minor h2 { font-size: 170%; }
+.announcement.sec h1 { color: #f00; font-family: Verdana, sans-serif; }


### PR DESCRIPTION
## What Does This PR Do

- Fix formatting of AI Announcement when TTS disabled
- Adjust margins and font-sizes of announcements to make them a more reasonable size
- Fix announcements not respecting chatlog font size preference
- Fix missing sounds when raising security levels
- Fix AI Announcement missing notification sound

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Eliminating logic errors in code, fixing UI experience for important cases.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<details>
<summary>AI TTS Announcement</summary>
Before:

![annc_ai_tts_before](https://user-images.githubusercontent.com/59303604/199828711-84d53dd6-c94a-4d00-a2f8-714cb4da1685.png)

After:

![annc_ai_tts_after](https://user-images.githubusercontent.com/59303604/199828723-9d371451-68de-4250-9fa3-c64b10d51810.png)

</details>

<details>
<summary>Overall Height/Density</summary>

Lots of alerts before (5 visible):

![annc_density_before](https://user-images.githubusercontent.com/59303604/199828836-d14671ea-888e-4b02-8510-9a7899bfd693.png)

Lots of alerts after (6 visible):

![annc_density_after](https://user-images.githubusercontent.com/59303604/199828859-aadbbc6c-1ba1-410b-9088-7110aa83d9ff.png)

Individual AI Announcement before:

![annc_individual_ai_height_before](https://user-images.githubusercontent.com/59303604/199828911-3035418a-fcd0-4328-974b-f3bc5085e835.png)

Individual AI Announcement After:

![annc_individual_ai_height_after](https://user-images.githubusercontent.com/59303604/199828941-7fee5548-2d82-481e-96cc-054832e65350.png)

</details>

<details>
<summary>Custom Font Size</summary>

Before:

![annc_custom_size_before](https://user-images.githubusercontent.com/59303604/199829275-6743ac0b-49ae-49d3-bcb3-380d9a23fd3a.png)

After:

![annc_custom_font_size_after](https://user-images.githubusercontent.com/59303604/199829291-d742ea71-2c09-4b1b-8c25-a4ed37acd4e7.png)

</details>

<details>
<summary>Security Alert Sounds</summary>
Before (with sound):

https://user-images.githubusercontent.com/59303604/199830507-1fd109c1-5447-48a0-90d9-72c9979b7e4a.mp4

After (with sound):

https://user-images.githubusercontent.com/59303604/199830526-8311108f-68fc-4822-a646-18be8d4b8f33.mp4

</details>

<details>
<summary>AI Announcement Sound</summary>

Before (with sound but not really):

https://user-images.githubusercontent.com/59303604/199831162-c70ae102-c52d-49df-8871-00c3afedc026.mp4

After (with sound):


https://user-images.githubusercontent.com/59303604/199831585-b315e7a3-845e-44d5-9bc9-3d608538d1ce.mp4

</details>

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fix formatting of AI Announcement when TTS disabled
fix: Fix announcements not respecting chatlog font size preference
fix: Adjust margins and font-sizes of announcements to make them a more reasonable size
fix: Fix missing sounds when raising security levels
fix: AI Announcement missing notification sound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
