### PR TITLE
Allows drones and mice to go under doors when hidden

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -131,6 +131,7 @@
 #define PASSMOB			16
 #define LETPASSTHROW	32
 #define PASSFENCE		64
+#define PASSDOOR		128
 
 //turf-only flags
 #define NOJAUNT		1

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -739,7 +739,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 			attack_ai(user)
 
 /obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target, height=0)
-	if(ismob(mover) && mover.checkpass(PASSDOOR) && !locked) // We really dont want mice/drones to get shocked on a door they're passing through
+	if(istype(mover) && mover.checkpass(PASSDOOR) && !locked) // We really dont want mice/drones to get shocked on a door they're passing through
 		return TRUE
 	if(isElectrified() && density && isitem(mover))
 		var/obj/item/I = mover

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -739,6 +739,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 			attack_ai(user)
 
 /obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target, height=0)
+	if(ismob(mover) && mover.checkpass(PASSDOOR) && !locked) // We really dont want mice/drones to get shocked on a door they're passing through
+		return TRUE
 	if(isElectrified() && density && isitem(mover))
 		var/obj/item/I = mover
 		if(I.flags & CONDUCT)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -739,8 +739,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 			attack_ai(user)
 
 /obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSDOOR)) // We really dont want mice/drones to get shocked on a door they're passing through
-		return !locked // Disallow if door is bolted
+	if(istype(mover) && mover.checkpass(PASSDOOR) && !locked) // We really dont want mice/drones to get shocked on a door they're passing through
+		return TRUE
 	if(isElectrified() && density && isitem(mover))
 		var/obj/item/I = mover
 		if(I.flags & CONDUCT)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -739,8 +739,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 			attack_ai(user)
 
 /obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSDOOR) && !locked) // We really dont want mice/drones to get shocked on a door they're passing through
-		return TRUE
+	if(istype(mover) && mover.checkpass(PASSDOOR)) // We really dont want mice/drones to get shocked on a door they're passing through
+		return !locked // Disallow if door is bolted
 	if(isElectrified() && density && isitem(mover))
 		var/obj/item/I = mover
 		if(I.flags & CONDUCT)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -144,8 +144,11 @@
 			bound_height = width * world.icon_size
 
 /obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return !opacity
+	if(istype(mover))
+		if(mover.checkpass(PASSDOOR) && !locked)
+			return TRUE
+		if(mover.checkpass(PASSGLASS))
+			return !opacity
 	return !density
 
 /obj/machinery/door/CanAtmosPass()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -145,8 +145,8 @@
 
 /obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover))
-		if(mover.checkpass(PASSDOOR))
-			return !locked // Disallow if door is bolted
+		if(mover.checkpass(PASSDOOR) && !locked)
+			return TRUE
 		if(mover.checkpass(PASSGLASS))
 			return !opacity
 	return !density

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -145,8 +145,8 @@
 
 /obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover))
-		if(mover.checkpass(PASSDOOR) && !locked)
-			return TRUE
+		if(mover.checkpass(PASSDOOR))
+			return !locked // Disallow if door is bolted
 		if(mover.checkpass(PASSGLASS))
 			return !opacity
 	return !density

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -29,9 +29,11 @@
 	if(layer != TURF_LAYER+0.2)
 		layer = TURF_LAYER+0.2
 		to_chat(src, text("<span class='notice'>You are now hiding.</span>"))
+		pass_flags |= PASSDOOR
 	else
 		layer = MOB_LAYER
 		to_chat(src, text("<span class='notice'>You have stopped hiding.</span>"))
+		pass_flags &= ~PASSDOOR
 
 /mob/living/silicon/robot/drone/verb/light()
 	set name = "Light On/Off"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -32,6 +32,7 @@
 	maxbodytemp = 323	//Above 50 Degrees Celcius
 	universal_speak = FALSE
 	can_hide = TRUE
+	pass_door_while_hidden = TRUE
 	holder_type = /obj/item/holder/mouse
 	can_collar = TRUE
 	gold_core_spawnable = FRIENDLY_SPAWN

--- a/code/modules/mob/living/simple_animal/powers.dm
+++ b/code/modules/mob/living/simple_animal/powers.dm
@@ -9,6 +9,10 @@
 	if(layer != TURF_LAYER+0.2)
 		layer = TURF_LAYER+0.2
 		visible_message("<B>[src] scurries to the ground!</B>", "<span class=notice'>You are now hiding.</span>")
+		if(pass_door_while_hidden)
+			pass_flags |= PASSDOOR
 	else
 		layer = MOB_LAYER
 		visible_message("[src] slowly peeks up from the ground...", "<span class=notice'>You have stopped hiding.</span>")
+		if(pass_door_while_hidden)
+			pass_flags &= ~PASSDOOR

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -69,6 +69,8 @@
 
 	var/speed = 1 //LETS SEE IF I CAN SET SPEEDS FOR SIMPLE MOBS WITHOUT DESTROYING EVERYTHING. Higher speed is slower, negative speed is faster
 	var/can_hide = FALSE
+	/// Allows a mob to pass unbolted doors while hidden
+	var/pass_door_while_hidden = FALSE
 
 	var/obj/item/clothing/accessory/petcollar/pcollar = null
 	var/collar_type //if the mob has collar sprites, define them.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Allows drones and mice to pass doors when hidden, using a new PASS DOOR flag. It does not allow them to pass doors when they are bolted. They have to use their hide verb first, which is to stop them from appearing on top of the door. Design port of yogstation13/Yogstation/pull/2209 and partial port of yogstation13/Yogstation/pull/7838

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Allows drones easier time to follow their laws, without having to worry about letting someone into a room. It also allows mice to get to more places, hopefully allowing for more fun for mouse players but also so there is less "BLOB TURBINE".

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_XqipbFdLx2](https://user-images.githubusercontent.com/91113370/200382963-a7b2c866-98a2-45e4-9ae0-183024f06b18.gif)


## Testing
<!-- How did you test the PR, if at all? -->
Yep, mice and drones can pass under doors when hidden, but not when the doors are bolted.

## Changelog
:cl:
add: Mice and drones can now crawl under unbolted doors when hidden.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
