### PR TITLE
Adds new emote keybinds, and emote keybind unit tests

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,8 +1,8 @@
 #define DEBUG
-//#define TESTING
+#define TESTING
 
 // Uncomment the following line to compile unit tests.
-// #define UNIT_TESTS
+#define UNIT_TESTS
 
 
 #ifdef CIBUILDING

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,8 +1,8 @@
 #define DEBUG
-#define TESTING
+//#define TESTING
 
 // Uncomment the following line to compile unit tests.
-#define UNIT_TESTS
+// #define UNIT_TESTS
 
 
 #ifdef CIBUILDING

--- a/code/datums/keybindings/emote.dm
+++ b/code/datums/keybindings/emote.dm
@@ -413,6 +413,10 @@
 	linked_emote = /datum/emote/living/carbon/human/snap
 	name = "Snap"
 
+/datum/keybinding/emote/carbon/human/crack
+	linked_emote = /datum/emote/living/carbon/human/crack
+	name = "Crack"
+
 /datum/keybinding/emote/carbon/human/fart
 	linked_emote = /datum/emote/living/carbon/human/fart
 	name = "Fart"

--- a/code/modules/unit_tests/emotes.dm
+++ b/code/modules/unit_tests/emotes.dm
@@ -40,8 +40,6 @@
 			Fail("emote [cur_emote]'s max_unintentional_stat_allowed is greater than its unintentional_stat_allowed, and would be unusable.")
 
 
-/datum/unit_test/emote/proc/has_punctuation(datum/emote/E, msg)
-	return E.remove_ending_punctuation(msg) == msg
 
 /datum/unit_test/emote/proc/get_emote_keybinds()
 	var/list/bound_emotes = list()

--- a/code/modules/unit_tests/emotes.dm
+++ b/code/modules/unit_tests/emotes.dm
@@ -2,10 +2,11 @@
 
 /datum/unit_test/emote/Run()
 
+	// Special cases that shouldn't need keybinds.
 	var/list/ignored_emote_types = list(
-		/datum/emote/living/simple_animal/slime,
+		/datum/emote/living/simple_animal/slime,  // The emotes are usable if you are a slime, but I don't think we need to flood the keybind list with them
 		/datum/emote/help,
-		/datum/emote/living/custom
+		/datum/emote/living/custom  // This one's handled by its own set of keybinds
 	)
 
 	var/list/keybound_emotes = get_emote_keybinds()
@@ -29,7 +30,7 @@
 				Fail("emote [cur_emote] has a null target type.")
 
 			// If we're at this point, we're definitely an emote that a user could use, and therefore ought to make sure it's bound to a keybind if possible.
-			if(!(emote_type in keybound_emotes) && !is_type_in_list(cur_emote, ignored_emote_types))
+			if(!is_type_in_list(cur_emote, keybound_emotes) && !is_type_in_list(cur_emote, ignored_emote_types))
 				Fail("Emote [cur_emote] is usable, but not assigned a keybind.")
 
 		if(isnum(cur_emote.max_stat_allowed) && cur_emote.max_stat_allowed < cur_emote.stat_allowed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Player-facing, adds new emotes for some keybinds like *crack and *sign. On the backend, adds unit tests to ensure newly added emotes get keyninds.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Emotes like this should be optionally bound to keys, I just forgot to do so in my original PR. Unit tests make sure that we don't have to make more PRs like this in the future.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Loaded in
- Bound key
- Cracked knuckles
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: *crack can now be bound to a key.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
