### PR TITLE
Uses the based alien queen sprite because they just look better and isnt a boring recolor

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1840,7 +1840,7 @@
 	..()
 	mind.assigned_role = "Alien"
 	//XENO HUMANOID
-/mob/living/carbon/alien/humanoid/queen/mind_initialize()
+/mob/living/carbon/alien/humanoid/queen/large/mind_initialize()
 	..()
 	mind.special_role = SPECIAL_ROLE_XENOMORPH_QUEEN
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -380,7 +380,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 					if("Hunter")	new_xeno = new /mob/living/carbon/alien/humanoid/hunter(T)
 					if("Sentinel")	new_xeno = new /mob/living/carbon/alien/humanoid/sentinel(T)
 					if("Drone")		new_xeno = new /mob/living/carbon/alien/humanoid/drone(T)
-					if("Queen")		new_xeno = new /mob/living/carbon/alien/humanoid/queen(T)
+					if("Queen")		new_xeno = new /mob/living/carbon/alien/humanoid/queen/large(T)
 					else//If we don't know what special role they have, for whatever reason, or they're a larva.
 						create_xeno(G_found.ckey)
 						return

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -31,7 +31,7 @@
 	if(powerc(500))
 		// Queen check
 		var/no_queen = TRUE
-		for(var/mob/living/carbon/alien/humanoid/queen/Q in GLOB.alive_mob_list)
+		for(var/mob/living/carbon/alien/humanoid/queen/large/Q in GLOB.alive_mob_list)
 			if(!Q.key && Q.get_int_organ(/obj/item/organ/internal/brain/))
 				continue
 			no_queen = FALSE
@@ -41,7 +41,7 @@
 			to_chat(src, "<span class='noticealien'>You begin to evolve!</span>")
 			for(var/mob/O in viewers(src, null))
 				O.show_message(text("<span class='alertalien'>[src] begins to twist and contort!</span>"), 1)
-			var/mob/living/carbon/alien/humanoid/queen/new_xeno = new(loc)
+			var/mob/living/carbon/alien/humanoid/queen/large/new_xeno = new(loc)
 			mind.transfer_to(new_xeno)
 			new_xeno.mind.name = new_xeno.name
 			SSblackbox.record_feedback("tally", "alien_growth", 1, "queen")

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -3,7 +3,7 @@
 	caste = "q"
 	maxHealth = 250
 	health = 250
-	icon_state = "alienq_s"
+	icon_state = "queen_s"
 	status_flags = CANPARALYSE
 	heal_rate = 5
 	large = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sprite change for alien queen that has been in the code. Gives them a new bigger more badass sprite.
## Why It's Good For The Game
Looks better, makes the queen feel more intimidating, plus aliens need to be iron'd out a ton and are lacking in some aspects. This makes the alien queen stand out more among a hive and crew.

## Images of changes
![dreamseeker_ggdpr9xDEQ](https://user-images.githubusercontent.com/62493359/200896026-12c90414-bcff-4936-89fa-56d4aa6de425.png)
![dreamseeker_KFATVjPtcj](https://user-images.githubusercontent.com/62493359/200896036-f522a42b-7449-42f2-85bd-ed973e1f2a42.png)
![dreamseeker_JA323TxIi6](https://user-images.githubusercontent.com/62493359/200896040-8611d2a3-d1d5-43fb-b26c-87f8aa7203eb.png)


## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Xeno queen sprite changed to a larger version
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
