### PR TITLE
Converts clown mask selection to a radial menu

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -116,20 +116,24 @@
 	resistance_flags = FLAMMABLE
 	dog_fashion = /datum/dog_fashion/head/clown
 
-/obj/item/clothing/mask/gas/clown_hat/attack_self(mob/user)
-
+/obj/item/clothing/mask/gas/clown_hat/attack_self(mob/living/user)
 	var/mob/M = usr
-	var/list/options = list()
-	options["True Form"] = "clown"
-	options["The Feminist"] = "sexyclown"
-	options["The Madman"] = "joker"
-	options["The Rainbow Color"] ="rainbow"
+	var/list/mask_type = list("True Form" = /obj/item/clothing/mask/gas/clown_hat,
+							"The Feminist" = /obj/item/clothing/mask/gas/clown_hat/sexy,
+							"The Madman" = /obj/item/clothing/mask/gas/clown_hat/joker,
+							"The Rainbow Color" = /obj/item/clothing/mask/gas/clown_hat/rainbow)
+	var/list/mask_icons = list("True Form" = image(icon = 'icons/obj/clothing/masks.dmi', icon_state = "clown"),
+							"The Feminist" = image(icon = 'icons/obj/clothing/masks.dmi', icon_state = "sexyclown"),
+							"The Madman" = image(icon = 'icons/obj/clothing/masks.dmi', icon_state = "joker"),
+							"The Rainbow Color" = image(icon = 'icons/obj/clothing/masks.dmi', icon_state = "rainbow"))
+	var/mask_choice = show_radial_menu(user, src, mask_icons)
+	var/picked_mask = mask_type[mask_choice]
 
-	var/choice = input(M,"To what form do you wish to Morph this mask?","Morph Mask") in options
-
-	if(src && choice && !M.stat && in_range(M,src))
-		icon_state = options[choice]
-		to_chat(M, "Your Clown Mask has now morphed into [choice], all praise the Honk Mother!")
+	if(src && picked_mask && !M.stat && in_range(M,src))
+		var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
+		qdel(src)
+		user.put_in_active_hand(new_mask)
+		to_chat(M, "Your Clown Mask has now morphed into its new form, all praise the Honk Mother!")
 		return 1
 
 /obj/item/clothing/mask/gas/clown_hat/sexy
@@ -137,6 +141,18 @@
 	desc = "A feminine clown mask for the dabbling crossdressers or female entertainers."
 	icon_state = "sexyclown"
 	item_state = "sexyclown"
+
+/obj/item/clothing/mask/gas/clown_hat/joker
+	name = "deranged clown wig and mask"
+	desc = "A fiendish clown mask that inspires a deranged mirth."
+	icon_state = "joker"
+	item_state = "joker"
+
+/obj/item/clothing/mask/gas/clown_hat/rainbow
+	name = "rainbow clown wig and mask"
+	desc = "A colorful clown mask for the clown that loves to dazzle and impress."
+	icon_state = "rainbow"
+	item_state = "rainbow"
 
 /obj/item/clothing/mask/gas/clownwiz
 	name = "wizard clown wig and mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -132,12 +132,11 @@
 		return
 	if(user.stat || !in_range(user, src))
 		return
-	else
-		var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
-		qdel(src)
-		user.put_in_active_hand(new_mask)
-		to_chat(user, "<span class='notice'>Your Clown Mask has now morphed into its new form, all praise the Honk Mother!</span>")
-		return 1
+	var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
+	qdel(src)
+	user.put_in_active_hand(new_mask)
+	to_chat(user, "<span class='notice'>Your Clown Mask has now morphed into its new form, all praise the Honk Mother!</span>")
+	return 1
 
 /obj/item/clothing/mask/gas/clown_hat/sexy
 	name = "sexy-clown wig and mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -129,15 +129,12 @@
 	var/mask_choice = show_radial_menu(user, src, mask_icons)
 	var/picked_mask = mask_type[mask_choice]
 
-	if(QDELETED(src) || !picked_mask)
-		return
-	if(M.stat || !in_range(M, src))
-	    return
-	var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
-	qdel(src)
-	user.put_in_active_hand(new_mask)
-	to_chat(M, "<span class='notice'>Your Clown Mask has now morphed into its new form, all praise the Honk Mother!</span>")
-	return 1
+	if(src && picked_mask && !M.stat && in_range(M,src))
+		var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
+		qdel(src)
+		user.put_in_active_hand(new_mask)
+		to_chat(M, "Your Clown Mask has now morphed into its new form, all praise the Honk Mother!")
+		return 1
 
 /obj/item/clothing/mask/gas/clown_hat/sexy
 	name = "sexy-clown wig and mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -109,7 +109,7 @@
 
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"
-	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."
+	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask. Its form can be changed by using it in your hand."
 	icon_state = "clown"
 	item_state = "clown_hat"
 	flags = BLOCK_GAS_SMOKE_EFFECT | AIRTIGHT | BLOCKHAIR
@@ -138,19 +138,19 @@
 
 /obj/item/clothing/mask/gas/clown_hat/sexy
 	name = "sexy-clown wig and mask"
-	desc = "A feminine clown mask for the dabbling crossdressers or female entertainers."
+	desc = "A feminine clown mask for the dabbling crossdressers or female entertainers. Its form can be changed by using it in your hand."
 	icon_state = "sexyclown"
 	item_state = "sexyclown"
 
 /obj/item/clothing/mask/gas/clown_hat/joker
 	name = "deranged clown wig and mask"
-	desc = "A fiendish clown mask that inspires a deranged mirth."
+	desc = "A fiendish clown mask that inspires a deranged mirth. Its form can be changed by using it in your hand."
 	icon_state = "joker"
 	item_state = "joker"
 
 /obj/item/clothing/mask/gas/clown_hat/rainbow
 	name = "rainbow clown wig and mask"
-	desc = "A colorful clown mask for the clown that loves to dazzle and impress."
+	desc = "A colorful clown mask for the clown that loves to dazzle and impress. Its form can be changed by using it in your hand."
 	icon_state = "rainbow"
 	item_state = "rainbow"
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -136,7 +136,7 @@
 	qdel(src)
 	user.put_in_active_hand(new_mask)
 	to_chat(user, "<span class='notice'>Your Clown Mask has now morphed into its new form, all praise the Honk Mother!</span>")
-	return 1
+	return TRUE
 
 /obj/item/clothing/mask/gas/clown_hat/sexy
 	name = "sexy-clown wig and mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -129,12 +129,15 @@
 	var/mask_choice = show_radial_menu(user, src, mask_icons)
 	var/picked_mask = mask_type[mask_choice]
 
-	if(src && picked_mask && !M.stat && in_range(M,src))
-		var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
-		qdel(src)
-		user.put_in_active_hand(new_mask)
-		to_chat(M, "Your Clown Mask has now morphed into its new form, all praise the Honk Mother!")
-		return 1
+	if(QDELETED(src) || !picked_mask)
+		return
+	if(M.stat || !in_range(M, src))
+	    return
+	var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
+	qdel(src)
+	user.put_in_active_hand(new_mask)
+	to_chat(M, "<span class='notice'>Your Clown Mask has now morphed into its new form, all praise the Honk Mother!</span>")
+	return 1
 
 /obj/item/clothing/mask/gas/clown_hat/sexy
 	name = "sexy-clown wig and mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -117,7 +117,6 @@
 	dog_fashion = /datum/dog_fashion/head/clown
 
 /obj/item/clothing/mask/gas/clown_hat/attack_self(mob/living/user)
-	var/mob/M = usr
 	var/list/mask_type = list("True Form" = /obj/item/clothing/mask/gas/clown_hat,
 							"The Feminist" = /obj/item/clothing/mask/gas/clown_hat/sexy,
 							"The Madman" = /obj/item/clothing/mask/gas/clown_hat/joker,
@@ -129,11 +128,15 @@
 	var/mask_choice = show_radial_menu(user, src, mask_icons)
 	var/picked_mask = mask_type[mask_choice]
 
-	if(src && picked_mask && !M.stat && in_range(M,src))
+	if(QDELETED(src) || !picked_mask)
+		return
+	if(user.stat || !in_range(user, src))
+		return
+	else
 		var/obj/item/clothing/mask/gas/clown_hat/new_mask = new picked_mask(get_turf(user))
 		qdel(src)
 		user.put_in_active_hand(new_mask)
-		to_chat(M, "Your Clown Mask has now morphed into its new form, all praise the Honk Mother!")
+		to_chat(user, "<span class='notice'>Your Clown Mask has now morphed into its new form, all praise the Honk Mother!</span>")
 		return 1
 
 /obj/item/clothing/mask/gas/clown_hat/sexy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
This PR changes the "use" effect of the Clown Mask from opening a window with options of other masks to change to, to opening a radial menu with other masks to change to. It also changes how the clown mask shifts (previously it simply changed icon state while keeping the old name, which was weird) and as a result properly adds the joker and rainbow clown masks to the game, which seemed to have previously only existed as icon state changes on the original clown mask.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Radial Menus are preferable over popup selection boxes, and this gives users a preview of what the mask will change into.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/71326864/201457536-32fb0333-3f59-4407-abec-3014bb6b842a.png)
And a clearer image without the jokes,
![image](https://user-images.githubusercontent.com/71326864/201457604-a9975fc9-d75e-4267-8e7d-bf6da69db3cd.png)
## Testing
<!-- How did you test the PR, if at all? -->
Joined as Clown, took off mask, confirmed radial menu worked, confirmed it shifts between mask types properly, confirmed closing the radial menu plays nicely, made sure it didn't work if the object was distant, et cetera. You can change it while it's being worn if the radial menu was already open but it will force it into your hands.
## Changelog
:cl:
tweak: Clown Mask selection now uses a radial menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
