### PR TITLE
Makes the arrival shuttle completely protected from solar flares

### DIFF
--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -20,7 +20,7 @@
 	immunity_type = "burn"
 	var/damage = 4
 	/// Areas which are "semi-protected". Mobs inside these areas take reduced burn damage from the solar flare.
-	var/semi_protected_areas = list(/area/hallway/secondary/entry)
+	var/list/semi_protected_areas = list(/area/hallway/secondary/entry)
 
 /datum/weather/solar_flare/generate_area_list()
 	..()

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -15,10 +15,12 @@
 	end_duration = 10 // wind_down() does not do anything for this event, so we just trigger end() semi-immediately
 	end_message = null
 	area_type = /area/space // read generate_area_list() as well below
-	protected_areas = list(/area/shuttle/arrival/station, /area/hallway/secondary/entry)
+	protected_areas = list(/area/shuttle/arrival/station)
 	target_trait = STATION_LEVEL
 	immunity_type = "burn"
 	var/damage = 4
+	/// Areas which are "semi-protected". Mobs inside these areas take reduced burn damage from the solar flare.
+	var/semi_protected_areas = list(/area/hallway/secondary/entry)
 
 /datum/weather/solar_flare/generate_area_list()
 	..()
@@ -50,8 +52,11 @@
 	return FALSE
 
 /datum/weather/solar_flare/weather_act(mob/living/L)
+	var/target_area = get_area(L)
+	if(target_area in protected_areas) // We do wanna protect new arrivals from horrible death.
+		return
 	var/adjusted_damage = damage
-	if(get_area(L) in protected_areas) //we do wanna protect new arrivals from horrible death
+	if(target_area in semi_protected_areas)
 		adjusted_damage = 1
 	L.adjustFireLoss(adjusted_damage)
 	L.flash_eyes()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the arrival shuttle completely protected from solar flares
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People loading into the game while a solar flare is happening should get some breathing room, and not instantly have their vision flashed and start taking damage.

Fixes #19206
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded into test server at the arrival shuttle, and fired the solar flare event. Stood in the arrival shuttle and stared at space, took no damage. Walked out into the initial arrival hallway, stared at space, took reduced damage.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Players in the arrival shuttle no longer take any damage from solar flares
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
