### PR TITLE
Fixes APCs being immune from explosion and tesla destruction

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -265,8 +265,8 @@
 	. = ..()
 	if(in_range(user, src))
 		if(stat & BROKEN)
-			. += "Looks broken."
-		else if(opened)
+			return
+		if(opened)
 			if(has_electronics() && terminal)
 				. += "The cover is [opened == APC_OPENED ? "removed" : "open"] and the power cell is [ cell ? "installed" : "missing"]."
 			else if(!has_electronics() && terminal)
@@ -1366,6 +1366,23 @@
 		update_icon()
 		update()
 	..()
+
+/obj/machinery/power/apc/ex_act(severity)
+	..()
+	if(severity < EXPLODE_LIGHT)
+		power_destroy()
+
+/obj/machinery/power/apc/zap_act(power, zap_flags)
+	. = ..()
+	power_destroy()
+
+/obj/machinery/power/apc/proc/power_destroy() // Caused only by explosions and teslas, not for deconstruction
+	if(obj_integrity <= integrity_failure && opened == APC_COVER_OFF)
+		var/drop_loc = drop_location()
+		new /obj/item/stack/sheet/metal(drop_loc, 3) // Metal from the frame
+		new /obj/item/stack/cable_coil(drop_loc, 10) // wiring from the terminal and the APC, some lost due to explosion
+		qdel(terminal) // We don't want floating terminals
+		qdel(src)
 
 /obj/machinery/power/apc/blob_act(obj/structure/blob/B)
 	set_broken()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1377,12 +1377,13 @@
 	power_destroy()
 
 /obj/machinery/power/apc/proc/power_destroy() // Caused only by explosions and teslas, not for deconstruction
-	if(obj_integrity <= integrity_failure && opened == APC_COVER_OFF)
-		var/drop_loc = drop_location()
-		new /obj/item/stack/sheet/metal(drop_loc, 3) // Metal from the frame
-		new /obj/item/stack/cable_coil(drop_loc, 10) // wiring from the terminal and the APC, some lost due to explosion
-		qdel(terminal) // We don't want floating terminals
-		qdel(src)
+	if(obj_integrity > integrity_failure || opened != APC_COVER_OFF)
+		return
+	var/drop_loc = drop_location()
+	new /obj/item/stack/sheet/metal(drop_loc, 3) // Metal from the frame
+	new /obj/item/stack/cable_coil(drop_loc, 10) // wiring from the terminal and the APC, some lost due to explosion
+	QDEL_NULL(terminal) // We don't want floating terminals
+	qdel(src)
 
 /obj/machinery/power/apc/blob_act(obj/structure/blob/B)
 	set_broken()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Allows APCs that have no cover to be destroyed, and fixes some weird duplicated messages. I think this method of not having it be under obj_deconstruction is good because it means people cant just welder down APCs when they're destroyed and will require full deconstruction. These explosions and tesla zaps are the exception.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Fixes partially #18334, fixes #13873 and fixes this 
![image](https://user-images.githubusercontent.com/91113370/203136081-a4585b39-6f76-4ab2-99dd-4b4b48e4eb39.png)
into this
![image](https://user-images.githubusercontent.com/91113370/203136113-3a6b9693-d37a-49cf-ac3b-8da469b93f76.png)

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. --> This used to be an APC
![image](https://user-images.githubusercontent.com/91113370/203136221-0ebcfef4-fcc8-47e4-ba1d-c3992c4f0df3.png)

## Testing
<!-- How did you test the PR, if at all? -->
Dropped some bombs, released some teslas, APCs got destroyed

## Changelog
:cl:
fix: APCs can be destroyed by explosions and teslas now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
