### PR TITLE
Cheese wheels now expend universal enzyme when created

### DIFF
--- a/code/modules/reagents/chemistry/recipes/food.dm
+++ b/code/modules/reagents/chemistry/recipes/food.dm
@@ -47,8 +47,7 @@
 	name = "Cheesewheel"
 	id = "cheesewheel"
 	result = null
-	required_reagents = list("milk" = 40)
-	required_catalysts = list("enzyme" = 5)
+	required_reagents = list("milk" = 40, "enzyme" = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/cheesewheel/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The cheese wheel recipe (40u milk reagent, 5u universal enzyme catalyst) has been changed to put universal enzyme in the reagent list; it will now be expended after the cheese wheel is created.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The chef starts with universal enzyme, which isn't depleted when creating cheese wheels. Milk is infinitely available from the bar, one room over. The natural result of this is that the chef can create infinite amounts of food from the very start of the round, with no consideration to resource management (or presentation).

With this PR, each cheese wheel will require 5u of enzyme to create, meaning the chef can create 10 cheese wheels with the enzyme he starts with. Past that, time to hit up cargo... or learn the dark secret of how to synthesize universal enzyme.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and tested on local debug server. Enzyme is expended when making cheese wheels
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Universal Enzyme is now expended when making cheese wheels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
