### PR TITLE
Another buff to radio jammers

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -388,7 +388,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/rankname // the formatting to be used for the mob's job
 
 	if(jammed && !syndiekey)
-		Gibberish_all(message_pieces, 100, 75)
+		Gibberish_all(message_pieces, 100, 70)
 
 	// --- Human: use their actual job ---
 	if(ishuman(M))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -387,8 +387,8 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/jobname // the mob's "job"
 	var/rankname // the formatting to be used for the mob's job
 
-	if(jammed)
-		Gibberish_all(message_pieces, 100)
+	if(jammed && !syndiekey)
+		Gibberish_all(message_pieces, 100, 75)
 
 	// --- Human: use their actual job ---
 	if(ishuman(M))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -344,9 +344,9 @@
 
 	return returntext
 
-/proc/Gibberish_all(list/message_pieces, p)
+/proc/Gibberish_all(list/message_pieces, p, replace_rate)
 	for(var/datum/multilingual_say_piece/S in message_pieces)
-		S.message = Gibberish(S.message, p)
+		S.message = Gibberish(S.message, p, replace_rate)
 
 
 /proc/muffledspeech(phrase)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Gives another spin to #19241
Headsets with syndicate encryption key are protected from jammer effects.
Jammer replace_rate has been increased (50 --> 70)
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![jammer](https://user-images.githubusercontent.com/77684085/201696163-d2339516-8c6f-46ec-8d3d-e5c0a4664d78.png)
The current scramble rate isnt enough to prevent the location or traitor name from being exposed to the public (even worse if the target is wounded), this buff should be enough to make most messages not that readable anymore.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![jammer_buff](https://user-images.githubusercontent.com/77684085/201693781-5ddd5bc1-d280-46fb-844b-b45b0e0671fb.png)

## Testing
<!-- How did you test the PR, if at all? -->
- tested while using syndie keys, was not affected.
- tested jammer with common keys, see images of changes.
## Changelog
:cl:
tweak: Headsets with syndiekeys are protected from jammers
tweak: Buffed jammer scramble rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
