### PR TITLE
Unequip gib victims earlier in the process.

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -16,6 +16,11 @@
 				thing.forceMove(get_turf(src))
 				thing.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 
+	for(var/obj/item/I in get_equipped_items(include_pockets = TRUE))
+		unEquip(I)
+		I.forceMove(get_turf(src))
+		I.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
+
 	for(var/obj/item/organ/external/E in bodyparts)
 		if(istype(E, /obj/item/organ/external/chest))
 			continue


### PR DESCRIPTION
## What Does This PR Do
This PR unequips human types on gib, tossing their equipment around randomly in the same way that their organs are. This adds to the list of equipment that may possibly survive an explosion, and ensures indestructible items are not wiped out of reality on gib.

This has several consequences and, depending on how you look at it, balance implications.

## Why It's Good For The Game

1. When a human type is gibbed, their internal and external organs are removed, and 'thrown' about in the area of the gib. This process does not consider certain things. The primary issue here is that objects, even indestructible ones, are simply deleted on gib when the human entity itself is deleted. Their damage resistance is completely ignored. This is a problem.

2. Typically, removing a limb will pop off any relevant worn clothing. Lose a foot, your shoes are removed. These items remain after a gib, but are not affected in the same way that organs are. Organs are tossed about in a random direction anywhere from 1 to 3 tiles away. The clothing simply remains on the same tile, like the person was just raptured. Now, these items will be tossed about. It's not a huge thing, but it "feels" better.

As I said, this has all kinds of weird spooky-action-at-a-distance balace implications. Two examples:

- If a nukie manages to cause an explosion that gibs the Captain, the NAD, if in their bag, is "destroyed", and the game, in order to prevent that, moves it to specified spawn markers randomly dotted throughout the station. (That's right, NAD teleports are not totally random. Did I just blow your mind?) Now, if the nukies manage an explosion on the bridge that gibs the Captain, the NAD will be right there.

- PDAs and IDs are in slots that gets them deleted on gib. Now, if characters gib, their IDs, if they don't get caught up in a subsequent explosion, are up for grabs. Or the CE's toolbelt. Or other similar items. Basically, the loot table for explosions strong enough to cause gibbing has been buffed.

I don't know enough about balance/design to think through if these are good things.

## Testing
Lots of explosions. This is an initial writeup and if it's good then I'll have testing videos and such.

Some sample CE explosions showing what might remain on a given gib/explosion blast-radius combination.

![17_26_55__Paradise Station 13-](https://user-images.githubusercontent.com/59303604/200198580-7172b0f1-f8e8-4970-83d8-3a91b1c563d9.png)


## Changelog
:cl:
fix: Gibbed players are unequipped entirely. This increases the chances that their items survive larger explosions, but does not guarantee it.
fix: Indestructible items will no longer be destroyed when in a container worn by a gibbed person, and will properly be affected by explosions.
/:cl: