### PR TITLE
Shortens the Mime's invisible wall duration

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -34,7 +34,7 @@
 	school = "mime"
 	panel = "Mime"
 	clothes_req = FALSE
-	base_cooldown = 300 SECONDS
+	base_cooldown = 5 MINUTES
 	human_req = TRUE
 
 	action_icon_state = "mime_silence"

--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -6,8 +6,8 @@
 	summon_type = list(/obj/effect/forcefield/mime)
 	invocation_type = "emote"
 	invocation_emote_self = "<span class='notice'>You form a wall in front of yourself.</span>"
-	summon_lifespan = 300
-	base_cooldown = 300
+	summon_lifespan = 20 SECONDS
+	base_cooldown = 30 SECONDS
 	clothes_req = FALSE
 	cast_sound = null
 	human_req = TRUE
@@ -34,7 +34,7 @@
 	school = "mime"
 	panel = "Mime"
 	clothes_req = FALSE
-	base_cooldown = 3000
+	base_cooldown = 300 SECONDS
 	human_req = TRUE
 
 	action_icon_state = "mime_silence"
@@ -70,7 +70,7 @@
 	wall_type = /obj/effect/forcefield/mime/advanced
 	invocation_type = "emote"
 	invocation_emote_self = "<span class='notice'>You form a blockade in front of yourself.</span>"
-	base_cooldown = 600
+	base_cooldown = 60 SECONDS
 	sound =  null
 	clothes_req = FALSE
 
@@ -94,7 +94,7 @@
 	school = "mime"
 	panel = "Mime"
 	clothes_req = FALSE
-	base_cooldown = 300
+	base_cooldown = 30 SECONDS
 	human_req = TRUE
 
 	action_icon_state = "fingergun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Reduces the uptime of Mime invisible wall spell from 30 seconds to 20 seconds. Cooldown is unchanged. All time values in the modified file have been converted from deciseconds to seconds.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Honestly, the Mime should not have had a 30 second unbreakable wall with a 30 second cooldown as part of its default kit. It's rarely used for RP value and is honestly just for shittery. Leaving it at 20 seconds keeps it as a powerful ability, but you will still have some downtime now for people to get their angry hands on you.
## Testing
<!-- How did you test the PR, if at all? -->
Spawned in as Mime, changed name to Mimeroni, created force wall, counted in sesames (very poorly), confirmed when the wall went away that the ability was not fully recharged. Everything else seemed to function fine with the conversion from deciseconds to seconds.
## Changelog
:cl:
tweak: Reduced uptime on Mime wall from 30 seconds to 20 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
