### PR TITLE
Rainbow/Mime crayons can no longer be used for infinite nutrition

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -21,6 +21,8 @@
 	var/dat
 	var/busy = FALSE
 	var/list/validSurfaces = list(/turf/simulated/floor)
+	var/times_eaten = 0 //How many times this crayon has been gnawed on
+	var/max_bites = 4 //How many times a crayon can be bitten before being depleted. You eated it
 
 /obj/item/toy/crayon/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is jamming the [name] up [user.p_their()] nose and into [user.p_their()] brain. It looks like [user.p_theyre()] trying to commit suicide.</span>")
@@ -108,17 +110,25 @@
 			if(!H.check_has_mouth())
 				to_chat(user, "<span class='warning'>You do not have a mouth!</span>")
 				return
+		times_eaten++
 		playsound(loc, 'sound/items/eatfood.ogg', 50, 0)
-		to_chat(user, "<span class='notice'>You take a [huffable ? "huff" : "bite"] of the [name]. Delicious!</span>")
 		user.adjust_nutrition(5)
-		if(uses)
-			uses -= 5
-			if(uses <= 0)
-				to_chat(user, "<span class='warning'>There is no more of [name] left!</span>")
-				qdel(src)
+		if(times_eaten < max_bites)
+			to_chat(user, "<span class='notice'>You take a [huffable ? "huff" : "bite"] of the [name]. Delicious!</span>")
+		else
+			to_chat(user, "<span class='warning'>There is no more of [name] left!</span>")
+			qdel(src)
 	else
 		..()
 
+/obj/item/toy/crayon/examine(mob/user)
+	. = ..()
+	if(!user.Adjacent(src) || !times_eaten)
+		return
+	if(times_eaten == 1)
+		. += "<span class='notice'>[src] was bitten by someone!</span>"
+	else
+		. += "<span class='notice'>[src] was bitten multiple times!</span>"
 
 /obj/item/toy/crayon/red
 	name = "red crayon"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
A sister PR to  #19664

The amount of times crayons are bitten into is now tracked. After four bites, the crayon is used up. For Rainbow and Mime crayons (which are otherwise unlimited use), this means they can now be depleted by eating them up.

The user can now examine crayons and notice that they've been bitten into, similar to food.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prior to this PR,  the amount of uses a crayon had was lowered after taking a bite out of them; after enough bites, the crayon would disappear. Because rainbow/mime crayons have *unlimited* uses (for graffiti), this had the effect of giving clowns and mimes an infinite source of nutrition. The hunger system should not be something that standard players can opt out of with roundstart items.

## Testing
Compiled and tested on local debug server. Rainbow/mime crayons can be eaten into oblivion as expected
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Rainbow/mime crayons are no longer infinitely eatable. Savor the flavor while it lasts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
