### PR TITLE
Chaos guardian buff and tweak to some descriptions

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -3,7 +3,7 @@
 	melee_damage_upper = 15
 	damage_transfer = 0.6
 	range = 13
-	playstyle_string = "As an <b>Explosive</b> type, you have only moderate close combat abilities, but are capable of converting any adjacent item into a disguised bomb via alt click."
+	playstyle_string = "As an <b>Explosive</b> type, you have only moderate close combat abilities, but are capable of converting any adjacent item into a disguised bomb via alt click even when not manifested."
 	magic_fluff_string = "..And draw the Scientist, master of explosive death."
 	tech_fluff_string = "Boot sequence complete. Explosive modules active. Holoparasite swarm online."
 	bio_fluff_string = "Your scarab swarm finishes mutating and stirs to life, capable of stealthily booby trapping items."

--- a/code/game/gamemodes/miniantags/guardian/types/charger.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/charger.dm
@@ -6,7 +6,7 @@
 	ranged_cooldown_time = 40
 	speed = -1
 	damage_transfer = 0.6
-	playstyle_string = "As a <b>Charger</b> type you do medium damage, have medium damage resistance, move very fast, and can charge at a location, damaging any target hit and forcing them to the ground. (Click a tile to use your charge ability)"
+	playstyle_string = "As a <b>Charger</b> type you do medium damage, have medium damage resistance, move very fast, and can charge at a location, damaging any target hit and forcing them to the ground. (Click a tile or foe to use your charge ability)"
 	magic_fluff_string = "..And draw the Hunter, an alien master of rapid assault."
 	tech_fluff_string = "Boot sequence complete. Charge modules loaded. Holoparasite swarm online."
 	bio_fluff_string = "Your scarab swarm finishes mutating and stirs to life, ready to deal damage."

--- a/code/game/gamemodes/miniantags/guardian/types/fire.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/fire.dm
@@ -5,7 +5,7 @@
 	attacktext = "sears"
 	damage_transfer = 0.8
 	range = 10
-	playstyle_string = "As a <b>Chaos</b> type, you have only light damage resistance, but will ignite any enemy you bump into. In addition, your melee attacks will randomly teleport enemies."
+	playstyle_string = "As a <b>Chaos</b> type, you have only light damage resistance, but will ignite any enemy you bump into. In addition, you can toggle modes to make your attacks teleport enemies or make them hallucinate."
 	environment_smash = 1
 	magic_fluff_string = "..And draw the Wizard, bringer of endless chaos!"
 	tech_fluff_string = "Boot sequence complete. Crowd control modules activated. Holoparasite swarm online."
@@ -19,13 +19,12 @@
 		summoner.adjust_fire_stacks(-20)
 
 /mob/living/simple_animal/hostile/guardian/fire/ToggleMode()
-	if(loc == summoner)
-		if(toggle)
-			to_chat(src, "<span class='notice'>You switch to dispersion mode, and will teleport victims away from your master.</span>")
-			toggle = FALSE
-		else
-			to_chat(src, "<span class='notice'>You switch to deception mode, and will turn your victims against their allies.</span>")
-			toggle = TRUE
+	if(toggle)
+		to_chat(src, "<span class='notice'>You switch to dispersion mode, and will teleport victims away from your master.</span>")
+		toggle = FALSE
+	else
+		to_chat(src, "<span class='notice'>You switch to deception mode, and will turn your victims against their allies.</span>")
+		toggle = TRUE
 
 /mob/living/simple_animal/hostile/guardian/fire/AttackingTarget()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Tweaked the playstyle_string to include a few useful informations (chaos, charger and explosive).
Buffed Chaos by removing the need to be un-manifested to toggle his mode.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The hallucinate mode makes your target see all carbons as if they are a guardian (15 SECONDS), this isnt that useful since he knows the real one did punch him last, but if combined by teleporting him soon after it could be the chaos that makes for the guardian name.
I think the hallucination mode isnt strong enough to deserve this restriction, if someone had to choose they would always keep the teleportation mode on as it is useful in a greater amount of situations than hallucination.
## Testing
<!-- How did you test the PR, if at all? -->
- Verified new messages and tried to toggle Chaos mode while manifested.
## Changelog
:cl:
tweak: Chaos guardian can now toggle modes while manifested
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
