### PR TITLE
NTTC now uses rank for formatting if the job title is non-standard

### DIFF
--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -176,6 +176,8 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/sender_name = "Error"
 	/// What job are they
 	var/sender_job = "Error"
+	/// What rank are they (this is used for formatting)
+	var/sender_rank = "Error"
 	/// Pieces of the message
 	var/list/message_pieces = list()
 	/// Source Z-level

--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -299,7 +299,7 @@
 		var/job = tcm.sender_job
 		var/rank = tcm.sender_rank
 		var/realjob = job
-		if (!(job in all_jobs))
+		if(!(job in all_jobs))
 			realjob = rank
 
 		if((realjob in ert_jobs) || (realjob in heads) || (realjob in cc_jobs) || (realjob in tsf_jobs))

--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -40,18 +40,30 @@
 		"Maintenance Technician" = "engradio",
 		"Station Engineer" = "engradio",
 		// Central Command
-		"Emergency Response Team Engineer" = "dsquadradio", // I know this says deathsquad but the class for responseteam is neon green. No.
+		"Custodian" = "dsquadradio", // I know this says deathsquad but the class for responseteam is neon green. No.
+		"Deathsquad Commando" = "dsquadradio",
+		"Emergency Response Team Engineer" = "dsquadradio",
 		"Emergency Response Team Leader" = "dsquadradio",
 		"Emergency Response Team Medic" = "dsquadradio",
 		"Emergency Response Team Member" = "dsquadradio",
 		"Emergency Response Team Officer" = "dsquadradio",
+		"Intel Officer" = "dsquadradio",
+		"Medical Officer" = "dsquadradio",
+		"Nanotrasen Navy Captain" = "dsquadradio",
 		"Nanotrasen Navy Officer" = "dsquadradio",
+		"Nanotrasen Navy Representative" = "dsquadradio",
+		"Research Officer" = "dsquadradio",
 		"Special Operations Officer" = "dsquadradio",
+		"Sol Trader" = "dsquadradio",
 		"Solar Federation General" = "dsquadradio",
+		"Solar Federation Representative" = "dsquadradio",
 		"Solar Federation Specops Lieutenant" = "dsquadradio",
 		"Solar Federation Specops Marine" = "dsquadradio",
 		"Solar Federation Lieutenant" = "dsquadradio",
 		"Solar Federation Marine" = "dsquadradio",
+		"Supreme Commander" = "dsquadradio",
+		"Thunderdome Overseer" = "dsquadradio",
+		"VIP Guest" = "dsquadradio",
 		// Medical
 		"Chemist" = "medradio",
 		"Chief Medical Officer" = "medradio",
@@ -60,6 +72,7 @@
 		"Microbiologist" = "medradio",
 		"Nurse" = "medradio",
 		"Paramedic" = "medradio",
+		"Pathologist" = "medradio",
 		"Pharmacologist" = "medradio",
 		"Pharmacist" = "medradio",
 		"Psychiatrist" = "medradio",
@@ -118,9 +131,9 @@
 	/// List of ERT jobs
 	var/list/ert_jobs = list("Emergency Response Team Officer", "Emergency Response Team Engineer", "Emergency Response Team Medic", "Emergency Response Team Leader", "Emergency Response Team Member")
 	/// List of CentComm jobs
-	var/list/cc_jobs = list("Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Solar Federation General")
+	var/list/cc_jobs = list("Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Intel Officer", "Medical Officer", "Nanotrasen Navy Captain", "Nanotrasen Navy Representative", "Research Officer", "Supreme Commander", "Thunderdome Overseer")
 	/// List of SolGov Marine jobs
-	var/list/tsf_jobs = list("Solar Federation Specops Lieutenant", "Solar Federation Specops Marine", "Solar Federation Lieutenant", "Solar Federation Marine")
+	var/list/tsf_jobs = list("Solar Federation Specops Lieutenant", "Solar Federation Specops Marine", "Solar Federation Lieutenant", "Solar Federation Marine", "Solar Federation Representative", "Solar Federation General", "VIP Guest")
 	// Defined so code compiles and incase someone has a non-standard job
 	var/job_class = "radio"
 	// NOW FOR ACTUAL TOGGLES
@@ -235,7 +248,12 @@
 	// All job and coloring shit
 	if(toggle_job_color || toggle_name_color)
 		var/job = tcm.sender_job
-		job_class = all_jobs[job]
+		var/rank = tcm.sender_rank
+		//if the job title is not custom, just use that to decide the rules of formatting
+		if (job in all_jobs)
+			job_class = all_jobs[job]
+		else
+			job_class = all_jobs[rank]
 
 	if(toggle_name_color)
 		var/new_name = "<span class=\"[job_class]\">[tcm.sender_name]</span>"
@@ -279,7 +297,12 @@
 	// Makes heads of staff bold
 	if(toggle_command_bold)
 		var/job = tcm.sender_job
-		if((job in ert_jobs) || (job in heads) || (job in cc_jobs) || (job in tsf_jobs))
+		var/rank = tcm.sender_rank
+		var/realjob = job
+		if (!(job in all_jobs))
+			realjob = rank
+
+		if((realjob in ert_jobs) || (realjob in heads) || (realjob in cc_jobs) || (realjob in tsf_jobs))
 			for(var/I in 1 to length(message_pieces))
 				var/datum/multilingual_say_piece/S = message_pieces[I]
 				if(!S.message)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -399,27 +399,22 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	// --- Carbon Nonhuman ---
 	else if(iscarbon(M)) // Nonhuman carbon mob
 		jobname = "No id"
-		rankname = "No id"
 
 	// --- AI ---
 	else if(isAI(M))
 		jobname = "AI"
-		rankname = "AI"
 
 	// --- Cyborg ---
 	else if(isrobot(M))
 		jobname = "Cyborg"
-		rankname = "Cyborg"
 
 	// --- Personal AI (pAI) ---
 	else if(ispAI(M))
 		jobname = "Personal AI"
-		rankname = "Personal AI"
 
 	// --- Unidentifiable mob ---
 	else
 		jobname = "Unknown"
-		rankname = "Unknown"
 
 
 	// --- Modifications to the mob's identity ---

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -385,6 +385,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/displayname = M.name	// grab the display name (name you get when you hover over someone's icon)
 	var/voicemask = 0 // the speaker is wearing a voice mask
 	var/jobname // the mob's "job"
+	var/rankname // the formatting to be used for the mob's job
 
 	if(jammed)
 		Gibberish_all(message_pieces, 100)
@@ -393,26 +394,32 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		jobname = H.get_assignment()
+		rankname = H.get_authentification_rank()
 
 	// --- Carbon Nonhuman ---
 	else if(iscarbon(M)) // Nonhuman carbon mob
 		jobname = "No id"
+		rankname = "No id"
 
 	// --- AI ---
 	else if(isAI(M))
 		jobname = "AI"
+		rankname = "AI"
 
 	// --- Cyborg ---
 	else if(isrobot(M))
 		jobname = "Cyborg"
+		rankname = "Cyborg"
 
 	// --- Personal AI (pAI) ---
 	else if(ispAI(M))
 		jobname = "Personal AI"
+		rankname = "Personal AI"
 
 	// --- Unidentifiable mob ---
 	else
 		jobname = "Unknown"
+		rankname = "Unknown"
 
 
 	// --- Modifications to the mob's identity ---
@@ -427,6 +434,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	if(syndiekey && syndiekey.change_voice && connection.frequency == SYND_FREQ)
 		displayname = syndiekey.fake_name
 		jobname = "Unknown"
+		rankname = "Unknown"
 		voicemask = TRUE
 
 	// Copy the message pieces so we can safely edit comms line without affecting the actual line
@@ -438,6 +446,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/datum/tcomms_message/tcm = new
 	tcm.sender_name = displayname
 	tcm.sender_job = jobname
+	tcm.sender_rank = rankname
 	tcm.message_pieces = message_pieces_copy
 	tcm.source_level = position.z
 	tcm.freq = connection.frequency


### PR DESCRIPTION
## What Does This PR Do
Alternate implementation of #19615, using AffectedArc's advice.

NTTC now checks rank as well as job title on the ID in regards to message formatting.
Rank is decided by the preset list of jobs on the HoP's ID computer, whereas using the "Custom" option only changes the Job Title displayed on the ID.

This allows Acting Heads to have the amplified "bold" font, as well as their departmental colors on their name and job title.
This also allows custom job titles to keep their departmental colors as well.

Note that only the job title is ever shown on the telecomm messages, never the rank.
The rank is only ever used for formatting.

## Why It's Good For The Game
Acting Heads are currently shown on the comms as default-green, and are not emboldened when they speak, making them indistinguishable at a quick glance from your normal Assistant chatter.
This is even worse for the "Acting Captain" job, since you forfeit your existing amplification and distinct departmental color by accepting the highest-responsibility job on station, and are instead confined to an unassuming green color and an unamplified voice, making your job of leading the station even harder.

This implementation additionally allows the person assigning the jobs more leeway with the job titles, without having to stick to a specific set of pre-determined job titles at the risk of losing the formatting if you don't; it's completely possible for a HoP to call the acting hos "Acting Head of Security", "Acting HoS", "Acting HOS", "HoS (Acting)" or any other alternate spelling they can think of, so long as the RANK of the ID is "Head of Security", then the Acting HoS will have the red departmental color and the bold voice.

Of note is that the system checks for job title first (like under the old implementation), and only looks for rank in case the job title does not have predefined formatting, this way malicious actors can simply change their job title to "Captain" or any other title using any means they want, and they would still acquire the same amplified font and departmental color as the real job, even if they don't have the rank or access to go with it, allowing them to fool security by impersonating other jobs.
This is the same as the old implementation, and is unchanged by this PR to avoid discouraging deceptive play.

To make sure that the behavior of impersonation is consistent, all CC and TSF jobs listed in access.dm were copied to the list of possible roundstart titles.
Additionally, Pathologist was added to the list of possible roundstart titles, as it is not a custom title and is selectable from the "Join Game" menu. I believe it was an oversight that got it removed from the list in the first place

## Images of changes
![image](https://user-images.githubusercontent.com/32230667/200153480-a929fba7-4ecf-472e-873f-51491b0790ea.png)

## Testing
Activated various telecomm options
Tested with different combinations of Ranks and Titles
Confirmed that Title formatting always overrides Rank formatting
Tested with impersonators
Tested with Agent ID to confirm that it works as intended

## Changelog
:cl:
tweak: Rank is now taken into consideration when formatting telecomm messages for custom job titles.
add: Acting Heads now keep their departmental colors, and even have the bold font of their non-acting counterparts.
add: Custom job titles also keep the formatting of the rank/access chosen on the ID computer.
fix: "Pathologist" is now considered a viable roundstart job title by the telecomms script, corresponding to the rank of "Virologist"
/:cl:
