### PR TITLE
Ensures update_pipe_vision is called only when you switch pipenets. Fixes lag caused by ventcrawlers

### DIFF
--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -157,6 +157,9 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/returnPipenet()
 	return
 
+/obj/machinery/atmospherics/proc/is_pipenet_split()
+	return FALSE
+
 /obj/machinery/atmospherics/proc/returnPipenetAir()
 	return
 
@@ -317,7 +320,7 @@ Pipelines + Other Objects -> Pipe network
 			user.forceMove(target_move.loc) //handles entering and so on
 			user.visible_message("You hear something squeezing through the ducts.", "You climb out of the ventilation system.")
 		else if(target_move.can_crawl_through())
-			if(returnPipenet(target_move) != target_move.returnPipenet())
+			if(is_pipenet_split()) // Going away from a split means we want to update the view of the pipenet
 				user.update_pipe_vision(target_move)
 			user.forceMove(target_move)
 			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -157,6 +157,10 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/returnPipenet()
 	return
 
+/**
+ * Whether or not this atmos machine has multiple pipenets attached to it
+ * Used to determine if a ventcrawler should update their vision or not
+ */
 /obj/machinery/atmospherics/proc/is_pipenet_split()
 	return FALSE
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/binary_atmos_base.dm
@@ -128,6 +128,9 @@
 	else if(A == node2)
 		return parent2
 
+/obj/machinery/atmospherics/binary/is_pipenet_split()
+	return TRUE
+
 /obj/machinery/atmospherics/binary/replacePipenet(datum/pipeline/Old, datum/pipeline/New)
 	if(Old == parent1)
 		parent1 = New

--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_base.dm
@@ -181,6 +181,9 @@
 	else if(A == node3)
 		return parent3
 
+/obj/machinery/atmospherics/trinary/is_pipenet_split()
+	return FALSE
+
 /obj/machinery/atmospherics/trinary/replacePipenet(datum/pipeline/Old, datum/pipeline/New)
 	if(Old == parent1)
 		parent1 = New

--- a/code/modules/atmospherics/machinery/pipes/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipe.dm
@@ -39,8 +39,6 @@
 	parent = null
 
 /obj/machinery/atmospherics/pipe/returnPipenet(obj/machinery/atmospherics/A)
-	if(A)
-		return // It's called by a moving mob that's already in the pipenet
 	return parent
 
 /obj/machinery/atmospherics/pipe/detailed_examine()

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -19,6 +19,6 @@
 		ranged_ability.add_ranged_ability(src, "<span class='notice'>You currently have <b>[ranged_ability]</b> active!</span>")
 
 	//Should update regardless of if we can ventcrawl, since we can end up in pipes in other ways.
-	update_pipe_vision()
+	update_pipe_vision(loc)
 
 	return .


### PR DESCRIPTION
## What Does This PR Do
Currently, every move a ventcrawler makes will cause a full update on the pipe vision. This is... less than ideal to say the least.
This PR ensures that `update_pipe_vision` is only called by `relay_move` when you actually switch pipenets. The other calls are from `forceMove`. I didn't refactor that part because it wasn't the worst offender.

pipes now always return their parent when `returnPipenet` is called. I've checked the usages, and the only other spot which could have been affected was overridden by the pipe subtype. It hardcoded parent there instead of `returnPipenet`.
![image](https://user-images.githubusercontent.com/15887760/200146391-7f3a7329-5a6d-4ce7-a665-458701ba2c8a.png)
I prefer to not touch too much of the atmos code. So I'll leave that as is now.

Why the new proc?
When you get on a splitting pipe, then you didn't leave the pipenet yet. You only leave the pipenet when you get onto another attached pipe. If you do any checks here then you will have lost your history from which pipenet you came. The splitting pipe is part of all pipenets so it can't tell you which one you just came from. And the new one just knows its own pipenet.
So the new proc will just tell you that you're on a splitting point. If you leave it you will have to update your pipe vision.

## Why It's Good For The Game
In a round with terror spiders, the total CPU used by relaymove was 145.721 out of the 2928 total CPU used. That's a ton for something that shouldn't be this expensive.

## Testing
Spawned as a terror spider. And went through the vents with debug lines in the `relaymove` proc at the pipenet change check. It only was called once, which was when you switched pipes. The switching between pipes also works as intended (same as on master).

Spawned as a mouse and logged out and back in. All guchi there for the most part. Except for the rare case where you log out on a switch pipe (where it switches pipenets), here you won't get your pipevision back till you move. This also happens on the master branch.

Performance test done by starting in the arrivals hallway and going all the way to security departure in Cyberiad. Both for the master branch and the PRs branch.

```
old
Proc Name                              Self CPU    Total CPU    Real Time     Overtime        Calls
/obj/machinery/atmospherics/relaymove  0.003        3.762        3.774        0.000          194
/mob/living/update_pipe_vision         0.019        3.699        3.711        0.000          364
/mob/living/forceMove                  0.002        3.524        3.537        0.000          183
/mob/living/reset_perspective          0.000        3.484        3.497        0.000          183
/mob/living/proc/add_ventcrawl         3.474        3.474        3.487        0.000          363
new
Proc Name                              Self CPU    Total CPU    Real Time     Overtime        Calls
/obj/machinery/atmospherics/relaymove  0.000        0.020        0.020        0.000          186
/mob/living/proc/add_ventcrawl         0.019        0.019        0.019        0.000            1
/atom/movable/proc/forceMove           0.009        0.015        0.017        0.000          366
/mob/living/reset_perspective          0.000        0.003        0.002        0.000          183
/mob/living/update_pipe_vision         0.000        0.000        0.000        0.000          183
```

## Changelog
N/A