### PR TITLE
Fix #18918 Soda can alt click shakes are now activated by ctrl clicks

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -44,7 +44,7 @@
 /obj/item/reagent_containers/food/drinks/cans/CtrlClick(mob/user)
 	var/mob/living/carbon/human/H
 	if(!can_shake || !ishuman(user))
-		return
+		return ..()
 	H = user
 	if(can_opened)
 		to_chat(H, "<span class='warning'>You can't shake up an already opened drink!")

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -13,7 +13,7 @@
 	if(can_opened)
 		. += "<span class='notice'>It has been opened.</span>"
 	else
-		. += "<span class='info'>Alt-click to shake it up!</span>"
+		. += "<span class='info'>Ctrl-click to shake it up!</span>"
 
 /obj/item/reagent_containers/food/drinks/cans/attack_self(mob/user)
 	if(can_opened)
@@ -65,8 +65,7 @@
 				addtimer(CALLBACK(src, PROC_REF(reset_shaken)), 20 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)
 				handle_bursting(user)
 	else
-		to_chat(H, "<span class='warning'>You need to hold [src] in order to shake it.</span>")
-	return
+		return ..()
 
 /obj/item/reagent_containers/food/drinks/cans/attack(mob/M, mob/user, proximity)
 	if(!can_opened)

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -44,11 +44,11 @@
 /obj/item/reagent_containers/food/drinks/cans/AltClick(mob/user)
 	var/mob/living/carbon/human/H
 	if(!can_shake || !ishuman(user))
-		return ..()
+		return
 	H = user
 	if(can_opened)
 		to_chat(H, "<span class='warning'>You can't shake up an already opened drink!")
-		return ..()
+		return
 	if(src == H.l_hand || src == H.r_hand)
 		can_shake = FALSE
 		addtimer(CALLBACK(src, PROC_REF(reset_shakable)), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
@@ -66,7 +66,7 @@
 				handle_bursting(user)
 	else
 		to_chat(H, "<span class='warning'>You need to hold [src] in order to shake it.</span>")
-	return ..()
+	return
 
 /obj/item/reagent_containers/food/drinks/cans/attack(mob/M, mob/user, proximity)
 	if(!can_opened)

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -41,7 +41,7 @@
 	qdel(src)
 	return crushed_can
 
-/obj/item/reagent_containers/food/drinks/cans/AltClick(mob/user)
+/obj/item/reagent_containers/food/drinks/cans/CtrlClick(mob/user)
 	var/mob/living/carbon/human/H
 	if(!can_shake || !ishuman(user))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Shake can is now activated by CtrlClick.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/18918

## Testing
<!-- How did you test the PR, if at all? -->
- Could shake it using Ctrl and open transfer menu with Alt.
- ## Changelog
:cl:
fix: Soda can is now shaked by clicking Ctrl
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
