### PR TITLE
Fixes the telecommunications core having "Noise" as a listed language

### DIFF
--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -177,7 +177,7 @@
 /datum/nttc_configuration/proc/update_languages()
 	for(var/language in GLOB.all_languages)
 		var/datum/language/L = GLOB.all_languages[language]
-		if(L.flags & HIVEMIND)
+		if(L.flags & (HIVEMIND | NONGLOBAL))
 			continue
 		valid_languages[language] = TRUE
 


### PR DESCRIPTION
## What Does This PR Do

Fixes #19610

The telecomms language conversion list included "Noise", which is not technically a language and it should not be there.

## Why It's Good For The Game

Less bugs, better gameplay.

## Images of changes

![image](https://user-images.githubusercontent.com/33333517/200122132-bed79622-993a-4b5b-95e9-86486d613b9e.png)

![image](https://user-images.githubusercontent.com/33333517/200122141-00d93f02-5953-44b4-be37-61cec0db6646.png) 

![image](https://user-images.githubusercontent.com/33333517/200122146-4951b870-89f8-4119-a462-d9c6273c0620.png)

## Testing

1. Go to telecomms machine
2. Select language conversion
3. It is not there

## Changelog
:cl:
fix: Removed "Noise" from the telecomms language conversion list as it is not a proper language (it is used for emotes).
/:cl:
