### PR TITLE
Fixes negative armor penetration not working as intended

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -10,28 +10,25 @@
 	1 - halfblock
 	2 - fullblock
 */
-/mob/living/proc/run_armor_check(def_zone = null, attack_flag = MELEE, absorb_text = null, soften_text = null, armour_penetration_flat = 0, penetrated_text, armour_penetration_percentage = 0)
+/mob/living/proc/run_armor_check(def_zone = null, attack_flag = MELEE, absorb_text = "Your armor absorbs the blow!", soften_text = "Your armor softens the blow!", armour_penetration_flat = 0, penetrated_text = "Your armor was penetrated!", armour_penetration_percentage = 0)
 	var/armor = getarmor(def_zone, attack_flag)
 
 	if(armor == INFINITY)
-		if(absorb_text)
-			to_chat(src, "<span class='userdanger'>[absorb_text]</span>")
-		else
-			to_chat(src, "<span class='userdanger'>Your armor absorbs the blow!</span>")
+		to_chat(src, "<span class='userdanger'>[absorb_text]</span>")
+		return armor
+	if(armor <= 0)
+		return armor
+	if(!armour_penetration_flat && armour_penetration_percentage <= 0)
+		to_chat(src, "<span class='userdanger'>[soften_text]</span>")
 		return armor
 
-	if(armor > 0)
-		if(armour_penetration_flat > 0 || armour_penetration_percentage > 0)
-			armor = max(0, (armor * ((100 - armour_penetration_percentage) / 100)) - armour_penetration_flat)
-			if(penetrated_text)
-				to_chat(src, "<span class='userdanger'>[penetrated_text]</span>")
-			else
-				to_chat(src, "<span class='userdanger'>Your armor was penetrated!</span>")
-		else
-			if(soften_text)
-				to_chat(src, "<span class='userdanger'>[soften_text]</span>")
-			else
-				to_chat(src, "<span class='userdanger'>Your armor softens the blow!</span>")
+	var/armor_original = armor
+	armor = max(0, (armor * ((100 - armour_penetration_percentage) / 100)) - armour_penetration_flat)
+	if(armor_original <= armor)
+		to_chat(src, "<span class='userdanger'>[soften_text]</span>")
+	else
+		to_chat(src, "<span class='userdanger'>[penetrated_text]</span>")
+
 	return armor
 
 //if null is passed for def_zone, then this should return something appropriate for all zones (e.g. area effect damage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Refactors `run_armor_check` so that it actually works with negative armour_penetration_flat. I asked Hal and armour_penetration_percentage should never be negative, only flat.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->It allows hollowpoint bullets to actually work properly, along with any future melee weapons that have negative armor penetration

## Testing
<!-- How did you test the PR, if at all? -->
Tested armor against riot, and normal security armor, with negative and positive armor penetration items, works as intended.

## Changelog
:cl:
fix: Hollowpoint bullets now properly interact with armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
