### PR TITLE
Fixes belt's overlays being weird when an item doesnt have a belt sprite

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -15,11 +15,14 @@
 
 /obj/item/storage/belt/update_overlays()
 	. = ..()
-	if(use_item_overlays)
-		for(var/obj/item/I in contents)
-			var/image/belt_image = image(icon, I.belt_icon)
-			belt_image.color = I.color
-			. += belt_image
+	if(!use_item_overlays)
+		return
+	for(var/obj/item/I in contents)
+		if(!I.belt_icon)
+			continue
+		var/image/belt_image = image(icon, I.belt_icon)
+		belt_image.color = I.color
+		. += belt_image
 
 /obj/item/storage/belt/proc/can_use()
 	return is_equipped()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->Checks that a sprite actually exists first before trying to create and apply an overlay for a non-existent image. Overlays for them will now work and not break if theres an item with no belt_icon

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #18638, Fixes #19336, Fixes #18706

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/91113370/203236463-19ac4eab-791d-4f7d-81d7-38d6534f7ac7.png)
![image](https://user-images.githubusercontent.com/91113370/203238172-32a26d1f-f695-4f5c-a959-4b3763e4c075.png)


## Testing
<!-- How did you test the PR, if at all? -->
See above, also fixes toolbelts and pocket extinguishers. Tested the advanced toolbelt and t-ray described as in the other issues, also fixed.

## Changelog
:cl:
fix: Things on belts will now show correctly, even if one of the items doesn't have a sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
