### PR TITLE
Changes how the garbage subsystem queue stores and processes info

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -136,17 +136,23 @@ SUBSYSTEM_DEF(garbage)
 
 	lastlevel = level
 
-	for(var/refID in queue)
-		if(!refID)
+	// The instinct is to use a for in loop here, to walk the entries in the queue
+	// The trouble is this performs a copy of the queue list, and since this can in theory balloon a LOT
+	// It's better to just go index by index. It's not a huge deal but it's worth doin IMO
+	for(var/i in 1 to length(queue))
+		var/list/packet = queue[i]
+		if(length(packet) != 2)
 			count++
 			if(MC_TICK_CHECK)
 				return
 			continue
 
-		var/GCd_at_time = queue[refID]
+		var/GCd_at_time = packet[2]
 		if(GCd_at_time > cut_off_time)
 			break // Everything else is newer, skip them
 		count++
+
+		var/refID = packet[1]
 
 		var/datum/D
 		D = locate(refID)
@@ -212,14 +218,12 @@ SUBSYSTEM_DEF(garbage)
 		HardDelete(D)
 		return
 	var/gctime = world.time
-	var/refid = "\ref[D]"
 
 	D.gc_destroyed = gctime
-	var/list/queue = queues[level]
-	if(queue[refid])
-		queue -= refid // Removing any previous references that were GC'd so that the current object will be at the end of the list.
 
-	queue[refid] = gctime
+	var/list/queue = queues[level]
+	// I hate byond lists so much man
+	queue[++queue.len] = list("\ref[D]", gctime)
 
 //this is mainly to separate things profile wise.
 /datum/controller/subsystem/garbage/proc/HardDelete(datum/D)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The way """we""" currently do it, each time you want to walk the queue you're forced to make a copy in memory of the whole thing

There's no real reason to want this, so it seems best to just avoid it entirely. It creates a TON of usage for no reason, and also risks a lot of overtime since you can't really batch a list copy like that.

So instead let's just iterate over the length of the queue, constant rather then O(N) time.

Similarly, rather then using an associated list in the form queue[ref] = gc time, we could store queue entries in what amounts to a tuple.

This means no associated list stuff, so the operation of queuing becomes cheaper, and pulling gc time similarly goes from O(log n) to constant time

I stole this work from myself and mso, tg pr 55595. I'm pring it here because I keep seeing affected complain about the garbage subsystem and he refuses to do it himself. No I don't have an ego problem I swear


## Why It's Good For The Game

Much faster, I can stop whining to affected

## Images of changes

I'll do you one better 

https://user-images.githubusercontent.com/58055496/200111453-2b59b98e-c8f1-4bb1-a6fe-d9bce43d3541.mp4

## Testing

Detonated 3 100 dev bombs to fill the gc queue (note the lack of any cost at all), and set the queue timeout to 0 to flush the standard queue

## Changelog
N/A
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
