### PR TITLE
Dufflebag rebalancing

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -365,7 +365,25 @@
 	icon_state = "duffel"
 	item_state = "duffel"
 	max_combined_w_class = 30
-	slowdown = 1
+	/// How long it takes to pull things out of this bag
+	var/access_time = 0.7 SECONDS
+
+/obj/item/storage/backpack/duffel/remove_from_storage(obj/item/I, atom/new_location)
+	if(!access_time || (I.loc != src))
+		return ..() //its not in the fooken bag (this proc is called twice when removing things for some reason) OR there should be no delay
+
+	if(!istype(I))
+		return FALSE
+
+	var/mob/M = usr
+	if(!istype(M))
+		return FALSE
+
+	if(!do_after(M, access_time, target = I, use_default_checks = FALSE))
+		return FALSE
+
+	return ..()
+
 
 /obj/item/storage/backpack/duffel/syndie
 	name = "suspicious looking duffelbag"
@@ -374,7 +392,7 @@
 	item_state = "duffel-syndiammo"
 	origin_tech = "syndicate=1"
 	silent = TRUE
-	slowdown = 0
+	access_time = 0
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/duffel/syndie/med

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -391,6 +391,7 @@
 
 		if(!zipped && zip_time) // Handle slowdown and stuff now that we just zipped it
 			slowdown = 1
+			show_to(usr)
 			return
 
 		slowdown = 0

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -361,37 +361,31 @@
 
 /obj/item/storage/backpack/duffel
 	name = "duffelbag"
-	desc = "A large grey duffelbag designed to hold more items than a regular bag. It slows you down when you carry it unzipped."
+	desc = "A large grey duffelbag designed to hold more items than a regular bag. It slows you down when unzipped."
 	icon_state = "duffel"
 	item_state = "duffel"
 	max_combined_w_class = 30
 	/// Is the bag zipped up?
 	var/zipped = TRUE
-	/// How long it takes to pull things out of this bag
+	/// How long it takes to toggle the zip state of this bag
 	var/zip_time = 0.7 SECONDS
 
 /obj/item/storage/backpack/duffel/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It is currently [zipped ? "zipped" : "unzipped"].</span>"
-	if(zipped)
-		. += "<span class='notice'>Ctrl+click or use the verb to un-zip it!</span>"
+	. += "<span class='notice'>It is currently [zipped ? "zipped" : "unzipped"]. Ctrl+click to [zipped ? "un-" : ""]zip it!</span>"
 
 /obj/item/storage/backpack/duffel/CtrlClick(mob/user)
 	. = ..()
-	handle_zipping()
+	handle_zipping(user)
 
-/obj/item/storage/backpack/duffel/verb/handle_zipping()
-	set name = "Toggle Duffelbag Zip"
-	set category = "Object"
-	set src in usr
-
-	if(!zip_time || do_after(usr, zip_time, target = src))
+/obj/item/storage/backpack/duffel/proc/handle_zipping(mob/user)
+	if(!zip_time || do_after(user, zip_time, target = src))
 		playsound(src, 'sound/items/zip.ogg', 75, TRUE)
 		zipped = !zipped
 
 		if(!zipped && zip_time) // Handle slowdown and stuff now that we just zipped it
 			slowdown = 1
-			show_to(usr)
+			show_to(user)
 			return
 
 		slowdown = 0

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -372,9 +372,9 @@
 
 /obj/item/storage/backpack/duffel/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It is currently [zipped ? "zipped" : "unzipped"]. Ctrl+click to [zipped ? "un-" : ""]zip it!</span>"
+	. += "<span class='notice'>It is currently [zipped ? "zipped" : "unzipped"]. Alt+Shift+Click to [zipped ? "un-" : ""]zip it!</span>"
 
-/obj/item/storage/backpack/duffel/CtrlClick(mob/user)
+/obj/item/storage/backpack/duffel/AltShiftClick(mob/user)
 	. = ..()
 	handle_zipping(user)
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -369,7 +369,7 @@
 	var/access_time = 0.7 SECONDS
 
 /obj/item/storage/backpack/duffel/remove_from_storage(obj/item/I, atom/new_location)
-	if(!access_time || (I.loc != src))
+	if(!access_time)
 		return ..() //its not in the fooken bag (this proc is called twice when removing things for some reason) OR there should be no delay
 
 	if(!istype(I))
@@ -383,7 +383,6 @@
 		return FALSE
 
 	return ..()
-
 
 /obj/item/storage/backpack/duffel/syndie
 	name = "suspicious looking duffelbag"

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -213,6 +213,13 @@
 		user.s_active = null
 
 /**
+  * Hides the current container interface from all viewers.
+  */
+/obj/item/storage/proc/hide_from_all()
+	for(var/mob/M in mobs_viewing)
+		hide_from(M)
+
+/**
   * Checks all mobs currently viewing the storage inventory, and hides it if they shouldn't be able to see it.
   */
 /obj/item/storage/proc/update_viewers()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a method to zip/unzip duffelbags.

Zipped duffelbags have no slowdown, but cannot be accessed.
Unzipped duffelbags cause slowdown, but can be accessed.

Zipping/unzipping takes 0.7 seconds.

Syndicate duffles do not have a slowdown or zip/unzip delay, in the same way they currently do not have a slowdown.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Duffel bags are in a bit of a sad state, and this is my first step towards a few item rebalances. (This was the simplest to code.)
Essentially, dufflebags are totally unviable currently due to the slowdown. There is no way in hell anyone is using them, and it is sad. This will hopefully mean they will see more use by non-combat focused players (while remaining a not-so-great choice for antags and sec).


<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
https://user-images.githubusercontent.com/12197162/203178123-a6785c1d-425a-433e-8acb-4efc27f1c284.mp4

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Duffelbags can now be zipped and unzipped after a short delay using Alt+Shift+Click. Zipped duffels have no slowdown but contents are inaccessible. Unzipped duffels cause slowdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
