### PR TITLE
Replace /proc/num2hex with a much faster macro.

### DIFF
--- a/code/__DEFINES/_math.dm
+++ b/code/__DEFINES/_math.dm
@@ -242,3 +242,5 @@
 
 // Gives you the percent of two inputs
 #define PERCENT_OF(val1, val2) (val1 * (val2 / 100))
+
+#define num2hex(X, len) uppertext(num2text(X, len, 16))

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -42,23 +42,6 @@
 		i--
 	return num
 
-//Returns the hex value of a number given a value assumed to be a base-ten value
-/proc/num2hex(num, placeholder = 2)
-	if(!isnum(num) || num < 0)
-		return
-
-	var/hex = ""
-	while(num)
-		var/val = num % 16
-		num = round(num / 16)
-
-		if(val > 9)
-			val = ascii2text(55 + val) // 65 - 70 correspond to "A" - "F"
-		hex = "[val][hex]"
-	while(length(hex) < placeholder)
-		hex = "0[hex]"
-	return hex || "0"
-
 //Returns an integer value for R of R/G/B given a hex color input.
 /proc/color2R(hex)
 	if(!(istext(hex)))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1378,9 +1378,7 @@ Standard way to write links -Sayu
 		colour = pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))
 	else
 		for(var/i=1;i<=3;i++)
-			var/temp_col = "[num2hex(rand(lower,upper))]"
-			if(length(temp_col )<2)
-				temp_col  = "0[temp_col]"
+			var/temp_col = "[num2hex(rand(lower,upper), 2)]"
 			colour += temp_col
 	return colour
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -363,7 +363,7 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 
 
 /proc/EncodeDNABlock(value)
-	return add_zero2(num2hex(value, 1), 3)
+	return num2hex(value, 3)
 
 /datum/dna/proc/UpdateUI()
 	uni_identity = ""

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -189,7 +189,7 @@
 				return
 			var/datum/data/record/G = new /datum/data/record()
 			G.fields["name"] = "New Record"
-			G.fields["id"] = "[add_zero(num2hex(rand(1, 1.6777215E7)), 6)]"
+			G.fields["id"] = "[num2hex(rand(1, 1.6777215E7), 6)]"
 			G.fields["rank"] = "Unassigned"
 			G.fields["real_rank"] = "Unassigned"
 			G.fields["sex"] = "Male"

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -329,7 +329,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!(NO_BLOOD in H.dna.species.species_traits) && !H.dna.species.exotic_blood)
-			H.dna.species.blood_color = "#[num2hex(rand(0, 255))][num2hex(rand(0, 255))][num2hex(rand(0, 255))]"
+			H.dna.species.blood_color = "#[num2hex(rand(0, 255), 2)][num2hex(rand(0, 255), 2)][num2hex(rand(0, 255), 2)]"
 	return ..()
 
 /datum/reagent/colorful_reagent/reaction_mob(mob/living/simple_animal/M, method=REAGENT_TOUCH, volume)


### PR DESCRIPTION
## What Does This PR Do
This PR swaps out a hand-rolled implementation of `num2hex` with a macro. Para's existing implementation used ascii2text, which used a "clever" offset trick to map values to _uppercase_ hex characters, so the macro (which uses the native `num2text` with a radix of 16) is wrapped with `uppertext`.

I guess I should mention this is a port from Goon, inasmuch as this change can be considered one. I don't know if we have a blanket acknowledgement for Goon port attribution outside of the directories mentioned in the README.

## Why It's Good For The Game
`num2hex` sits at the bottom of DNA code, and it fires a lot on init due to the creation of internal organs for various things, as well as the dent made by all players spawning, having their bodies built up, and having their DNA synced. The primary driver of this is `/proc/EncodeDNABlock`, and it gets called over 2 million times a round.

![num2hex_prof_stats](https://user-images.githubusercontent.com/59303604/200046749-a7769166-1f00-4aa8-8147-32eead3ddc90.png)

![EncodeDNABlock_prof_stats](https://user-images.githubusercontent.com/59303604/200046746-c5012c1d-98aa-4113-b678-2a16a9bf6082.png)

This highly scientific test suggests that the benefits to switching over to the macro are significant:

```c
#define num2hex_macro(X, len) num2text(X, len, 16)

/proc/main()
    sleep(1)
    BENCHT("num2hex_para", 50000, num2hex_para(rand(0, 10000), 8))
    BENCHT("num2hex_macro", 50000, num2hex_macro(rand(0, 10000), 8))
```

![14_20_41__#code_testing _ Paradise Station - Discord-](https://user-images.githubusercontent.com/59303604/200047866-8cc1ae04-fce4-4e7d-9639-ed4b3615baa5.png)


(where `num2hex_para` is the existing function).

Profiling is similarly promising. Since we're removing all non-native procs, `/proc/num2hex` will no longer show up as a zone, so we look for `/proc/EncodeDNABlock` instead.

Before:
![14_04_23__DREAMDAEMON @ 2022-11-04 14_00_48 - Tracy Profiler 0 8 2-](https://user-images.githubusercontent.com/59303604/200046970-022f4679-d4a1-4f60-b812-d503140e247e.png)

After:

![14_06_13__DREAMDAEMON @ 2022-11-04 14_05_10 - Tracy Profiler 0 8 2-](https://user-images.githubusercontent.com/59303604/200046972-932704eb-8e35-4291-bec7-7588d16cec36.png)


This is not a statistically sound analysis but it looks like the savings are anywhere from 40-60%, with the vast vast majority of that occurring during init or on the 'game start frame' where all players are instantiated.


## Testing
<!-- How did you test the PR, if at all? -->
Verified output is the same:

![15_29_10__byond_test_macros-](https://user-images.githubusercontent.com/59303604/200059603-14279155-b7ab-4e0c-a6d8-073da0122eb2.png)


Spawned in as Captain at round start, profiled from SS init to shortly after round start.

See profiling above.