### PR TITLE
Adds Blob burst status effect to both blob mice and humans

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -448,6 +448,7 @@
 
 /// Prepares a text to be used for maptext. Use this so it doesn't look hideous.
 #define MAPTEXT(text) {"<span class='maptext'>[##text]</span>"}
+#define MAPTEXT_CENTER(text) {"<span class='maptext' style='text-align: center'>[##text]</span>"}
 
 //Fullscreen overlay resolution in tiles.
 #define FULLSCREEN_OVERLAY_RESOLUTION_X 15

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -144,3 +144,5 @@
 #define STATUS_EFFECT_ADAPTIVELEARNING /datum/status_effect/adaptive_learning //tracks the total bonus damage needed to be done to target
 /// Status effect given when someone uses the Give Item command to offer an item to another player.
 #define STATUS_EFFECT_OFFERING_ITEM /datum/status_effect/offering_item
+
+#define STATUS_EFFECT_BLOB_BURST /datum/status_effect/blob_burst

--- a/code/datums/status_effects/blob_burst.dm
+++ b/code/datums/status_effects/blob_burst.dm
@@ -1,0 +1,24 @@
+/datum/status_effect/blob_burst
+	alert_type = /obj/screen/alert/status_effect/blob_burst
+	var/datum/callback/blob_burst_callback
+	var/font_size = 7
+
+/datum/status_effect/blob_burst/on_creation(mob/living/new_owner, duration = 120 SECONDS, datum/callback/burst_callback)
+	. = ..()
+	if(!.)
+		return
+	src.duration = duration
+	blob_burst_callback = burst_callback
+
+/datum/status_effect/blob_burst/tick()
+	var/time_left = (duration - world.time) / 10
+	linked_alert.maptext = "<div style=\"font-size:7pt;color:#FFFFFF;font:'Small Fonts';text-align:center;\" valign=\"bottom\">[round(time_left)]</div>"
+
+/datum/status_effect/blob_burst/on_timeout()
+	blob_burst_callback.Invoke()
+
+/obj/screen/alert/status_effect/blob_burst
+	name = "Blob burst"
+	desc = "You're about to burst into a blob! Be sure to find a safe place before that."
+	icon = 'icons/mob/blob.dmi'
+	icon_state = "ui_tocore"

--- a/code/datums/status_effects/blob_burst.dm
+++ b/code/datums/status_effects/blob_burst.dm
@@ -1,7 +1,6 @@
 /datum/status_effect/blob_burst
 	alert_type = /obj/screen/alert/status_effect/blob_burst
 	var/datum/callback/blob_burst_callback
-	var/font_size = 7
 
 /datum/status_effect/blob_burst/on_creation(mob/living/new_owner, duration = 120 SECONDS, datum/callback/burst_callback)
 	. = ..()
@@ -19,6 +18,6 @@
 
 /obj/screen/alert/status_effect/blob_burst
 	name = "Blob burst"
-	desc = "You're about to burst into a blob! Be sure to find a safe place before that."
+	desc = "You're about to burst into a blob, be sure to find a safe place before that you burst!"
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "ui_tocore"

--- a/code/datums/status_effects/blob_burst.dm
+++ b/code/datums/status_effects/blob_burst.dm
@@ -11,7 +11,7 @@
 
 /datum/status_effect/blob_burst/tick()
 	var/time_left = (duration - world.time) / 10
-	linked_alert.maptext = MAPTEXT_CENTER("[round(time_left)]")
+	linked_alert.maptext = MAPTEXT_CENTER(round(time_left))
 
 /datum/status_effect/blob_burst/on_timeout()
 	blob_burst_callback.Invoke()

--- a/code/datums/status_effects/blob_burst.dm
+++ b/code/datums/status_effects/blob_burst.dm
@@ -3,11 +3,15 @@
 	var/datum/callback/blob_burst_callback
 
 /datum/status_effect/blob_burst/on_creation(mob/living/new_owner, duration = 120 SECONDS, datum/callback/burst_callback)
+	src.duration = duration
 	. = ..()
 	if(!.)
 		return
-	src.duration = duration
 	blob_burst_callback = burst_callback
+
+/datum/status_effect/blob_burst/Destroy()
+	blob_burst_callback = null
+	return ..()
 
 /datum/status_effect/blob_burst/tick()
 	var/time_left = (duration - world.time) / 10

--- a/code/datums/status_effects/blob_burst.dm
+++ b/code/datums/status_effects/blob_burst.dm
@@ -11,7 +11,7 @@
 
 /datum/status_effect/blob_burst/tick()
 	var/time_left = (duration - world.time) / 10
-	linked_alert.maptext = "<div style=\"font-size:7pt;color:#FFFFFF;font:'Small Fonts';text-align:center;\" valign=\"bottom\">[round(time_left)]</div>"
+	linked_alert.maptext = MAPTEXT_CENTER("[round(time_left)]")
 
 /datum/status_effect/blob_burst/on_timeout()
 	blob_burst_callback.Invoke()

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	addtimer(CALLBACK(src, PROC_REF(stage), 1), (wait_time * 4 + wait_time / 2))
 
 	// Stage 2
-	addtimer(CALLBACK(src, PROC_REF(stage), 2), 50 MINUTES + wait_time * 4)
+	addtimer(CALLBACK(src, PROC_REF(stage), 2), 50 MINUTES + wait_time * 2)
 
 	return ..()
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	var/blobwincount = 350
 
 	/// Lower bound on time before messages, bursts and intercepts happen
-	var/const/wait_time_low = 600 SECONDS
+	var/const/wait_time_low = 60 SECONDS
 	/// Upper bound on time before messages, bursts and intercepts happen
 	var/const/wait_time_high = 180 SECONDS
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	addtimer(CALLBACK(src, PROC_REF(show_message), "<span class='userdanger'>You feel like you are about to burst.</span>"), wait_time * 2)
 
 	// Stage 1
-	addtimer(CALLBACK(src, PROC_REF(stage), 1), (wait_time * 4 + wait_time / 2))
+	addtimer(CALLBACK(src, PROC_REF(stage), 1), (wait_time * 4.5))
 
 	// Stage 2
 	addtimer(CALLBACK(src, PROC_REF(stage), 2), 50 MINUTES + wait_time * 2)

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -10,9 +10,9 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	name = "blob"
 	config_tag = "blob"
 
-	required_players = 1
-	required_enemies = 0
-	recommended_enemies = 0
+	required_players = 30
+	required_enemies = 1
+	recommended_enemies = 1
 	restricted_jobs = list("Cyborg", "AI")
 
 	var/burst = 0

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -10,9 +10,9 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	name = "blob"
 	config_tag = "blob"
 
-	required_players = 30
-	required_enemies = 1
-	recommended_enemies = 1
+	required_players = 1
+	required_enemies = 0
+	recommended_enemies = 0
 	restricted_jobs = list("Cyborg", "AI")
 
 	var/burst = 0
@@ -73,8 +73,8 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 	log_game("[key_name(blob)] has been selected as a Blob")
 	greet_blob(blobmind)
-	to_chat(blob, "<span class='userdanger'>You feel very tired and bloated!  You don't have long before you burst!</span>")
-	addtimer(CALLBACK(src, PROC_REF(burst_blob), blobmind), 60 SECONDS)
+	to_chat(blob, "<span class='userdanger'>You feel very tired and bloated! You don't have long before you burst!</span>")
+	blob.apply_status_effect(STATUS_EFFECT_BLOB_BURST, 60 SECONDS, CALLBACK(src, PROC_REF(burst_blob)))
 	return 1
 
 /datum/game_mode/blob/proc/make_blobs(count)
@@ -147,20 +147,18 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /datum/game_mode/blob/post_setup()
 
+	var/wait_time = rand(waittime_l, waittime_h)
 	for(var/datum/mind/blob in infected_crew)
 		greet_blob(blob)
 		update_blob_icons_added(blob)
+		blob.current.apply_status_effect(STATUS_EFFECT_BLOB_BURST, 10 SECONDS * 2.5, CALLBACK(src, PROC_REF(burst_blob), blob))
 
 	if(SSshuttle)
 		SSshuttle.emergencyNoEscape = 1
 
 	spawn(0)
 
-		var/wait_time = rand(waittime_l, waittime_h)
-
 		sleep(wait_time)
-
-		send_intercept(0)
 
 		sleep(100)
 
@@ -169,8 +167,6 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		sleep(wait_time)
 
 		show_message("<span class='userdanger'>You feel like you are about to burst.</span>")
-
-		addtimer(CALLBACK(src, PROC_REF(burst_blobs)), (wait_time / 2))
 
 		// Stage 1
 		addtimer(CALLBACK(src, PROC_REF(stage), 1), (wait_time * 2 + wait_time / 2))

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -37,8 +37,6 @@
 	var/uplink_welcome = "Syndicate Uplink Console:"
 	var/uplink_uses = 20
 
-	var/const/waittime_l = 600  //lower bound on time before intercept arrives (in tenths of seconds)
-	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 	var/list/player_draft_log = list()
 	var/list/datum/mind/xenos = list()
 	var/list/datum/mind/eventmiscs = list()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -163,17 +163,12 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	gold_core_spawnable = NO_SPAWN
-	var/cycles_alive = 0
-	var/cycles_limit = 60
-	var/has_burst = FALSE
 
 /mob/living/simple_animal/mouse/blobinfected/Initialize(mapload)
 	. = ..()
 	apply_status_effect(STATUS_EFFECT_BLOB_BURST, 120 SECONDS, CALLBACK(src, PROC_REF(burst), FALSE))
 
 /mob/living/simple_animal/mouse/blobinfected/Life()
-	cycles_alive++
-	var/timeleft = (cycles_limit - cycles_alive) * 2
 	if(ismob(loc)) // if someone ate it, burst immediately
 		burst(FALSE)
 	return ..()
@@ -183,14 +178,11 @@
 	return ..(gibbed)
 
 /mob/living/simple_animal/mouse/blobinfected/proc/burst(gibbed)
-	if(has_burst)
-		return FALSE
 	var/turf/T = get_turf(src)
 	if(!is_station_level(T.z) || isspaceturf(T))
 		to_chat(src, "<span class='userdanger'>You feel ready to burst, but this isn't an appropriate place!  You must return to the station!</span>")
 		apply_status_effect(STATUS_EFFECT_BLOB_BURST, 5 SECONDS, CALLBACK(src, PROC_REF(burst), FALSE))
 		return FALSE
-	has_burst = TRUE
 	var/datum/mind/blobmind = mind
 	var/client/C = client
 	if(istype(blobmind) && istype(C))

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -167,15 +167,15 @@
 	var/cycles_limit = 60
 	var/has_burst = FALSE
 
+/mob/living/simple_animal/mouse/blobinfected/Initialize(mapload)
+	. = ..()
+	apply_status_effect(STATUS_EFFECT_BLOB_BURST, 120 SECONDS, CALLBACK(src, PROC_REF(burst), FALSE))
+
 /mob/living/simple_animal/mouse/blobinfected/Life()
 	cycles_alive++
 	var/timeleft = (cycles_limit - cycles_alive) * 2
 	if(ismob(loc)) // if someone ate it, burst immediately
 		burst(FALSE)
-	else if(timeleft < 1) // if timer expired, burst.
-		burst(FALSE)
-	else if(cycles_alive % 2 == 0) // give the mouse/player a countdown reminder every 2 cycles
-		to_chat(src, "<span class='warning'>[timeleft] seconds until you burst, and become a blob...</span>")
 	return ..()
 
 /mob/living/simple_animal/mouse/blobinfected/death(gibbed)
@@ -188,6 +188,7 @@
 	var/turf/T = get_turf(src)
 	if(!is_station_level(T.z) || isspaceturf(T))
 		to_chat(src, "<span class='userdanger'>You feel ready to burst, but this isn't an appropriate place!  You must return to the station!</span>")
+		apply_status_effect(STATUS_EFFECT_BLOB_BURST, 5 SECONDS, CALLBACK(src, PROC_REF(burst), FALSE))
 		return FALSE
 	has_burst = TRUE
 	var/datum/mind/blobmind = mind

--- a/paradise.dme
+++ b/paradise.dme
@@ -508,6 +508,7 @@
 #include "code\datums\spells\trigger.dm"
 #include "code\datums\spells\turf_teleport.dm"
 #include "code\datums\spells\wizard.dm"
+#include "code\datums\status_effects\blob_burst.dm"
 #include "code\datums\status_effects\buffs.dm"
 #include "code\datums\status_effects\debuffs.dm"
 #include "code\datums\status_effects\gas.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds a status effect to blob-infected humans and mice. This effect has a timer on it like how the spell cooldown system does it.
Blob mice now don't get the spamming in the chat anymore of how long they still have. The messages humans get are still there.

The current icon works just fine with the better font. In a later rework :tm: this could be changed

## Why It's Good For The Game
The human blob infected don't have a good way to see when they are going to burst. This sometimes causes new players to burst in the middle of hallways which is not fun for anybody.
The mouse's current implementation is also quite bad. Spamming the chat with how long you still have ain't the best solution.

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/201480016-03afd9a7-d46e-465f-9de1-d42ff93ba47c.png)


## Testing
- Spawned a mouse and assumed direct control. And waited for it to burst
- Set the gamemode to blob and spawned as one. Then waited for the timer to run out and burst me into a blob core.
- Died as an infected mouse to check if it still worked

## Changelog
:cl:
tweak: Adds a blob status effect for infected humans and mice
/:cl:
