### PR TITLE
Prevents bypassing disabler cooldowns by using two.

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -58,6 +58,13 @@
 	flight_y_offset = 10
 	can_holster = TRUE
 
+/obj/item/gun/energy/disabler/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
+    var/obj/item/gun/energy/disabler/offhand_disabler = user.get_inactive_hand()
+    if(istype(offhand_disabler) && offhand_disabler.semicd && (user.a_intent != INTENT_HARM))
+        return
+
+    return ..()
+
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents users from bypassing recently added disabler cooldowns by using two disablers and rapidly switching between them while firing on help intent.

Akimbo firing on harm intent is unimpeded.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This cooldown was added for a reason guys, people being sweaty to get around it is not what anyone had in mind when adding the cooldown.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Fired guns, modded cooldowns to be much longer and tried firing both.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed being able to bypass disabler cooldowns by rapidly switching between two of them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
