### PR TITLE
Fix security announcement title size.

### DIFF
--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -432,4 +432,4 @@ span.body .coderesponses 		{color: #FF3333;}
 .announcement p { color: #d82020; line-height: 1.3; }
 .announcement.minor h1 { font-size: 180%; }
 .announcement.minor h2 { font-size: 170%; }
-.announcement.sec h1 { color: #f00; font-size: 80%; font-family: Verdana, sans-serif; }
+.announcement.sec h1 { color: #f00; font-size: 180%; font-family: Verdana, sans-serif; }

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -432,4 +432,4 @@ span.body .coderesponses {color: #FF0000;}
 .announcement p { color: #d82020; line-height: 1.3; }
 .announcement.minor h1 { font-size: 180%; }
 .announcement.minor h2 { font-size: 170%; }
-.announcement.sec h1 { color: #f00; font-size: 80%; font-family: Verdana, sans-serif; }
+.announcement.sec h1 { color: #f00; font-size: 180%; font-family: Verdana, sans-serif; }


### PR DESCRIPTION
## What Does This PR Do
Fixes security announcements to have properly-sized headers. Font sizes specified as percentages are relative to the inherited font size, not the element's default font size. In other words, if a normal sized h1 is 200%, a slightly smaller one is 180%; it is not 80% of the header's original font size.

Fixes #19687.

## Why It's Good For The Game
Visual regression fix.

## Images of changes

![20_00_27__Paradise Station 13-](https://user-images.githubusercontent.com/59303604/201554957-c623988e-a383-49af-93da-f552f9e28c2f.png)


## Testing
Launched game, toggled alerts.

## Changelog
:cl:
fix: Security announcements have properly sized titles.
/:cl:
