### PR TITLE
Buff sleeping carp keelhaul stamina damage

### DIFF
--- a/code/modules/martial_arts/combos/sleeping_carp/keelhaul.dm
+++ b/code/modules/martial_arts/combos/sleeping_carp/keelhaul.dm
@@ -17,6 +17,6 @@
 		target.drop_r_hand()
 		target.visible_message("<span class='warning'>[user] kicks [target] in the head, leaving them reeling in pain!</span>",
 							"<span class='userdanger'>You are kicked in the head by [user], and you reel in pain!</span>")
-	target.apply_damage(40, STAMINA)
+	target.apply_damage(50, STAMINA)
 	add_attack_logs(user, target, "Melee attacked with martial-art [MA] : Keelhaul", ATKLOG_ALL)
 	return MARTIAL_COMBO_DONE

--- a/code/modules/martial_arts/combos/sleeping_carp/keelhaul.dm
+++ b/code/modules/martial_arts/combos/sleeping_carp/keelhaul.dm
@@ -17,6 +17,6 @@
 		target.drop_r_hand()
 		target.visible_message("<span class='warning'>[user] kicks [target] in the head, leaving them reeling in pain!</span>",
 							"<span class='userdanger'>You are kicked in the head by [user], and you reel in pain!</span>")
-	target.apply_damage(50, STAMINA)
+	target.apply_damage(60, STAMINA)
 	add_attack_logs(user, target, "Melee attacked with martial-art [MA] : Keelhaul", ATKLOG_ALL)
 	return MARTIAL_COMBO_DONE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Increases the stamina damage of keelhaul from 40 to 60. This makes keelhaul stamcrit in 2 combos (4 hits), from 3 (6 hits).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
A carp user's only method of debiliating their opponent outside of already having a baton at hand is to perform three successive keelhauls. The fact that this takes six consecutive hits makes it vastly inferior to just using a baton instead. With crawling, this also means that you can be batonned at any point during this process by a user who can put their baton away in between each keelhaul (since it drops items in hand when performed on a horizontal target). 

This change doesn't majorly increase the viability of the 13tc martial art, but it does improve one of its weakest tools in the face of the suicidal nature of engaging in melee with baton-armed security.

## Testing
<!-- How did you test the PR, if at all? -->
Skrell successfully stamcritted slightly faster than before.

## Changelog
:cl:
tweak: Increased sleeping carp's keelhaul stamina damage from 40 to 60.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
