### PR TITLE
Gives some info about how headslugs work upon using Last Resort

### DIFF
--- a/code/modules/antagonists/changeling/powers/headslug.dm
+++ b/code/modules/antagonists/changeling/powers/headslug.dm
@@ -42,6 +42,8 @@
 			crab.origin.active = TRUE
 			crab.origin.transfer_to(crab)
 			to_chat(crab, "<span class='warning'>You burst out of the remains of your former body in a shower of gore!</span>")
+			to_chat(crab, "<span class='boldnotice'>We must bite the corpse of a non-primitive humanoid to lay our egg within them.</span>")
+			to_chat(crab, "<span class='boldnotice'>Though this form shall perish after laying the egg, our true self shall be reborn in time.</span>")
 
 	// This is done because after the original changeling gibs below, ALL of their actions are qdeleted
 	// We need to store their power types so we can re-create them later.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Adds two quick lines of text given to the user upon headslugging themselves as a Cling, instructing them as to how headslugs work. This is already done in the evolution menu but you can't view the evolution menu as a headslug, so this gives a little extra reminder for people, and was requested. Resolves https://github.com/ParadiseSS13/Paradise/issues/19703, at least the main part of it. Doesn't make it so headslugs work on monkeys, go out and find a person to bite >:)
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More clarity to users about how their ability works is always good, especially in case they didn't properly read it on the evolution menu.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/71326864/203044370-4167df57-3c79-44f6-bb45-742e3aa91b60.png)
## Testing
<!-- How did you test the PR, if at all? -->
See above.
## Changelog
:cl:
add: Added a few lines of text upon using Last Resort to explain how headslugs work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
