### PR TITLE
Adds shed tail and eating bugs to simplemob lizards

### DIFF
--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -194,6 +194,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_FORCE_DOORS 		"force_doors"
 #define TRAIT_AI_UNTRACKABLE	"AI_untrackable"
 #define TRAIT_REPEATSURGERY		"master_surgeon"  // Lets you automatically repeat surgeries regardless of tool
+#define TRAIT_EDIBLE_BUG		"edible_bug" // Lets lizards and other animals that can eat bugs eat ya
 #define TRAIT_ELITE_CHALLENGER "elite_challenger"
 
 //***** ITEM TRAITS *****//

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -108,6 +108,7 @@
 	pixel_y = rand(6,-6)
 	START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/swarming)
+	ADD_TRAIT(src, TRAIT_EDIBLE_BUG, "edible_bug") // Normally this is just used for mobs, but spiderlings are kind of that... 
 
 /obj/structure/spider/spiderling/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/mob/living/simple_animal/friendly/butterfly.dm
+++ b/code/modules/mob/living/simple_animal/friendly/butterfly.dm
@@ -17,11 +17,15 @@
 	density = FALSE
 	flying = TRUE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
-	ventcrawler = 2
+	ventcrawler = VENTCRAWLER_ALWAYS
 	mob_size = MOB_SIZE_TINY
 	mob_biotypes = MOB_ORGANIC | MOB_BUG
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat = 0)
 	gold_core_spawnable = FRIENDLY_SPAWN
+
+/mob/living/simple_animal/butterfly/Initialize(mapload) //Not the poor butterfly!
+	. = ..()
+	ADD_TRAIT(src, TRAIT_EDIBLE_BUG, "edible_bug")
 
 /mob/living/simple_animal/butterfly/New()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -25,6 +25,10 @@
 /mob/living/simple_animal/cockroach/can_die()
 	return ..() && !SSticker.cinematic //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
 
+/mob/living/simple_animal/cockroach/Initialize(mapload) //Lizards are a great way to deal with cockroaches
+	. = ..()
+	ADD_TRAIT(src, TRAIT_EDIBLE_BUG, "edible_bug")
+
 /mob/living/simple_animal/cockroach/Crossed(atom/movable/AM, oldloc)
 	if(isliving(AM))
 		var/mob/living/A = AM

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -33,14 +33,15 @@
 		if(prob(1))
 			custom_emote(EMOTE_VISIBLE, pick("sticks out its tongue", "wags its tail.", "lies down."))
 
-	if(isturf(loc) && !incapacitated())
-		for(var/mob/living/M in view(1, src))
-			if(!M.stat && Adjacent(M) && HAS_TRAIT(M, TRAIT_EDIBLE_BUG))
+	if(isturf(loc))
+		var/list/lizard_view = view(1, src)
+		for(var/mob/living/M in lizard_view)
+			if(M.stat == CONSCIOUS && Adjacent(M) && HAS_TRAIT(M, TRAIT_EDIBLE_BUG))
 				custom_emote(EMOTE_VISIBLE, "eats \the [M]!")
 				playsound(loc, eating_sound, 20, 1)
 				M.death()
 				break
-		for(var/obj/structure/spider/spiderling/Spider in view(1, src))
+		for(var/obj/structure/spider/spiderling/Spider in lizard_view)
 			if(Adjacent(Spider) && HAS_TRAIT(Spider, TRAIT_EDIBLE_BUG))
 				if(prob(90)) // Slippery things aren't they?
 					visible_message("<span class='notice'>The spiderling skitters away from the [src]!")
@@ -73,7 +74,6 @@
 /mob/living/simple_animal/lizard/proc/new_tail()
 	has_tail = TRUE
 	to_chat(src, "<span class='notice'>You regrow your tail!</span>")
-	return
 
 /mob/living/simple_animal/lizard/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(!isdrone(user))

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -24,17 +24,16 @@
 	can_collar = TRUE
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST | MOB_REPTILE
 	gold_core_spawnable = FRIENDLY_SPAWN
-	var/eats_bugs = TRUE
 	var/eating_sound = 'sound/weapons/bite.ogg'
 	/// Lizards start with a tail
-	var/still_has_tail = TRUE 
+	var/has_tail = TRUE 
 
 /mob/living/simple_animal/lizard/handle_automated_action()
 	if(!stat && !buckled)
 		if(prob(1))
 			custom_emote(EMOTE_VISIBLE, pick("sticks out its tongue", "wags its tail.", "lies down."))
 
-	if(eats_bugs && isturf(loc) && !incapacitated())
+	if(isturf(loc) && !incapacitated())
 		for(var/mob/living/M in view(1, src))
 			if(!M.stat && Adjacent(M) && HAS_TRAIT(M, TRAIT_EDIBLE_BUG))
 				custom_emote(EMOTE_VISIBLE, "eats \the [M]!")
@@ -60,7 +59,7 @@
 
 	if(stat != CONSCIOUS)
 		return
-	if(!still_has_tail)
+	if(!has_tail)
 		to_chat(usr, "<span class='warning'>You have no tail to shed!</span>")
 		return
 	for(var/obj/item/grab/G in usr.grabbed_by)
@@ -68,11 +67,11 @@
 		usr.visible_message("<span class='warning'>[usr] suddenly sheds their tail and slips out of [M]'s grasp!</span>")
 		M.KnockDown(3 SECONDS) // FUCK I TRIPPED
 		playsound(usr.loc, "sound/misc/slip.ogg", 75, 1)
-		still_has_tail = FALSE
+		has_tail = FALSE
 		addtimer(CALLBACK(src, PROC_REF(new_tail)), 5 MINUTES)
 
 /mob/living/simple_animal/lizard/proc/new_tail()
-	still_has_tail = TRUE
+	has_tail = TRUE
 	to_chat(src, "<span class='notice'>You regrow your tail!</span>")
 	return
 

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -33,25 +33,26 @@
 		if(prob(1))
 			custom_emote(EMOTE_VISIBLE, pick("sticks out its tongue", "wags its tail.", "lies down."))
 
-	if(isturf(loc))
-		var/list/lizard_view = view(1, src)
-		for(var/mob/living/M in lizard_view)
-			if(M.stat == CONSCIOUS && Adjacent(M) && HAS_TRAIT(M, TRAIT_EDIBLE_BUG))
-				custom_emote(EMOTE_VISIBLE, "eats \the [M]!")
+	if(!isturf(loc))
+		return
+	var/list/lizard_view = view(1, src)
+	for(var/mob/living/M in lizard_view)
+		if(M.stat == CONSCIOUS && Adjacent(M) && HAS_TRAIT(M, TRAIT_EDIBLE_BUG))
+			custom_emote(EMOTE_VISIBLE, "eats \the [M]!")
+			playsound(loc, eating_sound, 20, 1)
+			M.death()
+			break
+	for(var/obj/structure/spider/spiderling/spider in lizard_view)
+		if(Adjacent(spider) && HAS_TRAIT(spider, TRAIT_EDIBLE_BUG))
+			if(prob(90)) // Slippery things aren't they?
+				visible_message("<span class='notice'>The spiderling skitters away from the [src]!</span>")
+				spider.random_skitter()
+				return
+			else
+				custom_emote(EMOTE_VISIBLE, "eats \the [spider]!")
 				playsound(loc, eating_sound, 20, 1)
-				M.death()
+				qdel(spider)
 				break
-		for(var/obj/structure/spider/spiderling/spider in lizard_view)
-			if(Adjacent(spider) && HAS_TRAIT(spider, TRAIT_EDIBLE_BUG))
-				if(prob(90)) // Slippery things aren't they?
-					visible_message("<span class='notice'>The spiderling skitters away from the [src]!</span>")
-					spider.random_skitter()
-					return
-				else
-					custom_emote(EMOTE_VISIBLE, "eats \the [spider]!")
-					playsound(loc, eating_sound, 20, 1)
-					qdel(spider)
-					break
 
 /mob/living/simple_animal/lizard/verb/lose_tail()
 	set name = "Lose tail"

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -31,7 +31,7 @@
 /mob/living/simple_animal/lizard/handle_automated_action()
 	if(!stat && !buckled)
 		if(prob(1))
-			custom_emote(EMOTE_VISIBLE, pick("sticks out its tongue", "wags its tail.", "lies down."))
+			custom_emote(EMOTE_VISIBLE, pick("sticks out its tongue.", "wags its tail.", "lies down."))
 
 	if(!isturf(loc))
 		return

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -40,7 +40,6 @@
 				custom_emote(EMOTE_VISIBLE, "eats \the [M]!")
 				playsound(loc, eating_sound, 20, 1)
 				M.death()
-				stop_automated_movement = FALSE
 				break
 		for(var/obj/structure/spider/spiderling/Spider in view(1, src))
 			if(Adjacent(Spider) && HAS_TRAIT(Spider, TRAIT_EDIBLE_BUG))
@@ -51,8 +50,7 @@
 				else
 					custom_emote(EMOTE_VISIBLE, "eats \the [Spider]!")
 					playsound(loc, eating_sound, 20, 1)
-					Spider.Destroy()
-					stop_automated_movement = FALSE
+					qdel(Spider)
 					break
 
 /mob/living/simple_animal/lizard/verb/lose_tail()
@@ -62,7 +60,7 @@
 
 	if(stat != CONSCIOUS)
 		return
-	if(still_has_tail == FALSE)
+	if(!still_has_tail)
 		to_chat(usr, "<span class='warning'>You have no tail to shed!</span>")
 		return
 	for(var/obj/item/grab/G in usr.grabbed_by)

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -41,16 +41,16 @@
 				playsound(loc, eating_sound, 20, 1)
 				M.death()
 				break
-		for(var/obj/structure/spider/spiderling/Spider in lizard_view)
-			if(Adjacent(Spider) && HAS_TRAIT(Spider, TRAIT_EDIBLE_BUG))
+		for(var/obj/structure/spider/spiderling/spider in lizard_view)
+			if(Adjacent(spider) && HAS_TRAIT(spider, TRAIT_EDIBLE_BUG))
 				if(prob(90)) // Slippery things aren't they?
-					visible_message("<span class='notice'>The spiderling skitters away from the [src]!")
-					Spider.random_skitter()
+					visible_message("<span class='notice'>The spiderling skitters away from the [src]!</span>")
+					spider.random_skitter()
 					return
 				else
-					custom_emote(EMOTE_VISIBLE, "eats \the [Spider]!")
+					custom_emote(EMOTE_VISIBLE, "eats \the [spider]!")
 					playsound(loc, eating_sound, 20, 1)
-					qdel(Spider)
+					qdel(spider)
 					break
 
 /mob/living/simple_animal/lizard/verb/lose_tail()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds "lose tail" and the ability for NPC lizards to eat bugs
Player controlled lizards can now use the "lose tail" verb to escape a grab once every 5 minutes, after this is used, the person who grabbed them is knocked down for 3 seconds (as they tripped due to the lizard slipping out of their grasp) 
NPC lizards can now eat spiderlings, Butterflys, and cockroaches. This instantly kills all the types, but spiderlings have a 9/10 chance to slip out of the NPC's lizards grasp

## Why It's Good For The Game
These are some minor things to make lizards more distinct from mice


## Testing
Compiled and ran 

## Changelog
:cl:
add: NPC lizards now eat bugs
add: Player controlled lizards now can use the "lose tail" verb
/:cl:

