### PR TITLE
Xenomorphs can now *slap

### DIFF
--- a/code/datums/keybindings/emote.dm
+++ b/code/datums/keybindings/emote.dm
@@ -239,6 +239,10 @@
 	linked_emote = /datum/emote/living/carbon/kiss
 	name = "Kiss" //PG13
 
+/datum/keybinding/emote/carbon/slap
+	linked_emote = /datum/emote/living/carbon/slap
+	name = "Slap"
+
 /datum/keybinding/emote/carbon/wave
 	linked_emote = /datum/emote/living/carbon/wave
 	name = "Wave"
@@ -392,11 +396,6 @@
 /datum/keybinding/emote/carbon/human/sneeze
 	linked_emote = /datum/emote/living/carbon/human/sneeze
 	name = "Sneeze"
-
-/datum/keybinding/emote/carbon/human/slap
-	linked_emote = /datum/emote/living/carbon/human/slap
-	name = "Slap"
-
 /datum/keybinding/emote/carbon/human/wink
 	linked_emote = /datum/emote/living/carbon/human/wink
 	name = "Wink"

--- a/code/game/objects/items/hand_item.dm
+++ b/code/game/objects/items/hand_item.dm
@@ -11,7 +11,7 @@
 	/// How many smaller table smacks we can do before we're out
 	var/table_smacks_left = 3
 
-/obj/item/slapper/attack(mob/M, mob/living/carbon/human/user)
+/obj/item/slapper/attack(mob/M, mob/living/carbon/user)
 	user.do_attack_animation(M)
 	playsound(M, hitsound, 50, TRUE, -1)
 	user.visible_message("<span class='danger'>[user] slaps [M]!</span>", "<span class='notice'>You slap [M]!</span>", "<span class='hear'>You hear a slap.</span>")

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -56,6 +56,6 @@
 							visible_message("<span class='danger'>[M] has attempted to disarm [src]!</span>")
 
 /mob/living/carbon/alien/humanoid/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
-	if(!no_effect && !visual_effect_icon)
+	if(!no_effect && !visual_effect_icon && used_item)
 		visual_effect_icon = ATTACK_EFFECT_CLAW
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -56,6 +56,6 @@
 							visible_message("<span class='danger'>[M] has attempted to disarm [src]!</span>")
 
 /mob/living/carbon/alien/humanoid/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
-	if(!no_effect && !visual_effect_icon && used_item)
+	if(!no_effect && !visual_effect_icon && !get_active_hand())
 		visual_effect_icon = ATTACK_EFFECT_CLAW
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -45,3 +45,13 @@
 				if(l_store)		l_store.attack_alien(src)
 			if(slot_r_store)
 				if(r_store)		r_store.attack_alien(src)
+
+/mob/living/carbon/alien/humanoid/put_in_hands(obj/item/I)
+	if(!I)
+		return FALSE
+	if(put_in_active_hand(I))
+		return TRUE
+	else if(put_in_inactive_hand(I))
+		return TRUE
+	else
+		return FALSE

--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -43,6 +43,23 @@
 				'sound/misc/clap3.ogg',
 				'sound/misc/clap4.ogg')
 
+/datum/emote/living/carbon/slap
+	key = "slap"
+	key_third_person = "slaps"
+	hands_use_check = TRUE
+	cooldown = 3 SECONDS // to prevent endless table slamming
+
+/datum/emote/living/carbon/slap/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/obj/item/slapper/N = new(user)
+	if(user.put_in_hands(N))
+		to_chat(user, "<span class='notice'>You ready your slapping hand.</span>")
+	else
+		qdel(N)
+		to_chat(user, "<span class='warning'>You're incapable of slapping in your current state.</span>")
+
 /datum/emote/living/carbon/cross
 	key = "cross"
 	key_third_person = "crosses"

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -258,23 +258,6 @@
 	else
 		return H.dna.species.male_sneeze_sound
 
-/datum/emote/living/carbon/human/slap
-	key = "slap"
-	key_third_person = "slaps"
-	hands_use_check = TRUE
-	cooldown = 3 SECONDS // to prevent endless table slamming
-
-/datum/emote/living/carbon/human/slap/run_emote(mob/user, params, type_override, intentional)
-	. = ..()
-	if(!.)
-		return FALSE
-	var/obj/item/slapper/N = new(user)
-	if(user.put_in_hands(N))
-		to_chat(user, "<span class='notice'>You ready your slapping hand.</span>")
-	else
-		qdel(N)
-		to_chat(user, "<span class='warning'>You're incapable of slapping in your current state.</span>")
-
 /datum/emote/living/carbon/human/wink
 	key = "wink"
 	key_third_person = "winks"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR moves the *slap emote up to the carbon level, meaning it can now be used by humanoid Xenomorphs. All the functionality of slapping, including table smacking, now works on Xenos.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xenomorphs are intelligent two-armed creatures that already know how to swipe, grab, slash, pry, restrain, and strangle; it only makes sense that they would know how to slap.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Video of a REAL Xenomorph abduction
https://user-images.githubusercontent.com/3611705/200213266-dadb3c2f-be60-41bb-ac49-4b3a5e99ffbe.mp4

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled and tested on local debug server. *slap works as expected for both humans and Xenos. No strange unexpected behavior from Xenos.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Xenomorphs can now use the *slap emote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
