### PR TITLE
Drask can no longer eat soap for infinite nutrition

### DIFF
--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -1,3 +1,5 @@
+#define OVEREAT_LIMIT 7 //If you've eaten soap this many times in the last 20 seconds, you get a tummyache
+
 /obj/item/soap
 	name = "soap"
 	desc = "A cheap bar of soap. Doesn't smell."
@@ -15,7 +17,6 @@
 	var/times_eaten = 0 //How many times a Drask has chewed on this bar of soap
 	var/max_bites = 30 //The maximum amount of bites before the soap is depleted
 	var/overeat_counter = 0 //How many times this bar of soap has been RECENTLY chewed on.
-	var/overeat_limit = 7 //If you've eaten soap this many times in the last 20 seconds, you get a tummyache
 
 /obj/item/soap/Initialize(mapload)
 	. = ..()
@@ -42,7 +43,7 @@
 	else
 		to_chat(user, "<span class='notice'>You finish eating [src].</span>")
 		qdel(src)
-	if(overeat_counter >= overeat_limit)
+	if(overeat_counter >= OVEREAT_LIMIT)
 		user.Weaken(12 SECONDS)
 		user.adjust_nutrition(-30)
 		playsound(user, "sound/goonstation/misc/gurggle.ogg", 50, TRUE)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -44,10 +44,10 @@
 		to_chat(user, "<span class='notice'>You finish eating [src].</span>")
 		qdel(src)
 	if(overeat_counter >= OVEREAT_LIMIT)
-		user.Weaken(12 SECONDS)
+		user.Weaken(5 SECONDS)
 		user.adjust_nutrition(-30)
 		playsound(user, "sound/goonstation/misc/gurggle.ogg", 50, TRUE)
-		to_chat(user, "<span class='warning'>The lye in [src] gives you a horrible stomachache!</span>")
+		user.visible_message("<span class='warning'>[user] clutches their stomach in agony!</span>", "<span class='danger'>The lye in [src] gives you a horrible stomachache!</span>")
 
 /obj/item/soap/proc/cooldown_overeat()
 	if(!overeat_counter)
@@ -60,11 +60,9 @@
 		return
 	if(times_eaten < (max_bites * 0.3))
 		. += "<span class='notice'>[src] has bite marks on it!</span>"
-		return
-	if(times_eaten < (max_bites * 0.6))
+	else if(times_eaten < (max_bites * 0.6))
 		. += "<span class='notice'>Big chunks of [src] have been chewed off!</span>"
-		return
-	if(times_eaten < (max_bites * 0.9))
+	else if(times_eaten < (max_bites * 0.9))
 		. += "<span class='notice'>Most of [src] has been gnawed away!</span>"
 	else
 		. += "<span class='notice'>[src] has been eaten down to a sliver!</span>"

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -13,6 +13,7 @@
 	discrete = 1
 	var/cleanspeed = 50 //slower than mop
 	var/times_eaten = 0 //How many times a Drask has chewed on this bar of soap
+	var/max_bites = 4 //The maximum amount of bites before the soap is depleted
 
 /obj/item/soap/Initialize(mapload)
 	. = ..()
@@ -27,7 +28,7 @@
 			times_eaten += 1
 			playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
 			user.adjust_nutrition(2)
-			if(times_eaten <= 3)
+			if(times_eaten < max_bites)
 				to_chat(user, "<span class='notice'>You take a bite of [src]. Delicious!</span>")
 				return
 			else

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -1,5 +1,3 @@
-#define OVEREAT_LIMIT 7 //If you've eaten soap this many times in the last 20 seconds, you get a tummyache
-
 /obj/item/soap
 	name = "soap"
 	desc = "A cheap bar of soap. Doesn't smell."
@@ -16,7 +14,6 @@
 	var/cleanspeed = 50 //slower than mop
 	var/times_eaten = 0 //How many times a Drask has chewed on this bar of soap
 	var/max_bites = 30 //The maximum amount of bites before the soap is depleted
-	var/overeat_counter = 0 //How many times this bar of soap has been RECENTLY chewed on.
 
 /obj/item/soap/Initialize(mapload)
 	. = ..()
@@ -34,8 +31,6 @@
 
 /obj/item/soap/proc/eat_soap(mob/living/carbon/human/drask/user)
 	times_eaten++
-	overeat_counter++
-	addtimer(CALLBACK(src, PROC_REF(cooldown_overeat)), 20 SECONDS)
 	playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
 	user.adjust_nutrition(5)
 	if(times_eaten < max_bites)
@@ -43,16 +38,6 @@
 	else
 		to_chat(user, "<span class='notice'>You finish eating [src].</span>")
 		qdel(src)
-	if(overeat_counter >= OVEREAT_LIMIT)
-		user.Weaken(5 SECONDS)
-		user.adjust_nutrition(-30)
-		playsound(user, "sound/goonstation/misc/gurggle.ogg", 50, TRUE)
-		user.visible_message("<span class='warning'>[user] clutches their stomach in agony!</span>", "<span class='danger'>The lye in [src] gives you a horrible stomachache!</span>")
-
-/obj/item/soap/proc/cooldown_overeat()
-	if(!overeat_counter)
-		return
-	overeat_counter--
 
 /obj/item/soap/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -12,6 +12,7 @@
 	throw_range = 20
 	discrete = 1
 	var/cleanspeed = 50 //slower than mop
+	var/times_eaten = 0 //How many times a Drask has chewed on this bar of soap
 
 /obj/item/soap/Initialize(mapload)
 	. = ..()
@@ -23,11 +24,26 @@
 	if(target == user && user.a_intent == INTENT_GRAB && ishuman(target))
 		var/mob/living/carbon/human/muncher = user
 		if(muncher && isdrask(muncher))
-			to_chat(user, "<span class='notice'>You take a bite of [src]. Delicious!</span>")
+			times_eaten += 1
 			playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
 			user.adjust_nutrition(2)
-		return
+			if(times_eaten <= 3)
+				to_chat(user, "<span class='notice'>You take a bite of [src]. Delicious!</span>")
+				return
+			else
+				to_chat(user, "<span class='notice'>You finish eating [src].</span>")
+				qdel(src)
+				return
 	target.cleaning_act(user, src, cleanspeed)
+
+/obj/item/soap/examine(mob/user)
+	. = ..()
+	if(!user.Adjacent(src) || !times_eaten)
+		return
+	if(times_eaten == 1)
+		. += "<span class='notice'>[src] was bitten by someone!</span>"
+	else
+		. += "<span class='notice'>[src] was bitten multiple times!</span>"
 
 /obj/item/soap/attack(mob/target as mob, mob/user as mob)
 	if(target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_selected == "mouth" )

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -25,16 +25,15 @@
 	if(target == user && user.a_intent == INTENT_GRAB && ishuman(target))
 		var/mob/living/carbon/human/muncher = user
 		if(muncher && isdrask(muncher))
-			times_eaten += 1
+			times_eaten++
 			playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
 			user.adjust_nutrition(2)
 			if(times_eaten < max_bites)
 				to_chat(user, "<span class='notice'>You take a bite of [src]. Delicious!</span>")
-				return
 			else
 				to_chat(user, "<span class='notice'>You finish eating [src].</span>")
 				qdel(src)
-				return
+			return
 	target.cleaning_act(user, src, cleanspeed)
 
 /obj/item/soap/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Drasks now receive 5 nutrition per bite of soap, up from 2.
- Soap is now a finite source of food: After **30** bites, it disappears. The amount of bites remaining can be roughly tracked by examining the soap.
- Splits all soap-eating behavior into its own proc.

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prior to this PR, Drasks could use a single bar of soap as a source of infinite nutrition; the hunger system should not be something that standard players can opt out of with roundstart items. To encourage departmental cooperation, Drasks will now have to periodically consult with the janitor to acquire more food.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server. The drask had a soap but he eated it
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Drask can no longer infinitely eat a single bar of soap. Savor the flavor while it lasts.
tweak: Soap now provides slightly more nutrition to Drasks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
