### PR TITLE
Changeling voice mimic doesn't slow chemical production

### DIFF
--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -1,9 +1,9 @@
 /datum/action/changeling/mimicvoice
 	name = "Mimic Voice"
-	desc = "We shape our vocal glands to sound like a desired voice. Maintaining this power slows chemical production."
-	helptext = "Will turn your voice into the name that you enter. We must constantly expend chemicals to maintain our form like this."
+	desc = "We shape our vocal glands to sound like a desired voice.
+	helptext = "Will turn your voice into the name that you enter.
 	button_icon_state = "mimic_voice"
-	chemical_cost = 0 //constant chemical drain hardcoded
+	chemical_cost = 0
 	dna_cost = 1
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
@@ -13,7 +13,6 @@
 /datum/action/changeling/mimicvoice/sting_action(mob/user)
 	if(cling.mimicing)
 		cling.mimicing = ""
-		cling.chem_recharge_slowdown -= 0.5
 		to_chat(user, "<span class='notice'>We return our vocal glands to their original position.</span>")
 		return FALSE
 
@@ -22,9 +21,8 @@
 		return FALSE
 
 	cling.mimicing = mimic_voice
-	cling.chem_recharge_slowdown += 0.5
-	to_chat(user, "<span class='notice'>We shape our glands to take the voice of <b>[mimic_voice]</b>, this will stop us from regenerating chemicals while active.</span>")
-	to_chat(user, "<span class='notice'>Use this power again to return to our original voice and reproduce chemicals again.</span>")
+	to_chat(user, "<span class='notice'>We shape our glands to take the voice of <b>[mimic_voice]</b>.</span>")
+	to_chat(user, "<span class='notice'>Use this power again to return to our original voice.</span>")
 
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/mimicvoice
 	name = "Mimic Voice"
-	desc = "We shape our vocal glands to sound like a desired voice.
-	helptext = "Will turn your voice into the name that you enter.
+	desc = "We shape our vocal glands to sound like a desired voice."
+	helptext = "Will turn your voice into the name that you enter."
 	button_icon_state = "mimic_voice"
 	chemical_cost = 0
 	dna_cost = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Removes the chemical regeneration slowdown from the changeling's mimic voice ability.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
One of the biggest issues changelings have are they the good abilities are very good, and the bad ones are very bad. Mimic voice is good for doing gimmicks and tricking people over comms, but not a ton else. Part of the reason why it's underused otherwise is because it halves your resource production when its on. If you forget/don't want to turn it off, it can seriously mess with combat situations.

## Testing
<!-- How did you test the PR, if at all? -->
Made myself cling, changed my voice to "Wah" and then regenned chemicals as normal.
## Changelog
:cl:
tweak: Changelings don't slow chemical production down when using mimic voice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
