### PR TITLE
Changes the code of conduct to include that you have to discuss major changes with the proper teams

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,7 +30,9 @@ Headcoders may close your PR at their discretion if your PR history has little f
 
 All Pull Requests are expected to be tested prior to submission. If a submitted Pull Request fails to pass CI checks, the likelihood of it being merged will be significantly lower. If you can't take the time to compile/test your Pull Request, do not expect a warm reception.
 
-It is expected that contributors discuss larger changes on the forums or repository discussion tab prior to coding a Pull Request. The amount of time spent on any given Pull Request is not relevant. Repo staff are not responsible for contributors wasting their time creating features nobody asked for.
+It is expected that contributors discuss larger changes on the forums or repository discussion tab prior to coding a Pull Request. The amount of time spent on any given Pull Request is not relevant. Repo staff are not responsible for contributors wasting their time creating features nobody asked for. Be sure to inform the corresponding teams about the forum post or discussion.
+
+In addition, discussing any change with the corresponding teams is very much advised. For large changes, changes which have a lot of impact (balance or design), species changes (however minor) or other changes that might be controversial, you should always discuss this with the corresponding teams. Failure to do so might result in your PR being closed.
 
 Barring highly specific circumstances (such as single line changes, submissions from advanced users, or changes to repo documentation), we will not accept Pull Requests utilising the web editor.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,7 +32,7 @@ All Pull Requests are expected to be tested prior to submission. If a submitted 
 
 It is expected that contributors discuss larger changes on the forums or repository discussion tab prior to coding a Pull Request. The amount of time spent on any given Pull Request is not relevant. Repo staff are not responsible for contributors wasting their time creating features nobody asked for. Be sure to inform the corresponding teams about the forum post or discussion.
 
-In addition, discussing any change with the corresponding teams is very much advised. For large changes, changes which have a lot of impact (balance or design), species changes (however minor) or other changes that might be controversial, you should always discuss this with the corresponding teams. Failure to do so might result in your PR being closed.
+In addition, discussing any change with the relevant teams is strongly advised. For large changes, changes which have a lot of impact (balance or design), species changes (however minor), or other changes that might be controversial, you should always discuss this with the relevant teams. Failure to do so might result in your PR being closed.
 
 Barring highly specific circumstances (such as single line changes, submissions from advanced users, or changes to repo documentation), we will not accept Pull Requests utilising the web editor.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,7 +30,7 @@ Headcoders may close your PR at their discretion if your PR history has little f
 
 All Pull Requests are expected to be tested prior to submission. If a submitted Pull Request fails to pass CI checks, the likelihood of it being merged will be significantly lower. If you can't take the time to compile/test your Pull Request, do not expect a warm reception.
 
-It is expected that contributors discuss larger changes on the forums or repository discussion tab prior to coding a Pull Request. The amount of time spent on any given Pull Request is not relevant. Repo staff are not responsible for contributors wasting their time creating features nobody asked for. Be sure to inform the corresponding teams about the forum post or discussion.
+It is expected that contributors discuss larger changes on the forums or repository discussion tab prior to starting work on a Pull Request. The amount of time spent on any given Pull Request is not relevant. Repo staff are not responsible for contributors wasting their time creating features nobody asked for. Be sure to inform the corresponding teams about the forum post or discussion.
 
 In addition, discussing any change with the relevant teams is strongly advised. For large changes, changes which have a lot of impact (balance or design), species changes (however minor), or other changes that might be controversial, you should always discuss this with the relevant teams. Failure to do so might result in your PR being closed.
 


### PR DESCRIPTION
## What Does This PR Do
Our code of conduct surrounding PR procedure is a bit outdated and unclear about how to work with the new design and balance teams. This PR updates it to be in line with what we expect of our contributors.

- Major changes or major impact should be relatively common sense as to why this should be discussed with the teams.
- We've seen over the years that species changes, however minor, are usually a very sensitive topic. To avoid unneeded issues here we want to ensure that a PR is checked with the corresponding teams before it gets made. This should avoid big discussions.
- Any other controversial change is relatively vague, but you should be able to use common sense here if you play the actual game.

## Why It's Good For The Game
This should make it more clear to contributors what we expect them to do when they plan on making a PR. 

## Testing
SEEEEEEEEEAAAAAAN

## Changelog
N/A