### PR TITLE
Fixes cheesing syndicate turrets by standing on them

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1042,7 +1042,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	var/area/syndicate_depot/core/depotarea
 
 /obj/machinery/porta_turret/syndicate/CanPass(atom/A)
-    return !isliving(A)
+    return (stat & BROKEN || !isliving(A))
 
 /obj/machinery/porta_turret/syndicate/die()
 	. = ..()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1028,6 +1028,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 
 	faction = "syndicate"
 	emp_vulnerable = FALSE
+	density = TRUE
 
 	lethal = TRUE
 	lethal_is_configurable = FALSE

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1042,7 +1042,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	var/area/syndicate_depot/core/depotarea
 
 /obj/machinery/porta_turret/syndicate/CanPass(atom/A)
-    return (stat & BROKEN || !isliving(A))
+    return ((stat & BROKEN) || !isliving(A))
 
 /obj/machinery/porta_turret/syndicate/die()
 	. = ..()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1028,7 +1028,6 @@ GLOBAL_LIST_EMPTY(turret_icons)
 
 	faction = "syndicate"
 	emp_vulnerable = FALSE
-	density = TRUE
 
 	lethal = TRUE
 	lethal_is_configurable = FALSE
@@ -1041,6 +1040,9 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	check_synth	= TRUE
 	ailock = TRUE
 	var/area/syndicate_depot/core/depotarea
+
+/obj/machinery/porta_turret/syndicate/CanPass(atom/A)
+    return !isliving(A)
 
 /obj/machinery/porta_turret/syndicate/die()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Revives https://github.com/ParadiseSS13/Paradise/pull/17440

Prevents cheesing syndicate turrets by standing on them.

Normal turrets are dense when deployed, syndie turrets are always deployed so they are never dense. This fixes that.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: You can no longer stand on a syndicate turret to avoid it killing you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
