### PR TITLE
Fixes kitchen appliances partially sucking up ingredients when upgraded

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -270,16 +270,15 @@
 		return
 
 	var/datum/reagents/temp_reagents = new(500)
-	for(var/list/L as anything in recipes_to_make)		//cycle through each entry on the recipes_to_make list for processing
-		var/obj/source = L[1]	//this is the source of the recipe entry (mixing bowl or the machine)
-		var/datum/recipe/recipe = L[2]	//this is the recipe associated with the source (a valid recipe or null)
+	for(var/list/L as anything in recipes_to_make)
+		var/obj/source = L[1] // The machine or a mixing bowl
+		var/datum/recipe/recipe = L[2] // Valid recipe or RECIPE_FAIL
 
-		if(recipe == RECIPE_FAIL)		//we have a failure and create a burned mess
-			//failed recipe
+		if(recipe == RECIPE_FAIL)
 			fail()
-		else	//we have a valid recipe to begin making
-			for(var/obj/O in source.contents)	//begin processing the ingredients supplied
-				if(istype(O, /obj/item/mixing_bowl))	//ignore mixing bowls present among the ingredients in our source (only really applies to machine sourced recipes)
+		else
+			for(var/obj/O in source.contents) // Process supplied ingredients
+				if(istype(O, /obj/item/mixing_bowl)) // Mixing bowls are not ingredients, ignore
 					continue
 
 				if(O.reagents)
@@ -296,11 +295,11 @@
 				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
 			temp_reagents.clear_reagents()
 
-			var/obj/byproduct = recipe.get_byproduct()	//if the recipe has a byproduct, handle returning that (such as re-usable candy moulds)
+			var/obj/byproduct = recipe.get_byproduct()
 			if(byproduct)
 				new byproduct(loc)
 
-			if(istype(source, /obj/item/mixing_bowl))	//if the recipe's source was a mixing bowl, make it a little dirtier and return that for re-use.
+			if(istype(source, /obj/item/mixing_bowl)) // Cooking in mixing bowls returns them dirtier
 				var/obj/item/mixing_bowl/mb = source
 				mb.make_dirty(5 * efficiency)
 				mb.forceMove(loc)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -292,9 +292,8 @@
 
 			var/reagents_per_serving = temp_reagents.total_volume / efficiency
 			for(var/i in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
-				var/obj/cooked = new recipe.result()
+				var/obj/cooked = new recipe.result(loc)
 				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
-				cooked.forceMove(loc)
 			temp_reagents.clear_reagents()
 
 			var/obj/byproduct = recipe.get_byproduct()	//if the recipe has a byproduct, handle returning that (such as re-usable candy moulds)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -276,35 +276,36 @@
 
 		if(recipe == RECIPE_FAIL)
 			fail()
-		else
-			for(var/obj/O in source.contents) // Process supplied ingredients
-				if(istype(O, /obj/item/mixing_bowl)) // Mixing bowls are not ingredients, ignore
-					continue
+			continue
 
-				if(O.reagents)
-					O.reagents.del_reagent("nutriment")
-					O.reagents.update_total()
-					O.reagents.trans_to(temp_reagents, O.reagents.total_volume, no_react = TRUE) // Don't react with the abstract holder please
+		for(var/obj/O in source.contents) // Process supplied ingredients
+			if(istype(O, /obj/item/mixing_bowl)) // Mixing bowls are not ingredients, ignore
+				continue
 
-				qdel(O)
-			source.reagents.clear_reagents()
+			if(O.reagents)
+				O.reagents.del_reagent("nutriment")
+				O.reagents.update_total()
+				O.reagents.trans_to(temp_reagents, O.reagents.total_volume, no_react = TRUE) // Don't react with the abstract holder please
 
-			var/reagents_per_serving = temp_reagents.total_volume / efficiency
-			for(var/i in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
-				var/obj/cooked = new recipe.result(loc)
-				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
-			temp_reagents.clear_reagents()
+			qdel(O)
+		source.reagents.clear_reagents()
 
-			var/obj/byproduct = recipe.get_byproduct()
-			if(byproduct)
-				new byproduct(loc)
+		var/reagents_per_serving = temp_reagents.total_volume / efficiency
+		for(var/i in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
+			var/obj/cooked = new recipe.result(loc)
+			temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
+		temp_reagents.clear_reagents()
 
-			if(istype(source, /obj/item/mixing_bowl)) // Cooking in mixing bowls returns them dirtier
-				var/obj/item/mixing_bowl/mb = source
-				mb.make_dirty(5 * efficiency)
-				mb.forceMove(loc)
+		var/obj/byproduct = recipe.get_byproduct()
+		if(byproduct)
+			new byproduct(loc)
+
+		if(istype(source, /obj/item/mixing_bowl)) // Cooking in mixing bowls returns them dirtier
+			var/obj/item/mixing_bowl/mb = source
+			mb.make_dirty(5 * efficiency)
+			mb.forceMove(loc)
+
 	stop()
-	return
 
 /obj/machinery/kitchen_machine/proc/wzhzhzh(seconds)
 	for(var/i=1 to seconds)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -268,11 +268,13 @@
 /obj/machinery/kitchen_machine/proc/make_recipes(list/recipes_to_make)
 	if(!recipes_to_make)
 		return
+
 	var/datum/reagents/temp_reagents = new(500)
 	for(var/i in 1 to recipes_to_make.len)		//cycle through each entry on the recipes_to_make list for processing
 		var/list/L = recipes_to_make[i]
 		var/obj/source = L[1]	//this is the source of the recipe entry (mixing bowl or the machine)
 		var/datum/recipe/recipe = L[2]	//this is the recipe associated with the source (a valid recipe or null)
+
 		if(recipe == RECIPE_FAIL)		//we have a failure and create a burned mess
 			//failed recipe
 			fail()
@@ -280,10 +282,12 @@
 			for(var/obj/O in source.contents)	//begin processing the ingredients supplied
 				if(istype(O, /obj/item/mixing_bowl))	//ignore mixing bowls present among the ingredients in our source (only really applies to machine sourced recipes)
 					continue
+
 				if(O.reagents)
 					O.reagents.del_reagent("nutriment")
 					O.reagents.update_total()
 					O.reagents.trans_to(temp_reagents, O.reagents.total_volume, no_react = TRUE) // Don't react with the abstract holder please
+
 				qdel(O)
 			source.reagents.clear_reagents()
 

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -286,14 +286,17 @@
 					O.reagents.trans_to(temp_reagents, O.reagents.total_volume, no_react = TRUE) // Don't react with the abstract holder please
 				qdel(O)
 			source.reagents.clear_reagents()
+
 			for(var/e=1 to efficiency)		//upgraded machine? make additional servings and split the ingredient reagents among each serving equally.
 				var/obj/cooked = new recipe.result()
 				temp_reagents.trans_to(cooked, temp_reagents.total_volume/efficiency, no_react = TRUE) // Don't react with the abstract holder please
 				cooked.forceMove(loc)
 			temp_reagents.clear_reagents()
+
 			var/obj/byproduct = recipe.get_byproduct()	//if the recipe has a byproduct, handle returning that (such as re-usable candy moulds)
 			if(byproduct)
 				new byproduct(loc)
+
 			if(istype(source, /obj/item/mixing_bowl))	//if the recipe's source was a mixing bowl, make it a little dirtier and return that for re-use.
 				var/obj/item/mixing_bowl/mb = source
 				mb.make_dirty(5 * efficiency)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -270,8 +270,7 @@
 		return
 
 	var/datum/reagents/temp_reagents = new(500)
-	for(var/i in 1 to recipes_to_make.len)		//cycle through each entry on the recipes_to_make list for processing
-		var/list/L = recipes_to_make[i]
+	for(var/list/L as anything in recipes_to_make)		//cycle through each entry on the recipes_to_make list for processing
 		var/obj/source = L[1]	//this is the source of the recipe entry (mixing bowl or the machine)
 		var/datum/recipe/recipe = L[2]	//this is the recipe associated with the source (a valid recipe or null)
 
@@ -291,8 +290,8 @@
 				qdel(O)
 			source.reagents.clear_reagents()
 
-			var/reagents_per_serving = temp_reagents.total_volume/efficiency
-			for(var/j in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
+			var/reagents_per_serving = temp_reagents.total_volume / efficiency
+			for(var/i in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
 				var/obj/cooked = new recipe.result()
 				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
 				cooked.forceMove(loc)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -287,9 +287,10 @@
 				qdel(O)
 			source.reagents.clear_reagents()
 
+			var/reagents_per_serving = temp_reagents.total_volume/efficiency
 			for(var/e=1 to efficiency)		//upgraded machine? make additional servings and split the ingredient reagents among each serving equally.
 				var/obj/cooked = new recipe.result()
-				temp_reagents.trans_to(cooked, temp_reagents.total_volume/efficiency, no_react = TRUE) // Don't react with the abstract holder please
+				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
 				cooked.forceMove(loc)
 			temp_reagents.clear_reagents()
 

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -288,7 +288,7 @@
 			source.reagents.clear_reagents()
 
 			var/reagents_per_serving = temp_reagents.total_volume/efficiency
-			for(var/e=1 to efficiency)		//upgraded machine? make additional servings and split the ingredient reagents among each serving equally.
+			for(var/e=1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
 				var/obj/cooked = new recipe.result()
 				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
 				cooked.forceMove(loc)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -269,7 +269,7 @@
 	if(!recipes_to_make)
 		return
 	var/datum/reagents/temp_reagents = new(500)
-	for(var/i=1 to recipes_to_make.len)		//cycle through each entry on the recipes_to_make list for processing
+	for(var/i in 1 to recipes_to_make.len)		//cycle through each entry on the recipes_to_make list for processing
 		var/list/L = recipes_to_make[i]
 		var/obj/source = L[1]	//this is the source of the recipe entry (mixing bowl or the machine)
 		var/datum/recipe/recipe = L[2]	//this is the recipe associated with the source (a valid recipe or null)
@@ -288,7 +288,7 @@
 			source.reagents.clear_reagents()
 
 			var/reagents_per_serving = temp_reagents.total_volume/efficiency
-			for(var/i in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
+			for(var/j in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
 				var/obj/cooked = new recipe.result()
 				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
 				cooked.forceMove(loc)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -288,7 +288,7 @@
 			source.reagents.clear_reagents()
 
 			var/reagents_per_serving = temp_reagents.total_volume/efficiency
-			for(var/e=1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
+			for(var/i in 1 to efficiency) // Extra servings when upgraded, ingredient reagents split equally
 				var/obj/cooked = new recipe.result()
 				temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
 				cooked.forceMove(loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where kitchen machines would fail to preserve all of the ingredient reagents when making additional servings, due to the code using a portion of a _constantly updating_ total reagent volume for its transfers, rather than caching the total first.

In other words, for an example of 2 servings, the code would first transfer 50% of the full 100% total ingredient reagents into the 1st serving, then 50% of the *new* total (reduced to 50%, so only 25% transferred) into the 2nd serving, then delete the remaining 25% of ingredient reagents.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Food vanishing in weird ways is bad. As much as kitchen machines eating up some of the food is funny and kinda realistic, it could be implemented in a better, more controlled and sane way (instead of via buggy code).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. Spawned in a `snacks/sandwich`, shoved into an unupgraded oven, cooked it
2. Ground up the resulting toasted sandwich, saved in a beaker
3. Spawned in a second `snacks/sandwich`, shoved into a fully (tier 4) upgraded oven, cooked it
4. Ground up together the resulting 4 toasted sandwich portions, saved in a separate beaker
5. Made sure the Vitamin content between the beakers is the same (1u)

Note that the Nutriment and Carbon content will be scaled up 4x in the second beaker, due to each of the 4 created toasted sandwich instances spawning with a fixed amount of Nutriment and Carbon (and to a lesser extent, due to Nutriment being excluded from reagents preserved when cooking).
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Upgraded kitchen machines no longer partially delete ingredient reagents when creating extra servings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
