### PR TITLE
Supply packs tweaks

### DIFF
--- a/code/modules/supply/supply_packs/pack_engineering.dm
+++ b/code/modules/supply/supply_packs/pack_engineering.dm
@@ -12,6 +12,17 @@
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
 
+/datum/supply_packs/engineering/tools		//the most robust crate
+	name = "Toolbox Crate"
+	contains = list(/obj/item/storage/toolbox/electrical,
+					/obj/item/storage/toolbox/electrical,
+					/obj/item/storage/toolbox/electrical,
+					/obj/item/storage/toolbox/mechanical,
+					/obj/item/storage/toolbox/mechanical,
+					/obj/item/storage/toolbox/mechanical)
+	cost = 500
+	containername = "electrical maintenance crate"
+
 /datum/supply_packs/vending/engivend
 	name = "Engineering Vendor Supply Crate"
 	cost = 50

--- a/code/modules/supply/supply_packs/pack_engineering.dm
+++ b/code/modules/supply/supply_packs/pack_engineering.dm
@@ -12,17 +12,6 @@
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
 
-/datum/supply_packs/engineering/tools		//the most robust crate
-	name = "Toolbox Crate"
-	contains = list(/obj/item/storage/toolbox/electrical,
-					/obj/item/storage/toolbox/electrical,
-					/obj/item/storage/toolbox/electrical,
-					/obj/item/storage/toolbox/mechanical,
-					/obj/item/storage/toolbox/mechanical,
-					/obj/item/storage/toolbox/mechanical)
-	cost = 500
-	containername = "electrical maintenance crate"
-
 /datum/supply_packs/vending/engivend
 	name = "Engineering Vendor Supply Crate"
 	cost = 50
@@ -194,7 +183,7 @@
 	access = ACCESS_EVA
 
 /datum/supply_packs/engineering/inflatable
-	name = "Inflatable barriers Crate"
+	name = "Inflatable Barriers Crate"
 	contains = list(/obj/item/storage/briefcase/inflatable,
 					/obj/item/storage/briefcase/inflatable,
 					/obj/item/storage/briefcase/inflatable)
@@ -220,17 +209,3 @@
 	containername = "thermo-electric generator crate"
 	access = ACCESS_CE
 	announce_beacons = list("Engineering" = list("Chief Engineer's Desk", "Atmospherics"))
-
-/datum/supply_packs/engineering/conveyor
-	name = "Conveyor Assembly Crate"
-	contains = list(/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_switch_construct,
-					/obj/item/paper/conveyor)
-	cost = 100
-	containername = "conveyor assembly crate"
-	department_restrictions = list() //anyone should be able to order conveyors (especially since they can just be made at an autolathe)

--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -136,18 +136,11 @@
 					/obj/item/reagent_containers/iv_bag/blood/OPlus,
 					/obj/item/reagent_containers/iv_bag/blood/OMinus,
 					/obj/item/reagent_containers/iv_bag/slime,
-					/obj/item/reagent_containers/iv_bag/blood/vox)
+					/obj/item/reagent_containers/iv_bag/blood/vox,
+					/obj/structure/closet/crate/secure)
 	cost = 500
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "blood pack crate"
-
-/datum/supply_packs/medical/iv_drip
-	name = "IV Drip Crate"
-	contains = list(/obj/machinery/iv_drip)
-	cost = 300
-	containertype = /obj/structure/closet/crate/secure
-	containername = "IV drip crate"
-	access = ACCESS_MEDICAL
 
 /datum/supply_packs/medical/surgery
 	name = "Surgery Crate"

--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -137,7 +137,7 @@
 					/obj/item/reagent_containers/iv_bag/blood/OMinus,
 					/obj/item/reagent_containers/iv_bag/slime,
 					/obj/item/reagent_containers/iv_bag/blood/vox,
-					/obj/structure/closet/crate/secure)
+					/obj/machinery/iv_drip)
 	cost = 500
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "blood pack crate"

--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -144,6 +144,9 @@
 					/obj/item/poster/random_official,
 					/obj/item/poster/random_official,
 					/obj/item/poster/random_official,
+					/obj/item/poster/random_official,
+					/obj/item/poster/random_official,
+					/obj/item/poster/random_official,
 					/obj/item/poster/random_official)
 	cost = 50
 	containername = "corporate posters crate"
@@ -245,15 +248,6 @@
 	cost = 400
 	containername = "costume crate"
 
-/datum/supply_packs/misc/wizard
-	name = "Wizard Costume Crate"
-	contains = list(/obj/item/twohanded/staff,
-					/obj/item/clothing/suit/wizrobe/fake,
-					/obj/item/clothing/shoes/sandal,
-					/obj/item/clothing/head/wizard/fake)
-	cost = 400
-	containername = "wizard costume crate"
-
 /datum/supply_packs/misc/mafia
 	name = "Mafia Supply Crate"
 	contains = list(/obj/item/clothing/suit/browntrenchcoat,
@@ -334,7 +328,7 @@
 	contraband = 1
 
 /datum/supply_packs/misc/bigband
-	name = "Big band instrument collection"
+	name = "Big Band Instrument Collection"
 	contains = list(/obj/item/instrument/violin,
 					/obj/item/instrument/guitar,
 					/obj/item/instrument/eguitar,
@@ -347,7 +341,7 @@
 					/obj/item/instrument/xylophone,
 					/obj/structure/piano)
 	cost = 500
-	containername = "Big band musical instruments collection"
+	containername = "big band musical instruments collection"
 
 /datum/supply_packs/misc/randomised/contraband
 	num_contained = 5
@@ -533,18 +527,11 @@
 	cost = 100
 	contains = list(
 					/obj/item/bathroom_parts,
-					/obj/item/bathroom_parts/urinal
-					)
-	containername = "lavatory crate"
-
-/datum/supply_packs/misc/hygiene
-	name = "Hygiene Station Crate"
-	cost = 100
-	contains = list(
+					/obj/item/bathroom_parts/urinal,
 					/obj/item/bathroom_parts/sink,
 					/obj/item/mounted/shower
 					)
-	containername = "hygiene station crate"
+	containername = "lavatory crate"
 
 /datum/supply_packs/misc/snow_machine
 	name = "Snow Machine Crate"

--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -232,7 +232,11 @@
 
 /datum/supply_packs/misc/costume
 	name = "Costume Crate"
-	contains = list(/obj/item/clothing/head/foragecap,
+	contains = list(/obj/item/twohanded/staff,
+					/obj/item/clothing/suit/wizrobe/fake,
+					/obj/item/clothing/shoes/sandal,
+					/obj/item/clothing/head/wizard/fake,
+					/obj/item/clothing/head/foragecap,
 					/obj/item/clothing/suit/officercoat,
 					/obj/item/clothing/under/costume/officeruniform,
 					/obj/item/clothing/suit/lordadmiral,

--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -275,11 +275,3 @@
 					/obj/item/clothing/suit/beekeeper_suit)
 	cost = 150
 	containername = "beekeeper suits"
-
-//Bottler
-/datum/supply_packs/organic/bottler
-	name = "Brewing Buddy Bottler Unit"
-	contains = list(/obj/machinery/bottler,
-					/obj/item/wrench)
-	cost = 200
-	containername = "bottler crate"

--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -177,6 +177,7 @@
 	name = "Bunny Crate"
 	cost = 200
 	containertype = /obj/structure/closet/critter/bunny
+	contains = list(/obj/item/petcollar)
 	containername = "bunny crate"
 
 ////// hippy gear
@@ -261,19 +262,12 @@
 					/obj/item/honey_frame,
 					/obj/item/queen_bee/bought,
 					/obj/item/clothing/head/beekeeper_head,
+					/obj/item/clothing/head/beekeeper_head,
+					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/melee/flyswatter)
 	cost = 150
 	containername = "beekeeping starter kit"
-
-/datum/supply_packs/organic/hydroponics/beekeeping_suits
-	name = "2 Beekeeper suits"
-	contains = list(/obj/item/clothing/head/beekeeper_head,
-					/obj/item/clothing/suit/beekeeper_suit,
-					/obj/item/clothing/head/beekeeper_head,
-					/obj/item/clothing/suit/beekeeper_suit)
-	cost = 150
-	containername = "beekeeper suits"
 
 //Bottler
 /datum/supply_packs/organic/bottler

--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -262,12 +262,19 @@
 					/obj/item/honey_frame,
 					/obj/item/queen_bee/bought,
 					/obj/item/clothing/head/beekeeper_head,
-					/obj/item/clothing/head/beekeeper_head,
-					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/melee/flyswatter)
 	cost = 150
 	containername = "beekeeping starter kit"
+
+/datum/supply_packs/organic/hydroponics/beekeeping_suits
+	name = "Beekeeper Suits"
+	contains = list(/obj/item/clothing/head/beekeeper_head,
+					/obj/item/clothing/suit/beekeeper_suit,
+					/obj/item/clothing/head/beekeeper_head,
+					/obj/item/clothing/suit/beekeeper_suit)
+	cost = 150
+	containername = "beekeeper suits"
 
 //Bottler
 /datum/supply_packs/organic/bottler

--- a/code/modules/supply/supply_packs/pack_science.dm
+++ b/code/modules/supply/supply_packs/pack_science.dm
@@ -21,7 +21,7 @@
 	announce_beacons = list("Research Division" = list("Robotics", "Research Director's Desk"))
 
 /datum/supply_packs/science/mechcore
-	name = "Mech power core crate"
+	name = "Mech Power Core Crate"
 	contains = list(/obj/item/mecha_parts/core)
 	cost = 1500
 	containertype = /obj/structure/closet/crate/secure/scisec

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -40,7 +40,7 @@
 	containername = "helmet crate"
 
 /datum/supply_packs/security/justiceinbound
-	name = "Standard Justice Enforcer Crat3e"
+	name = "Standard Justice Enforcer Crate"
 	contains = list(/obj/item/clothing/head/helmet/justice,
 					/obj/item/clothing/head/helmet/justice,
 					/obj/item/clothing/head/helmet/justice/escape,
@@ -162,7 +162,7 @@
 	containername = "tactical webbing crate"
 
 /datum/supply_packs/security/armory/swat
-	name = "SWAT gear crate"
+	name = "SWAT Gear Crate"
 	contains = list(/obj/item/clothing/head/helmet/swat,
 					/obj/item/clothing/head/helmet/swat,
 					/obj/item/clothing/suit/space/swat,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Fixes a few crates typos.
**Removes the following crates:** 
Conveyor assembly
Wizard costume
hygiene station
IV drip crate
Bottler crate

**Tweaked the following crates:** 
Blood pack crate (added iv drip)
Corporate posters crate (5 --> 8 posters, 5 is too little)
Lavatory crate (added hygiene station contents)
Costume crate (added wizard crate contents to it)

Suggestions are welcome.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Supply packs are currently bloated, removing unnecessary crates will help with that.
Conveyor crate: Cargo already prints it using the autolathe, theres no reason to order this crate.
Wizard costume: It's contents can be found inside the costume vendor, it would be better to order a vendor refill for multiple wizard costumes than ordering an expensive crate.
Bottler crate will become unnecessary if PR #19755 is merged

## Testing
<!-- How did you test the PR, if at all? -->
- Verified the crates contents.
## Changelog
:cl:
del: Removed conveyor assembly, wizard costume, bottler, hygiene station and IV drip crates
tweak: Tweaked blood pack, corporate poster, lavatory, costume crates contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
