### PR TITLE
Rev buff day 1 patch

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -343,6 +343,9 @@
 
 	if(!successes) //no items to throw
 		to_chat(user, "<span class='revennotice'>No nearby objects to haunt!</span>")
+		user.essence += cast_amount //refund the spell and reset
+		cooldown_handler.revert_cast()
+		action.UpdateButtonIcon()
 		return
 
 	// Stop the looping attacks after 65 seconds, roughly 14 attack cycles depending on lag

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -165,7 +165,8 @@
 /obj/effect/proc_holder/spell/aoe/revenant/revert_cast(mob/user)
 	. = ..()
 	to_chat(user, "<span class='revennotice'>Your ability wavers and fails!</span>")
-	user.essence += cast_amount //refund the spell and reset
+	var/mob/living/simple_animal/revenant/R = user
+	R?.essence += cast_amount //refund the spell and reset
 
 /obj/effect/proc_holder/spell/aoe/revenant/can_cast(mob/living/simple_animal/revenant/user = usr, charge_check = TRUE, show_message = FALSE)
 	if(user.inhibited)

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -162,6 +162,11 @@
 	else
 		name = "[initial(name)] ([cast_amount]E)"
 
+/obj/effect/proc_holder/spell/aoe/revenant/revert_cast(mob/user)
+	. = ..()
+	to_chat(user, "<span class='revennotice'>Your ability wavers and fails!</span>")
+	user.essence += cast_amount //refund the spell and reset
+
 /obj/effect/proc_holder/spell/aoe/revenant/can_cast(mob/living/simple_animal/revenant/user = usr, charge_check = TRUE, show_message = FALSE)
 	if(user.inhibited)
 		return FALSE
@@ -342,10 +347,7 @@
 		successes++
 
 	if(!successes) //no items to throw
-		to_chat(user, "<span class='revennotice'>No nearby objects to haunt!</span>")
-		user.essence += cast_amount //refund the spell and reset
-		cooldown_handler.revert_cast()
-		action.UpdateButtonIcon()
+		revert_cast()
 		return
 
 	// Stop the looping attacks after 65 seconds, roughly 14 attack cycles depending on lag
@@ -386,7 +388,7 @@
 /// Sets the glow on the haunted object, scales up based on throwforce
 /obj/effect/proc_holder/spell/aoe/revenant/haunt_object/proc/set_outline(mob/living/simple_animal/possessed_object/possessed_object)
 	possessed_object.remove_filter("haunt_glow")
-	var/outline_size = round((possessed_object.possessed_item.throwforce / 15) * 3, 1)
+	var/outline_size = min((possessed_object.possessed_item.throwforce / 15) * 3, 3)
 	possessed_object.add_filter("haunt_glow", 2, list("type" = "outline", "color" = "#7A4FA9", "size" = outline_size)) // Give it spooky purple outline
 
 /// Stop all attack timers cast by the previous spell use

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -316,6 +316,7 @@
 /obj/effect/proc_holder/spell/aoe/revenant/haunt_object/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(!attempt_cast(user))
 		return
+
 	var/successes = 0
 	for(var/obj/item/nearby_item as anything in targets)
 		if(successes >= max_targets) // End loop if we've already got 7 spooky items
@@ -341,6 +342,7 @@
 		successes++
 
 	if(!successes) //no items to throw
+		to_chat(user, "<span class='revennotice'>No nearby objects to haunt!</span>")
 		return
 
 	// Stop the looping attacks after 65 seconds, roughly 14 attack cycles depending on lag
@@ -350,28 +352,39 @@
 /obj/effect/proc_holder/spell/aoe/revenant/haunt_object/proc/make_spooky(obj/item/item_to_possess, mob/living/simple_animal/revenant/user)
 	new /obj/effect/temp_visual/revenant(get_turf(item_to_possess)) // Thematic spooky visuals
 	var/mob/living/simple_animal/possessed_object/possessed_object = new(item_to_possess) // Begin haunting object
-	possessed_object.add_filter("haunt_glow", 2, list("type" = "outline", "color" = "#7A4FA9", "size" = 1)) // Give it spooky purple outline
-	item_to_possess.throwforce = clamp(item_to_possess.throwforce, item_to_possess.throwforce + 5, 15) // Damage it should do? throwforce+5 or 15, whichever is lower. Undone on possessed mob death
+	item_to_possess.throwforce = min(item_to_possess.throwforce + 5, 15) // Damage it should do? throwforce+5 or 15, whichever is lower
+	set_outline(possessed_object)
 	possessed_object.maxHealth = 100 // Double the regular HP of possessed objects
 	possessed_object.health = 100
 	possessed_object.escape_chance = 100 // We cannot be contained
 
-	addtimer(CALLBACK(src, PROC_REF(attack), possessed_object, user), 2 SECONDS, TIMER_UNIQUE) // Short warm-up for floaty ambience
-	attack_timers.Add(addtimer(CALLBACK(src, PROC_REF(attack), possessed_object, user), 5 SECONDS, TIMER_UNIQUE|TIMER_LOOP|TIMER_STOPPABLE)) // 5 second looping attacks
+	addtimer(CALLBACK(src, PROC_REF(attack), possessed_object, user), 1 SECONDS, TIMER_UNIQUE) // Short warm-up for floaty ambience
+	attack_timers.Add(addtimer(CALLBACK(src, PROC_REF(attack), possessed_object, user), 4 SECONDS, TIMER_UNIQUE|TIMER_LOOP|TIMER_STOPPABLE)) // 5 second looping attacks
 	addtimer(CALLBACK(possessed_object, TYPE_PROC_REF(/mob/living/simple_animal/possessed_object, death)), 70 SECONDS, TIMER_UNIQUE) // De-haunt the object
 
 /// Handles finding a valid target and throwing us at it
 /obj/effect/proc_holder/spell/aoe/revenant/haunt_object/proc/attack(mob/living/simple_animal/possessed_object/possessed_object, mob/living/simple_animal/revenant/user)
 	var/list/potential_victims = list()
 	for(var/mob/living/carbon/potential_victim in range(aoe_range, get_turf(possessed_object)))
-		if(!can_see(possessed_object, potential_victim)) // You can't see me
+		if(!can_see(possessed_object, potential_victim, aoe_range)) // You can't see me
 			continue
 		if(potential_victim.stat != CONSCIOUS) // Don't kill our precious essence-filled sleepy mobs
 			continue
 		potential_victims.Add(potential_victim)
 
+	if(!length(potential_victims))
+		possessed_object.possessed_item.throwforce = min(possessed_object.possessed_item.throwforce + 5, 15) // If an item is stood still for a while it can gather power
+		set_outline(possessed_object)
+		return
+
 	var/mob/living/carbon/victim = pick(potential_victims)
-	possessed_object.throw_at(victim, 15, 2, user, dodgeable = FALSE)
+	possessed_object.throw_at(victim, aoe_range, 2, user)
+
+/// Sets the glow on the haunted object, scales up based on throwforce
+/obj/effect/proc_holder/spell/aoe/revenant/haunt_object/proc/set_outline(mob/living/simple_animal/possessed_object/possessed_object)
+	possessed_object.remove_filter("haunt_glow")
+	var/outline_size = round((possessed_object.possessed_item.throwforce / 15) * 3, 1)
+	possessed_object.add_filter("haunt_glow", 2, list("type" = "outline", "color" = "#7A4FA9", "size" = outline_size)) // Give it spooky purple outline
 
 /// Stop all attack timers cast by the previous spell use
 /obj/effect/proc_holder/spell/aoe/revenant/haunt_object/proc/stop_timers()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some oversights and weaknesses in the rev buff PR.

Notably:

- If no valid targets existed for the haunted objects, they just runtimed.
- No feedback to rev if haunting failed due to no objects, so it is now refunded and prints in chat.
- The range for checking for valid targets was 5 instead of the desired 7.
- No feedback was available to victims regarding dangerous-ness of the haunted items, so the filter size now scales with throwforce.
- Items that have no targets to throw at just sit there uselessly, so they now gain 5 throwforce for every idle cycle (up to the 15 cap).
- Items were attacking too slowly after server lag was being taken into account.
- Damage values were not being properly applied to haunted objects
- `Dodgeable = false` lead to the items hitting each other more than victimts

<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Testing
death to monkey
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Fixes and slight tweaks for new reventant spells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
