### PR TITLE
Recategorize in-game announcements by priority.

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -26,7 +26,7 @@ SUBSYSTEM_DEF(nightshift)
 	check_nightshift()
 
 /datum/controller/subsystem/nightshift/proc/announce(message)
-	GLOB.major_announcement.Announce(message, new_sound = 'sound/misc/notice2.ogg', new_title = "Automated Lighting System Announcement")
+	GLOB.minor_announcement.Announce(message, new_sound = 'sound/misc/notice2.ogg', new_title = "Automated Lighting System Announcement")
 
 /datum/controller/subsystem/nightshift/proc/check_nightshift(check_canfire=FALSE)
 	if(check_canfire && !can_fire)

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -60,7 +60,7 @@
 /datum/weather/rad_storm/end()
 	if(..())
 		return
-	GLOB.major_announcement.Announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
+	GLOB.minor_announcement.Announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
 	status_alarm(FALSE)
 	if(!pre_maint_all_access)
 		revoke_maint_all_access()

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -66,6 +66,6 @@
 /datum/weather/solar_flare/end()
 	if(..())
 		return
-	GLOB.event_announcement.Announce("The solar flare has passed.", "Solar Flare Advisory")
+	GLOB.minor_announcement.Announce("The solar flare has passed.", "Solar Flare Advisory")
 	// Ends the temporary 40x increase that happened during the weather event
 	SSsun.solar_gen_rate = initial(SSsun.solar_gen_rate)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -1,6 +1,5 @@
 GLOBAL_DATUM_INIT(minor_announcement, /datum/announcer, new(config_type = /datum/announcement_configuration/minor))
 GLOBAL_DATUM_INIT(major_announcement, /datum/announcer, new(config_type = /datum/announcement_configuration/major))
-GLOBAL_DATUM_INIT(event_announcement, /datum/announcer, new(config_type = /datum/announcement_configuration/event))
 
 /datum/announcement_configuration
 	var/default_title = "Attention"
@@ -160,9 +159,11 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcer, new(config_type = /datum
 	add_log = TRUE
 	log_name = ANNOUNCE_KIND_PRIORITY
 	sound = sound('sound/misc/notice2.ogg')
+	style = "major"
 
 /datum/announcement_configuration/ai
 	default_title = ANNOUNCE_KIND_AI
 	add_log = TRUE
 	log_name = ANNOUNCE_KIND_AI
 	sound = sound('sound/misc/notice2.ogg')
+	style = "major"

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 /datum/game_mode/blob/proc/stage(stage)
 	switch(stage)
 		if(1)
-			GLOB.event_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
+			GLOB.major_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 		if(2)
 			send_intercept(1)
 

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -32,7 +32,7 @@
 					log_admin("The station AI has received a new law zero due to a blob round continuing for over 50 minutes after initial burst. Zero Law: [law]")
 
 	print_command_report(intercepttext, interceptname, FALSE)
-	GLOB.event_announcement.Announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg', new_subtitle = "NAS Trurl Update")
+	GLOB.minor_announcement.Announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg', new_subtitle = "NAS Trurl Update")
 
 /datum/station_state
 	var/floor = 0

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -244,7 +244,7 @@
 
 /datum/action/innate/ai/nuke_station/proc/set_us_up_the_bomb()
 	to_chat(owner_AI, "<span class='notice'>Nuclear device armed.</span>")
-	GLOB.event_announcement.Announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", 'sound/AI/aimalf.ogg')
+	GLOB.major_announcement.Announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", 'sound/AI/aimalf.ogg')
 	set_security_level("delta")
 	owner_AI.nuking = TRUE
 	var/obj/machinery/doomsday_device/DOOM = new /obj/machinery/doomsday_device(owner_AI)
@@ -291,7 +291,7 @@
 /obj/machinery/doomsday_device/process()
 	var/turf/T = get_turf(src)
 	if(!T || !is_station_level(T.z))
-		GLOB.minor_announcement.Announce("DOOMSDAY DEVICE OUT OF STATION RANGE, ABORTING", "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 'sound/misc/notice1.ogg')
+		GLOB.major_announcement.Announce("DOOMSDAY DEVICE OUT OF STATION RANGE, ABORTING", "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 'sound/misc/notice1.ogg')
 		SSshuttle.emergencyNoEscape = 0
 		if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 			SSshuttle.emergency.mode = SHUTTLE_DOCKED
@@ -309,7 +309,7 @@
 	else
 		if(!(sec_left % 60) && !announced)
 			var/message = "[sec_left] SECONDS UNTIL DOOMSDAY DEVICE ACTIVATION!"
-			GLOB.minor_announcement.Announce(message, "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 'sound/misc/notice1.ogg')
+			GLOB.major_announcement.Announce(message, "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 'sound/misc/notice1.ogg')
 			announced = 10
 		announced = max(0, announced-1)
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -48,7 +48,7 @@
 	if(!check_allowed(user) || !war_declaration)
 		return
 
-	GLOB.event_announcement.Announce(war_declaration, "Declaration of War", 'sound/effects/siren.ogg', msg_sanitized = TRUE)
+	GLOB.major_announcement.Announce(war_declaration, "Declaration of War", 'sound/effects/siren.ogg', msg_sanitized = TRUE)
 
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 	to_chat(user, "<b>Your bonus telecrystals have been split between your team's uplinks.</b>")

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -75,7 +75,7 @@
 	switch(rand(1, 5000))
 		if(1)
 			atom_say("JACKPOT! [userName] has won two thousand credits!")
-			GLOB.event_announcement.Announce("Congratulations to [userName] on winning the Jackpot of TWO THOUSAND CREDITS!", "Jackpot Winner")
+			GLOB.minor_announcement.Announce("Congratulations to [userName] on winning the Jackpot of TWO THOUSAND CREDITS!", "Jackpot Winner")
 			result = "JACKPOT! You win two thousand credits!"
 			resultlvl = "teal"
 			win_money(2000, 'sound/goonstation/misc/airraid_loop.ogg')

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -231,7 +231,7 @@
 			var/turf/turf_to = get_turf(chosen) // the turf of origin we're travelling TO
 
 			playsound(turf_to, 'sound/effects/phasein.ogg', 100, TRUE)
-			GLOB.event_announcement.Announce("Massive bluespace translocation detected.", "Anomaly Alert")
+			GLOB.minor_announcement.Announce("Massive bluespace translocation detected.", "Anomaly Alert")
 
 			var/list/flashers = list()
 			for(var/mob/living/carbon/C in viewers(turf_to, null))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -824,13 +824,13 @@ GLOBAL_VAR_INIT(gamma_ship_location, 1) // 0 = station , 1 = space
 		toArea = locate(/area/shuttle/gamma/station)
 		for(var/obj/machinery/door/airlock/hatch/gamma/H in GLOB.airlocks)
 			H.unlock(TRUE)
-		GLOB.event_announcement.Announce("Central Command has deployed the Gamma Armory shuttle.", new_sound = 'sound/AI/commandreport.ogg')
+		GLOB.major_announcement.Announce("Central Command has deployed the Gamma Armory shuttle.", new_sound = 'sound/AI/commandreport.ogg')
 	else
 		fromArea = locate(/area/shuttle/gamma/station)
 		toArea = locate(/area/shuttle/gamma/space)
 		for(var/obj/machinery/door/airlock/hatch/gamma/H in GLOB.airlocks)
 			H.lock(TRUE)
-		GLOB.event_announcement.Announce("Central Command has recalled the Gamma Armory shuttle.", new_sound = 'sound/AI/commandreport.ogg')
+		GLOB.major_announcement.Announce("Central Command has recalled the Gamma Armory shuttle.", new_sound = 'sound/AI/commandreport.ogg')
 	fromArea.move_contents_to(toArea)
 
 	for(var/obj/machinery/mech_bay_recharge_port/P in toArea)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2274,7 +2274,7 @@
 			log_admin("[owner] denied [key_name(H)]'s ERT request with the message [reason]. Announced to [announce_to_crew ? "the entire crew." : "only the sender"].")
 
 			if(announce_to_crew)
-				GLOB.event_announcement.Announce("[station_name()], we are unfortunately unable to send you an Emergency Response Team at this time. Your ERT request has been denied for the following reasons:\n[reason]", "ERT Unavailable")
+				GLOB.major_announcement.Announce("[station_name()], we are unfortunately unable to send you an Emergency Response Team at this time. Your ERT request has been denied for the following reasons:\n[reason]", "ERT Unavailable")
 				return
 
 			if(H.stat != CONSCIOUS)
@@ -2786,11 +2786,11 @@
 				if(GLOB.gravity_is_on)
 					log_admin("[key_name(usr)] toggled gravity on.", 1)
 					message_admins("<span class='notice'>[key_name_admin(usr)] toggled gravity on.</span>", 1)
-					GLOB.event_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.")
+					GLOB.minor_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.")
 				else
 					log_admin("[key_name(usr)] toggled gravity off.", 1)
 					message_admins("<span class='notice'>[key_name_admin(usr)] toggled gravity off.</span>", 1)
-					GLOB.event_announcement.Announce("Feedback surge detected in mass-distributions systems. Artifical gravity has been disabled whilst the system reinitializes. Further failures may result in a gravitational collapse and formation of blackholes. Have a nice day.")
+					GLOB.minor_announcement.Announce("Feedback surge detected in mass-distributions systems. Artifical gravity has been disabled whilst the system reinitializes. Further failures may result in a gravitational collapse and formation of blackholes. Have a nice day.")
 
 			if("power")
 				switch(alert("What Would You Like to Do?", "Make All Areas Powered", "Power all APCs", "Repair all APCs", "Repair and Power APCs")) //Alert notification in this code for standarization purposes
@@ -2992,7 +2992,7 @@
 					if(is_station_level(W.z) && !istype(get_area(W), /area/bridge) && !istype(get_area(W), /area/crew_quarters) && !istype(get_area(W), /area/security/prison))
 						W.req_access = list()
 				message_admins("[key_name_admin(usr)] activated Egalitarian Station mode")
-				GLOB.event_announcement.Announce("Centcomm airlock control override activated. Please take this time to get acquainted with your coworkers.", new_sound = 'sound/AI/commandreport.ogg')
+				GLOB.minor_announcement.Announce("Centcomm airlock control override activated. Please take this time to get acquainted with your coworkers.", new_sound = 'sound/AI/commandreport.ogg')
 			if("onlyone")
 				SSblackbox.record_feedback("tally", "admin_secrets_fun_used", 1, "Only One")
 				usr.client.only_one()

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -23,7 +23,7 @@
 		CRASH("Anomaly: Unable to find a valid turf to spawn the anomaly. Last area tried: [impact_area] - [impact_area.type]")
 
 /datum/event/anomaly/announce()
-	GLOB.event_announcement.Announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_flux.ogg')
+	GLOB.minor_announcement.Announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_flux.ogg')
 
 /datum/event/anomaly/start()
 	var/newAnomaly = new anomaly_path(target_turf)

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -5,4 +5,4 @@
 	anomaly_path = /obj/effect/anomaly/bluespace
 
 /datum/event/anomaly/anomaly_bluespace/announce()
-	GLOB.event_announcement.Announce("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_bluespace.ogg')
+	GLOB.minor_announcement.Announce("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_bluespace.ogg')

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -5,4 +5,4 @@
 	anomaly_path = /obj/effect/anomaly/flux
 
 /datum/event/anomaly/anomaly_flux/announce()
-	GLOB.event_announcement.Announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_flux.ogg')
+	GLOB.minor_announcement.Announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_flux.ogg')

--- a/code/modules/events/anomaly_grav.dm
+++ b/code/modules/events/anomaly_grav.dm
@@ -5,4 +5,4 @@
 	anomaly_path = /obj/effect/anomaly/grav
 
 /datum/event/anomaly/anomaly_grav/announce()
-	GLOB.event_announcement.Announce("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_gravity.ogg')
+	GLOB.minor_announcement.Announce("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_gravity.ogg')

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -5,4 +5,4 @@
 	anomaly_path = /obj/effect/anomaly/pyro
 
 /datum/event/anomaly/anomaly_pyro/announce()
-	GLOB.event_announcement.Announce("Atmospheric anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_pyro.ogg')
+	GLOB.minor_announcement.Announce("Atmospheric anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly_pyro.ogg')

--- a/code/modules/events/anomaly_vortex.dm
+++ b/code/modules/events/anomaly_vortex.dm
@@ -5,4 +5,4 @@
 	anomaly_path = /obj/effect/anomaly/bhole
 
 /datum/event/anomaly/anomaly_vortex/announce()
-	GLOB.event_announcement.Announce("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert", 'sound/AI/anomaly_vortex.ogg')
+	GLOB.minor_announcement.Announce("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert", 'sound/AI/anomaly_vortex.ogg')

--- a/code/modules/events/apc_overload.dm
+++ b/code/modules/events/apc_overload.dm
@@ -21,7 +21,7 @@
 		SEND_SOUND(M, S)
 
 /datum/event/apc_overload/announce()
-	GLOB.event_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please check all underfloor APC terminals.", "Critical Power Failure", 'sound/AI/power_overload.ogg')
+	GLOB.minor_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please check all underfloor APC terminals.", "Critical Power Failure", 'sound/AI/power_overload.ogg')
 
 /datum/event/apc_overload/end()
 	return TRUE
@@ -33,7 +33,7 @@
 		/area/turret_protected/ai)
 
 	if(announce)
-		GLOB.event_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please check all underfloor APC terminals.", "Critical Power Failure", 'sound/AI/power_overload.ogg')
+		GLOB.minor_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please check all underfloor APC terminals.", "Critical Power Failure", 'sound/AI/power_overload.ogg')
 
 	// break APC_BREAK_PROBABILITY% of all of the APCs on the station
 	var/affected_apc_count = 0

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -20,7 +20,7 @@
 		SEND_SOUND(M, S)
 
 /datum/event/apc_short/announce()
-	GLOB.event_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please repair shorted APCs.", "Systems Power Failure", 'sound/AI/power_overload.ogg')
+	GLOB.minor_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please repair shorted APCs.", "Systems Power Failure", 'sound/AI/power_overload.ogg')
 
 /datum/event/apc_short/end()
 	return TRUE
@@ -30,7 +30,7 @@
 		/area/engine/engineering,
 		/area/engine/supermatter,
 		/area/turret_protected/ai)
-	GLOB.event_announcement.Announce("Power failure detected in [station_name()]'s powernet. All APCs have lost power. Gravity systems likely to fail.", "Systems Power Failure", 'sound/AI/attention.ogg')
+	GLOB.minor_announcement.Announce("Power failure detected in [station_name()]'s powernet. All APCs have lost power. Gravity systems likely to fail.", "Systems Power Failure", 'sound/AI/attention.ogg')
 	for(var/thing in GLOB.apcs)
 		var/obj/machinery/power/apc/A = thing
 		var/area/current_area = get_area(A)
@@ -49,7 +49,7 @@
 		/area/engine/supermatter,
 		/area/turret_protected/ai)
 	if(announce)
-		GLOB.event_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please repair shorted APCs.", "Systems Power Failure", 'sound/AI/power_overload.ogg')
+		GLOB.minor_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please repair shorted APCs.", "Systems Power Failure", 'sound/AI/power_overload.ogg')
 	// break APC_BREAK_PROBABILITY% of all of the APCs on the station
 	var/affected_apc_count = 0
 	for(var/thing in GLOB.apcs)
@@ -76,7 +76,7 @@
 /proc/power_restore(announce = TRUE, power_type)
 	if(power_type == 0)	//Power without Repairing
 		if(announce)
-			GLOB.event_announcement.Announce("All operational APCs on \the [station_name()] have been fully charged.", "Power Systems Nominal", 'sound/AI/power_restore.ogg')
+			GLOB.minor_announcement.Announce("All operational APCs on \the [station_name()] have been fully charged.", "Power Systems Nominal", 'sound/AI/power_restore.ogg')
 		var/affected_apc_count = 0
 		for(var/thing in GLOB.apcs)
 			var/obj/machinery/power/apc/A = thing
@@ -90,7 +90,7 @@
 		log_and_message_admins("Power has been restored to [affected_apc_count] APCs.")
 	if(power_type == 1)	//Repair without charging
 		if(announce)
-			GLOB.event_announcement.Announce("All APCs on \the [station_name()] have been repaired.", "Power Systems Nominal", 'sound/AI/power_restore.ogg')
+			GLOB.minor_announcement.Announce("All APCs on \the [station_name()] have been repaired.", "Power Systems Nominal", 'sound/AI/power_restore.ogg')
 		for(var/thing in GLOB.apcs)
 			var/obj/machinery/power/apc/A = thing
 			var/area/current_area = get_area(A)
@@ -101,7 +101,7 @@
 		log_and_message_admins("Power has been restored to all APCs.")
 	if(power_type == 2)	//Repair and Power APCs
 		if(announce)
-			GLOB.event_announcement.Announce("All APCs on \the [station_name()] have been repaired and recharged. We apologize for the inconvenience.", "Power Systems Optimal", 'sound/AI/power_restore.ogg')
+			GLOB.minor_announcement.Announce("All APCs on \the [station_name()] have been repaired and recharged. We apologize for the inconvenience.", "Power Systems Optimal", 'sound/AI/power_restore.ogg')
 		// repair the APCs and recharge them
 		for(var/thing in GLOB.apcs)
 			var/obj/machinery/power/apc/A = thing
@@ -115,7 +115,7 @@
 
 /proc/power_restore_quick(announce = TRUE)
 	if(announce)
-		GLOB.event_announcement.Announce("All SMESs on \the [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal", 'sound/AI/power_restore.ogg')
+		GLOB.minor_announcement.Announce("All SMESs on \the [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal", 'sound/AI/power_restore.ogg')
 	// fix all of the SMESs
 	for(var/obj/machinery/power/smes/S in GLOB.machines)
 		if(!is_station_level(S.z))

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -5,7 +5,7 @@
 
 /datum/event/blob/announce()
 	if(successSpawn)
-		GLOB.event_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
+		GLOB.major_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 	else
 		log_and_message_admins("Warning: Could not spawn any mobs for event Blob")
 

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -14,7 +14,7 @@
 									 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either.")
 
 /datum/event/brand_intelligence/announce()
-	GLOB.event_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by. The origin is believed to be \a [originMachine.name].", "Machine Learning Alert", 'sound/AI/brand_intelligence.ogg')
+	GLOB.minor_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by. The origin is believed to be \a [originMachine.name].", "Machine Learning Alert", 'sound/AI/brand_intelligence.ogg')
 
 /datum/event/brand_intelligence/start()
 	for(var/obj/machinery/economy/vending/V in GLOB.machines)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -16,7 +16,7 @@
 		announcement = "Massive migration of unknown biological entities has been detected near [station_name()], please stand-by."
 	else
 		announcement = "Unknown biological entities have been detected near [station_name()], please stand-by."
-	GLOB.event_announcement.Announce(announcement, "Lifesign Alert")
+	GLOB.minor_announcement.Announce(announcement, "Lifesign Alert")
 
 /datum/event/carp_migration/start()
 

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -12,7 +12,7 @@
 		to_chat(A, "<br>")
 
 	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
-		GLOB.event_announcement.Announce(alert)
+		GLOB.minor_announcement.Announce(alert)
 
 /datum/event/communications_blackout/start()
 	// This only affects the cores, relays should be unaffected imo

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -3,7 +3,7 @@
 	var/lightsoutRange	= 25
 
 /datum/event/electrical_storm/announce()
-	GLOB.event_announcement.Announce("An electrical storm has been detected in your area, please repair potential electronic overloads.", "Electrical Storm Alert", 'sound/AI/elec_storm.ogg')
+	GLOB.minor_announcement.Announce("An electrical storm has been detected in your area, please repair potential electronic overloads.", "Electrical Storm Alert", 'sound/AI/elec_storm.ogg')
 
 /datum/event/electrical_storm/start()
 	var/list/epicentreList = list()

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -11,7 +11,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	announceWhen = 5
 
 /datum/event/immovable_rod/announce()
-	GLOB.event_announcement.Announce("What the fuck was that?!", "General Alert")
+	GLOB.minor_announcement.Announce("What the fuck was that?!", "General Alert")
 
 /datum/event/immovable_rod/start()
 	var/startside = pick(GLOB.cardinal)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -94,7 +94,7 @@
 
 
 /datum/event/infestation/announce()
-	GLOB.event_announcement.Announce("Bioscans indicate that [vermstring] have been breeding in [locstring]. Clear them out, before this starts to affect productivity.", "Lifesign Alert")
+	GLOB.minor_announcement.Announce("Bioscans indicate that [vermstring] have been breeding in [locstring]. Clear them out, before this starts to affect productivity.", "Lifesign Alert")
 
 #undef LOC_KITCHEN
 #undef LOC_ATMOS

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -18,7 +18,7 @@
 
 /datum/event/ion_storm/announce()
 	if(announceEvent == ION_ANNOUNCE || (announceEvent == ION_RANDOM && prob(ionAnnounceChance)))
-		GLOB.event_announcement.Announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", 'sound/AI/ions.ogg')
+		GLOB.minor_announcement.Announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", 'sound/AI/ions.ogg')
 
 /datum/event/ion_storm/start()
 	//AI laws

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -15,4 +15,4 @@
 		H.AdjustHallucinate(rand(50, 100))
 
 /datum/event/mass_hallucination/announce()
-	GLOB.event_announcement.Announce("The [station_name()] is passing through a minor radiation field. Be advised that acute exposure to space radiation can induce hallucinogenic episodes.")
+	GLOB.minor_announcement.Announce("The [station_name()] is passing through a minor radiation field. Be advised that acute exposure to space radiation can induce hallucinogenic episodes.")

--- a/code/modules/events/meaty_gore.dm
+++ b/code/modules/events/meaty_gore.dm
@@ -1,5 +1,5 @@
 /datum/event/meteor_wave/gore/announce()
-		GLOB.event_announcement.Announce("Unknown biological debris have been detected near [station_name()], please stand-by.", "Debris Alert")
+		GLOB.minor_announcement.Announce("Unknown biological debris have been detected near [station_name()], please stand-by.", "Debris Alert")
 
 /datum/event/meteor_wave/gore/setup()
 	waves = 3
@@ -11,4 +11,4 @@
 	return GLOB.meteors_gore
 
 /datum/event/meteor_wave/gore/end()
-	GLOB.event_announcement.Announce("The station has cleared the debris.", "Debris Alert")
+	GLOB.minor_announcement.Announce("The station has cleared the debris.", "Debris Alert")

--- a/code/modules/events/meaty_ops.dm
+++ b/code/modules/events/meaty_ops.dm
@@ -1,6 +1,6 @@
 /datum/event/meteor_wave/goreop/announce()
 	var/meteor_declaration = "MeteorOps have declared their intent to utterly destroy [station_name()] with their own bodies, and dares the crew to try and stop them."
-	GLOB.event_announcement.Announce(meteor_declaration, "Declaration of 'War'", 'sound/effects/siren.ogg')
+	GLOB.major_announcement.Announce(meteor_declaration, "Declaration of 'War'", 'sound/effects/siren.ogg')
 
 /datum/event/meteor_wave/goreop/setup()
 	waves = 3
@@ -12,4 +12,4 @@
 	return GLOB.meteors_ops
 
 /datum/event/meteor_wave/goreop/end()
-	GLOB.event_announcement.Announce("All MeteorOps are dead. Major Station Victory.", "MeteorOps")
+	GLOB.minor_announcement.Announce("All MeteorOps are dead. Major Station Victory.", "MeteorOps")

--- a/code/modules/events/meaty_ores.dm
+++ b/code/modules/events/meaty_ores.dm
@@ -1,8 +1,8 @@
 /datum/event/dust/meaty/announce()
 	if(prob(16))
-		GLOB.event_announcement.Announce("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
+		GLOB.minor_announcement.Announce("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
 	else
-		GLOB.event_announcement.Announce("Meaty ores have been detected on collision course with the station.", "Meaty Ore Alert", new_sound = 'sound/AI/meteors.ogg')
+		GLOB.minor_announcement.Announce("Meaty ores have been detected on collision course with the station.", "Meaty Ore Alert", new_sound = 'sound/AI/meteors.ogg')
 
 /datum/event/dust/meaty/setup()
 	qnty = rand(45,125)

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -10,9 +10,9 @@
 /datum/event/meteor_wave/announce()
 	switch(severity)
 		if(EVENT_LEVEL_MAJOR)
-			GLOB.event_announcement.Announce("Meteors have been detected on collision course with the station.", "Meteor Alert", new_sound = 'sound/AI/meteors.ogg')
+			GLOB.minor_announcement.Announce("Meteors have been detected on collision course with the station.", "Meteor Alert", new_sound = 'sound/AI/meteors.ogg')
 		else
-			GLOB.event_announcement.Announce("The station is now in a meteor shower.", "Meteor Alert")
+			GLOB.minor_announcement.Announce("The station is now in a meteor shower.", "Meteor Alert")
 
 //meteor showers are lighter and more common,
 /datum/event/meteor_wave/tick()
@@ -25,9 +25,9 @@
 /datum/event/meteor_wave/end()
 	switch(severity)
 		if(EVENT_LEVEL_MAJOR)
-			GLOB.event_announcement.Announce("The station has cleared the meteor storm.", "Meteor Alert")
+			GLOB.minor_announcement.Announce("The station has cleared the meteor storm.", "Meteor Alert")
 		else
-			GLOB.event_announcement.Announce("The station has cleared the meteor shower", "Meteor Alert")
+			GLOB.minor_announcement.Announce("The station has cleared the meteor shower", "Meteor Alert")
 
 /datum/event/meteor_wave/proc/get_meteors()
 	switch(severity)

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -37,7 +37,7 @@
 
 /datum/event/prison_break/announce()
 	if(areas && areas.len > 0)
-		GLOB.event_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] [(eventDept == "Security")? "imprisonment":"containment"] subroutines. Secure any compromised areas immediately. Station AI involvement is recommended.", "[eventDept] Alert")
+		GLOB.minor_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] [(eventDept == "Security")? "imprisonment":"containment"] subroutines. Secure any compromised areas immediately. Station AI involvement is recommended.", "[eventDept] Alert")
 
 /datum/event/prison_break/start()
 	for(var/area/A in world)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -4,7 +4,7 @@
 	announceWhen = 1
 
 /datum/event/radiation_storm/announce()
-	GLOB.major_announcement.Announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", 'sound/AI/radiation.ogg')
+	GLOB.minor_announcement.Announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", 'sound/AI/radiation.ogg')
 	//sound not longer matches the text, but an audible warning is probably good
 
 /datum/event/radiation_storm/start()

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -21,7 +21,7 @@
 		msg = "Contact has been lost with a combat drone wing operating out of the NSV Icarus. If any are sighted in the area, approach with caution."
 	else
 		msg = "Unidentified hackers have targeted a combat drone wing deployed from the NSV Icarus. If any are sighted in the area, approach with caution."
-	GLOB.event_announcement.Announce(msg, "Rogue drone alert")
+	GLOB.minor_announcement.Announce(msg, "Rogue drone alert")
 
 /datum/event/rogue_drone/tick()
 	return
@@ -34,6 +34,6 @@
 		num_recovered++
 
 	if(num_recovered > drones_list.len * 0.75)
-		GLOB.event_announcement.Announce("Icarus drone control reports the malfunctioning wing has been recovered safely.", "Rogue drone alert")
+		GLOB.minor_announcement.Announce("Icarus drone control reports the malfunctioning wing has been recovered safely.", "Rogue drone alert")
 	else
-		GLOB.event_announcement.Announce("Icarus drone control registers disappointment at the loss of the drones, but the survivors have been recovered.", "Rogue drone alert")
+		GLOB.minor_announcement.Announce("Icarus drone control registers disappointment at the loss of the drones, but the survivors have been recovered.", "Rogue drone alert")

--- a/code/modules/events/solarflare.dm
+++ b/code/modules/events/solarflare.dm
@@ -4,7 +4,7 @@
 	announceWhen = 1
 
 /datum/event/solar_flare/announce()
-	GLOB.event_announcement.Announce("A solar flare has been detected on collision course with the station. Do not conduct space walks or approach windows until the flare has passed!", "Incoming Solar Flare", 'sound/AI/flare.ogg')
+	GLOB.minor_announcement.Announce("A solar flare has been detected on collision course with the station. Do not conduct space walks or approach windows until the flare has passed!", "Incoming Solar Flare", 'sound/AI/flare.ogg')
 
 /datum/event/solar_flare/start()
 	SSweather.run_weather(/datum/weather/solar_flare)

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -12,7 +12,7 @@ GLOBAL_VAR_INIT(sent_spiders_to_station, 0)
 
 /datum/event/spider_infestation/announce()
 	if(successSpawn)
-		GLOB.event_announcement.Announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
+		GLOB.minor_announcement.Announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
 	else
 		log_and_message_admins("Warning: Could not spawn any mobs for event Spider Infestation")
 

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -33,7 +33,7 @@
 	TE = new /obj/effect/tear(location)
 
 /datum/event/tear/announce()
-	GLOB.event_announcement.Announce("A tear in the fabric of space and time has opened. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly.ogg')
+	GLOB.minor_announcement.Announce("A tear in the fabric of space and time has opened. Expected location: [impact_area.name].", "Anomaly Alert", 'sound/AI/anomaly.ogg')
 
 /datum/event/tear/end()
 	if(TE)

--- a/code/modules/events/tear_honk.dm
+++ b/code/modules/events/tear_honk.dm
@@ -8,7 +8,7 @@
 	HE = new /obj/effect/tear/honk(location)
 
 /datum/event/tear/honk/announce()
-	GLOB.event_announcement.Announce("A Honknomoly has opened. Expected location: [impact_area.name].", "Honknomoly Alert", 'sound/items/airhorn.ogg')
+	GLOB.minor_announcement.Announce("A Honknomoly has opened. Expected location: [impact_area.name].", "Honknomoly Alert", 'sound/items/airhorn.ogg')
 
 /datum/event/tear/honk/end()
 	if(HE)

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	if(!station) // If there are no unused stations, just no.
 		return
 	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED)
-		GLOB.event_announcement.Announce("A trading shuttle from Jupiter Station has been denied docking permission due to the heightened security alert aboard [station_name()].", "Trader Shuttle Docking Request Refused")
+		GLOB.minor_announcement.Announce("A trading shuttle from Jupiter Station has been denied docking permission due to the heightened security alert aboard [station_name()].", "Trader Shuttle Docking Request Refused")
 		// if the docking request was refused, fire another major event in 60 seconds
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
 		EC.next_event_time = world.time + (60 * 10)
@@ -55,7 +55,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 			greet_trader(M)
 			success_spawn = TRUE
 	if(success_spawn)
-		GLOB.event_announcement.Announce("A trading shuttle from Jupiter Station has been granted docking permission at [station_name()] arrivals port 4.", "Trader Shuttle Docking Request Accepted")
+		GLOB.minor_announcement.Announce("A trading shuttle from Jupiter Station has been granted docking permission at [station_name()] arrivals port 4.", "Trader Shuttle Docking Request Accepted")
 	else
 		GLOB.unused_trade_stations += station // Return the station to the list of usable stations.
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -6,7 +6,7 @@
 	var/list/vents  = list()
 
 /datum/event/vent_clog/announce()
-	GLOB.event_announcement.Announce("The scrubbers network is experiencing a backpressure surge.  Some ejection of contents may occur.", "Atmospherics alert", 'sound/AI/scrubbers.ogg')
+	GLOB.minor_announcement.Announce("The scrubbers network is experiencing a backpressure surge.  Some ejection of contents may occur.", "Atmospherics alert", 'sound/AI/scrubbers.ogg')
 
 /datum/event/vent_clog/setup()
 	endWhen = rand(25, 100)

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -21,7 +21,7 @@
 		wormholes += new /obj/effect/portal/wormhole(T, null, null, -1)
 
 /datum/event/wormholes/announce()
-	GLOB.event_announcement.Announce("Space-time anomalies detected on the station. There is no additional data.", "Anomaly Alert", new_sound = 'sound/AI/spanomalies.ogg')
+	GLOB.minor_announcement.Announce("Space-time anomalies detected on the station. There is no additional data.", "Anomaly Alert", new_sound = 'sound/AI/spanomalies.ogg')
 
 /datum/event/wormholes/tick()
 	if(activeFor % shift_frequency == 0)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -747,14 +747,14 @@
 					to_chat(H, "<span class='userdanger'>You feel surrounded by sadness. Sadness... and HONKS!</span>")
 					H.makeCluwne()
 			else if(myeffect == "Demote")
-				GLOB.event_announcement.Announce("[target.real_name] is hereby demoted to the rank of Assistant. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
+				GLOB.major_announcement.Announce("[target.real_name] is hereby demoted to the rank of Assistant. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
 				for(var/datum/data/record/R in sortRecord(GLOB.data_core.security))
 					if(R.fields["name"] == target.real_name)
 						R.fields["criminal"] = SEC_RECORD_STATUS_DEMOTE
 						R.fields["comments"] += "Central Command Demotion Order, given on [GLOB.current_date_string] [station_time_timestamp()]<BR> Process this demotion immediately. Failure to comply with these orders is grounds for termination."
 				update_all_mob_security_hud()
 			else if(myeffect == "Demote with Bot")
-				GLOB.event_announcement.Announce("[target.real_name] is hereby demoted to the rank of Assistant. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
+				GLOB.major_announcement.Announce("[target.real_name] is hereby demoted to the rank of Assistant. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
 				for(var/datum/data/record/R in sortRecord(GLOB.data_core.security))
 					if(R.fields["name"] == target.real_name)
 						R.fields["criminal"] = SEC_RECORD_STATUS_ARREST

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -258,10 +258,10 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 			M.equipOutfit(command_outfit)
 
 /datum/response_team/proc/cannot_send_team()
-	GLOB.event_announcement.Announce("[station_name()], we are unfortunately unable to send you an Emergency Response Team at this time.", "ERT Unavailable")
+	GLOB.major_announcement.Announce("[station_name()], we are unfortunately unable to send you an Emergency Response Team at this time.", "ERT Unavailable")
 
 /datum/response_team/proc/announce_team()
-	GLOB.event_announcement.Announce("Attention, [station_name()]. We are sending a team of highly trained assistants to aid(?) you. Standby.", "ERT En-Route")
+	GLOB.major_announcement.Announce("Attention, [station_name()]. We are sending a team of highly trained assistants to aid(?) you. Standby.", "ERT En-Route")
 
 // -- AMBER TEAM --
 
@@ -274,7 +274,7 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 	paranormal_outfit = /datum/outfit/job/centcom/response_team/paranormal/amber
 
 /datum/response_team/amber/announce_team()
-	GLOB.event_announcement.Announce("Attention, [station_name()]. We are sending a code AMBER light Emergency Response Team. Standby.", "ERT En-Route")
+	GLOB.major_announcement.Announce("Attention, [station_name()]. We are sending a code AMBER light Emergency Response Team. Standby.", "ERT En-Route")
 
 // -- RED TEAM --
 
@@ -288,7 +288,7 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 	borg_path = /mob/living/silicon/robot/ert/red
 
 /datum/response_team/red/announce_team()
-	GLOB.event_announcement.Announce("Attention, [station_name()]. We are sending a code RED Emergency Response Team. Standby.", "ERT En-Route")
+	GLOB.major_announcement.Announce("Attention, [station_name()]. We are sending a code RED Emergency Response Team. Standby.", "ERT En-Route")
 
 // -- GAMMA TEAM --
 
@@ -302,7 +302,7 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 	borg_path = /mob/living/silicon/robot/ert/gamma
 
 /datum/response_team/gamma/announce_team()
-	GLOB.event_announcement.Announce("Attention, [station_name()]. We are sending a code GAMMA elite Emergency Response Team. Standby.", "ERT En-Route")
+	GLOB.major_announcement.Announce("Attention, [station_name()]. We are sending a code GAMMA elite Emergency Response Team. Standby.", "ERT En-Route")
 
 /datum/outfit/job/centcom/response_team
 	name = "Response team"

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -326,7 +326,7 @@
 	else if(input_level > desired_level)
 		input_level--
 	if(prob(input_level - safe_levels + (emagged * 5)))	//at dangerous levels, start doing freaky shit. prob with values less than 0 treat it as 0
-		GLOB.event_announcement.Announce("Unexpected power spike during Bluespace Harvester Operation. Extra-dimensional intruder alert. Expected location: [get_area(src).name]. [emagged ? "DANGER: Emergency shutdown failed! Please proceed with manual shutdown." : "Emergency shutdown initiated."]", "Bluespace Harvester Malfunction", 'sound/AI/harvester.ogg')
+		GLOB.major_announcement.Announce("Unexpected power spike during Bluespace Harvester Operation. Extra-dimensional intruder alert. Expected location: [get_area(src).name]. [emagged ? "DANGER: Emergency shutdown failed! Please proceed with manual shutdown." : "Emergency shutdown initiated."]", "Bluespace Harvester Malfunction", 'sound/AI/harvester.ogg')
 		if(!emagged)
 			input_level = 0	//emergency shutdown unless we're sabotaged
 			desired_level = 0

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -12,7 +12,7 @@
 	var/report_message = "Complete this goal."
 
 /datum/station_goal/proc/send_report()
-	GLOB.major_announcement.Announce("Priority Nanotrasen directive received. Project \"[name]\" details inbound.", "Incoming Priority Message", 'sound/AI/commandreport.ogg')
+	GLOB.minor_announcement.Announce("Priority Nanotrasen directive received. Project \"[name]\" details inbound.", "Incoming Priority Message", 'sound/AI/commandreport.ogg')
 	print_command_report(get_report(), "Nanotrasen Directive [pick(GLOB.phonetic_alphabet)] \Roman[rand(1,50)]", FALSE)
 	on_report()
 

--- a/code/modules/tgui/modules/ert_manager.dm
+++ b/code/modules/tgui/modules/ert_manager.dm
@@ -102,7 +102,7 @@
 			notify_ghosts("An ERT is being dispatched. Type: [ert_type]. Open positions: [slot_text]")
 			message_admins("[key_name_admin(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]", 1)
 			log_admin("[key_name(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]")
-			GLOB.event_announcement.Announce("Attention, [station_name()]. We are attempting to assemble an ERT. Standby.", "ERT Protocol Activated")
+			GLOB.major_announcement.Announce("Attention, [station_name()]. We are attempting to assemble an ERT. Standby.", "ERT Protocol Activated")
 			trigger_armed_response_team(D, commander_slots, security_slots, medical_slots, engineering_slots, janitor_slots, paranormal_slots, cyborg_slots, cyborg_security)
 		else
 			return FALSE

--- a/code/modules/unit_tests/announcements.dm
+++ b/code/modules/unit_tests/announcements.dm
@@ -31,7 +31,7 @@
 		new_sound = 'sound/misc/notice2.ogg'
 	)
 
-	GLOB.event_announcement.Announce("Bioscans indicate that lizards have been breeding in the kitchen. Clear them out, before this starts to affect productivity.", "Lifesign Alert")
+	GLOB.minor_announcement.Announce("Bioscans indicate that lizards have been breeding in the kitchen. Clear them out, before this starts to affect productivity.", "Lifesign Alert")
 
 	var/datum/announcer/ai_announcer = new(config_type = /datum/announcement_configuration/ai)
 	ai_announcer.author = "AI-NAME-0345"


### PR DESCRIPTION
## What Does This PR Do
This PR removes the vague and overused 'event' announcement category, placing existing announcements in either a minor or major category. This includes things such as making nightshift lighting changes and vermin infestations minor announcements.

I chose these placements arbitrarily and put those decisions in this spreadsheet: https://docs.google.com/spreadsheets/d/1tp_46bs96381nBY0ehK8WVlXgDI1YTlBGIAeT08yHLw/edit#gid=0

The summary is:

1. Announcements from Command, AI, and Central are major. Dangerous threats, and the de-escalation of those threats (such as Malf AI) are major.
2. Most other events, and events which are deceptively unimportant (such as the initial lifeform-boarding announcement for xenos/terrors) are minor.
3. Dangerous events, such as meteors, have a major starting announcement and a minor ending announcement.
3. Notifications that faxes have arrived, even in the event of dangerous situations, are minor, because the important thing is the message on the fax.

Obviously point out if you think any of these specific sites should be switched.

## Why It's Good For The Game

This helps address the visual problems with announcements, which is that rarely is there a useful relationship between the appearance and importance of an announcement. It can become a habit to treat comms like a chat room, but I feel strongly that its visual appearance is an important aspect of immersion, and improving its relationship to what is happening in game is a tiny step.

## Images of Changes

Nothing about the styles themselves have changed here, but for reference, here are the relative sizes of major and minor announcements, as they will appear after #19595 gets in.

![19_45_03__Paradise Station 13-](https://user-images.githubusercontent.com/59303604/200446844-e7a9fdc9-ad73-4c28-a04b-afed3e4e94ff.png)

## Future Work

I do have an ulterior motive to all this cleanup, which is making a _big_ step to improving the relationship between the importance of announcements and their appearance. I've shared this around before, and obviously it is not a final design vetted and blessed by _anyone_, but it has been positively received, and helps demonstrate the direction I'd like announcements to take. This is specifically why I've been so zealous about announcements lately.

<details><summary>Potential Announcement Redesign Drafts</summary>

![19_19_46__C__Users_warriorstar_iCloudDrive_Process_godknows html - Internet Explorer-](https://user-images.githubusercontent.com/59303604/200446875-6d3405e6-caef-46d2-a346-b2c3bc1d5489.png)

![19_19_54__C__Users_warriorstar_iCloudDrive_Process_godknows html - Internet Explorer-](https://user-images.githubusercontent.com/59303604/200446916-ac99dfbb-9f5e-4c50-bbd9-40d724994b61.png)

![19_20_07__C__Users_warriorstar_iCloudDrive_Process_godknows html - Internet Explorer-](https://user-images.githubusercontent.com/59303604/200446920-c6522e91-1950-4e16-b8a4-1dd9c328a8db.png)

![19_20_00__C__Users_warriorstar_iCloudDrive_Process_godknows html - Internet Explorer-](https://user-images.githubusercontent.com/59303604/200446934-c4f2e124-efa6-4d34-b187-e38bf74c434c.png)
</details>

One way or another, the announcement system is old code, constantly bolted onto, with little flexibility for implementors or admins to make sure announcements are formatted and sent in a sane manner, so even if this work doesn't occur, all of this cleanup was still fairly valuable.

## Changelog
:cl:
tweak: The font size of all announcements now more accurately reflects the announcement's urgency.
/:cl: