### PR TITLE
Tajaran, Unathi and Vulpkanin can now eat bees!

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -160,8 +160,6 @@
 					if(!foundghost)
 						msg += " and [p_their()] soul has departed"
 			msg += "...</span>\n"
-	for(var/mob/living/simple_animal/hostile/poison/bees in stomach_contents) //Get bloated mouth from eating a bee
-		msg += "<span class='warning'>[p_their(TRUE)] mouth looks bloated.</span>\n"
 	if(!get_int_organ(/obj/item/organ/internal/brain))
 		msg += "<span class='deadsay'>It appears that [p_their()] brain is missing...</span>\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -160,7 +160,8 @@
 					if(!foundghost)
 						msg += " and [p_their()] soul has departed"
 			msg += "...</span>\n"
-
+	for(var/mob/living/simple_animal/hostile/poison/bees in stomach_contents) //Get bloated mouth from eating a bee
+		msg += "<span class='warning'>[p_their(TRUE)] mouth looks bloated.</span>\n"
 	if(!get_int_organ(/obj/item/organ/internal/brain))
 		msg += "<span class='deadsay'>It appears that [p_their()] brain is missing...</span>\n"
 

--- a/code/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/code/modules/mob/living/carbon/human/species/tajaran.dm
@@ -45,7 +45,7 @@
 															 unless they choose otherwise by selecting the colourblind disability in character creation (darksight = 8 but colourblind).*/
 		)
 
-	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/chick, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot)
+	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/chick, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/hostile/poison/bees)
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -48,7 +48,7 @@
 		)
 
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
-								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot)
+								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/hostile/poison/bees)
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",

--- a/code/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -40,7 +40,7 @@
 		)
 
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
-								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot)
+								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/hostile/poison/bees)
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -386,7 +386,7 @@
 				var/obj/item/organ/external/mouth = user.get_organ(BODY_ZONE_PRECISE_MOUTH)
 				mouth.receive_damage(1)
 				user.reagents.add_reagent("spidertoxin", 5)
-				to_chat(user, "<span class='danger'>Your mouth has been stinged. IT HURTS!</span>")
+				to_chat(user, "<span class='danger'>Your mouth has been stinged, it's now bloated!</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)
 			qdel(src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -384,11 +384,13 @@
 				add_attack_logs(attacker, affecting, "Devoured")
 			if(istype(affecting, /mob/living/simple_animal/hostile/poison/bees)) //Eating a bee will end up damaging you
 				var/obj/item/organ/external/mouth = user.get_organ(BODY_ZONE_PRECISE_MOUTH)
+				var/mob/living/simple_animal/hostile/poison/bees/B = affecting
 				mouth.receive_damage(1)
-				if(istype(affecting, /mob/living/simple_animal/hostile/poison/bees/syndi))
-					user.reagents.add_reagent("facid", rand(1, 5))
+				if(B.beegent)
+					B.beegent.reaction_mob(assailant, REAGENT_INGEST)
+					assailant.reagents.add_reagent(B.beegent.id, rand(1, 5))
 				else
-					user.reagents.add_reagent("spidertoxin", 5)
+					assailant.reagents.add_reagent("spidertoxin", 5)
 				user.visible_message("<span class='warning'>[user]'s mouth became bloated.</span>", "<span class='danger'>Your mouth has been stung, it's now bloating!</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -382,7 +382,11 @@
 			user.visible_message("<span class='danger'>[user] devours \the [affecting]!</span>")
 			if(affecting.mind)
 				add_attack_logs(attacker, affecting, "Devoured")
-
+			if((istype(affecting, /mob/living/simple_animal/hostile/poison/bees))) //Eating a bee will end up damaging you
+				var/obj/item/organ/external/mouth = user.get_organ(BODY_ZONE_PRECISE_MOUTH)
+				mouth.receive_damage(1)
+				user.reagents.add_reagent("spidertoxin", 5)
+				to_chat(user, "<span class='danger'>Your mouth has been stinged. IT HURTS!</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)
 			qdel(src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -386,7 +386,7 @@
 				var/obj/item/organ/external/mouth = user.get_organ(BODY_ZONE_PRECISE_MOUTH)
 				mouth.receive_damage(1)
 				user.reagents.add_reagent("spidertoxin", 5)
-				to_chat(user, "<span class='danger'>Your mouth has been stinged, it's now bloated!</span>")
+				to_chat(user, "<span class='danger'>Your mouth has been stung, it's now bloated!</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)
 			qdel(src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -389,7 +389,8 @@
 					user.reagents.add_reagent("facid", rand(1, 5))
 				else
 					user.reagents.add_reagent("spidertoxin", 5)
-				to_chat(user, "<span class='danger'>Your mouth has been stung, it's now bloated!</span>")
+				to_chat(user, "<span class='danger'>Your mouth has been stung, it's now bloating!</span>")
+				user.visible_message("<span class='warning'>[user]'s mouth begins to bloat...</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)
 			qdel(src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -382,15 +382,14 @@
 			user.visible_message("<span class='danger'>[user] devours \the [affecting]!</span>")
 			if(affecting.mind)
 				add_attack_logs(attacker, affecting, "Devoured")
-			if((istype(affecting, /mob/living/simple_animal/hostile/poison/bees))) //Eating a bee will end up damaging you
+			if(istype(affecting, /mob/living/simple_animal/hostile/poison/bees)) //Eating a bee will end up damaging you
 				var/obj/item/organ/external/mouth = user.get_organ(BODY_ZONE_PRECISE_MOUTH)
 				mouth.receive_damage(1)
 				if(istype(affecting, /mob/living/simple_animal/hostile/poison/bees/syndi))
 					user.reagents.add_reagent("facid", rand(1, 5))
 				else
 					user.reagents.add_reagent("spidertoxin", 5)
-				to_chat(user, "<span class='danger'>Your mouth has been stung, it's now bloating!</span>")
-				user.visible_message("<span class='warning'>[user]'s mouth became bloated.</span>")
+				user.visible_message("<span class='warning'>[user]'s mouth became bloated.</span>", "<span class='danger'>Your mouth has been stung, it's now bloating!</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)
 			qdel(src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -385,7 +385,10 @@
 			if((istype(affecting, /mob/living/simple_animal/hostile/poison/bees))) //Eating a bee will end up damaging you
 				var/obj/item/organ/external/mouth = user.get_organ(BODY_ZONE_PRECISE_MOUTH)
 				mouth.receive_damage(1)
-				user.reagents.add_reagent("spidertoxin", 5)
+				if(istype(affecting, /mob/living/simple_animal/hostile/poison/bees/syndi))
+					user.reagents.add_reagent("facid", rand(1, 5))
+				else
+					user.reagents.add_reagent("spidertoxin", 5)
 				to_chat(user, "<span class='danger'>Your mouth has been stung, it's now bloated!</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -390,7 +390,7 @@
 				else
 					user.reagents.add_reagent("spidertoxin", 5)
 				to_chat(user, "<span class='danger'>Your mouth has been stung, it's now bloating!</span>")
-				user.visible_message("<span class='warning'>[user]'s mouth begins to bloat...</span>")
+				user.visible_message("<span class='warning'>[user]'s mouth became bloated.</span>")
 			affecting.forceMove(user)
 			LAZYADD(attacker.stomach_contents, affecting)
 			qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Includes bees into allowed_consumed_mobs for tajaran, unathi and vulps. Will be stinged by it if eaten.
https://www.paradisestation.org/forum/topic/20908-make-tajaransunathivulps-able-to-eat-bees/
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It makes sense that those species should be able to eat bees.
Being able to punish those stupid enough to eat living bees is worth it.

## Testing
<!-- How did you test the PR, if at all? -->
- Ate lots of bees while wearing a bee suit.
## Changelog
:cl:
add: Tajaran, Unathi and Vulpkanin can now eat bees
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
