### PR TITLE
Merges Forcewall and Greater Forcewall into a single spell

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -76,7 +76,6 @@
 
 	action_icon_state = "mime_bigwall"
 	action_background_icon_state = "bg_mime"
-	large = TRUE
 
 /obj/effect/proc_holder/spell/forcewall/mime/Click()
 	if(usr && usr.mind)

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -192,7 +192,7 @@
 
 /obj/effect/proc_holder/spell/forcewall
 	name = "Force Wall"
-	desc = "This spell creates a small unbreakable wall that only you can pass through, and does not need wizard garb. Lasts 30 seconds."
+	desc = "This spell creates a 3 tile wide unbreakable wall that only you can pass through, and does not need wizard garb. Lasts 30 seconds."
 
 	school = "transmutation"
 	base_cooldown = 100
@@ -203,30 +203,18 @@
 	action_icon_state = "shield"
 	cooldown_min = 50 //12 deciseconds reduction per rank
 	var/wall_type = /obj/effect/forcefield/wizard
-	var/large = FALSE
 
 /obj/effect/proc_holder/spell/forcewall/create_new_targeting()
 	return new /datum/spell_targeting/self
 
 /obj/effect/proc_holder/spell/forcewall/cast(list/targets, mob/user = usr)
 	new wall_type(get_turf(user), user)
-	if(large) //Extra THICK
-		if(user.dir == SOUTH || user.dir == NORTH)
-			new wall_type(get_step(user, EAST), user)
-			new wall_type(get_step(user, WEST), user)
-		else
-			new wall_type(get_step(user, NORTH), user)
-			new wall_type(get_step(user, SOUTH), user)
-
-/obj/effect/proc_holder/spell/forcewall/greater
-	name = "Greater Force Wall"
-	desc = "Create a larger magical barrier that only you can pass through, but requires wizard garb. Lasts 30 seconds."
-
-	clothes_req = TRUE
-	invocation = "TARCOL GRANDI ZHERI"
-	invocation_type = "shout"
-	large = TRUE
-	action_icon_state = "shield_greater"
+	if(user.dir == SOUTH || user.dir == NORTH)
+		new wall_type(get_step(user, EAST), user)
+		new wall_type(get_step(user, WEST), user)
+	else
+		new wall_type(get_step(user, NORTH), user)
+		new wall_type(get_step(user, SOUTH), user)
 
 /obj/effect/proc_holder/spell/aoe/conjure/timestop
 	name = "Stop Time"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -184,13 +184,6 @@
 	category = "Defensive"
 	cost = 1
 
-/datum/spellbook_entry/greaterforcewall
-	name = "Greater Force Wall"
-	spell_type = /obj/effect/proc_holder/spell/forcewall/greater
-	log_name = "GFW"
-	category = "Defensive"
-	cost = 1
-
 /datum/spellbook_entry/repulse
 	name = "Repulse"
 	spell_type = /obj/effect/proc_holder/spell/aoe/repulse

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -14,12 +14,12 @@
 /datum/spellbook_entry/loadout/lich
 	name = "Defense Focus : Lich"
 	desc = "This spellset uses the Bind Soul spell to safeguard your life as a lich and allow for more dangerous offensive spells to be used. <br> \
-		Ethereal Jaunt provides escape, Fireball and Rod Form are your offensive spells, and Disable Tech and Greater Forcewall provides utility in disabling sec equipment or blocking their path. <br> \
+		Ethereal Jaunt provides escape, Fireball and Rod Form are your offensive spells, and Disable Tech and Forcewall provides utility in disabling sec equipment or blocking their path. <br> \
 		Care should be taken in hiding the item you choose as your phylactery after using Bind Soul, as you cannot revive if it destroyed or too far from your body! <br><br> \
 		</i>Provides Bind Soul, Ethereal Jaunt,  Fireball, Rod Form, Disable Tech, and Greater Forcewall.<i>"
 	log_name = "DL"
 	spells_path = list(/obj/effect/proc_holder/spell/lichdom, /obj/effect/proc_holder/spell/ethereal_jaunt, /obj/effect/proc_holder/spell/fireball, \
-		/obj/effect/proc_holder/spell/rod_form, /obj/effect/proc_holder/spell/emplosion/disable_tech, /obj/effect/proc_holder/spell/forcewall/greater)
+		/obj/effect/proc_holder/spell/rod_form, /obj/effect/proc_holder/spell/emplosion/disable_tech, /obj/effect/proc_holder/spell/forcewall)
 	is_ragin_restricted = TRUE
 
 /datum/spellbook_entry/loadout/wands

--- a/code/modules/mob/living/simple_animal/hostile/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hellhound.dm
@@ -127,7 +127,7 @@
 	knockspell.invocation_type = "none"
 	AddSpell(knockspell)
 	// Defense
-	var/obj/effect/proc_holder/spell/forcewall/greater/wallspell = new
+	var/obj/effect/proc_holder/spell/forcewall/wallspell = new
 	wallspell.clothes_req = FALSE
 	wallspell.invocation_type = "none"
 	AddSpell(wallspell)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Was discussed over at [#19266 ](https://github.com/ParadiseSS13/Paradise/discussions/19266) - the basic forcewall is very situational to use and often considered noobbait since newbie wizards might not realise the greater one exists. This PR merges them into a single forcewall spell to fix these issues. This does also means that healer apprentices, magical morphs and anyone that acquires a forcewall spell book will also now cast a 3 tile wide version.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better for newbie wizards so they don't take the 1-tile wide version of the spell by accident and get themselves killed thinking it's the better version of the spell.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in and tested that the forcewall spell now deploys a 3 tile wide wall, and that other sources of the spell are working as intended (invisible greater wall etc.).
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Greater forcewall and regular forcewall have been merged into a single spell.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
