### PR TITLE
Add untick file check to CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           tools/ci/build_tgui.sh
           tools/ci/check_grep.sh
           python3 tools/ci/check_line_endings.py
+          python3 tools/ci/unticked_files.py ${GITHUB_WORKSPACE}
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
         uses: yogstation13/DreamAnnotate@v2

--- a/tools/ci/unticked_files.py
+++ b/tools/ci/unticked_files.py
@@ -30,6 +30,8 @@ def get_unticked_files(root:Path):
             print(f'Found {len(included)} includes in {root / includer}')
             ticked_files.update([root / Path(includer).parent / i for i in included])
 
+    print(f"Ticked files found: {ticked_files}")
+
     all_dm_files = {f for f in root.glob('**/*.dm')}
     return all_dm_files - ticked_files - {root / f for f in IGNORE_FILES}
 

--- a/tools/ci/unticked_files.py
+++ b/tools/ci/unticked_files.py
@@ -6,7 +6,15 @@
 #
 # Returns 0 if all existing files are considered ticked, 1 otherwise.
 
-from pathlib import Path
+# When running in POSIX environments, the include paths in the codebase need to
+# be munged into PureWindowsPaths before being spit back out. Otherwise, the
+# checker will attempt to find files named e.g. /workspace/code\\foo.dm, which
+# translates to the (completely legitimate) filename "code\foo.dm" in the
+# /workspace directory.
+#
+# For more information, see the discussion of pure paths in the pathlib
+# documentation.
+from pathlib import Path, PureWindowsPath
 import argparse
 import sys
 
@@ -28,9 +36,7 @@ def get_unticked_files(root:Path):
             lines = [line for line in f.readlines() if line.startswith('#include')]
             included = [line.replace('#include ', '').rstrip('\r\n').strip('"') for line in lines]
             print(f'Found {len(included)} includes in {root / includer}')
-            ticked_files.update([root / Path(includer).parent / i for i in included])
-
-    print(f"Ticked files found: {ticked_files}")
+            ticked_files.update([root / Path(includer).parent / Path(PureWindowsPath(i)) for i in included])
 
     all_dm_files = {f for f in root.glob('**/*.dm')}
     return all_dm_files - ticked_files - {root / f for f in IGNORE_FILES}


### PR DESCRIPTION
## What Does This PR Do
Adds the script introduced in #19590 to the CI workflow.

## Why It's Good For The Game
As in previous explanations in previous PRs (#19612, #19588, #19587), unticked files in the repo are bad.

## Testing
CI. I only tested on Windows so we'll see what happens.