### PR TITLE
Fixes runtimes and GC issues with antag datums / the traitor datum

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -76,7 +76,7 @@
 
 /datum/mind/Destroy()
 	SSticker.minds -= src
-	QDEL_LIST(antag_datums)
+	remove_all_antag_datums()
 	current = null
 	return ..()
 
@@ -1541,14 +1541,20 @@
  */
 /datum/mind/proc/remove_antag_datum(datum_type)
 	var/datum/antagonist/A = has_antag_datum(datum_type)
-	LAZYREMOVE(antag_datums, A)
 	qdel(A)
 
 /**
  * Removes all antag datums from the src mind.
+ *
+ * Use this over doing `QDEL_LIST(antag_datums)`.
  */
-/datum/mind/proc/remove_all_antag_datums() //For the Lazy amongst us.
-	QDEL_LIST(antag_datums)
+/datum/mind/proc/remove_all_antag_datums()
+	// This is not `QDEL_LIST(antag_datums)`because it's possible for the `antag_datums` list to be set to null during deletion of an antag datum.
+	// Then `QDEL_LIST` would runtime because it would be doing `null.Cut()`.
+	for(var/datum/antagonist/A as anything in antag_datums)
+		qdel(A)
+	antag_datums?.Cut()
+	antag_datums = null
 
 /// This proc sets the hijack speed for a mob. If greater than zero, they can hijack. Outputs in seconds.
 /datum/mind/proc/get_hijack_speed()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -44,7 +44,7 @@
 		slaved.leave_serv_hud(owner)
 		owner.som = null
 
-	owner.current.client.chatOutput?.clear_syndicate_codes()
+	owner.current.client?.chatOutput?.clear_syndicate_codes()
 
 	// Try removing their uplink, check PDA
 	var/mob/M = owner.current


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
**Fix 1:** 
`owner.current.client.chatOutput?.clear_syndicate_codes()` was runtiming because it's possible for client to be null if either the user disconnects too quickly or if they're ghosting out of a cryo pod. So I added a null check on client.

**Fix 2:**
Since it's possible for the `antag_datums` list to become null during `/datum/antagonist/Destroy`, I've changed the use of `QDEL_LIST(antag_datums)` over to manually looping through entries and deleting them/cutting the list etc. This was causing runtimes and potential GC issues due to the `L.Cut()`.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Testing
Spawned as a mob, gave myself traitor, vampire and changeling antag datums, then either deleted my mob or ghosted via the cryopod (deletes you as well).
<!-- How did you test the PR, if at all? -->

## Changelog
No player-facing changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
