### PR TITLE
Balances windows (and by extension some walls)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -547,7 +547,8 @@ in the SQL/updates folder.
     * Failure to run Map Merge on a map after editing greatly increases the risk of the map's key dictionary becoming corrupted by future edits after running map merge. Resolving the corruption issue involves rebuilding the map's key dictionary;
 
 * StrongDMM
-  * When using StrongDMM, the following options should be enabled to avoid file bloat. They can be found under `File > Preferences` in SDMM2.
+  * We only accept contributions from StrongDMM version 2.0 or greater
+  * When using StrongDMM, the following options should be enabled to avoid file bloat. They can be found under `File > Preferences`.
     * Sanitize Variables - Removes variables that are declared on the map, but are the same as default. (For example: A standard floor turf that has `dir = 2` declared on the map will have that variable deleted as it is redundant.)
     * Save format - Either `Initial` or `TGM`, never `DM`.
 
@@ -580,12 +581,14 @@ in the SQL/updates folder.
       * A good example would be the template [Department name] - [Area], so Brig - Cell 1, or Medbay - Treatment Center. Consistency is key to good camera naming.
     * Fire alarms should not be placed next to expected heat sources.
     * Use the following "on" subtype of vents and scrubbers as opposed to var-editing: `/obj/machinery/atmospherics/unary/vent_scrubber/on` and `/obj/machinery/atmospherics/unary/vent_pump/on`
-  * Head of staff officers should contain a requests console.
-  * Firelocks should be used at area boundaries over doors and windows. Firelocks can also be used to break up hallways at reasonable intervals.
+  * Head of staff offices should contain a requests console.
+  * Firelocks should be used at area boundaries over doors and optionally windows. Firelocks can also be used to break up hallways at reasonable intervals.
     * Double firelocks are to be avoided unless absolutely necessary.
     * Maintenance access doors should not have firelocks placed over them.
-  * Windows to secure areas or external areas should be reinforced. Windows in engine areas should be reinforced plasma glass.
-    * Windows in high security areas, such as the brig, bridge, and head of staff offices, should be electrified by placing a wire node under the window.
+  * Windows should generally match the surrounding walls. (i.e. reinforced windows with reinforced walls)
+  	* The following should generally be reinforced windows: Windows that transition unsecured and secured areas (brig, bridge, etc), external windows.
+  	* Windows in engine areas should be reinforced plasma glass.
+  * Windows that have an easily accessible secondary security method (shutters, blast doors, etc) can be unreinforced, even in secure areas. Use common sense with this.* Windows in high security areas (brig, bridge, head of staff offices, etc) should be electrified by placing a wire node under the window.
   * Lights are to be used sparingly, they draw a significant amount of power.
   * Ensure door and windoor access is correctly set, these are handled by the variables `req_access_txt` and `req_one_access_txt`. Public doors should have both of these values as `"0"`. For a list of access values, see [`code\__DEFINES\access.dm`](code/__DEFINES/access.dm).
     * Always use numerical values encased in quotes for these variables. Multiple access values can be defined by separating them with a `;`, for example: `"28;31"` for kitchen AND cargo access.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -588,7 +588,8 @@ in the SQL/updates folder.
   * Windows should generally match the surrounding walls. (i.e. reinforced windows with reinforced walls)
   	* The following should generally be reinforced windows: Windows that transition unsecured and secured areas (brig, bridge, etc), external windows.
   	* Windows in engine areas should be reinforced plasma glass.
-  * Windows that have an easily accessible secondary security method (shutters, blast doors, etc) can be unreinforced, even in secure areas. Use common sense with this.* Windows in high security areas (brig, bridge, head of staff offices, etc) should be electrified by placing a wire node under the window.
+  * Windows that have an easily accessible secondary security method (shutters, blast doors, etc) can be unreinforced, even in secure areas. Use common sense with this.
+  * Windows in high security areas (brig, bridge, head of staff offices, etc) should be electrified by placing a wire node under the window.
   * Lights are to be used sparingly, they draw a significant amount of power.
   * Ensure door and windoor access is correctly set, these are handled by the variables `req_access_txt` and `req_one_access_txt`. Public doors should have both of these values as `"0"`. For a list of access values, see [`code\__DEFINES\access.dm`](code/__DEFINES/access.dm).
     * Always use numerical values encased in quotes for these variables. Multiple access values can be defined by separating them with a `;`, for example: `"28;31"` for kitchen AND cargo access.

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -17978,7 +17978,7 @@
 /area/atmos)
 "aYO" = (
 /obj/structure/sign/securearea,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos)
 "aYP" = (
 /obj/machinery/space_heater,
@@ -29165,9 +29165,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/aisat)
-"bwN" = (
-/turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
 "bwQ" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -89197,10 +89194,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
-"hdy" = (
-/obj/structure/sign/fire,
-/turf/simulated/wall,
-/area/atmos)
 "hdV" = (
 /obj/effect/spawner/window,
 /obj/structure/cable{
@@ -92561,6 +92554,9 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/misc_lab)
+"nvW" = (
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai_upload)
 "nyK" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -95889,6 +95885,10 @@
 "tks" = (
 /turf/simulated/floor/wood,
 /area/maintenance/starboard)
+"tkO" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall,
+/area/atmos)
 "tmo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -117527,13 +117527,13 @@ aaa
 aaa
 aaa
 acF
-bwN
-bwN
-bwN
-bwN
-bwN
-bwN
-bwN
+bzL
+bzL
+bzL
+bzL
+bzL
+bzL
+bzL
 acF
 abj
 abj
@@ -117784,13 +117784,13 @@ aaa
 aaa
 aaa
 acF
-bwN
+bzL
 bzE
 bzE
 bDb
 bzE
 bzE
-bwN
+bzL
 acF
 dij
 aaa
@@ -118041,13 +118041,13 @@ aaa
 aaa
 aaa
 abj
-bwN
+bzL
 bzE
 bBi
 bBj
 bEG
 bGB
-bwN
+bzL
 abj
 dij
 aaa
@@ -118298,13 +118298,13 @@ aaa
 aaa
 aaa
 abj
-bwN
+bzL
 bzE
 bBj
 bDc
 bBj
 bzE
-bwN
+bzL
 abj
 abj
 abj
@@ -118555,13 +118555,13 @@ aaa
 aaa
 aaa
 acF
-bwN
+bzL
 bzE
 bBi
 bBj
 bBi
 bzE
-bwN
+bzL
 abj
 dij
 aaa
@@ -118812,13 +118812,13 @@ aaa
 aaa
 aaa
 acF
-bwN
+bzL
 bzE
 bzE
 bzE
 bzE
 bzE
-bwN
+bzL
 abj
 abj
 aaa
@@ -119069,13 +119069,13 @@ aaa
 aaa
 aaa
 acF
-bwN
+bzL
 bzG
 bBl
 bDd
 bBl
 bGs
-bwN
+bzL
 abj
 bVs
 bXG
@@ -119326,13 +119326,13 @@ aaa
 aaa
 aaa
 abj
-bwN
+bzL
 bzH
 bBo
 bfO
 bge
 bGu
-bwN
+bzL
 abj
 bXF
 abj
@@ -119583,13 +119583,13 @@ abj
 abj
 abj
 abj
-bwN
+bzL
 bzI
 bBn
 bDf
 bEI
 bGv
-bwN
+bzL
 byl
 bPD
 byl
@@ -119840,13 +119840,13 @@ aSN
 aSN
 abj
 abj
-bwN
+bzL
 bzJ
 bBp
 bDh
 bEK
 bGw
-bwN
+bzL
 bJZ
 bPE
 bVt
@@ -120097,13 +120097,13 @@ bpv
 aSN
 abj
 abj
-bwN
+bzL
 bzK
 bBr
 bDg
 bEM
 bGx
-bwN
+bzL
 byl
 bPF
 byl
@@ -120354,13 +120354,13 @@ bpv
 aSN
 abj
 bzL
-bwN
+bzL
 bzL
 bEL
 bDi
 bEL
 bzL
-bwN
+bzL
 opo
 bMd
 bNW
@@ -121361,9 +121361,9 @@ aMC
 ohO
 ohO
 ohO
-aXo
-aXo
-aXo
+aOg
+aOg
+aOg
 bmN
 aOb
 baj
@@ -121375,7 +121375,7 @@ aYO
 bmN
 aOb
 baj
-aXo
+aOg
 baj
 aOb
 bmN
@@ -123434,9 +123434,9 @@ bmA
 ohO
 bpF
 ohO
-aXo
-aXo
-aXo
+aOg
+aOg
+aOg
 byl
 byl
 byl
@@ -123693,7 +123693,7 @@ bpG
 brG
 btm
 buu
-aXo
+aOg
 bwV
 byt
 bzS
@@ -123950,7 +123950,7 @@ bpH
 brH
 aYK
 buv
-aXo
+aOg
 bwW
 bIA
 bIA
@@ -124207,7 +124207,7 @@ bpI
 brI
 brI
 buw
-aXq
+tkO
 bwX
 byv
 bKr
@@ -124464,7 +124464,7 @@ bpJ
 brJ
 btn
 bux
-aXo
+aOg
 byl
 byl
 byl
@@ -124721,7 +124721,7 @@ bpK
 brK
 bto
 buy
-aXo
+aOg
 bwY
 bOg
 bzW
@@ -125235,7 +125235,7 @@ bpM
 brL
 btq
 buA
-hdy
+aOk
 bxa
 bOi
 bzW
@@ -125487,12 +125487,12 @@ mzZ
 ban
 bkM
 bmI
-aXo
-aXo
+aOg
+aOg
 ohO
 btr
 mhi
-aXo
+aOg
 aXo
 aXo
 aXo
@@ -125744,7 +125744,7 @@ ban
 ban
 bkM
 bmJ
-aXo
+aOg
 brN
 brN
 bts
@@ -126001,7 +126001,7 @@ bhp
 bhp
 bkN
 bmK
-aXo
+aOg
 brO
 brO
 btt
@@ -126258,7 +126258,7 @@ bhq
 biZ
 bkO
 bmL
-aXo
+aOg
 bpQ
 brP
 btu
@@ -126515,7 +126515,7 @@ bhr
 bja
 bkP
 bmM
-aXo
+aOg
 btv
 btv
 btv
@@ -126756,9 +126756,9 @@ atd
 atd
 atd
 aOl
-aXo
-aXo
-aXo
+aOg
+aOg
+aOg
 aUi
 aOb
 aUi
@@ -126770,9 +126770,9 @@ aYO
 bmN
 aOb
 baj
-aXo
+aOg
 bmN
-aXo
+aOg
 btw
 brR
 btw
@@ -136808,7 +136808,7 @@ bCl
 byU
 bFy
 bHn
-bOT
+nvW
 bOT
 bOT
 bOT
@@ -137065,7 +137065,7 @@ bCl
 byU
 bFy
 bHo
-bOT
+nvW
 bKP
 bMW
 bOO
@@ -137322,7 +137322,7 @@ bCq
 bEd
 bFF
 bHp
-bOT
+nvW
 bMY
 bMX
 bOP
@@ -137579,7 +137579,7 @@ bCr
 bEe
 bFG
 bHq
-bOT
+nvW
 bKR
 bMX
 bKG
@@ -137836,7 +137836,7 @@ bCs
 bEf
 bFI
 bHs
-bOT
+nvW
 bKS
 bMY
 bKI
@@ -138350,7 +138350,7 @@ bEb
 bEh
 bFJ
 bHt
-bOT
+nvW
 bKU
 bMY
 bKJ
@@ -138607,7 +138607,7 @@ bCr
 bEi
 bFK
 bHu
-bOT
+nvW
 bKV
 bMX
 bKY
@@ -138864,7 +138864,7 @@ bCu
 bEj
 bFL
 bHv
-bOT
+nvW
 bMY
 bMX
 bOR
@@ -139121,7 +139121,7 @@ bCl
 byU
 bFy
 bHw
-bOT
+nvW
 bKP
 bNa
 bOS
@@ -139378,7 +139378,7 @@ bCv
 byU
 bFy
 cHe
-bOT
+nvW
 bOT
 bOT
 bOT

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -336,12 +336,6 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
-"aee" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
 "aef" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
@@ -728,14 +722,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"agk" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
 "agm" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -841,15 +827,14 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"agD" = (
-/turf/simulated/wall/mineral/titanium/nodiagonal,
-/area/shuttle/arrival/station)
 "agE" = (
-/turf/simulated/wall/mineral/titanium,
+/turf/simulated/wall/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "agF" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "agH" = (
 /turf/simulated/floor/plasteel{
@@ -869,35 +854,7 @@
 	},
 /area/hallway/secondary/entry)
 "agT" = (
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange,
-/obj/structure/closet/crate/internals,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"agU" = (
-/obj/structure/closet/wardrobe/mixed,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"agV" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"agW" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"agX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/wall/indestructible/arrivals_shuttle/nodiagonal,
 /area/shuttle/arrival/station)
 "ahg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -964,24 +921,10 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"ahB" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plasteel,
-/area/shuttle/arrival/station)
 "ahC" = (
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"ahE" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
-	},
-/obj/effect/decal/warning_stripes/west,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/airlock/titanium,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "ahF" = (
 /obj/machinery/door/airlock/external{
@@ -990,15 +933,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"ahV" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"ahW" = (
-/obj/machinery/light,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "aik" = (
 /obj/machinery/light{
 	dir = 1
@@ -1008,18 +942,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "ail" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"aim" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/wall/indestructible/fakeglass/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "aio" = (
 /obj/machinery/light{
@@ -1057,13 +980,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"aiG" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/window/full/shuttle,
-/turf/simulated/floor/grass/no_creep,
-/area/shuttle/arrival/station)
 "aiH" = (
 /obj/structure/chair{
 	dir = 4
@@ -1115,18 +1031,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"ajD" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/crew/assistant,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"ajF" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/storage/pill_bottle/dice,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "ajH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1214,12 +1118,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
-"aka" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "akb" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -1227,28 +1125,13 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"akw" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "akx" = (
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aky" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"akz" = (
-/obj/structure/closet/wardrobe/yellow,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"akA" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "akG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -1258,18 +1141,20 @@
 	},
 /area/hallway/secondary/entry)
 "akY" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/mineral/titanium,
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "akZ" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
+/obj/machinery/requests_console{
+	department = "Arrival Shuttle";
+	name = "Arrival Shuttle Requests Console";
+	pixel_y = -30
 	},
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "ala" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/mineral/titanium,
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "alk" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
@@ -1302,16 +1187,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"alv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"alw" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "alx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1348,10 +1223,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"alH" = (
-/obj/structure/computerframe,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "alJ" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -89152,6 +89023,14 @@
 	icon_state = "darkred"
 	},
 /area/security/brig)
+"gNG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "gQW" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/launch)
@@ -90787,6 +90666,14 @@
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
+"jMV" = (
+/obj/machinery/computer/arcade{
+	dir = 4
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "jPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -91229,6 +91116,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/chapel/office)
+"kVF" = (
+/obj/structure/closet/walllocker/emerglocker/east,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "kVM" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -92739,6 +92632,12 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/prisonershuttle)
+"nEw" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "nFv" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -93147,6 +93046,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/engine/break_room)
+"opr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "ops" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
@@ -93301,6 +93208,17 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/starboard)
+"oDS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "oDZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -94249,6 +94167,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/magistrateoffice)
+"qgZ" = (
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "qjR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -94430,6 +94354,12 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
+"qDK" = (
+/obj/structure/closet/wardrobe/xenos,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "qET" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -95126,6 +95056,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"rJm" = (
+/obj/effect/landmark/spawner/late/crew,
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "rLu" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -97215,6 +97150,17 @@
 	icon_state = "dark"
 	},
 /area/security/seceqstorage)
+"vDX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "vDY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -97658,6 +97604,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
+"wwe" = (
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "wzJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -136783,14 +136736,14 @@ abj
 abj
 abj
 acC
-ahA
+afb
 acC
 abj
-aaa
-aaa
+abj
+abj
 abj
 acC
-ahA
+afb
 acC
 abj
 abj
@@ -137037,19 +136990,19 @@ aaa
 abj
 aaa
 aaa
-agE
-agD
-agE
-ahB
-agE
-agF
-agF
-agF
-agF
-agE
-ahB
-agE
-agE
+aaa
+aaa
+acC
+aeb
+acC
+abj
+aaa
+aaa
+abj
+acC
+aeb
+acC
+aaa
 aaa
 aaa
 aaa
@@ -137293,19 +137246,19 @@ acF
 aaa
 abj
 aaa
-aee
-agE
+aaa
+aaa
 agE
 agT
 ahC
-ahV
+agE
+agE
 ail
 ail
-ail
-ail
-ahV
+agE
+agE
 ahC
-akw
+agE
 agE
 aaa
 aaa
@@ -137550,23 +137503,23 @@ acF
 aaa
 abj
 aaa
-aee
-agk
+aaa
+aaa
 agF
-agU
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
+agE
+akx
+gNG
+qgZ
+qDK
+jMV
+nEw
+oDS
+akx
 akx
 agE
 agE
-agF
-agE
+aaa
+aaa
 aaa
 acC
 ant
@@ -137807,23 +137760,23 @@ acF
 aaa
 abj
 aaa
-aee
-agk
+aaa
+aaa
 agF
-agV
-ahC
-ahC
-aim
-aim
-aim
-aim
-ajD
-ahC
+agE
+aky
+rJm
+akx
+rJm
+akx
+rJm
+akx
+rJm
 aky
 akY
-alv
-alH
-agF
+agE
+aaa
+aaa
 aaa
 acC
 ant
@@ -138064,23 +138017,23 @@ acF
 abj
 abj
 aaa
-agE
-agE
-agD
-agW
-ahC
-ahW
-agD
-aiG
-aiG
-aiG
-agD
-aka
-ahC
-akZ
-alw
-alH
+aaa
+aaa
 agF
+agE
+wwe
+rJm
+akx
+rJm
+akx
+rJm
+akx
+rJm
+aky
+akZ
+agE
+aaa
+aaa
 aaa
 acC
 ant
@@ -138321,23 +138274,23 @@ acF
 aaa
 abj
 aaa
-aee
-agk
+aaa
+aaa
 agF
-agX
-ahC
-ahC
-ail
-ail
-ail
-ail
-ajF
-ahC
+agE
+aky
+rJm
+akx
+rJm
+akx
+rJm
+akx
+rJm
 aky
 ala
-alv
-alH
-agF
+agE
+aaa
+aaa
 aaa
 acC
 ant
@@ -138578,23 +138531,23 @@ acF
 aaa
 abj
 aaa
-aee
-agk
-agF
-agU
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-akz
-agE
-agE
+aaa
+aaa
 agF
 agE
+akx
+opr
+kVF
+akx
+akx
+akx
+vDX
+akx
+akx
+agE
+agE
+aaa
+aaa
 aaa
 acC
 ant
@@ -138835,19 +138788,19 @@ acF
 aaa
 abj
 aaa
-aee
-agE
+aaa
+aaa
 agE
 agT
 ahC
-ahV
-aim
-aim
-aim
-aim
-ahV
+agE
+agE
+ail
+ail
+agE
+agE
 ahC
-akA
+agE
 agE
 aaa
 aaa
@@ -139093,19 +139046,19 @@ aaa
 abj
 aaa
 aaa
-agE
-agD
-agE
-ahE
-agE
-agF
-agF
-agF
-agF
-agE
-ahE
-agE
-agE
+aaa
+aaa
+acC
+adZ
+acC
+abj
+aaa
+aaa
+abj
+acC
+adZ
+acC
+aaa
 aaa
 aaa
 aaa
@@ -139353,14 +139306,14 @@ abj
 abj
 abj
 acC
-ahF
+afb
 acC
 abj
-aaa
-aaa
+abj
+abj
 abj
 acC
-ahF
+afb
 acC
 abj
 abj

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -476,7 +476,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "afg" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarstarboard)
 "afh" = (
 /obj/effect/decal/warning_stripes/north,
@@ -1250,9 +1250,6 @@
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
-"akB" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/fore2)
 "akG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -1383,7 +1380,7 @@
 /area/maintenance/fore2)
 "alN" = (
 /obj/structure/barricade/wooden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "alO" = (
@@ -1409,7 +1406,6 @@
 "alS" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -2124,7 +2120,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "aou" = (
@@ -2275,7 +2271,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -2293,7 +2288,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -2604,7 +2598,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/customs)
 "apO" = (
@@ -3669,7 +3663,7 @@
 /area/maintenance/electrical_shop)
 "asn" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/customs)
 "aso" = (
@@ -3757,7 +3751,7 @@
 /area/security/customs)
 "asz" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "asA" = (
@@ -4713,7 +4707,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "auK" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/controlroom)
 "auL" = (
@@ -6411,7 +6405,6 @@
 /obj/item/hand_labeler,
 /obj/item/crowbar,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -9106,7 +9099,7 @@
 	},
 /area/crew_quarters/toilet)
 "aEP" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "aEQ" = (
@@ -9344,14 +9337,14 @@
 /turf/simulated/wall,
 /area/clownoffice)
 "aFu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/clownoffice)
 "aFv" = (
 /turf/simulated/wall,
 /area/mimeoffice)
 "aFw" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/mimeoffice)
 "aFx" = (
@@ -10034,7 +10027,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "aGY" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarport)
 "aGZ" = (
 /turf/simulated/wall/r_wall,
@@ -10854,7 +10847,7 @@
 /area/engine/controlroom)
 "aIM" = (
 /obj/structure/barricade/wooden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hydroponics/abandoned_garden)
 "aIN" = (
@@ -11011,7 +11004,7 @@
 	},
 /area/hallway/primary/fore)
 "aJd" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aJe" = (
@@ -11159,7 +11152,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "aJC" = (
@@ -11417,7 +11410,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/controlroom)
 "aJZ" = (
@@ -13127,7 +13120,7 @@
 /area/maintenance/incinerator)
 "aOe" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos)
 "aOf" = (
@@ -13251,7 +13244,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aOx" = (
@@ -13310,7 +13303,7 @@
 /area/crew_quarters/bar)
 "aOH" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "aOI" = (
@@ -13840,7 +13833,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -14165,7 +14157,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "aQx" = (
@@ -14237,11 +14229,11 @@
 /area/security/permabrig)
 "aQJ" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/permasolitary)
 "aQK" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -15136,7 +15128,7 @@
 /area/atmos)
 "aSO" = (
 /obj/structure/barricade/wooden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "aSP" = (
@@ -18115,7 +18107,7 @@
 /area/atmos)
 "aYO" = (
 /obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "aYP" = (
 /obj/machinery/space_heater,
@@ -21193,7 +21185,7 @@
 	},
 /area/hallway/primary/fore)
 "bfq" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
 "bfr" = (
@@ -22089,7 +22081,6 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/crew/botanist,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -24693,7 +24684,7 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "bmW" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep)
 "bmX" = (
@@ -24717,7 +24708,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/aisat)
 "bmZ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "bna" = (
@@ -25017,7 +25008,7 @@
 	dir = 8;
 	initialize_directions = 11
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos)
 "bnT" = (
@@ -25025,7 +25016,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos)
 "bnU" = (
@@ -25033,7 +25024,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos)
 "bnV" = (
@@ -25053,7 +25044,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos)
 "bnX" = (
@@ -25408,7 +25399,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -25777,7 +25767,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/newscaster/security_unit{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -25963,7 +25952,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos)
 "bpG" = (
@@ -28238,7 +28227,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -28345,7 +28334,7 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "buT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "buU" = (
@@ -28702,10 +28691,6 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/atmos)
-"bvK" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
 /area/atmos)
 "bvL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -29312,12 +29297,9 @@
 "bwN" = (
 /turf/simulated/wall/r_wall,
 /area/engine/gravitygenerator)
-"bwP" = (
-/turf/simulated/wall/r_wall,
-/area/engine/break_room)
 "bwQ" = (
 /obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/engine/break_room)
 "bwR" = (
 /obj/structure/cable{
@@ -29342,7 +29324,7 @@
 /area/hallway/primary/fore)
 "bwS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "bwT" = (
@@ -29352,7 +29334,7 @@
 /area/library)
 "bwU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "bwV" = (
@@ -29451,7 +29433,7 @@
 	},
 /area/atmos)
 "bxd" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -30621,7 +30603,7 @@
 /obj/structure/sign/electricshock{
 	pixel_y = 32
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bzH" = (
@@ -30725,7 +30707,7 @@
 /area/engine/engineering)
 "bzR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "bzS" = (
@@ -30794,7 +30776,7 @@
 /area/atmos)
 "bAc" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos)
 "bAd" = (
@@ -31148,7 +31130,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/newscaster/security_unit{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -31227,7 +31208,7 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bBl" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bBn" = (
@@ -31615,7 +31596,6 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -32747,7 +32727,7 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "bDQ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "bDR" = (
@@ -33077,9 +33057,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
-"bEx" = (
-/turf/simulated/wall/r_wall,
-/area/security/warden)
 "bEy" = (
 /obj/structure/chair/comfy/red{
 	dir = 4
@@ -33358,7 +33335,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "bFh" = (
@@ -33925,7 +33902,7 @@
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bGt" = (
@@ -35062,7 +35039,6 @@
 /obj/item/clipboard,
 /obj/item/gps/engineering,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -35185,7 +35161,7 @@
 /area/storage/tech)
 "bIK" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "bIN" = (
@@ -36046,7 +36022,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
 "bKF" = (
@@ -38161,11 +38137,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "bPu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/warden)
 "bPv" = (
@@ -38184,7 +38160,7 @@
 	},
 /area/security/prison/cell_block)
 "bPw" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hos)
 "bPx" = (
@@ -38602,7 +38578,6 @@
 "bQj" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -38676,7 +38651,7 @@
 /turf/simulated/wall,
 /area/engine/engineering)
 "bQs" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "bQt" = (
@@ -38940,7 +38915,7 @@
 /turf/simulated/wall,
 /area/storage/tools)
 "bQW" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/tools)
 "bQX" = (
@@ -40082,7 +40057,7 @@
 	},
 /area/security/prison/cell_block)
 "bTr" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/seceqstorage)
 "bTs" = (
@@ -41678,7 +41653,7 @@
 	},
 /area/security/brig)
 "bWt" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "bWu" = (
@@ -42411,7 +42386,7 @@
 /turf/simulated/wall,
 /area/library)
 "bYk" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/library)
 "bYl" = (
@@ -42469,7 +42444,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id_tag = "hop";
@@ -42503,12 +42478,6 @@
 /obj/machinery/pdapainter,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
-"bYv" = (
-/turf/simulated/wall/r_wall,
-/area/ntrep)
-"bYx" = (
-/turf/simulated/wall/r_wall,
-/area/blueshield)
 "bYy" = (
 /obj/machinery/photocopier,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -42595,7 +42564,7 @@
 /turf/space,
 /area/space/nearstation)
 "bYK" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
 "bYL" = (
@@ -42988,7 +42957,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "bZD" = (
@@ -43092,7 +43061,6 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -43180,7 +43148,6 @@
 "cac" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/newscaster/security_unit{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -43244,7 +43211,6 @@
 "cak" = (
 /obj/machinery/computer/crew,
 /obj/machinery/newscaster/security_unit{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -43392,7 +43358,6 @@
 "caB" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -44774,7 +44739,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "cdo" = (
@@ -45480,7 +45445,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "cfg" = (
@@ -46012,7 +45977,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -48070,7 +48034,7 @@
 /turf/simulated/wall,
 /area/engine/engineering)
 "clv" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/engine/engine_smes)
 "clw" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
@@ -49346,7 +49310,7 @@
 /area/library)
 "coA" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
 	id_tag = "hop";
@@ -49542,7 +49506,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "cpa" = (
@@ -51097,7 +51061,7 @@
 /area/maintenance/starboard2)
 "csg" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "csh" = (
@@ -51450,9 +51414,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
-"csV" = (
-/turf/simulated/wall/r_wall,
-/area/gateway)
 "csW" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -52100,7 +52061,7 @@
 	},
 /area/hallway/primary/central)
 "cuw" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/locker)
 "cux" = (
@@ -52726,7 +52687,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/gateway)
 "cvP" = (
@@ -52951,7 +52912,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/hardsuitstorage)
 "cwy" = (
@@ -53226,7 +53187,7 @@
 /turf/simulated/floor/plating,
 /area/assembly/showroom)
 "cxa" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/assembly/showroom)
 "cxb" = (
 /obj/machinery/door/firedoor,
@@ -53304,7 +53265,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/gateway)
 "cxj" = (
@@ -53514,7 +53475,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/hardsuitstorage)
 "cxL" = (
@@ -54876,7 +54837,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/hardsuitstorage)
 "cAJ" = (
@@ -55636,7 +55597,7 @@
 /area/maintenance/port)
 "cCr" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/hardsuitstorage)
 "cCs" = (
@@ -55852,7 +55813,7 @@
 /area/hallway/primary/central)
 "cCZ" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/gateway)
 "cDa" = (
@@ -56236,19 +56197,19 @@
 /area/ai_monitored/storage/eva)
 "cEe" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/showroom)
 "cEf" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/assembly/showroom)
 "cEg" = (
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/showroom)
 "cEh" = (
@@ -56263,7 +56224,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/showroom)
 "cEi" = (
@@ -56271,7 +56232,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/showroom)
 "cEj" = (
@@ -58512,7 +58473,7 @@
 /turf/simulated/wall,
 /area/hallway/primary/central)
 "cIW" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/research)
 "cIX" = (
@@ -58602,7 +58563,7 @@
 /turf/simulated/wall,
 /area/medical/reception)
 "cJg" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/medbay)
 "cJh" = (
@@ -58685,7 +58646,6 @@
 "cJs" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -58928,7 +58888,6 @@
 "cKa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -59605,7 +59564,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "cLG" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "cLH" = (
@@ -60250,7 +60209,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "cNq" = (
@@ -60281,7 +60240,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "cNs" = (
@@ -60334,7 +60293,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "cNv" = (
@@ -60363,7 +60322,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "cNx" = (
@@ -60710,7 +60669,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cOg" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/biostorage)
 "cOh" = (
@@ -61272,7 +61231,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/reception)
 "cPC" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/starboardsolar)
 "cPD" = (
 /obj/structure/disposalpipe/segment,
@@ -61516,7 +61475,6 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -63192,7 +63150,7 @@
 	id_tag = "robodesk";
 	name = "Robotics Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "cTQ" = (
@@ -63217,7 +63175,7 @@
 	id_tag = "researchdesk1";
 	name = "Research Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "cTU" = (
@@ -63255,7 +63213,7 @@
 	id_tag = "chemdesk1";
 	name = "Chemistry Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -63309,7 +63267,7 @@
 	name = "Chemistry Desk Shutters"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -63411,7 +63369,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -63486,7 +63443,7 @@
 	},
 /area/medical/medbreak)
 "cUr" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
 "cUs" = (
@@ -63992,7 +63949,6 @@
 /obj/item/wrench,
 /obj/item/clothing/glasses/welding,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -64006,7 +63962,7 @@
 	id_tag = "researchdesk2";
 	name = "Research Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "cVA" = (
@@ -64021,7 +63977,7 @@
 	id_tag = "chemdesk2";
 	name = "Chemistry Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -64042,7 +63998,6 @@
 	pixel_y = -3
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -64471,7 +64426,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "cWE" = (
@@ -64730,7 +64685,7 @@
 	},
 /area/hallway/primary/aft)
 "cXe" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/chemistry)
 "cXf" = (
 /obj/structure/closet/secure_closet/reagents,
@@ -65256,7 +65211,7 @@
 /area/medical/chemistry)
 "cYI" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/chemistry)
 "cYJ" = (
 /obj/structure/table/glass,
@@ -66487,7 +66442,7 @@
 /obj/structure/sign/greencross{
 	pixel_x = 32
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
 "dbw" = (
@@ -66625,7 +66580,7 @@
 /area/maintenance/port2)
 "dbL" = (
 /obj/structure/barricade/wooden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
 "dbM" = (
@@ -67511,7 +67466,7 @@
 /turf/simulated/floor/wood,
 /area/maintenance/library)
 "ddC" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "ddD" = (
@@ -68377,10 +68332,10 @@
 	},
 /area/medical/research)
 "dfo" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/assembly/chargebay)
 "dfp" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "dfq" = (
@@ -68445,14 +68400,11 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/medical/chemistry)
-"dfx" = (
-/turf/simulated/wall/r_wall,
-/area/medical/genetics_cloning)
 "dfy" = (
 /turf/simulated/wall,
 /area/medical/genetics_cloning)
 "dfz" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/genetics_cloning)
 "dfA" = (
@@ -68903,9 +68855,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
-"dgD" = (
-/turf/simulated/wall/r_wall,
-/area/medical/paramedic)
 "dgE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemistry Maintenance";
@@ -73344,12 +73293,12 @@
 	id_tag = "robodesk";
 	name = "Robotics Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "dqn" = (
 /obj/structure/sign/science,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/assembly/robotics)
 "dqo" = (
 /obj/structure/cable{
@@ -73360,9 +73309,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
-"dqp" = (
-/turf/simulated/wall/r_wall,
-/area/assembly/robotics)
 "dqq" = (
 /obj/machinery/camera{
 	c_tag = "Research West Hallway";
@@ -74376,7 +74322,7 @@
 	id_tag = "geneticsdesk";
 	name = "Genetics Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "dsO" = (
@@ -74501,7 +74447,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/genetics)
 "dta" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "dtb" = (
@@ -75825,7 +75771,7 @@
 /area/crew_quarters/theatre)
 "dvT" = (
 /obj/structure/barricade/wooden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
 "dvU" = (
@@ -75991,7 +75937,7 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/server)
 "dwn" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "dwo" = (
@@ -76275,7 +76221,6 @@
 /area/crew_quarters/theatre)
 "dwT" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -76382,7 +76327,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -78827,7 +78771,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/medical/medbay)
 "dCo" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/surgeryobs)
 "dCq" = (
@@ -79896,7 +79840,7 @@
 /area/toxins/test_area)
 "dFh" = (
 /obj/structure/barricade/wooden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "dFi" = (
@@ -80715,7 +80659,6 @@
 /obj/structure/table/glass,
 /obj/item/flashlight/lamp,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -81501,7 +81444,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "dJh" = (
@@ -81665,7 +81608,6 @@
 /area/hallway/secondary/exit)
 "dJC" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -83817,9 +83759,6 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/apmaint)
-"dOS" = (
-/turf/simulated/wall/r_wall,
-/area/chapel/office)
 "dOT" = (
 /obj/structure/crematorium,
 /turf/simulated/floor/plasteel/dark,
@@ -83972,7 +83911,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "dPq" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/portsolar)
 "dPr" = (
 /obj/structure/cable{
@@ -84212,7 +84151,7 @@
 /area/hallway/secondary/exit)
 "dPS" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology)
 "dPT" = (
 /obj/structure/disposalpipe/segment,
@@ -84278,12 +84217,12 @@
 /area/maintenance/portsolar)
 "dQb" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/apmaint)
 "dQc" = (
 /obj/structure/barricade/wooden,
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "dQe" = (
@@ -84719,10 +84658,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"dQS" = (
-/obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall/r_wall,
-/area/maintenance/apmaint)
 "dQT" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
@@ -85064,10 +84999,6 @@
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor/plasteel/dark,
 /area/maintenance/apmaint)
-"dRJ" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
-/area/maintenance/apmaint)
 "dRK" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -85204,7 +85135,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -87309,7 +87239,6 @@
 	},
 /obj/item/storage/box/masks,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -87767,7 +87696,7 @@
 /turf/space,
 /area/space)
 "eaa" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/arcade)
 "eaH" = (
@@ -87872,7 +87801,7 @@
 	},
 /area/security/main)
 "enC" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "epr" = (
@@ -87941,9 +87870,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
-"euc" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/primary/central/south)
 "eud" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -88135,7 +88061,7 @@
 /area/maintenance/fsmaint)
 "ePS" = (
 /obj/structure/lattice,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/security/securearmoury)
 "eQg" = (
 /obj/machinery/biogenerator,
@@ -89005,6 +88931,10 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block)
+"gtI" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/hallway/primary/central)
 "guk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89080,7 +89010,6 @@
 /area/assembly/showroom)
 "gzU" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -89227,7 +89156,7 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/launch)
 "gSt" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -89389,8 +89318,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
+"hdy" = (
+/obj/structure/sign/fire,
+/turf/simulated/wall,
+/area/atmos)
 "hdV" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -90053,7 +89986,7 @@
 	},
 /area/crew_quarters/fitness)
 "ipz" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/civilian/barber)
 "ipD" = (
@@ -90172,6 +90105,10 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/starboard)
+"iCB" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/quartermaster/miningdock)
 "iCN" = (
 /obj/structure/chair{
 	dir = 4
@@ -90233,7 +90170,6 @@
 /area/medical/surgery2)
 "iIw" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -90466,6 +90402,14 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/maintenance/library)
+"iZn" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "iZW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Affairs Maintenance";
@@ -91057,7 +91001,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/securearmoury)
 "kit" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/medbreak)
 "kiL" = (
@@ -91222,6 +91166,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"kII" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "kOC" = (
 /obj/structure/table,
 /obj/item/storage/fancy/crayons,
@@ -91299,7 +91247,7 @@
 /turf/simulated/floor/plasteel/white,
 /area/medical/research)
 "kXM" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -91398,7 +91346,7 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "lhu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/art)
 "ljZ" = (
@@ -91522,6 +91470,13 @@
 	icon_state = "darkred"
 	},
 /area/security/seceqstorage)
+"lpm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/atmos)
 "lqK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light_switch{
@@ -91864,7 +91819,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block)
 "mfI" = (
@@ -91895,6 +91850,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
+"mhi" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/atmos)
 "mhu" = (
 /turf/simulated/wall/r_wall,
 /area/security/permasolitary)
@@ -91927,7 +91889,7 @@
 	},
 /area/medical/surgery1)
 "mkp" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
 "mks" = (
@@ -92034,6 +91996,11 @@
 	icon_state = "darkred"
 	},
 /area/security/main)
+"mpo" = (
+/obj/structure/cable,
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "mqS" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -92221,7 +92188,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/execution)
 "mGS" = (
@@ -92253,6 +92220,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/engine,
 /area/toxins/mixing)
+"mIt" = (
+/turf/simulated/wall,
+/area/maintenance/incinerator)
 "mKM" = (
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -92635,7 +92605,6 @@
 /area/medical/reception)
 "nqC" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -93107,6 +93076,10 @@
 	icon_state = "dark"
 	},
 /area/security/main)
+"ohO" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/atmos)
 "oix" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93295,6 +93268,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"oCI" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "oCK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -93445,6 +93422,10 @@
 	icon_state = "darkred"
 	},
 /area/security/brig)
+"oNQ" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/quartermaster/storage)
 "oOe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -93591,7 +93572,7 @@
 	id_tag = "geneticsdesk";
 	name = "Genetics Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -93731,9 +93712,17 @@
 	},
 /area/security/execution)
 "ppu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/reception)
+"prb" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "prh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93942,7 +93931,7 @@
 	},
 /area/hallway/secondary/exit)
 "pKg" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -94112,7 +94101,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "pXX" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -94492,6 +94481,9 @@
 	icon_state = "darkredfull"
 	},
 /area/security/processing)
+"qNT" = (
+/turf/simulated/wall,
+/area/security/securearmoury)
 "qOd" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94547,7 +94539,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block)
 "qUB" = (
@@ -95102,7 +95094,6 @@
 "rHU" = (
 /obj/structure/chair,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -95135,6 +95126,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"rLu" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/assembly/showroom)
 "rMG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95162,9 +95161,6 @@
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard)
-"rOW" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
 "rQz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -95298,6 +95294,14 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
+"sdN" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "sdP" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -95555,6 +95559,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
+"swp" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/toxins/misc_lab)
 "swV" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/glowshroom,
@@ -95701,6 +95709,10 @@
 	icon_state = "barber"
 	},
 /area/civilian/barber)
+"sPr" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
 "sPz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -96328,6 +96340,10 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block)
+"tQy" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness)
 "tRM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -96584,7 +96600,7 @@
 	},
 /area/maintenance/fsmaint)
 "umm" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -97102,6 +97118,14 @@
 	icon_state = "darkred"
 	},
 /area/security/processing)
+"vxw" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "vxz" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -97418,6 +97442,10 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
+"war" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/quartermaster/qm)
 "wdH" = (
 /obj/structure/chair/sofa/pew/right{
 	dir = 8;
@@ -97580,6 +97608,10 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block)
+"wqn" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/security/prisonershuttle)
 "wsN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -97655,7 +97687,7 @@
 	},
 /area/medical/reception)
 "wBO" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/civilian/pet_store)
 "wDm" = (
@@ -97875,6 +97907,10 @@
 /obj/item/chair/stool/bar,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
+"xjl" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry)
 "xkE" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -120593,7 +120629,7 @@ abj
 abj
 abj
 aaa
-aGZ
+mIt
 aIt
 aMO
 aLb
@@ -120601,7 +120637,7 @@ aMA
 aNY
 aPr
 aQP
-aGZ
+mIt
 aTU
 aSN
 aXc
@@ -121107,7 +121143,7 @@ aaa
 abj
 abj
 abj
-aGZ
+mIt
 aIv
 aJO
 aLd
@@ -121115,7 +121151,7 @@ aMB
 aOa
 aPB
 aQR
-aGZ
+mIt
 abj
 aSM
 bbF
@@ -121364,17 +121400,17 @@ aBV
 aAe
 aJy
 aBV
-aGZ
+mIt
 aIw
 aJO
 aLe
 aMC
-aOb
-aOb
-aOb
-aOg
-aOg
-aOg
+ohO
+ohO
+ohO
+aXo
+aXo
+aXo
 bmN
 aOb
 baj
@@ -121386,13 +121422,13 @@ aYO
 bmN
 aOb
 baj
-aOg
+aXo
 baj
 aOb
 bmN
-aOg
-aOg
-bwP
+aXo
+aXo
+byl
 byl
 byl
 byl
@@ -121621,12 +121657,12 @@ ayG
 azR
 aIT
 aEa
-aGZ
+mIt
 aIx
 aJO
 aLf
 aMC
-aOb
+ohO
 aPH
 aPH
 aSA
@@ -121649,7 +121685,7 @@ bvU
 btg
 buo
 bvD
-bwP
+byl
 bym
 bzN
 bIx
@@ -122140,7 +122176,7 @@ aIz
 aJQ
 aLh
 aMF
-aOb
+ohO
 aPH
 aQU
 aSC
@@ -122157,13 +122193,13 @@ aYy
 bdo
 bkz
 bmv
-aUi
+lpm
 bpA
 brB
 aTZ
 ban
 bvF
-bwP
+byl
 bzO
 bzN
 bBy
@@ -122392,12 +122428,12 @@ aDC
 aEa
 aDC
 aBV
-aGZ
+mIt
 aIA
 aJR
 aLi
 aMG
-aOb
+ohO
 aPH
 aQV
 aSD
@@ -122420,7 +122456,7 @@ brC
 bti
 buq
 bvG
-bwP
+byl
 byp
 bzN
 bBy
@@ -122671,7 +122707,7 @@ aXk
 biO
 bkB
 bmx
-aUi
+lpm
 bpC
 brD
 btj
@@ -122934,7 +122970,7 @@ brE
 ban
 bus
 bvI
-bwP
+byl
 byl
 byl
 byl
@@ -123442,13 +123478,13 @@ bhk
 biT
 bkM
 bmA
-aOb
+ohO
 bpF
-aOb
-aOg
-aOg
-aOg
-bwP
+ohO
+aXo
+aXo
+aXo
+byl
 byl
 byl
 bBB
@@ -123690,9 +123726,9 @@ aUc
 aVJ
 aXo
 aXo
-aOb
-aOb
-aOb
+ohO
+ohO
+ohO
 aXo
 aXo
 bhl
@@ -123704,7 +123740,7 @@ bpG
 brG
 btm
 buu
-aOg
+aXo
 bwV
 byt
 bzS
@@ -123945,13 +123981,13 @@ aQZ
 aSD
 aUc
 aVI
-aOb
+ohO
 aYF
 baq
 bbR
 bdq
 beL
-aOb
+ohO
 bhk
 biT
 bkF
@@ -123961,7 +123997,7 @@ bpH
 brH
 aYK
 buv
-aOg
+aXo
 bwW
 bIA
 bIA
@@ -124218,7 +124254,7 @@ bpI
 brI
 brI
 buw
-bvK
+aXq
 bwX
 byv
 bKr
@@ -124459,13 +124495,13 @@ aRc
 aSD
 aUc
 aVI
-aOb
+ohO
 aYH
 bas
 bbT
 bds
 beN
-aOb
+ohO
 bhk
 aZm
 bkF
@@ -124475,7 +124511,7 @@ bpJ
 brJ
 btn
 bux
-aOg
+aXo
 byl
 byl
 byl
@@ -124718,9 +124754,9 @@ aUc
 aVL
 aXo
 aXo
-aOb
-aOb
-aOb
+ohO
+ohO
+ohO
 aXo
 aXo
 bho
@@ -124732,7 +124768,7 @@ bpK
 brK
 bto
 buy
-aOg
+aXo
 bwY
 bOg
 bzW
@@ -125246,7 +125282,7 @@ bpM
 brL
 btq
 buA
-aOk
+hdy
 bxa
 bOi
 bzW
@@ -125498,17 +125534,17 @@ mzZ
 ban
 bkM
 bmI
-aOg
-aOg
-aOb
+aXo
+aXo
+ohO
 btr
-bmN
-aOg
-aOg
-aOg
-aOg
-aOg
-aOg
+mhi
+aXo
+aXo
+aXo
+aXo
+aXo
+aXo
 bFb
 bGI
 bIA
@@ -125755,7 +125791,7 @@ ban
 ban
 bkM
 bmJ
-aOg
+aXo
 brN
 brN
 bts
@@ -125765,7 +125801,7 @@ bxb
 byz
 bzX
 bBJ
-aOg
+aXo
 bFc
 bGH
 bIF
@@ -126012,7 +126048,7 @@ bhp
 bhp
 bkN
 bmK
-aOg
+aXo
 brO
 brO
 btt
@@ -126022,7 +126058,7 @@ ban
 bzY
 bzY
 bBK
-aOg
+aXo
 byl
 bGJ
 byl
@@ -126033,7 +126069,7 @@ bSl
 bIA
 bUw
 bWv
-bwP
+byl
 bZC
 cfg
 cdn
@@ -126269,7 +126305,7 @@ bhq
 biZ
 bkO
 bmL
-aOg
+aXo
 bpQ
 brP
 btu
@@ -126279,7 +126315,7 @@ bfv
 byB
 bzZ
 bBL
-aOg
+aXo
 bFd
 bGK
 bID
@@ -126290,7 +126326,7 @@ jkP
 bSm
 bUx
 bWw
-bwP
+byl
 bZD
 cbv
 cdo
@@ -126526,7 +126562,7 @@ bhr
 bja
 bkP
 bmM
-aOg
+aXo
 btv
 btv
 btv
@@ -126536,7 +126572,7 @@ ban
 byC
 ban
 bBM
-aOg
+aXo
 bFe
 bGM
 kIs
@@ -126547,7 +126583,7 @@ bIA
 bIA
 bGC
 bWx
-bwP
+byl
 fQU
 cbw
 cdp
@@ -126767,9 +126803,9 @@ atd
 atd
 atd
 aOl
-aOg
-aOg
-aOg
+aXo
+aXo
+aXo
 aUi
 aOb
 aUi
@@ -126781,9 +126817,9 @@ aYO
 bmN
 aOb
 baj
-aOg
+aXo
 bmN
-aOg
+aXo
 btw
 brR
 btw
@@ -126793,7 +126829,7 @@ bxc
 byD
 bAb
 bBN
-aOg
+aXo
 bFf
 bGL
 bII
@@ -126804,7 +126840,7 @@ bQv
 bXE
 bUz
 bWy
-bwP
+byl
 bZE
 cbx
 cdq
@@ -127040,17 +127076,17 @@ aSM
 buX
 bkQ
 aOW
-aOg
-aOg
-aOg
-bvK
+aXo
+aXo
+aXo
+aXq
 buH
 bvS
 bxd
 byE
 bAc
-aOg
-aOg
+aXo
+aXo
 bFg
 bGN
 bIK
@@ -127061,7 +127097,7 @@ bQs
 bQs
 byl
 byl
-bwP
+byl
 clv
 clv
 clv
@@ -127614,9 +127650,9 @@ cIM
 cKo
 doQ
 ddi
-ddi
-ddi
-ddi
+dds
+dds
+dds
 dhA
 ddi
 ddi
@@ -128332,7 +128368,7 @@ aaa
 aaa
 aaa
 aaa
-bxh
+brW
 bAg
 bBP
 bDE
@@ -128680,14 +128716,14 @@ dNA
 plp
 dOP
 dPt
-dbw
-dbw
-dbw
-dbw
-dbw
-dbw
-dQS
-dbw
+ddy
+ddy
+ddy
+ddy
+ddy
+ddy
+dku
+ddy
 abj
 aaa
 aaa
@@ -129715,7 +129751,7 @@ dRZ
 dko
 dSO
 dUS
-dQS
+dku
 abj
 aaa
 aaa
@@ -129874,7 +129910,7 @@ aaa
 aaa
 aaa
 aaa
-bxh
+brW
 bAk
 bBU
 bDI
@@ -129965,14 +130001,14 @@ dNE
 plp
 dbp
 dPy
-dbw
+ddy
 dQP
 dRC
 dSc
 dSb
 dSQ
 dlJ
-dQS
+dku
 abj
 aaa
 aaa
@@ -130131,17 +130167,17 @@ brW
 brW
 brX
 brW
-bxh
-bxh
-bxh
-bxh
-bxh
-bxh
-bxh
-bxh
-bxh
-bxh
-bxh
+brW
+brW
+brW
+brW
+brW
+brW
+brW
+brW
+brW
+brW
+brW
 cWa
 bUI
 bWH
@@ -130229,7 +130265,7 @@ djZ
 dRK
 dSW
 dTj
-dbw
+ddy
 abj
 aaa
 aaa
@@ -130993,7 +131029,7 @@ plp
 byA
 dik
 dPB
-dbw
+ddy
 dQR
 dRs
 dRI
@@ -131250,14 +131286,14 @@ dgm
 dOn
 dOQ
 dPC
-dbw
-dQS
-dQS
-dRJ
-dbw
-dbw
-dbw
-dbw
+ddy
+dku
+dku
+dlJ
+ddy
+ddy
+ddy
+ddy
 abj
 aaa
 aaa
@@ -132019,11 +132055,11 @@ dJu
 dMQ
 dJu
 dIx
-dOS
-dOS
-dOS
-dOS
-dOS
+dIx
+dIx
+dIx
+dIx
+dIx
 dIx
 dIx
 dIx
@@ -132153,7 +132189,7 @@ aVK
 aVK
 aDH
 awX
-awM
+kII
 awX
 awX
 awX
@@ -133538,7 +133574,7 @@ drv
 drA
 dsE
 dtZ
-dff
+dqf
 dwj
 dxs
 dyI
@@ -134000,10 +134036,10 @@ bHj
 bSE
 bsv
 cgE
-btH
-btH
-btH
-btH
+gtI
+gtI
+gtI
+gtI
 ctE
 chd
 bSE
@@ -134027,10 +134063,10 @@ dxV
 ddl
 cIV
 cYA
-cYz
-cYz
-cYz
-cYz
+swp
+swp
+swp
+swp
 dvf
 dvf
 dvf
@@ -134052,7 +134088,7 @@ dqf
 drC
 dsG
 dub
-dff
+dqf
 dwl
 dxu
 dyK
@@ -134248,7 +134284,7 @@ bAr
 bCl
 byU
 bFR
-bHj
+bHk
 bIY
 bKF
 bMM
@@ -134505,7 +134541,7 @@ bAs
 bCB
 bAs
 bAs
-bHj
+bHk
 bIZ
 bKN
 bMN
@@ -134762,7 +134798,7 @@ aot
 bCk
 bEk
 asz
-bHj
+bHk
 bJa
 bOG
 bMP
@@ -135333,7 +135369,7 @@ dnF
 dfo
 dfp
 dfo
-dqp
+dql
 dql
 dql
 dwn
@@ -135590,7 +135626,7 @@ doy
 doT
 doU
 dqj
-dqp
+dql
 dsJ
 duj
 dwq
@@ -136577,7 +136613,7 @@ cdI
 cfK
 chk
 ciF
-bYv
+bOZ
 aaa
 aaa
 dER
@@ -137091,13 +137127,13 @@ cdJ
 cfG
 chl
 ciH
-bYv
+bOZ
 dER
 dER
 dER
 cpX
 cry
-euc
+dER
 ctZ
 csN
 cxa
@@ -137389,7 +137425,7 @@ dnz
 dnz
 dnz
 drF
-dqp
+dql
 cTP
 dwo
 cTP
@@ -137603,9 +137639,9 @@ dne
 dnf
 cfK
 drp
-bYv
+bOZ
 chp
-bYv
+bOZ
 clS
 ckv
 ckv
@@ -137614,7 +137650,7 @@ cuf
 csP
 cub
 cvE
-cwZ
+rLu
 cyk
 czM
 cBp
@@ -137646,7 +137682,7 @@ doR
 doR
 dpc
 dfo
-dqp
+dql
 drK
 dce
 dce
@@ -137793,7 +137829,7 @@ acC
 ant
 anT
 aoy
-acC
+xjl
 aqb
 aqW
 asj
@@ -138050,7 +138086,7 @@ acC
 ant
 anU
 aoz
-acC
+xjl
 aqc
 aqW
 arP
@@ -138307,7 +138343,7 @@ acC
 ant
 anT
 aoF
-acC
+xjl
 aqd
 aqW
 asj
@@ -138631,9 +138667,9 @@ bQI
 bQI
 bQI
 bQI
-bYx
+bQI
 ciN
-bYx
+bQI
 clU
 ckv
 ckv
@@ -138642,7 +138678,7 @@ crH
 csT
 cuf
 cvG
-cwZ
+rLu
 cyk
 czP
 cBs
@@ -138658,7 +138694,7 @@ cNQ
 cPA
 ppu
 hjK
-rOW
+tDw
 cVD
 cXe
 cVD
@@ -138915,7 +138951,7 @@ wAW
 mTs
 cRj
 cSx
-rOW
+tDw
 cVE
 cXf
 cYD
@@ -138923,7 +138959,7 @@ cXe
 cVD
 dcl
 cVD
-dgD
+dfv
 dgF
 dkY
 dkZ
@@ -139147,13 +139183,13 @@ cdQ
 cfN
 chr
 ciP
-bYx
+bQI
 dER
 dER
 dER
 cqe
 crP
-euc
+dER
 cuh
 csN
 cxa
@@ -139180,7 +139216,7 @@ cZD
 dbd
 dch
 ddZ
-dgD
+dfv
 dgG
 diy
 dlf
@@ -139429,7 +139465,7 @@ cNT
 cPD
 cRl
 cSz
-rOW
+tDw
 cZE
 dat
 dax
@@ -139437,7 +139473,7 @@ dgo
 dcg
 dcs
 dfq
-dgD
+dfv
 dgH
 diz
 dmk
@@ -139661,21 +139697,21 @@ cdS
 cfP
 chs
 ciR
-bYx
+bQI
 aaa
 aaa
 dER
 cqg
 crP
-csV
-csV
+cyv
+cyv
 cvI
-csV
-csV
-csV
-csV
-csV
-csV
+cyv
+cyv
+cyv
+cyv
+cyv
+cyv
 cEY
 bqu
 cHK
@@ -139694,7 +139730,7 @@ dlW
 ctb
 cXg
 ddN
-dgD
+dfv
 dfv
 djV
 dfv
@@ -139924,7 +139960,7 @@ cht
 cht
 ygv
 crP
-csV
+cyv
 cuk
 cvK
 cxe
@@ -139932,7 +139968,7 @@ cyr
 czW
 cBw
 cCV
-csV
+cyv
 gaZ
 bqu
 cHK
@@ -140181,7 +140217,7 @@ cmX
 cht
 ygv
 fmE
-csV
+cyv
 cul
 cxh
 cCX
@@ -140189,7 +140225,7 @@ cyt
 cCX
 cCX
 cCW
-csV
+cyv
 cEZ
 bqu
 cHK
@@ -140208,7 +140244,7 @@ doE
 daV
 cXk
 ddP
-dfx
+dfy
 dfy
 dfy
 dfy
@@ -140465,7 +140501,7 @@ ddV
 daW
 dck
 ddQ
-dfx
+dfy
 dgI
 diA
 djX
@@ -140695,7 +140731,7 @@ cnA
 cht
 cqj
 crP
-csV
+cyv
 cuX
 cCX
 cxh
@@ -140703,7 +140739,7 @@ cyu
 cCX
 cBC
 dte
-csV
+cyv
 cFa
 bqu
 cHK
@@ -140714,7 +140750,7 @@ ncT
 giz
 ckJ
 cSE
-rOW
+tDw
 cXe
 cXe
 cYI
@@ -140722,7 +140758,7 @@ cXe
 daX
 ddL
 dfw
-dfx
+dfy
 dgJ
 diB
 djY
@@ -140952,7 +140988,7 @@ cnB
 coF
 cqk
 crO
-csV
+cyv
 cvJ
 cvY
 cxJ
@@ -140960,7 +140996,7 @@ cyI
 cCX
 cBC
 cDa
-csV
+cyv
 cFa
 bqu
 cHK
@@ -141126,7 +141162,7 @@ afz
 agp
 aXy
 bKa
-akB
+axm
 alJ
 alZ
 apo
@@ -141209,15 +141245,15 @@ cnB
 coG
 cql
 crP
-csV
-csV
+cyv
+cyv
 cvO
 cxi
 cyv
 cvO
 cBA
 cCZ
-csV
+cyv
 cFf
 bqu
 cHO
@@ -141383,7 +141419,7 @@ afB
 agq
 bdA
 bSk
-akB
+axm
 alX
 ama
 amC
@@ -141425,11 +141461,11 @@ bcI
 ayD
 bbe
 bbe
-bbi
+iCB
 bin
-bbi
+iCB
 blJ
-bbi
+iCB
 bbe
 bbe
 boz
@@ -141444,7 +141480,7 @@ aot
 bCA
 bkf
 asz
-bHx
+bWX
 bJp
 bLe
 bNg
@@ -141467,7 +141503,7 @@ cht
 cre
 crP
 csZ
-csV
+cyv
 cvP
 cxj
 cyw
@@ -141640,7 +141676,7 @@ afC
 agH
 bya
 bSB
-akB
+axm
 auu
 amb
 amD
@@ -141701,7 +141737,7 @@ bAs
 bCB
 boT
 bAs
-bHx
+bWX
 bJq
 bLf
 bLf
@@ -141724,7 +141760,7 @@ coH
 ygv
 crP
 cta
-csV
+cyv
 cvQ
 cxk
 cyx
@@ -141897,7 +141933,7 @@ afM
 afg
 afg
 afi
-akB
+axm
 alM
 amc
 amE
@@ -141937,7 +141973,7 @@ aUY
 aWw
 aBS
 aZo
-bbi
+iCB
 bcE
 bfZ
 beg
@@ -141945,7 +141981,7 @@ bfA
 bib
 bjH
 blN
-bbi
+iCB
 bov
 aXY
 ado
@@ -141958,7 +141994,7 @@ bAr
 bCl
 aZe
 bFR
-bHx
+bWX
 bJr
 bLg
 bNh
@@ -141981,7 +142017,7 @@ cht
 ygv
 crP
 ctk
-csV
+cyv
 cvR
 cxl
 cyy
@@ -142154,7 +142190,7 @@ afN
 aED
 afg
 abj
-akB
+axm
 alN
 amd
 amF
@@ -142237,15 +142273,15 @@ cht
 cht
 crQ
 csX
-csV
-csV
-csV
-csV
-csV
-csV
-csV
-csV
-csV
+cyv
+cyv
+cyv
+cyv
+cyv
+cyv
+cyv
+cyv
+cyv
 cGL
 dxV
 lso
@@ -142411,7 +142447,7 @@ afP
 aUs
 afg
 aaa
-akB
+axm
 alO
 ame
 amG
@@ -142668,7 +142704,7 @@ afQ
 aUt
 afg
 abj
-akB
+axm
 alP
 ajI
 ajM
@@ -142925,7 +142961,7 @@ afR
 afi
 afi
 abj
-akB
+axm
 atS
 amf
 amG
@@ -142967,11 +143003,11 @@ aBS
 aUG
 bbe
 bbe
-bbi
+iCB
 bio
-bbi
+iCB
 blK
-bbi
+iCB
 bbe
 bbe
 boC
@@ -143182,7 +143218,7 @@ agm
 afi
 abj
 abj
-akB
+axm
 alR
 amg
 amH
@@ -143439,7 +143475,7 @@ agn
 afi
 abj
 abj
-akB
+axm
 alS
 ajJ
 amI
@@ -143474,12 +143510,12 @@ aQr
 aCN
 aKK
 aRZ
-aSa
-aSa
+war
+war
 bbj
-aSa
-aSa
-aSa
+war
+war
+war
 bfC
 ben
 hYQ
@@ -143696,7 +143732,7 @@ ago
 abj
 abj
 aaa
-akB
+axm
 asJ
 ajL
 ajN
@@ -143730,13 +143766,13 @@ aBS
 aEX
 aBS
 aKK
-aSa
+war
 aTz
 bhZ
 aWE
 aYg
 aZv
-aSa
+war
 boD
 bek
 bfF
@@ -143953,7 +143989,7 @@ adg
 abj
 abj
 abj
-akB
+axm
 atS
 amG
 ajL
@@ -143987,7 +144023,7 @@ aBS
 aEZ
 aBS
 aWG
-aSa
+war
 aTA
 aVf
 aWF
@@ -144210,7 +144246,7 @@ adg
 aaa
 abj
 abj
-akB
+axm
 axm
 amh
 amh
@@ -144467,7 +144503,7 @@ adg
 abj
 abj
 abj
-akB
+axm
 abj
 acF
 acF
@@ -144501,16 +144537,16 @@ aDX
 aSw
 aQv
 aKJ
-aSa
+war
 aTC
 aVh
 aWH
 aYi
 aZB
-aSa
-bbi
+war
+iCB
 bes
-bbi
+iCB
 bbe
 bil
 bjQ
@@ -144758,17 +144794,17 @@ aJE
 aQs
 aQv
 aKJ
-aSa
+war
 aTD
 aYg
 aWI
 aYg
 aZC
-aSa
+war
 aVX
 beq
 blC
-bbi
+iCB
 bil
 bjR
 bJs
@@ -145006,7 +145042,7 @@ aFR
 aFR
 aGP
 aFN
-aFR
+oNQ
 aFN
 aIk
 aFR
@@ -145121,9 +145157,9 @@ dIW
 abj
 dQv
 dIc
-dFG
+dGw
 dFI
-dFG
+dGw
 dFH
 dOE
 abj
@@ -145520,7 +145556,7 @@ aaa
 aFR
 aGP
 aFN
-aFR
+oNQ
 aFN
 aIk
 aFR
@@ -145633,13 +145669,13 @@ dLU
 dMv
 dIX
 abj
-dFG
+dGw
 dNi
 hbU
 dMx
 dNk
 dRh
-dFG
+dGw
 aaa
 aaa
 aaa
@@ -146022,7 +146058,7 @@ aaa
 abj
 asd
 asR
-asc
+sPr
 auZ
 awE
 azS
@@ -146142,9 +146178,9 @@ dDE
 bng
 aaa
 aaa
-dFG
+dGw
 dHb
-dFG
+dGw
 aaa
 aaa
 dKB
@@ -146279,7 +146315,7 @@ aaa
 abj
 asd
 asS
-asc
+sPr
 avv
 avv
 awF
@@ -146404,13 +146440,13 @@ dHc
 dIc
 abj
 abj
-dFG
+dGw
 dNY
 wdL
 dMz
 dNn
 dWT
-dFG
+dGw
 aaa
 aaa
 aaa
@@ -146661,13 +146697,13 @@ dHd
 dIc
 aaa
 aaa
-dFG
+dGw
 dXG
 dPg
 dQw
 dfQ
 dWU
-dFG
+dGw
 abj
 abj
 abj
@@ -146912,21 +146948,21 @@ dCm
 dDD
 bng
 aaa
-dFG
-dFG
-dHe
-dFG
-dFG
-dFG
-dFG
-dJW
-dFH
-dMB
-dIc
 dGw
-dFG
-dFG
-dFG
+dGw
+dHe
+dGw
+dGw
+dGw
+dGw
+dJW
+iZn
+dMB
+mpo
+dGw
+dGw
+dGw
+dGw
 abj
 abj
 abj
@@ -147169,7 +147205,7 @@ cSY
 dDC
 bng
 abj
-dFG
+dGw
 dGt
 dHf
 dId
@@ -147683,7 +147719,7 @@ cSZ
 dDE
 bng
 abj
-dFG
+dGw
 dGv
 dNv
 dIk
@@ -147697,7 +147733,7 @@ dXi
 dOf
 dXi
 dPl
-dFG
+dGw
 dWZ
 dXe
 abj
@@ -147940,24 +147976,24 @@ cSZ
 dDE
 bng
 aaa
-dFG
 dGw
-dNr
+dGw
+oCI
 dJa
 dJf
 dGw
 dGw
 dGw
-dKB
+sdN
 dGw
-dNr
+oCI
 dOg
-dNr
+oCI
 dGw
-dFG
-dFG
-dFG
-dFG
+dGw
+dGw
+dGw
+dGw
 abj
 aaa
 aaa
@@ -148197,7 +148233,7 @@ cSY
 dDC
 bng
 abj
-dFG
+dGw
 dGx
 dHj
 dJb
@@ -148210,11 +148246,11 @@ dGw
 dNs
 dOh
 dOJ
-dIc
+mpo
 dPU
 dQx
 dXf
-dFG
+dGw
 abj
 aaa
 aaa
@@ -148463,7 +148499,7 @@ dJT
 dXE
 dLi
 dOd
-dFI
+prb
 dNt
 oEs
 dOK
@@ -148717,7 +148753,7 @@ dJi
 dJc
 dXh
 dJU
-dIc
+mpo
 dLj
 dQG
 dYF
@@ -148728,7 +148764,7 @@ dGw
 dGw
 dGw
 dGw
-dFG
+dGw
 abj
 aaa
 aaa
@@ -148968,7 +149004,7 @@ iVO
 dDF
 bqC
 abj
-dFG
+dGw
 dGA
 dHm
 dJd
@@ -148977,7 +149013,7 @@ dJV
 dGw
 dLk
 dXi
-dKB
+sdN
 dNv
 dOk
 dOM
@@ -149186,7 +149222,7 @@ oNd
 oNd
 oNd
 cFw
-csj
+tQy
 cIm
 aFt
 aFt
@@ -149225,7 +149261,7 @@ aOx
 dDG
 dDG
 abj
-dFG
+dGw
 dGw
 dGw
 dIl
@@ -149238,11 +149274,11 @@ dGw
 dNw
 dOl
 dON
-dIc
+mpo
 dPX
 dQA
 dXf
-dFG
+dGw
 abj
 aaa
 aaa
@@ -149483,23 +149519,23 @@ dDH
 dDG
 abj
 abj
-dFG
+dGw
 dHo
 dIm
 dJh
 dJX
-dFG
-dFG
-dFG
-dFG
-dFG
+dGw
+dGw
+dGw
+dGw
+dGw
 dKB
-dFG
-dFG
-dFG
-dFG
-dFG
-dFG
+dGw
+dGw
+dGw
+dGw
+dGw
+dGw
 abj
 aaa
 aaa
@@ -149918,9 +149954,9 @@ lNl
 bLA
 bLA
 bno
-bqM
+wqn
 boJ
-bqM
+wqn
 tmp
 bui
 bPt
@@ -149997,12 +150033,12 @@ dDJ
 dEt
 aaa
 abj
-dFG
+dGw
 dHq
 dIo
 dJj
 dJZ
-dFG
+dGw
 abj
 aaa
 aaa
@@ -150161,7 +150197,7 @@ aSh
 aTF
 aVk
 aWK
-aJJ
+vxw
 aZH
 bbr
 bfV
@@ -150254,12 +150290,12 @@ dDK
 aOx
 aaa
 abj
-dFG
-dFG
-dFG
-dFG
-dFG
-dFG
+dGw
+dGw
+dGw
+dGw
+dGw
+dGw
 aaa
 aaa
 aaa
@@ -152207,7 +152243,7 @@ aml
 feV
 aGV
 aIm
-aJJ
+vxw
 aKU
 aPe
 aNG
@@ -152270,7 +152306,7 @@ bmW
 aFx
 aFx
 dwJ
-csj
+tQy
 cIm
 rwU
 rwU
@@ -154545,16 +154581,16 @@ biH
 vxz
 bpf
 bum
-bEx
-bEx
+bJL
+bJL
 bEA
 fDE
-bEx
+bJL
 bEA
 fEr
 gTW
 bIe
-bEx
+bJL
 phF
 boI
 boI
@@ -154802,7 +154838,7 @@ bsX
 bpf
 bpf
 nJE
-ngg
+qNT
 esj
 esj
 esj
@@ -154811,7 +154847,7 @@ kii
 iTV
 iMr
 fox
-ngg
+qNT
 bzr
 boI
 szk
@@ -155582,7 +155618,7 @@ eDh
 uJk
 lEr
 wMd
-ngg
+qNT
 pvv
 qdY
 qdY
@@ -155839,7 +155875,7 @@ kkM
 bnp
 bqO
 brn
-ngg
+qNT
 trH
 bml
 bPB
@@ -156896,8 +156932,8 @@ cCa
 cCa
 cCa
 cFH
-csj
-csj
+tQy
+tQy
 cJH
 cLw
 cLw
@@ -157410,8 +157446,8 @@ csj
 csj
 csj
 cFE
-csj
-csj
+tQy
+tQy
 cJE
 csj
 csj

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18175,14 +18175,9 @@
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/arrival/station)
 "bip" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/arrival/station)
-"biq" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "bit" = (
 /obj/machinery/firealarm{
@@ -18918,57 +18913,58 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "bka" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/closet/walllocker/emerglocker/north,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "bkb" = (
-/turf/simulated/floor/mineral/titanium/blue,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "bkc" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/mineral/titanium/blue,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "bkd" = (
-/obj/structure/closet/wardrobe/green,
-/turf/simulated/floor/mineral/titanium/blue,
+/obj/structure/closet/wardrobe/mixed,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "bke" = (
-/obj/structure/closet/wardrobe/black,
-/obj/structure/sign/double/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bkf" = (
-/obj/structure/closet/wardrobe/mixed,
-/obj/structure/sign/double/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
+/obj/structure/closet/wardrobe/xenos,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"bkg" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bkh" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Shuttle"
-	},
+/obj/structure/closet/walllocker/emerglocker/north,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/closet/walllocker/emerglocker/north,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "bkk" = (
 /obj/effect/spawner/window,
@@ -19693,39 +19689,19 @@
 	icon_state = "dark"
 	},
 /area/aisat)
-"blP" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"blQ" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "blS" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
-"blU" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "blV" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
 	icon_state = "burst_r"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "blW" = (
 /obj/machinery/light{
@@ -20435,7 +20411,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "bnI" = (
 /obj/effect/spawner/window/reinforced,
@@ -21185,19 +21161,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
-"bpw" = (
-/obj/machinery/light,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"bpx" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "bpy" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2";
@@ -21977,47 +21940,22 @@
 /turf/simulated/floor/plating/airless,
 /area/solar/auxport)
 "brp" = (
-/obj/machinery/light,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "brq" = (
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"brr" = (
-/obj/structure/sign/double/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = -32
-	},
 /obj/machinery/light,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"brs" = (
-/obj/structure/sign/double/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = -32
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"brt" = (
-/obj/machinery/requests_console{
-	department = "Arrival shuttle";
-	pixel_y = -30
-	},
-/obj/machinery/light,
-/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bru" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
 	icon_state = "burst_l"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "brv" = (
 /obj/structure/cable/yellow{
@@ -59628,6 +59566,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/security/prison/cell_block/A)
+"gsJ" = (
+/turf/simulated/wall/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "gsM" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -61964,6 +61905,9 @@
 	},
 /turf/simulated/floor/bluegrid/telecomms,
 /area/toxins/xenobiology)
+"hCK" = (
+/turf/simulated/wall/indestructible/fakeglass/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "hCM" = (
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel{
@@ -64907,6 +64851,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard)
+"iTy" = (
+/obj/effect/landmark{
+	icon = 'icons/effects/spawner_icons.dmi';
+	icon_state = "spooky";
+	name = "Observer-Start"
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
+/area/shuttle/arrival/station)
 "iTB" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -73160,7 +73114,7 @@
 	},
 /area/medical/medbreak)
 "mXy" = (
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "mXE" = (
 /obj/structure/table,
@@ -80046,6 +80000,10 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
+"qyR" = (
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "qzz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -82495,10 +82453,12 @@
 	},
 /area/medical/exam_room)
 "rJJ" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
+/obj/machinery/requests_console{
+	department = "Arrival Shuttle";
+	name = "Arrival Shuttle Requests Console";
+	pixel_x = -30
 	},
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "rJR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
@@ -85367,6 +85327,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medmaint)
+"tfL" = (
+/turf/simulated/wall/indestructible/arrivals_shuttle/nodiagonal,
+/area/shuttle/arrival/station)
 "tfM" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -87648,6 +87611,13 @@
 	icon_state = "white"
 	},
 /area/maintenance/aft)
+"uqS" = (
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "urH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -89910,6 +89880,10 @@
 	icon_state = "white"
 	},
 /area/medical/reception)
+"vBm" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "vBv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -104310,11 +104284,11 @@ aUN
 abq
 aaa
 aaa
-bin
-bin
-biq
-bin
-bin
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 abq
@@ -104567,11 +104541,11 @@ bhR
 abq
 aaa
 aaa
-bin
-blP
-mXy
-bpw
-bin
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 abq
@@ -104824,11 +104798,11 @@ aUN
 abq
 aaa
 aaa
-bin
-blQ
-mXy
-bpx
-bin
+gsJ
+gsJ
+gsJ
+gsJ
+gsJ
 aaa
 aaa
 abq
@@ -105080,13 +105054,13 @@ bga
 aWD
 abq
 aaa
-bin
-bin
-bin
+gsJ
+gsJ
+qyR
 rJJ
-bin
-bin
-bin
+vBm
+gsJ
+gsJ
 aaa
 abq
 aWD
@@ -105337,13 +105311,13 @@ dgx
 aUN
 aUN
 aUN
-bin
+gsJ
 bka
 mXy
 mXy
 mXy
 brp
-bin
+gsJ
 aUN
 aUN
 aUN
@@ -105592,17 +105566,17 @@ aZk
 myY
 dgx
 bdR
+avX
 aYg
-bdR
 bip
-bkb
+brp
 blS
 blS
 blS
-bkb
+brp
 bip
-bdR
 bzw
+avX
 bdR
 eGG
 bFe
@@ -105851,13 +105825,13 @@ dgx
 aUN
 aUN
 aUN
-bin
+gsJ
 bkc
-bkb
-bkb
-bkb
+brp
+brp
+brp
 brq
-bin
+gsJ
 aUN
 aUN
 aUN
@@ -106108,13 +106082,13 @@ bcR
 bcy
 bhb
 aUN
-biq
+gsJ
 bkd
 blS
 blS
 blS
 bkb
-biq
+gsJ
 aUN
 bAR
 bzx
@@ -106365,13 +106339,13 @@ bBt
 dgx
 bhb
 aUN
-bin
+hCK
 bke
-bkb
-bkb
-bkb
-brr
-bin
+brp
+iTy
+brp
+brp
+hCK
 aUN
 bAQ
 baJ
@@ -106622,13 +106596,13 @@ bBt
 dgx
 bhW
 aUN
-bin
+hCK
 bkf
 blS
 blS
 blS
-brs
-bin
+brp
+hCK
 aUN
 bhb
 baJ
@@ -106879,13 +106853,13 @@ bcS
 bed
 bhj
 aUN
-biq
-bkg
-bkb
-bkb
-bkb
-bkb
-biq
+gsJ
+brp
+brp
+brp
+brp
+brp
+gsJ
 aUN
 bDU
 bzy
@@ -107136,13 +107110,13 @@ dgx
 aUN
 aUN
 aUN
-bin
+gsJ
 bkh
 blS
 blS
 blS
-brt
-bin
+brq
+gsJ
 aUN
 aUN
 aUN
@@ -107391,17 +107365,17 @@ aWD
 tjR
 dgx
 bdR
+avX
 aYg
-bdR
 bip
-bkb
+brp
 mXy
+uqS
 mXy
-mXy
-bkb
+brp
 bip
-bdR
 bzw
+avX
 bdR
 bOz
 bFG
@@ -107650,13 +107624,13 @@ dgx
 aUN
 aUN
 aUN
-bin
-bin
-blU
-blU
-blU
-bin
-bin
+tfL
+gsJ
+gsJ
+gsJ
+gsJ
+gsJ
+tfL
 aUN
 aUN
 aUN

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -639,7 +639,6 @@
 	},
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/glass/bottle/facid{
-	name = "fluorosulfuric acid bottle";
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -912,10 +911,6 @@
 "air" = (
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
-"aiz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/wall/r_wall,
-/area/maintenance/aft2)
 "aiE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1126,7 +1121,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "ajB" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarport)
 "ajC" = (
 /obj/structure/cable{
@@ -1717,7 +1712,7 @@
 	name = "\improper Recreation Area"
 	})
 "amk" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/engine/gravitygenerator)
 "amm" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -1976,7 +1971,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "ans" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarstarboard)
 "anv" = (
 /obj/machinery/door/poddoor/preopen{
@@ -2150,7 +2145,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "anN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
@@ -2535,9 +2530,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"apz" = (
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
 "apG" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3115,7 +3107,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "asi" = (
@@ -3145,7 +3137,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "asu" = (
@@ -3732,7 +3724,7 @@
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/hallway/secondary/entry)
 "auj" = (
 /obj/machinery/camera/autoname{
@@ -4348,7 +4340,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "awo" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/mrchangs)
 "awp" = (
@@ -4657,9 +4649,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
-"axh" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/starboard)
 "axk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/poddoor/shutters{
@@ -4691,7 +4680,6 @@
 /area/storage/emergency2)
 "axq" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -5001,7 +4989,7 @@
 	},
 /area/crew_quarters/dorms)
 "ayf" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep)
 "ayi" = (
@@ -5067,16 +5055,14 @@
 	icon_state = "1-8"
 	},
 /obj/structure/table,
-/obj/item/paper/gravity_gen{
-	layer = 3
-	},
+/obj/item/paper/gravity_gen,
 /obj/item/pen/blue,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "ayA" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/fsmaint)
 "ayB" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -5526,7 +5512,6 @@
 /area/crew_quarters/dorms)
 "aAc" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -6180,7 +6165,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/hardsuitstorage)
 "aCU" = (
@@ -6517,7 +6502,7 @@
 /turf/simulated/floor/engine/vacuum,
 /area/toxins/mixing)
 "aEf" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -8443,9 +8428,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"aJv" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/secondary/entry)
 "aJw" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -8680,6 +8662,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
+"aJZ" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/crew_quarters/arcade)
 "aKd" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -8813,7 +8799,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "hop";
 	name = "privacy shutters"
@@ -8998,7 +8984,7 @@
 	name = "\improper Restrooms"
 	})
 "aLa" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 9
 	},
@@ -9533,7 +9519,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aMf" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/hallway/primary/fore)
 "aMg" = (
 /obj/structure/cable/yellow{
@@ -9899,7 +9885,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aMY" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/quartermaster/qm)
 "aMZ" = (
@@ -10786,7 +10772,7 @@
 /area/construction)
 "aPC" = (
 /obj/structure/cable/yellow,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "hop";
 	name = "privacy shutters"
@@ -11903,7 +11889,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -12716,7 +12702,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
@@ -13658,7 +13644,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "aXi" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "aXk" = (
@@ -14556,9 +14542,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engine_smes)
-"aZJ" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/primary/central)
 "aZK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -14791,11 +14774,11 @@
 	},
 /area/crew_quarters/locker)
 "bai" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/library)
 "baj" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "bak" = (
@@ -16764,7 +16747,6 @@
 /area/hallway/primary/central)
 "beS" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -16999,7 +16981,6 @@
 "bfD" = (
 /obj/structure/girder,
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -17663,7 +17644,7 @@
 	},
 /area/storage/tech)
 "bhe" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/construction/hallway{
 	name = "\improper Storage Wing"
@@ -17779,7 +17760,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 6
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos/control)
 "bhw" = (
@@ -17961,7 +17942,7 @@
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -17993,7 +17974,7 @@
 	name = "Arrivals"
 	})
 "bhY" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
@@ -18520,9 +18501,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
-"bje" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/maintcentral)
 "bjf" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -18993,7 +18971,7 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bkk" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/tools)
 "bkl" = (
@@ -20170,7 +20148,6 @@
 "bmS" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/newscaster/security_unit{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -20380,9 +20357,6 @@
 	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/starboard)
-"bnt" = (
-/turf/simulated/wall/r_wall,
-/area/engine/break_room)
 "bnv" = (
 /obj/structure/safe{
 	known_by = list("captain")
@@ -22483,7 +22457,6 @@
 /area/civilian/barber)
 "bss" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -22980,7 +22953,6 @@
 /area/bridge)
 "btS" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -26797,7 +26769,6 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -26944,7 +26915,7 @@
 	name = "\improper Captain's Quarters"
 	})
 "bCu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
@@ -27069,9 +27040,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"bCM" = (
-/turf/simulated/wall/r_wall,
-/area/atmos)
 "bCN" = (
 /turf/simulated/wall,
 /area/engine/controlroom)
@@ -27121,7 +27089,7 @@
 /turf/simulated/wall/r_wall,
 /area/space/nearstation)
 "bCY" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/equipmentstorage{
 	name = "Shared Engineering Storage"
@@ -27315,7 +27283,6 @@
 "bDw" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -27791,7 +27758,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room{
 	name = "\improper Command Hallway"
@@ -27801,7 +27768,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -27927,7 +27894,7 @@
 	id_tag = "council blast";
 	name = "Council Blast Doors"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bFd" = (
@@ -28179,11 +28146,6 @@
 /area/bridge/meeting_room{
 	name = "\improper Command Hallway"
 	})
-"bFI" = (
-/turf/simulated/wall/r_wall,
-/area/bridge/meeting_room{
-	name = "\improper Command Hallway"
-	})
 "bFJ" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -28397,7 +28359,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bGk" = (
@@ -28414,7 +28376,7 @@
 	id_tag = "council blast";
 	name = "Council Blast Doors"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bGl" = (
@@ -28452,7 +28414,7 @@
 	id_tag = "council blast";
 	name = "Council Blast Doors"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bGv" = (
@@ -28737,7 +28699,7 @@
 	id_tag = "council blast";
 	name = "Council Blast Doors"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bHz" = (
@@ -28748,7 +28710,7 @@
 	name = "\improper Captain's Quarters"
 	})
 "bHA" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "bHB" = (
@@ -28987,7 +28949,6 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -29550,7 +29511,6 @@
 "bJz" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -30681,7 +30641,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "bNh" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/gateway)
 "bNi" = (
 /turf/simulated/wall,
@@ -32410,7 +32370,7 @@
 /turf/simulated/floor/plating,
 /area/assembly/showroom)
 "bSc" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/assembly/showroom)
 "bSd" = (
 /obj/structure/table/wood,
@@ -32725,7 +32685,7 @@
 	},
 /area/hallway/primary/central)
 "bSX" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "bSZ" = (
@@ -33228,7 +33188,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bUu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id_tag = "rndlab2";
@@ -33730,7 +33690,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)
 "bVT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -33844,7 +33804,7 @@
 /turf/space,
 /area/space/nearstation)
 "bWe" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "bWh" = (
@@ -35145,7 +35105,7 @@
 	},
 /area/maintenance/starboard)
 "bZl" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/blueshield)
 "bZm" = (
 /turf/simulated/floor/plasteel{
@@ -35154,7 +35114,7 @@
 	},
 /area/medical/virology)
 "bZn" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/ntrep)
 "bZo" = (
 /obj/structure/table,
@@ -35734,10 +35694,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"cbc" = (
-/obj/effect/spawner/random_spawners/fungus_maybe,
-/turf/simulated/wall/r_wall,
-/area/maintenance/fsmaint)
 "cbd" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -36243,7 +36199,6 @@
 	pixel_y = 3
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -37084,8 +37039,11 @@
 	},
 /area/chapel/main)
 "ceF" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/control)
+"ceL" = (
+/turf/simulated/wall,
+/area/security/armoury)
 "ceN" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -37183,9 +37141,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"cfc" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/aft)
 "cfd" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/nanotrasen,
@@ -37580,7 +37535,6 @@
 /area/medical/surgery2)
 "cga" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -38103,7 +38057,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "chC" = (
@@ -38308,7 +38262,7 @@
 	},
 /area/medical/paramedic)
 "cia" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -39718,9 +39672,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"cmo" = (
-/turf/simulated/wall/r_wall,
-/area/toxins/lab)
 "cmq" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -39758,9 +39709,6 @@
 "cmv" = (
 /turf/simulated/wall,
 /area/medical/cryo)
-"cmz" = (
-/turf/simulated/wall/r_wall,
-/area/medical/research)
 "cmA" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -40670,7 +40618,7 @@
 /area/atmos)
 "cpq" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "cpr" = (
 /obj/machinery/door/airlock/atmos/glass{
@@ -40683,7 +40631,7 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "cpt" = (
 /obj/structure/girder/reinforced,
@@ -40997,7 +40945,7 @@
 	id_tag = "rndlab2";
 	name = "Secondary Research and Development Shutter"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "cqo" = (
@@ -42324,7 +42272,6 @@
 "cuE" = (
 /obj/structure/girder,
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -42414,7 +42361,7 @@
 	},
 /area/medical/medbay)
 "cuN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio1";
 	name = "Xenobio Pen 1 Blast Door"
@@ -42548,7 +42495,7 @@
 	},
 /area/medical/virology)
 "cvh" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/medbay)
 "cvj" = (
@@ -42631,7 +42578,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -42726,7 +42672,7 @@
 	},
 /area/medical/biostorage)
 "cvU" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "imnotmakingyoulubepissoff";
 	name = "Chemistry Privacy Shutter"
@@ -42926,7 +42872,6 @@
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -43867,7 +43812,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "czs" = (
@@ -44308,7 +44253,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
 "cAL" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -44386,7 +44331,6 @@
 "cBc" = (
 /obj/structure/girder,
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -44588,7 +44532,7 @@
 	},
 /area/medical/genetics_cloning)
 "cBE" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/biostorage)
 "cBG" = (
@@ -44697,7 +44641,6 @@
 /area/medical/morgue)
 "cBZ" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -44827,7 +44770,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -45821,7 +45763,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology)
 "cFj" = (
 /obj/structure/cable,
@@ -45973,7 +45915,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cFO" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "cFT" = (
@@ -46006,7 +45948,7 @@
 	},
 /area/medical/genetics_cloning)
 "cGa" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/genetics_cloning)
 "cGb" = (
@@ -46195,7 +46137,7 @@
 /turf/space,
 /area/solar/starboard)
 "cGw" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/cryo)
 "cGx" = (
@@ -46862,7 +46804,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medmaint)
 "cIp" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/floor/plating,
 /area/medical/cryo)
@@ -46885,9 +46827,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
-"cIu" = (
-/turf/simulated/wall/r_wall,
-/area/assembly/chargebay)
 "cIv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -46906,9 +46845,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/medical/coldroom)
-"cIx" = (
-/turf/simulated/wall/r_wall,
-/area/assembly/robotics)
 "cIy" = (
 /turf/simulated/wall,
 /area/toxins/test_area)
@@ -47150,7 +47086,6 @@
 /area/assembly/robotics)
 "cJs" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -47339,7 +47274,7 @@
 	},
 /area/medical/coldroom)
 "cKe" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/medbreak)
 "cKh" = (
@@ -47642,7 +47577,7 @@
 	},
 /area/medical/surgeryobs)
 "cLb" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/surgeryobs)
 "cLd" = (
 /turf/simulated/wall,
@@ -47746,9 +47681,6 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
-"cLw" = (
-/turf/simulated/wall/r_wall,
-/area/medical/coldroom)
 "cLy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -48035,7 +47967,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -48579,10 +48510,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/medical/research)
-"cOm" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
 /area/medical/research)
 "cOp" = (
 /turf/simulated/wall/r_wall,
@@ -49203,7 +49130,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "cQC" = (
@@ -49251,9 +49178,6 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
-"cQJ" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/disposal)
 "cQK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -49264,7 +49188,6 @@
 "cQL" = (
 /obj/structure/girder,
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -49316,7 +49239,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cQW" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/starboardsolar)
 "cRc" = (
 /obj/structure/closet/crate,
@@ -49635,7 +49558,6 @@
 /area/medical/virology)
 "cSc" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -50177,7 +50099,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -50356,7 +50277,6 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -51717,7 +51637,6 @@
 "cZy" = (
 /obj/structure/girder,
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -53107,7 +53026,7 @@
 	})
 "dgC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology)
 "dgG" = (
 /obj/machinery/iv_drip,
@@ -53418,7 +53337,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medmaint)
 "djx" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
 "djO" = (
@@ -54700,7 +54619,7 @@
 	},
 /area/security/brig)
 "dYi" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -55273,7 +55192,7 @@
 	},
 /area/bridge)
 "eod" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/cmostore)
 "eoe" = (
 /turf/simulated/wall/r_wall,
@@ -55299,7 +55218,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "eoD" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
@@ -56137,7 +56056,7 @@
 	})
 "eGL" = (
 /obj/structure/cable/yellow,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "eIg" = (
@@ -56225,7 +56144,6 @@
 /area/maintenance/aft2)
 "eJT" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -56551,7 +56469,7 @@
 	},
 /area/medical/cmo)
 "eTo" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -56823,7 +56741,7 @@
 	},
 /area/crew_quarters/locker)
 "eZW" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/scibreak)
 "fae" = (
@@ -57354,7 +57272,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "fno" = (
 /obj/structure/disposalpipe/segment,
@@ -57707,6 +57625,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
+"fuR" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "fvH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58581,7 +58503,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/toxins/test_chamber)
 "fRm" = (
 /turf/simulated/floor/plasteel{
@@ -58862,7 +58784,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/distribution)
 "fWS" = (
 /obj/effect/turf_decal/stripes/line,
@@ -59340,7 +59262,6 @@
 /area/toxins/storage)
 "ghD" = (
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -60104,7 +60025,7 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_2)
 "gFO" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -60225,7 +60146,7 @@
 	},
 /area/atmos)
 "gIJ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -60488,6 +60409,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
+"gQX" = (
+/turf/simulated/wall,
+/area/security/warden)
 "gRw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/effect/spawner/airlock/s_to_n,
@@ -60565,7 +60489,7 @@
 	},
 /area/toxins/xenobiology)
 "gSO" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "rdrnd";
 	name = "Research and Development Shutters"
@@ -60804,9 +60728,6 @@
 	icon_state = "dark"
 	},
 /area/security/securearmoury)
-"gYO" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/fore2)
 "gZe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -61542,7 +61463,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medmaint)
 "hph" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/prisonlockers)
 "hpp" = (
@@ -61640,6 +61561,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"htv" = (
+/turf/simulated/wall,
+/area/security/securearmoury)
 "htP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/milk{
@@ -62260,7 +62184,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
 "hHE" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/controlroom)
 "hHV" = (
@@ -62642,7 +62566,6 @@
 /area/toxins/mixing)
 "hQX" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -64019,7 +63942,7 @@
 	},
 /area/chapel/main)
 "izh" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio8";
 	name = "Xenobio Pen 8 Blast Door"
@@ -64033,7 +63956,7 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "izK" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -64188,7 +64111,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "iBR" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -64658,7 +64581,7 @@
 /area/security/permabrig)
 "iLE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/distribution)
 "iLI" = (
 /obj/machinery/door/airlock/maintenance,
@@ -64757,7 +64680,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "iOO" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -64893,10 +64816,10 @@
 	},
 /area/toxins/mixing)
 "iRu" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/distribution)
 "iSf" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id_tag = "roboticsprivacy";
@@ -65312,6 +65235,14 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
+"jhi" = (
+/obj/effect/spawner/window,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/security/securearmoury)
 "jiK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -65419,7 +65350,7 @@
 	},
 /area/hallway/primary/aft)
 "jmx" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -65643,6 +65574,10 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"juW" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/atmos/distribution)
 "juY" = (
 /obj/structure/rack,
 /obj/item/poster/random_contraband,
@@ -65918,7 +65853,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 6
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "jCY" = (
@@ -66381,7 +66316,6 @@
 "jLY" = (
 /obj/structure/lattice,
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -66858,7 +66792,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -67096,7 +67030,7 @@
 	},
 /area/medical/virology)
 "kdi" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio1";
 	name = "Xenobio Pen 1 Blast Door"
@@ -67480,7 +67414,7 @@
 /obj/machinery/door/firedoor/heavy{
 	opacity = 0
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "kri" = (
@@ -67573,7 +67507,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "ktc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -68160,7 +68094,7 @@
 	},
 /area/quartermaster/office)
 "kFY" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -68298,7 +68232,7 @@
 	},
 /area/solar/auxport)
 "kIP" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -68633,7 +68567,6 @@
 "kPI" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -68851,6 +68784,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
+"kVt" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
 "kVN" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -68949,7 +68886,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "kWT" = (
@@ -70568,7 +70505,7 @@
 	},
 /area/medical/scibreak)
 "lJO" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -71040,9 +70977,6 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"lSh" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/portsolar)
 "lSn" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -71488,7 +71422,6 @@
 /area/engine/break_room)
 "meT" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -71616,7 +71549,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -71811,7 +71743,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "mmD" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
@@ -72655,6 +72587,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/securearmoury)
+"mKx" = (
+/turf/simulated/wall,
+/area/toxins/server)
 "mKy" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -72698,7 +72633,7 @@
 /turf/space,
 /area/space/nearstation)
 "mMv" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/toxins/test_chamber)
 "mMD" = (
 /obj/structure/table/glass,
@@ -74127,6 +74062,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"nrX" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/toxins/launch{
+	name = "Toxins Launch Room"
+	})
 "nsm" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -74727,6 +74668,9 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
+"nHa" = (
+/turf/simulated/wall,
+/area/security/hos)
 "nHB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -75028,6 +74972,9 @@
 	icon_state = "grimy"
 	},
 /area/chapel/office)
+"nTj" = (
+/turf/simulated/wall,
+/area/medical/virology)
 "nTF" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75736,7 +75683,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/distribution)
 "omK" = (
 /obj/structure/chair/stool{
@@ -76125,7 +76072,7 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "oBh" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -76352,7 +76299,6 @@
 /area/toxins/mixing)
 "oFQ" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -76974,7 +76920,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "oWE" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -77660,7 +77606,7 @@
 	name = "\improper Departure Lounge"
 	})
 "pri" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
 	id_tag = "imnotmakingyoulubepissoff";
@@ -77764,7 +77710,7 @@
 	},
 /area/medical/paramedic)
 "pte" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -77910,11 +77856,10 @@
 	icon_state = "darkgrey"
 	},
 /area/medical/morgue)
-"pyX" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/secondary/entry{
-	name = "Arrivals"
-	})
+"pyj" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/quartermaster/storage)
 "pzC" = (
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
@@ -79256,7 +79201,7 @@
 	},
 /area/medical/research)
 "qcP" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -79409,7 +79354,7 @@
 	},
 /area/turret_protected/ai)
 "qfW" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -79465,8 +79410,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/control)
+"qhG" = (
+/obj/effect/spawner/window,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
 "qiA" = (
 /obj/structure/closet/crate/sci,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -79670,7 +79623,7 @@
 	},
 /area/maintenance/aft)
 "qoX" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio1";
 	name = "Xenobio Pen 1 Blast Door"
@@ -79686,6 +79639,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
+"qoY" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/crew_quarters/fitness{
+	name = "\improper Recreation Area"
+	})
 "qpe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80037,6 +79996,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/security/range)
+"qxB" = (
+/turf/simulated/wall,
+/area/ai_monitored/storage/eva{
+	name = "E.V.A. Storage"
+	})
 "qxI" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -80142,6 +80106,11 @@
 	icon_state = "white"
 	},
 /area/toxins/explab)
+"qAO" = (
+/obj/effect/spawner/window,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/plating,
+/area/security/warden)
 "qAP" = (
 /obj/machinery/button/windowtint{
 	dir = 8;
@@ -80269,7 +80238,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/control)
 "qGf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80711,6 +80680,14 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"qVW" = (
+/obj/effect/spawner/window,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "qVY" = (
 /obj/item/storage/secure/safe{
 	pixel_y = 32
@@ -81308,6 +81285,9 @@
 	icon_state = "darkbluecorners"
 	},
 /area/medical/surgeryobs)
+"rjK" = (
+/turf/simulated/wall,
+/area/security/execution)
 "rjU" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
@@ -81538,7 +81518,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft2)
 "rqj" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/surgeryobs)
 "rqq" = (
@@ -82181,6 +82161,9 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
+"rDY" = (
+/turf/simulated/wall,
+/area/teleporter)
 "rEa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -82827,7 +82810,6 @@
 "rRh" = (
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -82930,7 +82912,6 @@
 /area/space/nearstation)
 "rUv" = (
 /obj/effect/spawner/lootdrop{
-	color = null;
 	icon_state = "grille";
 	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
 	name = "normal or broken grille spawner"
@@ -83024,7 +83005,7 @@
 	},
 /area/crew_quarters/courtroom)
 "rWr" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -83301,6 +83282,10 @@
 	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
+"sdY" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/engimaint)
 "seE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -85573,7 +85558,6 @@
 "tiH" = (
 /obj/structure/chair,
 /obj/machinery/newscaster{
-	dir = 2;
 	name = "north bump";
 	pixel_y = 28
 	},
@@ -85768,6 +85752,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"toy" = (
+/obj/effect/spawner/window,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/security/armoury)
 "toD" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -85856,6 +85848,14 @@
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
+"tqg" = (
+/obj/effect/spawner/window,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/security/main)
 "tqh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -86605,7 +86605,7 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_2)
 "tMS" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Engineering";
 	name = "Engineering Security Doors"
@@ -87085,7 +87085,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "uaQ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "uaU" = (
@@ -88165,7 +88165,7 @@
 	},
 /area/security/permabrig)
 "uGy" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -88237,7 +88237,7 @@
 	})
 "uJn" = (
 /obj/effect/spawner/airlock/w_to_e,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/fsmaint)
 "uJs" = (
 /obj/structure/bed,
@@ -89761,7 +89761,7 @@
 /area/quartermaster/storage)
 "vxc" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "executionfireblast"
 	},
@@ -90273,7 +90273,7 @@
 	},
 /area/toxins/storage)
 "vLP" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio8";
 	name = "Xenobio Pen 8 Blast Door"
@@ -90652,7 +90652,7 @@
 	},
 /area/medical/morgue)
 "vXb" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -90846,7 +90846,7 @@
 	},
 /area/medical/research)
 "wez" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
 	id_tag = "roboticsprivacy2";
@@ -91117,7 +91117,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medmaint)
 "wku" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "wky" = (
@@ -91460,7 +91460,7 @@
 	},
 /area/medical/surgeryobs)
 "wtN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -91825,7 +91825,7 @@
 	},
 /area/atmos/distribution)
 "wDf" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio8";
 	name = "Xenobio Pen 8 Blast Door"
@@ -92083,7 +92083,7 @@
 /area/maintenance/spacehut)
 "wLt" = (
 /obj/structure/sign/biohazard,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/research)
 "wLB" = (
 /obj/machinery/door/airlock/security/glass{
@@ -92438,7 +92438,7 @@
 	},
 /area/medical/research)
 "wUa" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/engimaint)
 "wUr" = (
 /obj/machinery/door/airlock/maintenance{
@@ -92716,7 +92716,7 @@
 /area/atmos)
 "xbs" = (
 /obj/structure/sign/poster/official/random,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/toxins/mixing)
 "xbu" = (
 /obj/structure/disposalpipe/segment{
@@ -93186,7 +93186,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 5
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/control)
 "xpD" = (
 /obj/structure/cable/yellow{
@@ -93561,7 +93561,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 10
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/control)
 "xBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -103789,7 +103789,7 @@ abq
 aWD
 aWD
 aWD
-aJv
+vaO
 eEV
 kmF
 aaa
@@ -104046,7 +104046,7 @@ aSq
 aSq
 aWG
 ayC
-aJv
+vaO
 dAs
 kmF
 aUN
@@ -104578,7 +104578,7 @@ abq
 bhR
 baJ
 dgx
-pyX
+aWD
 aaa
 aaa
 aaa
@@ -105089,7 +105089,7 @@ bin
 bin
 aaa
 abq
-pyX
+aWD
 bDo
 bDm
 bhR
@@ -105606,13 +105606,13 @@ bzw
 bdR
 eGG
 bFe
-pyX
+aWD
 aaa
 aaa
 aaa
 aaa
 aaa
-pyX
+aWD
 baJ
 juN
 aUN
@@ -105872,7 +105872,7 @@ aaa
 aUN
 baJ
 cZf
-pyX
+aWD
 abq
 abq
 aaa
@@ -106643,7 +106643,7 @@ aaa
 aWD
 bCx
 odF
-pyX
+aWD
 abq
 abq
 aaa
@@ -107148,13 +107148,13 @@ aUN
 aUN
 bOz
 bDm
-pyX
+aWD
 abq
 kmF
 bKu
 kmF
 abq
-pyX
+aWD
 bRV
 uep
 aUN
@@ -107405,13 +107405,13 @@ bzw
 bdR
 bOz
 bFG
-pyX
+aWD
 kmF
 kmF
 bOx
 kmF
 kmF
-pyX
+aWD
 bCx
 dfZ
 cdT
@@ -108162,17 +108162,17 @@ aOB
 baM
 bBt
 bhV
-pyX
-pyX
-pyX
+aWD
+aWD
+aWD
 aUN
 aUN
 aUN
 aUN
 aUN
-pyX
-pyX
-pyX
+aWD
+aWD
+aWD
 bCx
 bBx
 bDt
@@ -108200,7 +108200,7 @@ cFf
 cHd
 cqS
 csG
-tlw
+crG
 cyx
 cOE
 cAx
@@ -108729,19 +108729,19 @@ aef
 abq
 aaa
 aaa
-dtE
-dtE
+nTj
+nTj
 cFv
 cFv
 cFv
-dtE
-dtE
+nTj
+nTj
 cSb
 cHi
 cFi
 cOI
 cfU
-dtE
+nTj
 aaa
 aaa
 aaa
@@ -108986,19 +108986,19 @@ aef
 abq
 aaa
 aaa
-dtE
+nTj
 kPI
 kzx
 ccp
 rzl
 qQH
-dtE
+nTj
 dad
 oaj
 cFi
 eRy
 cCm
-dtE
+nTj
 aaa
 aaa
 aaa
@@ -109243,19 +109243,19 @@ aef
 abq
 aaa
 aaa
-dtE
+nTj
 cmI
 crc
 bRn
 cad
 kMD
-dtE
+nTj
 cDS
 cnq
 cFi
 cIg
 dfU
-dtE
+nTj
 abq
 abq
 abq
@@ -109490,7 +109490,7 @@ cMR
 cMR
 cAn
 cMR
-tlw
+crG
 tlw
 abq
 abq
@@ -109500,20 +109500,20 @@ crG
 sTg
 abq
 abq
-dtE
+nTj
 cty
 cvg
 ccI
 xbA
 fxD
-dtE
+nTj
 czr
 cNA
 cFi
 xcF
 eGL
-dtE
-dtE
+nTj
+nTj
 aaa
 aaa
 aaa
@@ -109757,13 +109757,13 @@ cOF
 bZP
 aaa
 aaa
-dtE
+nTj
 kdh
 cvg
 hCM
 fFX
 htr
-dtE
+nTj
 pps
 cuP
 nsm
@@ -110014,7 +110014,7 @@ crG
 bZP
 bZP
 aaa
-dtE
+nTj
 pTW
 cGp
 cyI
@@ -110277,7 +110277,7 @@ aww
 nIG
 mRr
 euU
-cFv
+fuR
 inq
 bZS
 ckJ
@@ -110528,20 +110528,20 @@ czg
 crG
 bZP
 abq
-dtE
-dtE
+nTj
+nTj
 chP
-dtE
-dtE
-dtE
-dtE
-dtE
-cSb
+nTj
+nTj
+nTj
+nTj
+nTj
+qVW
 cPT
 cQA
 cfU
-dtE
-dtE
+nTj
+nTj
 aaa
 aaa
 aaa
@@ -110791,7 +110791,7 @@ wjw
 cFv
 aaa
 aaa
-dtE
+nTj
 crP
 ewk
 cxz
@@ -111048,7 +111048,7 @@ wjw
 cFv
 aaa
 aaa
-dtE
+nTj
 cZw
 axH
 col
@@ -111305,7 +111305,7 @@ iPY
 cFv
 aaa
 aaa
-dtE
+nTj
 tkb
 kuc
 clU
@@ -111562,14 +111562,14 @@ jDC
 dtE
 dtE
 abq
-dtE
-dtE
+nTj
+nTj
 cSb
 cyz
 dei
 cfU
-dtE
-dtE
+nTj
+nTj
 aaa
 aaa
 aaa
@@ -111983,7 +111983,7 @@ aGj
 aaa
 aaa
 akI
-akI
+kVt
 akt
 akt
 akt
@@ -112845,7 +112845,7 @@ bVf
 xPC
 jWr
 vVr
-cfc
+bZU
 bZU
 bZU
 qvd
@@ -112858,7 +112858,7 @@ bZU
 bZU
 bZU
 bZU
-cfc
+bZU
 cbo
 sFP
 cbo
@@ -113098,7 +113098,7 @@ bZP
 bZP
 tlV
 bZP
-cGo
+bZP
 nup
 jFX
 xYT
@@ -113115,7 +113115,7 @@ deH
 cPA
 jWJ
 cBM
-cfc
+bZU
 ckd
 bOL
 cMD
@@ -113269,7 +113269,7 @@ agX
 ajB
 ajB
 ajB
-cQJ
+akt
 anB
 akt
 akt
@@ -113355,11 +113355,11 @@ bZP
 pJv
 glk
 cIv
-cLw
+ctP
 cLb
 cLi
 cLb
-cfc
+bZU
 ken
 chy
 chy
@@ -113376,7 +113376,7 @@ crF
 cLe
 awe
 bTj
-lSh
+cUm
 aaa
 aaa
 abq
@@ -113526,7 +113526,7 @@ onG
 ajC
 akv
 ajE
-aky
+aOB
 anC
 bss
 pxf
@@ -113629,11 +113629,11 @@ bZU
 bZU
 bZU
 cwO
-cfc
+bZU
 cpL
 bXI
 cNv
-lSh
+cUm
 aaa
 aaa
 abq
@@ -113886,11 +113886,11 @@ rbo
 bZU
 vCt
 cwO
-cfc
-cfc
-cfc
-cfc
-lSh
+bZU
+bZU
+bZU
+bZU
+cUm
 aaa
 aaa
 abq
@@ -114040,7 +114040,7 @@ agX
 anm
 akx
 alw
-aky
+aOB
 xrZ
 bmq
 bmr
@@ -114297,10 +114297,10 @@ agX
 ajB
 ajB
 ajB
-aky
-aky
+aOB
+aOB
 uaH
-aky
+aOB
 aOB
 uaH
 aOB
@@ -114553,7 +114553,7 @@ aaa
 aaa
 aaa
 aaa
-aky
+aOB
 alx
 amt
 adY
@@ -115067,7 +115067,7 @@ abW
 abq
 abq
 abq
-aky
+aOB
 aly
 amv
 adY
@@ -115324,8 +115324,8 @@ abW
 aaa
 aaa
 aaa
-aky
-aky
+aOB
+aOB
 anI
 aph
 aqA
@@ -115582,10 +115582,10 @@ aaa
 aaa
 aaa
 abq
-aky
-aky
-aky
-aky
+aOB
+aOB
+aOB
+aOB
 aOB
 aOB
 aOB
@@ -115866,7 +115866,7 @@ bsi
 bsi
 gqF
 gqF
-aKl
+pyj
 jPT
 hDK
 msj
@@ -117390,7 +117390,7 @@ dhI
 aOB
 aOB
 aOB
-aOB
+aky
 aHI
 aHI
 aHI
@@ -118252,10 +118252,10 @@ ryB
 daP
 eod
 eod
-cfc
-cfc
-cfc
-cfc
+bZU
+bZU
+bZU
+bZU
 cwO
 bZU
 cSR
@@ -118512,7 +118512,7 @@ ctI
 ctI
 jUN
 lNT
-cfc
+bZU
 cDC
 cID
 cSS
@@ -118647,9 +118647,9 @@ eJT
 kbN
 kbN
 kbN
-kbN
-kbN
-kbN
+rjK
+rjK
+rjK
 saw
 cNo
 rUz
@@ -118683,20 +118683,20 @@ axN
 aty
 aHI
 aMf
-gYO
+lIM
 aKs
-gYO
+lIM
 aKm
-gYO
-gYO
-gYO
-gYO
-gYO
-gYO
-gYO
+lIM
+lIM
+lIM
+lIM
+lIM
+lIM
+lIM
 aKm
-gYO
-gYO
+lIM
+lIM
 bQF
 ben
 bqb
@@ -118769,7 +118769,7 @@ uAj
 cjA
 eDx
 kYX
-cfc
+bZU
 cyi
 bZU
 hLT
@@ -118906,7 +118906,7 @@ abq
 abW
 oNZ
 sfG
-kbN
+rjK
 xtp
 gbP
 hiy
@@ -118918,7 +118918,7 @@ gFO
 mQb
 adi
 eAU
-tfl
+vdE
 evl
 wnz
 kmj
@@ -118952,7 +118952,7 @@ aaa
 aaa
 abq
 aaa
-aZJ
+bZu
 bbg
 bNp
 bek
@@ -119026,7 +119026,7 @@ adM
 roi
 nfW
 eqS
-cfc
+bZU
 dfQ
 bZU
 cST
@@ -119163,9 +119163,9 @@ aaa
 abW
 oVx
 jiW
-kbN
-kbN
-kbN
+rjK
+rjK
+rjK
 vmA
 kbN
 rRh
@@ -119175,7 +119175,7 @@ uYF
 fVB
 fVB
 ryp
-tfl
+vdE
 mlj
 uSc
 uSc
@@ -119279,11 +119279,11 @@ daM
 lBu
 cmi
 eod
-cfc
-cfc
-cfc
-cfc
-cfc
+bZU
+bZU
+bZU
+bZU
+bZU
 cgU
 bZU
 cSU
@@ -119432,7 +119432,7 @@ aEf
 adi
 adi
 jOS
-tfl
+vdE
 vdE
 vdE
 vdE
@@ -119466,7 +119466,7 @@ aUj
 aXE
 aOG
 aaa
-aZJ
+bZu
 dbb
 bNp
 qWN
@@ -119492,10 +119492,10 @@ bMW
 bzV
 uEE
 wyB
-bMW
-bMS
-bMS
-bMS
+rDY
+qxB
+qxB
+qxB
 bMS
 cIA
 ben
@@ -119676,8 +119676,8 @@ aaa
 aaa
 abW
 eFV
-abW
-abW
+udK
+udK
 mXw
 iNl
 niv
@@ -119749,7 +119749,7 @@ bMW
 bPn
 bQX
 bSN
-bMW
+rDY
 bWh
 bWC
 bXY
@@ -119986,10 +119986,10 @@ bgF
 bek
 bfR
 bht
-bje
+bht
 bcc
-bje
-bje
+bht
+bht
 bht
 bvn
 bqc
@@ -119999,14 +119999,14 @@ bym
 bCb
 bqc
 bLR
-bFI
+bFB
 bJs
 bKT
 bMW
 bPp
 bSh
 bTk
-bMW
+rDY
 bWB
 bWD
 cBo
@@ -120191,7 +120191,7 @@ aaa
 abW
 oVx
 jiW
-abW
+udK
 tiq
 xYC
 dfd
@@ -120246,8 +120246,8 @@ aYx
 abq
 abq
 abq
-bkW
-bkW
+byq
+byq
 buw
 bkW
 bwd
@@ -120255,15 +120255,15 @@ bwd
 bAa
 bwd
 bqc
-bFI
-bFI
+bFB
+bFB
 jQo
 bMX
 bOe
 bPo
 bRY
 bXZ
-bMW
+rDY
 bPS
 bQn
 bZw
@@ -120448,7 +120448,7 @@ aaa
 abW
 vXM
 sOR
-abW
+udK
 iuq
 adi
 vSm
@@ -120520,7 +120520,7 @@ bMW
 bPq
 bSk
 bST
-bMW
+rDY
 bWR
 bWF
 cJH
@@ -120725,10 +120725,10 @@ amI
 cAJ
 aqQ
 iJg
-aHO
-aHO
+htv
+htv
 keN
-aHO
+htv
 bLu
 avB
 wlv
@@ -120982,7 +120982,7 @@ kzg
 fxV
 fae
 dZp
-xBX
+jhi
 mRy
 kRc
 gLa
@@ -121008,7 +121008,7 @@ aUn
 aXG
 aOG
 aaa
-aZJ
+bZu
 bbm
 bNp
 bek
@@ -121239,7 +121239,7 @@ yev
 vJo
 sNG
 rZA
-aHO
+htv
 rJh
 yiU
 gLa
@@ -121287,7 +121287,7 @@ bFK
 bkW
 bLl
 cnj
-bFI
+bFB
 bOH
 bOH
 bSc
@@ -121492,14 +121492,14 @@ aaa
 aaa
 aaa
 aHO
-aHO
-aHO
-aHO
-aHO
-aHO
+htv
+htv
+htv
+htv
+htv
 nxO
 gYN
-aHO
+htv
 lHl
 fdu
 oQF
@@ -121522,7 +121522,7 @@ aaa
 aaa
 abq
 aaa
-aZJ
+bZu
 bbo
 oYO
 svH
@@ -121756,13 +121756,13 @@ aBx
 xdb
 arV
 uBY
-aHO
+htv
 fGA
 cjQ
-aqu
+gQX
 sDN
 xHy
-aqu
+gQX
 thW
 pvo
 aqu
@@ -122016,7 +122016,7 @@ iao
 qFe
 gdb
 aFz
-aqu
+gQX
 dZL
 qOx
 eyP
@@ -122780,19 +122780,19 @@ eoe
 aHO
 xBX
 hKK
-aHO
-aHO
-aHO
-aHO
-aHO
+htv
+htv
+htv
+htv
+htv
 irb
 avB
-aqu
+gQX
 tDB
 wtN
-aqu
+gQX
 izK
-pvo
+qAO
 aqu
 aKL
 aJk
@@ -122847,23 +122847,23 @@ cft
 cib
 bCG
 cHM
-cIu
-cIu
-cIu
+cBJ
+cBJ
+cBJ
 bjK
-cIu
-cIu
-cIx
+cBJ
+cBJ
+cJp
 lfO
 cwE
 cwE
-cIx
-cIx
-cIx
-cIx
-cIx
-cIx
-cOp
+cJp
+cJp
+cJp
+cJp
+cJp
+cJp
+coG
 coG
 jzk
 coG
@@ -123033,7 +123033,7 @@ tKm
 jvC
 oXd
 pds
-eoe
+ceL
 hlN
 eVZ
 vSB
@@ -123104,17 +123104,17 @@ cgz
 cic
 bGl
 bXF
-cIu
+cBJ
 coH
 bNH
 lsC
 fdc
 rmn
-cIx
+cJp
 iSf
 jHu
 iSf
-cIx
+cJp
 oAs
 iAO
 hEo
@@ -123304,7 +123304,7 @@ ceq
 oSi
 bCD
 apP
-pJh
+qhG
 jNd
 xVR
 giK
@@ -123343,7 +123343,7 @@ bFS
 bkW
 bJt
 bLf
-bFI
+bFB
 bOH
 bOH
 bSc
@@ -123367,7 +123367,7 @@ iCZ
 bGS
 nUu
 rSC
-cIx
+cJp
 sFN
 jAh
 oco
@@ -123547,7 +123547,7 @@ ggc
 eyY
 vuZ
 iKQ
-eoe
+ceL
 pGO
 eLh
 ule
@@ -123801,13 +123801,13 @@ nwC
 eUL
 eoe
 eoe
-xUC
+toy
 iBR
-eoe
-eoe
-apO
-apO
-pMT
+ceL
+ceL
+aSm
+aSm
+tqg
 wLB
 aSm
 uGy
@@ -123818,10 +123818,10 @@ aSm
 vqm
 bdT
 uCW
-apz
-apz
-apz
-apz
+abZ
+abZ
+abZ
+abZ
 xNV
 mlC
 xNV
@@ -124132,7 +124132,7 @@ fPC
 bUR
 cie
 cla
-cIu
+cBJ
 cnx
 uYo
 nlQ
@@ -124359,15 +124359,15 @@ abq
 abq
 abq
 bkW
-bkW
-bkW
+byq
+byq
 buc
 byA
-bkW
-bhw
-bhw
+byq
+boI
+boI
 bEh
-bhw
+boI
 bhw
 jJR
 bLg
@@ -124389,7 +124389,7 @@ cxO
 wey
 cjM
 cUE
-cIu
+cBJ
 cFO
 cBJ
 cFO
@@ -124409,16 +124409,16 @@ cJp
 pcx
 cwR
 mPh
-cOp
-cOp
-cOp
-cOp
-cOp
-cOp
-cOp
-cOp
-cOp
-cOp
+coG
+coG
+coG
+coG
+coG
+coG
+coG
+coG
+coG
+coG
 csi
 coG
 coG
@@ -124617,10 +124617,10 @@ bhw
 bhw
 bhw
 bqm
-bhw
-bhw
-bhw
-bhw
+boI
+boI
+boI
+boI
 bAl
 bCm
 bEi
@@ -124666,7 +124666,7 @@ cJp
 uVl
 cwR
 taW
-cEK
+cFH
 jFr
 mAA
 qbe
@@ -124846,7 +124846,7 @@ akL
 hXX
 cpK
 gZV
-apz
+abZ
 hQZ
 lcg
 kXX
@@ -124932,7 +124932,7 @@ vfp
 ojA
 tUn
 myi
-aiz
+jFH
 svK
 coG
 aqe
@@ -125103,7 +125103,7 @@ uGy
 ckr
 cjQ
 qeK
-apz
+abZ
 xNV
 xNV
 xNV
@@ -125160,7 +125160,7 @@ cgu
 qnt
 qnt
 clc
-cmz
+cfw
 tCw
 bVj
 cic
@@ -125180,7 +125180,7 @@ cJp
 uuG
 cwR
 riF
-cEK
+cFH
 kYR
 jOM
 kgx
@@ -125189,7 +125189,7 @@ vrZ
 eNY
 smL
 xUk
-cOp
+coG
 fuQ
 coG
 coG
@@ -125412,12 +125412,12 @@ caM
 bek
 bdb
 bbg
-cmo
+cvl
 bUu
 nQa
 bUu
 bUu
-cmo
+cvl
 bUu
 cvl
 cqn
@@ -125446,7 +125446,7 @@ eNY
 nec
 krx
 bnx
-cOp
+coG
 mtr
 dTn
 jFH
@@ -125669,7 +125669,7 @@ caM
 nWH
 bdb
 dbb
-cmo
+cvl
 mZe
 bVZ
 lVF
@@ -125703,7 +125703,7 @@ hQB
 nbM
 nbM
 lKa
-aiz
+jFH
 iHc
 dTn
 mVS
@@ -125926,7 +125926,7 @@ cPD
 uhY
 bdb
 dbb
-cmo
+cvl
 hYA
 ckP
 cjk
@@ -126117,7 +126117,7 @@ nsJ
 fcT
 esA
 fcT
-esA
+goq
 aFe
 gqv
 uhf
@@ -126183,7 +126183,7 @@ cbj
 bek
 bfJ
 cej
-cmo
+cvl
 clS
 cQe
 cta
@@ -126440,12 +126440,12 @@ aKI
 cMh
 cdE
 cte
-cmB
-cmB
-cmB
-cmB
-cmB
-cmB
+cte
+cte
+cte
+cte
+cte
+cte
 onF
 gqN
 ljS
@@ -126631,7 +126631,7 @@ avc
 avc
 rOp
 avc
-avc
+nHa
 fJr
 hwP
 gWB
@@ -126714,7 +126714,7 @@ kJT
 rXS
 clG
 lJA
-cOm
+cHM
 hIK
 sPr
 cic
@@ -126888,9 +126888,9 @@ avc
 wzx
 jNU
 hOA
-avc
+nHa
 nLZ
-avc
+nHa
 ivv
 myk
 apO
@@ -126959,7 +126959,7 @@ cte
 cte
 cte
 lOv
-cmB
+cte
 cqo
 esJ
 cHK
@@ -126971,7 +126971,7 @@ oFn
 keQ
 keQ
 rfD
-cOm
+cHM
 pMS
 fCW
 mdy
@@ -127147,7 +127147,7 @@ fvU
 wKS
 azL
 glG
-avc
+nHa
 rdw
 rPt
 awp
@@ -127233,11 +127233,11 @@ cfw
 nhU
 cGQ
 dZB
-bdN
-bdN
-bdN
-bdN
-cEK
+cPc
+cPc
+cPc
+cPc
+cFH
 hyp
 cgG
 cEK
@@ -127473,7 +127473,7 @@ cgN
 cip
 cte
 lOv
-cmB
+cte
 cvl
 hBB
 gSO
@@ -127485,12 +127485,12 @@ afT
 dxD
 eRc
 geG
-cOm
+cHM
 cBV
 cwV
 cQK
 lle
-bdN
+cPc
 cKi
 cUf
 cPc
@@ -127499,7 +127499,7 @@ euy
 mVD
 coG
 cJs
-coG
+cOp
 cQd
 cQd
 cOp
@@ -127661,7 +127661,7 @@ jln
 khy
 kdl
 dvY
-avc
+nHa
 tYH
 fpy
 awp
@@ -127730,7 +127730,7 @@ cgO
 ciq
 cte
 lOv
-cmB
+cte
 daw
 aiM
 xPE
@@ -127747,7 +127747,7 @@ kvG
 vxI
 cwR
 bXi
-bdN
+cPc
 fVO
 hiP
 qlX
@@ -127987,7 +127987,7 @@ cgP
 baj
 cte
 lOv
-cmB
+cte
 rnT
 wDg
 vZh
@@ -128004,7 +128004,7 @@ vVD
 dnN
 cwR
 dAy
-bdN
+cPc
 cnt
 pKM
 cPc
@@ -128261,7 +128261,7 @@ bNN
 aeF
 cwR
 bPm
-bdN
+cPc
 aeA
 pKM
 bdN
@@ -128501,7 +128501,7 @@ cda
 ciC
 cjV
 fLJ
-cmB
+cte
 cnF
 cxS
 eQc
@@ -128518,7 +128518,7 @@ dRX
 pFG
 cwR
 xdT
-bdN
+cPc
 lHn
 pKM
 bdN
@@ -128758,7 +128758,7 @@ ces
 vKI
 cte
 cRX
-cmB
+cte
 qgw
 cNu
 cLB
@@ -128775,7 +128775,7 @@ dUC
 awL
 cwR
 xdT
-bdN
+cPc
 yfv
 pKM
 bdN
@@ -129289,7 +129289,7 @@ kvG
 mYv
 cwR
 qta
-bdN
+cPc
 flh
 bPl
 bdN
@@ -129546,7 +129546,7 @@ kvG
 mfG
 cwR
 kib
-bdN
+cPc
 flh
 bPl
 bdN
@@ -129796,14 +129796,14 @@ kvG
 kvG
 riX
 riX
-fId
-fId
-fId
+mKx
+mKx
+mKx
 fId
 cyr
 cwR
 cxO
-bdN
+cPc
 cgo
 daQ
 bdN
@@ -129818,7 +129818,7 @@ mfM
 lVI
 cRQ
 cRQ
-cHp
+nrX
 cRQ
 cRQ
 cRQ
@@ -129968,7 +129968,7 @@ aij
 ajm
 apR
 ctw
-aij
+aJZ
 aih
 cRK
 aqO
@@ -130060,7 +130060,7 @@ fId
 cAH
 cwR
 cxO
-bdN
+cPc
 flh
 bPl
 bdN
@@ -130225,7 +130225,7 @@ aij
 alb
 wzV
 alb
-aij
+aJZ
 aii
 cWS
 oVM
@@ -130317,7 +130317,7 @@ sCr
 kDU
 cwR
 cxO
-bdN
+cPc
 flh
 bPl
 bdN
@@ -130482,7 +130482,7 @@ aij
 akk
 apV
 akk
-aij
+aJZ
 ail
 cWS
 aki
@@ -130574,7 +130574,7 @@ fId
 ctm
 shY
 cNy
-bdN
+cPc
 flh
 bPl
 meT
@@ -130831,7 +130831,7 @@ cmB
 cfw
 iBI
 cfw
-bdN
+cPc
 flh
 bPl
 emj
@@ -130997,7 +130997,7 @@ akk
 apV
 cyF
 cKm
-aij
+aJZ
 cWS
 akj
 ald
@@ -131338,7 +131338,7 @@ crr
 cwG
 cwG
 cwG
-cmB
+cte
 cwd
 dhG
 cte
@@ -131511,7 +131511,7 @@ akk
 rDe
 akk
 cZi
-aij
+aJZ
 ajn
 akl
 ald
@@ -131599,10 +131599,10 @@ cmB
 cmB
 cmB
 cmB
-cmz
+cfw
 cWK
-cmz
-bdN
+cfw
+cPc
 meT
 bPl
 emj
@@ -131859,7 +131859,7 @@ cSl
 cLm
 xXD
 gqQ
-bdN
+cPc
 cHq
 bPl
 meT
@@ -132116,7 +132116,7 @@ rOD
 cDa
 xXD
 sdj
-bdN
+cPc
 csa
 bPl
 cOc
@@ -132373,7 +132373,7 @@ mUl
 cAe
 qbl
 cPf
-bdN
+cPc
 hrM
 cEN
 bnB
@@ -132386,7 +132386,7 @@ cPc
 cPc
 cPc
 cPc
-bdN
+cPc
 cQW
 cQW
 cQW
@@ -132630,7 +132630,7 @@ cUQ
 cYh
 mfA
 gZT
-bdN
+cPc
 cAS
 adu
 meT
@@ -132643,7 +132643,7 @@ cJk
 cWz
 cNf
 bBg
-bdN
+cPc
 cJm
 fFW
 cuq
@@ -132796,16 +132796,16 @@ afH
 agi
 afH
 afb
-aeN
-aeN
-aeN
+qoY
+qoY
+qoY
 alh
-aeN
-aeN
+qoY
+qoY
 alh
-aeN
-aeN
-aeN
+qoY
+qoY
+qoY
 avv
 avv
 sdX
@@ -132887,7 +132887,7 @@ cDE
 cUT
 lrD
 bcC
-bdN
+cPc
 cPc
 cPc
 cPc
@@ -133144,7 +133144,7 @@ cSl
 cOk
 rHl
 cRH
-cmz
+cfw
 aaa
 aaa
 aaa
@@ -133157,7 +133157,7 @@ cPc
 cPc
 emj
 cAO
-bdN
+cPc
 cVr
 cSx
 cFJ
@@ -133401,7 +133401,7 @@ cBR
 wLt
 vkT
 wLt
-cmz
+cfw
 aaa
 aaa
 aaa
@@ -133414,7 +133414,7 @@ aaa
 cPc
 dar
 cPc
-bdN
+cPc
 cQW
 cQW
 cQW
@@ -133585,22 +133585,22 @@ aLl
 aLl
 fpk
 hZE
+aLl
+aLl
+aLl
+aLl
+aLl
+aLl
 aBZ
 aBZ
 aBZ
 aBZ
 aBZ
 aBZ
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
+aLl
+aLl
+aLl
+aLl
 aBZ
 aBZ
 bam
@@ -133842,7 +133842,7 @@ hZE
 aLl
 aMB
 blA
-aBZ
+aLl
 aHH
 aIV
 aJI
@@ -134099,7 +134099,7 @@ bVY
 bmM
 gip
 avA
-aBZ
+aLl
 ajS
 aHa
 bAY
@@ -134342,8 +134342,8 @@ aeN
 aeN
 afb
 alh
-aeN
-aeN
+qoY
+qoY
 alh
 aLl
 aLl
@@ -134356,7 +134356,7 @@ bVY
 aLl
 nYq
 avA
-aBZ
+aLl
 aIz
 bVS
 joD
@@ -134389,12 +134389,12 @@ aoG
 aoG
 cSV
 aoG
-axh
-axh
-axh
-axh
-axh
-axh
+aoG
+aoG
+aoG
+aoG
+aoG
+aoG
 cwQ
 buy
 aoG
@@ -134613,7 +134613,7 @@ aLl
 aLl
 bUW
 nMk
-aBZ
+aLl
 akP
 bVS
 xeW
@@ -134651,10 +134651,10 @@ cgn
 qkM
 tBp
 qRI
-axh
-axh
-axh
-axh
+aoG
+aoG
+aoG
+aoG
 bgV
 asJ
 bZI
@@ -134870,7 +134870,7 @@ aLl
 avA
 qQy
 avA
-aBZ
+aLl
 ajS
 aIv
 aID
@@ -134911,7 +134911,7 @@ rJR
 mPo
 kbr
 vud
-axh
+aoG
 cyv
 asJ
 aDa
@@ -135126,8 +135126,8 @@ aLl
 aLl
 aCc
 dHr
-aBZ
-aBZ
+aLl
+aLl
 bIf
 aCM
 aJR
@@ -135168,7 +135168,7 @@ kEy
 gDW
 vYQ
 pZe
-axh
+aoG
 cBG
 avC
 asJ
@@ -135383,7 +135383,7 @@ aLl
 bcd
 bfb
 dHr
-aBZ
+aLl
 aEA
 aGc
 aIA
@@ -135411,12 +135411,12 @@ bam
 uaQ
 fga
 uaQ
-bnt
-bnt
+bjN
+bjN
 uaQ
 xFE
 uaQ
-bnt
+bjN
 ceF
 oJW
 ciE
@@ -135425,20 +135425,20 @@ cmE
 fLw
 bow
 ibu
-axh
+aoG
 bSI
 bVL
 dbI
 aXP
 lJt
-axh
-axh
+aoG
+aoG
 cds
-axh
-axh
-bCM
+aoG
+aoG
+aAG
 fmX
-bCM
+aAG
 mpF
 clA
 clA
@@ -135640,7 +135640,7 @@ aLl
 mdS
 mdS
 dHr
-aBZ
+aLl
 lCb
 aHg
 jke
@@ -135682,20 +135682,20 @@ cmE
 rUK
 tdA
 xWt
-axh
+aoG
 cCr
 bVM
 bXt
 csf
 arr
-axh
+aoG
 fcB
 iuU
 fDO
 bCU
 rjm
 pmE
-bCM
+aAG
 oYa
 omW
 omW
@@ -135897,7 +135897,7 @@ oTw
 ayr
 cxr
 aCa
-aBZ
+aLl
 hrZ
 jPv
 bCj
@@ -135939,20 +135939,20 @@ oMT
 qgH
 xBg
 xoS
-axh
-axh
-axh
-axh
-axh
-axh
-axh
+aoG
+aoG
+aoG
+aoG
+aoG
+aoG
+aoG
 blr
 pRz
 fWW
 fWW
 rqW
 pmE
-bCM
+aAG
 abq
 bGL
 bGL
@@ -136152,9 +136152,9 @@ iqp
 iNk
 aLl
 aAI
-aBZ
+aLl
 aEx
-aBZ
+aLl
 aGb
 kxf
 uyC
@@ -136200,7 +136200,7 @@ bSJ
 bSJ
 bVN
 bVN
-bCM
+aAG
 biJ
 biJ
 cDi
@@ -136409,7 +136409,7 @@ paT
 aLl
 aLl
 azs
-aBZ
+aLl
 aEy
 aEz
 rGY
@@ -136429,7 +136429,7 @@ aZe
 aHi
 aHi
 aCg
-aCg
+aFR
 qpO
 tMS
 tMS
@@ -136659,11 +136659,11 @@ amk
 amk
 amk
 amk
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
+aLl
+aLl
+aLl
+aLl
+aLl
 ayN
 ayI
 amk
@@ -136742,7 +136742,7 @@ abq
 jLY
 jLY
 abq
-qnJ
+cAb
 ivU
 uQm
 cZr
@@ -136750,7 +136750,7 @@ cwT
 cZr
 uQm
 ivU
-qnJ
+cAb
 abq
 jLY
 jLY
@@ -136999,7 +136999,7 @@ aaa
 jLY
 aaa
 aaa
-uQm
+cZr
 fcb
 gMT
 kls
@@ -137007,7 +137007,7 @@ pCx
 gbz
 kvh
 cEn
-uQm
+cZr
 aaa
 aaa
 jLY
@@ -137435,9 +137435,9 @@ asQ
 avV
 avI
 amk
-aBZ
+aLl
 nwp
-aBZ
+aLl
 ksf
 aEn
 llU
@@ -137474,8 +137474,8 @@ lmi
 rsq
 omI
 iRu
-bvk
-bvk
+juW
+juW
 jCT
 eoD
 aLa
@@ -137692,9 +137692,9 @@ asj
 nnI
 avH
 axM
-aBZ
+aLl
 aAK
-aBZ
+aLl
 aFZ
 aHg
 iOr
@@ -137719,7 +137719,7 @@ aFR
 aFR
 bjN
 bjN
-bnt
+bjN
 xrx
 auq
 lQJ
@@ -137770,7 +137770,7 @@ abq
 abq
 abq
 abq
-uQm
+cZr
 eus
 gSu
 tau
@@ -137778,7 +137778,7 @@ olg
 vKU
 pji
 lcO
-uQm
+cZr
 abq
 abq
 abq
@@ -137949,9 +137949,9 @@ asg
 awn
 awU
 ayz
-aBZ
+aLl
 aEv
-aBZ
+aLl
 dxF
 aHg
 iOr
@@ -137980,12 +137980,12 @@ nmh
 aLw
 pKi
 aiE
-bnt
-bnt
-bnt
-bnt
-bnt
-bnt
+bjN
+bjN
+bjN
+bjN
+bjN
+bjN
 iRu
 mpP
 skc
@@ -138024,21 +138024,21 @@ jLY
 aaa
 aaa
 aaa
-uQm
-uQm
-uQm
-uQm
-uQm
+cZr
+cZr
+cZr
+cZr
+cZr
 gzU
 iUe
 cDI
 mCu
 erC
-uQm
-uQm
-uQm
-uQm
-uQm
+cZr
+cZr
+cZr
+cZr
+cZr
 aaa
 aaa
 aaa
@@ -138204,11 +138204,11 @@ amk
 amk
 amk
 amk
-aBZ
-aBZ
-cbc
+aLl
+aLl
+aIo
 pxj
-aBZ
+aLl
 aCD
 ksf
 aSn
@@ -138230,7 +138230,7 @@ ccu
 gBW
 iEX
 bza
-aCg
+aFR
 gLH
 nya
 lEQ
@@ -138465,7 +138465,7 @@ bnI
 pIi
 nbN
 pxj
-aBZ
+aLl
 aBZ
 aHi
 aHi
@@ -138485,16 +138485,16 @@ uNp
 ebM
 bbC
 aCg
-aCg
-aCg
-aCg
-bnt
-bnt
-bnt
+aFR
+aFR
+aFR
+bjN
+bjN
+bjN
 xYR
 nCm
 tyW
-bnt
+bjN
 bvv
 tNQ
 mAZ
@@ -138719,7 +138719,7 @@ apg
 ans
 ans
 ans
-aBZ
+aLl
 hQX
 tSX
 tHk
@@ -138744,7 +138744,7 @@ eax
 xEY
 mdN
 mLC
-aCg
+aFR
 aaa
 aaa
 wUa
@@ -138755,7 +138755,7 @@ wUa
 bsI
 bxx
 bly
-bnt
+bjN
 bpi
 iRu
 fmo
@@ -138795,7 +138795,7 @@ abq
 abq
 abq
 fsj
-uQm
+cZr
 mDq
 rcr
 mDq
@@ -138809,7 +138809,7 @@ vLP
 mDq
 jNt
 mDq
-uQm
+cZr
 kTP
 abq
 abq
@@ -138976,7 +138976,7 @@ gRw
 asU
 auj
 arT
-aBZ
+aLl
 azr
 aEv
 vmT
@@ -139001,7 +139001,7 @@ bbC
 aCg
 lRu
 xXh
-aCg
+aFR
 aaa
 aaa
 wUa
@@ -139012,7 +139012,7 @@ wUa
 bRq
 sls
 hEA
-bnt
+bjN
 wkk
 iRu
 yif
@@ -139036,7 +139036,7 @@ swW
 csp
 isU
 kOd
-bCM
+aAG
 abq
 bGL
 bGL
@@ -139052,7 +139052,7 @@ aaa
 aaa
 cAb
 xnG
-uQm
+cZr
 gsM
 pXn
 lSn
@@ -139066,7 +139066,7 @@ cBb
 unZ
 fUb
 hSV
-uQm
+cZr
 uBl
 cAb
 aaa
@@ -139258,7 +139258,7 @@ bbC
 aCg
 qCP
 orw
-aCg
+aFR
 aaa
 abq
 wUa
@@ -139269,7 +139269,7 @@ bUv
 bsJ
 aXO
 aXO
-bnt
+bjN
 cwh
 iRu
 ciD
@@ -139293,7 +139293,7 @@ sHf
 lSg
 mEu
 pRI
-bCM
+aAG
 abq
 abq
 abq
@@ -139309,7 +139309,7 @@ aef
 cZr
 cZr
 yji
-uQm
+cZr
 kzU
 lHc
 lHc
@@ -139323,7 +139323,7 @@ rIX
 lHc
 lHc
 wxR
-uQm
+cZr
 jOA
 cZr
 cZr
@@ -139546,12 +139546,12 @@ bzL
 bHG
 bzL
 bIt
-bCM
-bCM
-bCM
+aAG
+aAG
+aAG
 wul
-bCM
-bCM
+aAG
+aAG
 abq
 aaa
 aaa
@@ -139747,7 +139747,7 @@ apg
 ans
 ans
 ans
-aBZ
+aLl
 aIo
 aCc
 tsq
@@ -139805,10 +139805,10 @@ abq
 bMj
 abq
 abq
-bCM
+aAG
 ciI
 jJf
-bCM
+aAG
 abq
 abq
 abq
@@ -139822,8 +139822,8 @@ aaa
 aaa
 ivU
 cxU
-uQm
-uQm
+cZr
+cZr
 lJO
 cBb
 cEd
@@ -139837,8 +139837,8 @@ cji
 kjo
 cBb
 lJO
-uQm
-uQm
+cZr
+cZr
 dcD
 ivU
 aaa
@@ -140007,7 +140007,7 @@ aaa
 aLl
 jGk
 bfb
-aBZ
+aLl
 aBZ
 aCg
 aHi
@@ -140033,9 +140033,9 @@ iab
 ixU
 aef
 wUa
-bUv
+sdY
 baE
-bUv
+sdY
 wUa
 buW
 abq
@@ -140062,10 +140062,10 @@ bZN
 bMk
 bGL
 abq
-bCM
+aAG
 cja
-bCM
-bCM
+aAG
+aAG
 aaa
 abq
 aaa
@@ -140079,7 +140079,7 @@ aaa
 aaa
 cZr
 odT
-uQm
+cZr
 mdi
 cjl
 ico
@@ -140095,7 +140095,7 @@ kjo
 tbY
 fNn
 mdi
-uQm
+cZr
 dcD
 cZr
 aaa
@@ -140264,7 +140264,7 @@ aaa
 bnI
 blA
 avA
-aBZ
+aLl
 aaa
 aaa
 aef
@@ -140319,13 +140319,13 @@ cch
 cdz
 bGL
 abq
-bCM
+aAG
 cbp
-bCM
+aAG
 abq
 aaa
 abq
-bCM
+aAG
 cpt
 cqW
 qbf
@@ -140336,7 +140336,7 @@ aef
 aef
 ivU
 cxU
-uQm
+cZr
 ssA
 wBz
 nfc
@@ -140352,7 +140352,7 @@ kjo
 rsi
 cEM
 ddY
-uQm
+cZr
 dcD
 ivU
 aef
@@ -140518,10 +140518,10 @@ aaa
 aef
 aaa
 aaa
-aBZ
+aLl
 azf
 dAH
-aBZ
+aLl
 aaa
 aaa
 aef
@@ -140576,9 +140576,9 @@ cci
 cbl
 bGL
 abq
-bCM
+aAG
 ckY
-bCM
+aAG
 clH
 cmP
 cob
@@ -140593,7 +140593,7 @@ aaa
 aaa
 cZr
 cxU
-uQm
+cZr
 mdi
 cjl
 aHh
@@ -140609,7 +140609,7 @@ kjo
 gOX
 fNn
 mdi
-uQm
+cZr
 dcD
 cZr
 aaa
@@ -140850,8 +140850,8 @@ aaa
 aaa
 ivU
 cxU
-uQm
-uQm
+cZr
+cZr
 jmx
 cBb
 cEd
@@ -140865,8 +140865,8 @@ iUe
 kjo
 cBb
 jmx
-uQm
-uQm
+cZr
+cZr
 dcD
 ivU
 aaa
@@ -141035,7 +141035,7 @@ aef
 aef
 aLl
 xQV
-aBZ
+aLl
 aaa
 aaa
 aaa
@@ -141100,7 +141100,7 @@ cps
 cqV
 cqU
 cqU
-bCM
+aAG
 aaa
 jLY
 aaa
@@ -141108,7 +141108,7 @@ aaa
 ivU
 iKM
 iVP
-uQm
+cZr
 iPP
 dVK
 cTI
@@ -141122,7 +141122,7 @@ xUb
 hnx
 nXr
 kOw
-uQm
+cZr
 dcD
 dcD
 ivU
@@ -141292,7 +141292,7 @@ aaa
 aef
 aLl
 avA
-aBZ
+aLl
 aaa
 aaa
 aaa
@@ -141365,7 +141365,7 @@ aef
 cZr
 cZr
 cxU
-uQm
+cZr
 qMX
 hlK
 nln
@@ -141379,7 +141379,7 @@ gSu
 aIa
 dBo
 iEP
-uQm
+cZr
 dcD
 cZr
 cZr
@@ -141549,7 +141549,7 @@ aaa
 aef
 aef
 aef
-aBZ
+aLl
 aaa
 aaa
 aaa
@@ -141622,7 +141622,7 @@ aaa
 aaa
 ivU
 cxU
-uQm
+cZr
 jkZ
 aFt
 hfR
@@ -141636,7 +141636,7 @@ bQl
 byZ
 kZN
 jkZ
-uQm
+cZr
 dcD
 ivU
 aaa
@@ -141879,7 +141879,7 @@ jLY
 aaa
 ivU
 cxU
-uQm
+cZr
 mdi
 ivR
 cqk
@@ -141893,7 +141893,7 @@ hfR
 sjV
 ivR
 mdi
-uQm
+cZr
 dcD
 ivU
 aaa
@@ -142136,7 +142136,7 @@ jLY
 abq
 cZr
 cxU
-uQm
+cZr
 mdi
 gxC
 cqk
@@ -142150,7 +142150,7 @@ cqk
 sjV
 gxC
 mdi
-uQm
+cZr
 dcD
 cZr
 abq
@@ -142393,10 +142393,10 @@ abq
 abq
 cZr
 cxU
-uQm
-uQm
-uQm
-uQm
+cZr
+cZr
+cZr
+cZr
 sjV
 mdi
 cqk
@@ -142404,10 +142404,10 @@ lWe
 sjV
 mdi
 cqk
-uQm
-uQm
-uQm
-uQm
+cZr
+cZr
+cZr
+cZr
 dcD
 cZr
 abq
@@ -142653,15 +142653,15 @@ cxU
 dcD
 hEj
 sjS
-uQm
-uQm
+cZr
+cZr
 wZa
 uFN
 slT
 mnt
 xnj
-uQm
-uQm
+cZr
+cZr
 mPr
 dcD
 dcD
@@ -142911,13 +142911,13 @@ ngG
 ngG
 igv
 xQR
-uQm
+cZr
 bdp
 reP
 uDq
 wXA
 qcu
-uQm
+cZr
 uHv
 dcD
 dcD

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55189,6 +55189,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"epx" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/starboard)
 "epG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -57210,7 +57213,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos)
 "fno" = (
 /obj/structure/disposalpipe/segment,
@@ -58722,7 +58725,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/distribution)
 "fWS" = (
 /obj/effect/turf_decal/stripes/line,
@@ -64525,7 +64528,7 @@
 /area/security/permabrig)
 "iLE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/distribution)
 "iLI" = (
 /obj/machinery/door/airlock/maintenance,
@@ -64760,7 +64763,7 @@
 	},
 /area/toxins/mixing)
 "iRu" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/distribution)
 "iSf" = (
 /obj/effect/spawner/window,
@@ -68207,6 +68210,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mule_bot,
 /turf/simulated/floor/plasteel,
+/area/maintenance/starboard)
+"kJQ" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall/r_wall,
 /area/maintenance/starboard)
 "kJT" = (
 /obj/structure/disposalpipe/segment{
@@ -75637,7 +75644,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/distribution)
 "omK" = (
 /obj/structure/chair/stool{
@@ -79364,7 +79371,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/control)
 "qhG" = (
 /obj/effect/spawner/window,
@@ -79976,6 +79983,9 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"qxL" = (
+/turf/simulated/wall/r_wall,
+/area/atmos/control)
 "qyo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/turf_decal/stripes/line{
@@ -80196,7 +80206,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/control)
 "qGf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -84884,6 +84894,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
+"sWE" = (
+/turf/simulated/wall/r_wall,
+/area/atmos)
 "sWO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -93160,7 +93173,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 5
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/control)
 "xpD" = (
 /obj/structure/cable/yellow{
@@ -93535,7 +93548,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 10
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/atmos/control)
 "xBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -133611,13 +133624,13 @@ ssc
 bwE
 bgV
 asJ
-dcx
-aoG
-aoG
-aoG
-aoG
-aoG
-cte
+kJQ
+epx
+epx
+epx
+epx
+epx
+cmB
 cqG
 csl
 ctr
@@ -133868,13 +133881,13 @@ cQF
 czZ
 asJ
 oFQ
-aoG
+epx
 chs
 ckb
 agj
 cmF
 cnJ
-cte
+cmB
 cte
 cte
 cte
@@ -134125,7 +134138,7 @@ oFQ
 cdm
 asJ
 lRY
-aoG
+epx
 ciF
 clz
 clz
@@ -134381,8 +134394,8 @@ aoG
 cwQ
 cPd
 coX
-aoG
-aoG
+epx
+epx
 chQ
 aRQ
 cso
@@ -134895,7 +134908,7 @@ asJ
 aAL
 cfy
 asJ
-aoG
+epx
 cgW
 chX
 cjB
@@ -135152,7 +135165,7 @@ csf
 aoG
 aQT
 cLr
-aoG
+epx
 chf
 ciJ
 cjq
@@ -135405,14 +135418,14 @@ bVL
 dbI
 aXP
 lJt
-aoG
-aoG
+epx
+epx
 cds
-aoG
-aoG
-aAG
+epx
+epx
+sWE
 fmX
-aAG
+sWE
 mpF
 clA
 clA
@@ -135662,14 +135675,14 @@ bVM
 bXt
 csf
 arr
-aoG
+epx
 fcB
 iuU
 fDO
 bCU
 rjm
 pmE
-aAG
+sWE
 oYa
 omW
 omW
@@ -135913,20 +135926,20 @@ oMT
 qgH
 xBg
 xoS
-aoG
-aoG
-aoG
-aoG
-aoG
-aoG
-aoG
+epx
+epx
+epx
+epx
+epx
+epx
+epx
 blr
 pRz
 fWW
 fWW
 rqW
 pmE
-aAG
+sWE
 abq
 bGL
 bGL
@@ -136424,7 +136437,7 @@ ceF
 chR
 sNA
 nyT
-ceF
+qxL
 nfk
 jVQ
 cka
@@ -139010,7 +139023,7 @@ swW
 csp
 isU
 kOd
-aAG
+sWE
 abq
 bGL
 bGL
@@ -139267,7 +139280,7 @@ sHf
 lSg
 mEu
 pRI
-aAG
+sWE
 abq
 abq
 abq
@@ -139520,12 +139533,12 @@ bzL
 bHG
 bzL
 bIt
-aAG
-aAG
-aAG
+sWE
+sWE
+sWE
 wul
-aAG
-aAG
+sWE
+sWE
 abq
 aaa
 aaa
@@ -139779,10 +139792,10 @@ abq
 bMj
 abq
 abq
-aAG
+sWE
 ciI
 jJf
-aAG
+sWE
 abq
 abq
 abq
@@ -140036,10 +140049,10 @@ bZN
 bMk
 bGL
 abq
-aAG
+sWE
 cja
-aAG
-aAG
+sWE
+sWE
 aaa
 abq
 aaa

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -17085,10 +17085,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "aRU" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
-	},
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "aRV" = (
@@ -18777,11 +18774,10 @@
 "aVX" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "aVY" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/indestructible/fakeglass/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "aWb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19360,7 +19356,7 @@
 	dir = 4;
 	icon_state = "burst_r"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "aXo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -19390,40 +19386,53 @@
 /area/hallway/secondary/entry)
 "aXr" = (
 /obj/structure/closet/walllocker/emerglocker/north,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aXs" = (
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aXt" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aXu" = (
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/floor/mineral/titanium/blue,
+/obj/structure/closet/wardrobe/mixed,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aXv" = (
-/obj/structure/closet/wardrobe/xenos,
-/turf/simulated/floor/mineral/titanium/blue,
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aXw" = (
-/obj/structure/closet/wardrobe/mixed,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"aXx" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/simulated/floor/mineral/titanium/blue,
+/obj/structure/closet/wardrobe/xenos,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aXy" = (
 /obj/structure/closet/walllocker/emerglocker/north,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "aXA" = (
 /obj/structure/cable{
@@ -19963,17 +19972,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"aYL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"aYM" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "aYO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20014,7 +20012,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "aYU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20026,15 +20024,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)
-"aYV" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
 "aYW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20081,7 +20070,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "aZa" = (
 /obj/structure/table/reinforced,
@@ -20869,7 +20858,9 @@
 	icon_state = "spooky";
 	name = "Observer-Start"
 	},
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "bbb" = (
 /obj/structure/cable{
@@ -21503,12 +21494,6 @@
 	icon_state = "grimy"
 	},
 /area/chapel/office)
-"bcr" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "bcs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21671,13 +21656,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"bcN" = (
-/obj/machinery/light,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "bcO" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -22525,11 +22503,13 @@
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bes" = (
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
 	},
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "bet" = (
 /obj/structure/chair{
@@ -22575,20 +22555,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"bex" = (
-/obj/machinery/requests_console{
-	department = "Arrival Shuttle";
-	name = "Arrival Shuttle Requests Console";
-	pixel_y = -30
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "bey" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
 	icon_state = "burst_l"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/indestructible,
 /area/shuttle/arrival/station)
 "bez" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -22620,7 +22592,9 @@
 /area/crew_quarters/bar)
 "beG" = (
 /obj/machinery/light,
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/indestructible/arrivals_shuttle{
+	icon_state = "titanium_blue"
+	},
 /area/shuttle/arrival/station)
 "beH" = (
 /obj/structure/disposalpipe/segment,
@@ -23574,7 +23548,6 @@
 /turf/simulated/floor/plasteel,
 /area/storage/office)
 "bgy" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
@@ -69282,6 +69255,12 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"eJB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry)
 "eKd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -75585,7 +75564,7 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "jyO" = (
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "jyP" = (
 /obj/machinery/airlock_sensor{
@@ -75884,8 +75863,12 @@
 	},
 /area/medical/virology)
 "jMw" = (
-/obj/machinery/door/airlock/titanium,
-/turf/simulated/floor/mineral/titanium,
+/obj/machinery/requests_console{
+	department = "Arrival Shuttle";
+	name = "Arrival Shuttle Requests Console";
+	pixel_x = -30
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle,
 /area/shuttle/arrival/station)
 "jMx" = (
 /obj/structure/lattice/catwalk,
@@ -75902,6 +75885,9 @@
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
+"jOe" = (
+/turf/simulated/wall/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "jOj" = (
 /obj/structure/table/wood,
 /obj/item/vending_refill/boozeomat,
@@ -76954,6 +76940,9 @@
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
+"kDD" = (
+/turf/simulated/wall/indestructible/arrivals_shuttle/nodiagonal,
+/area/shuttle/arrival/station)
 "kDY" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small,
@@ -77992,6 +77981,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"lFe" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "lFH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89231,6 +89224,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
+"uHO" = (
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "uHT" = (
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
@@ -89302,6 +89299,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"uKf" = (
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor/indestructible/arrivals_shuttle,
+/area/shuttle/arrival/station)
 "uKy" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -102115,11 +102119,11 @@ aaa
 aaa
 aaa
 aaa
-aVV
-aVV
-aVY
-aVV
-aVV
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aab
@@ -102372,11 +102376,11 @@ aab
 aab
 aaa
 aaa
-aVV
-aYM
-jyO
-bcr
-aVV
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aab
@@ -102629,11 +102633,11 @@ aab
 aMs
 aaa
 aaa
-aVV
-aYL
-jyO
-bcN
-aVV
+jOe
+jOe
+jOe
+jOe
+jOe
 aaa
 aaa
 bjQ
@@ -102885,13 +102889,13 @@ aSd
 aMs
 aMs
 aaa
-aVV
-aVV
-aVV
+jOe
+jOe
+uHO
 jMw
-aVV
-aVV
-aVV
+lFe
+jOe
+jOe
 aaa
 aMs
 aMs
@@ -103142,13 +103146,13 @@ aMB
 aSd
 aSd
 aSd
-aVV
+jOe
 aXr
 jyO
 jyO
 jyO
 aXs
-aVV
+jOe
 aSd
 aSd
 aSd
@@ -103396,7 +103400,7 @@ aOQ
 aPZ
 aMd
 aSf
-aRU
+bgy
 aOQ
 aRU
 aVX
@@ -103406,7 +103410,7 @@ aYZ
 aYZ
 aXs
 aVX
-bgy
+eJB
 aOQ
 bgy
 aSf
@@ -103656,13 +103660,13 @@ aMD
 aSd
 aSd
 aSd
-aVV
+jOe
 aXt
 aXs
 aXs
 aXs
 beG
-aVV
+jOe
 aSd
 aSd
 aSd
@@ -103913,13 +103917,13 @@ aME
 aTo
 aUl
 aSd
-aVV
+jOe
 aXu
 aYZ
 aYZ
 aYZ
 bes
-aVV
+jOe
 aSd
 bid
 aTo
@@ -104684,13 +104688,13 @@ aRd
 aTp
 aUm
 aSd
-aVV
-aXx
+jOe
 aXs
 aXs
 aXs
-bex
-aVV
+aXs
+aXs
+jOe
 aSd
 bjS
 aTp
@@ -104941,13 +104945,13 @@ aMD
 aSd
 aSd
 aSd
-aVV
+jOe
 aXy
 aYZ
 aYZ
 aYZ
 beG
-aVV
+jOe
 aSd
 aSd
 aSd
@@ -105195,17 +105199,17 @@ aKa
 aGn
 aPR
 aSf
-aRU
+bgy
 aOQ
 aRU
 aVX
 aXs
 jyO
-jyO
+uKf
 jyO
 aXs
 aVX
-bgy
+eJB
 aOQ
 bgy
 aSf
@@ -105455,13 +105459,13 @@ aRe
 aSd
 aSd
 aSd
-aVV
-aVV
-aYV
-aYV
-aYV
-aVV
-aVV
+kDD
+jOe
+jOe
+jOe
+jOe
+jOe
+kDD
 aSd
 aSd
 aSd

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -50469,7 +50469,7 @@
 /area/maintenance/incinerator)
 "cwy" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "cwz" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -69023,6 +69023,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"eyF" = (
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai_upload)
 "ezy" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -79491,6 +79494,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
+"mMy" = (
+/turf/simulated/wall/r_wall,
+/area/server)
 "mMB" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -86229,6 +86235,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"slK" = (
+/turf/simulated/wall/r_wall,
+/area/engine/gravitygenerator)
 "smL" = (
 /obj/structure/toilet{
 	dir = 4
@@ -87090,9 +87099,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
-"sWI" = (
-/turf/simulated/wall,
-/area/maintenance/incinerator)
 "sXh" = (
 /obj/machinery/economy/vending/autodrobe,
 /turf/simulated/floor/plasteel{
@@ -87614,7 +87620,7 @@
 /area/maintenance/asmaint2)
 "tzm" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "tzW" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -111165,7 +111171,7 @@ cgQ
 cgQ
 cqs
 lNi
-sWI
+cwx
 cyo
 czP
 cAX
@@ -111422,13 +111428,13 @@ vdx
 cgQ
 cqs
 lNi
-sWI
+cwx
 cyn
 czH
 cBm
 czJ
 cDV
-sWI
+cwx
 amh
 aaa
 aaa
@@ -111679,13 +111685,13 @@ mmE
 heN
 coL
 fWy
-sWI
+cwx
 cyb
 czQ
 cBa
 cCt
 cDL
-sWI
+cwx
 aab
 aab
 cNF
@@ -111942,7 +111948,7 @@ czJ
 cBb
 cCz
 cDX
-sWI
+cwx
 ayi
 aab
 cpz
@@ -112199,7 +112205,7 @@ czK
 cBc
 aag
 cDZ
-sWI
+cwx
 aaa
 aab
 cNM
@@ -112450,13 +112456,13 @@ cqz
 gYs
 ctN
 mKg
-sWI
+cwx
 cye
 czK
 cBd
 czJ
 cBb
-sWI
+cwx
 ayi
 aab
 aaa
@@ -112713,7 +112719,7 @@ czR
 cBn
 cCD
 cDO
-sWI
+cwx
 ayi
 aab
 aab
@@ -112964,13 +112970,13 @@ gzN
 cgQ
 coL
 fmg
-sWI
+cwx
 cwy
-sWI
-sWI
+cwx
+cwx
 cCC
-sWI
-sWI
+cwx
+cwx
 cLi
 cLi
 cLi
@@ -119096,14 +119102,14 @@ bmb
 bgP
 bmV
 bAy
-bxl
-bxl
+bxm
+bxm
 bzR
 bzR
 bzR
-bxl
-bxl
-bxl
+bxm
+bxm
+bxm
 bMs
 bNZ
 bME
@@ -119353,7 +119359,7 @@ bmb
 bgP
 bmV
 bAB
-bxl
+bxm
 byG
 bzN
 bDo
@@ -119610,14 +119616,14 @@ blZ
 bsp
 bwN
 bAA
-bxl
+bxm
 byH
 bEN
 bHg
 bHg
 bJG
 bxl
-bxl
+bxm
 bMv
 bOj
 bMG
@@ -119867,14 +119873,14 @@ qPj
 bsu
 bwS
 bwg
-bxl
+bxm
 byI
 bEZ
 bDs
 bDs
 bJH
 bJa
-bxl
+bxm
 bMC
 bOo
 bMG
@@ -120124,14 +120130,14 @@ qPj
 bdi
 bwR
 bkR
-bxl
+bxm
 byJ
 bEV
 bBu
 bCG
 bJH
 bFF
-bxl
+bxm
 bMB
 bOl
 bMG
@@ -120388,9 +120394,9 @@ bBv
 bCC
 bJH
 bFI
-bxl
-bxl
-bxl
+bxm
+bxm
+bxm
 bMG
 bOC
 bQl
@@ -121170,7 +121176,7 @@ bQo
 bQo
 bQo
 bQo
-bQo
+bMG
 cdY
 cgb
 ciS
@@ -121409,7 +121415,7 @@ bqR
 bqS
 bxu
 bvV
-bvX
+eyF
 bvX
 bvX
 bvX
@@ -121427,7 +121433,7 @@ bTJ
 bVB
 bXc
 bYU
-bTJ
+mMy
 ces
 cgi
 cji
@@ -121665,8 +121671,8 @@ bpo
 bqS
 bqS
 bxr
-bvX
-bvX
+eyF
+eyF
 byO
 bzT
 bBy
@@ -121684,7 +121690,7 @@ bTJ
 bXr
 bYZ
 cbe
-bTJ
+mMy
 cfv
 cgh
 cjh
@@ -121922,7 +121928,7 @@ bpt
 bqS
 bqS
 bxA
-bvX
+eyF
 bxo
 bDV
 bFb
@@ -121941,7 +121947,7 @@ bTJ
 bXt
 bZe
 cbg
-bTJ
+mMy
 ceu
 cgj
 cdN
@@ -122179,7 +122185,7 @@ bpq
 buo
 bvA
 bxw
-bvX
+eyF
 bxp
 bDT
 bxq
@@ -122198,7 +122204,7 @@ bTJ
 bTJ
 bZd
 bTJ
-bTJ
+mMy
 cet
 cgj
 cdN
@@ -122436,7 +122442,7 @@ bpu
 bqU
 bsF
 bxD
-bvX
+eyF
 bxq
 bDY
 byP
@@ -122455,7 +122461,7 @@ bTN
 bFC
 bZg
 cbh
-bFC
+slK
 cew
 cgl
 cjk
@@ -122950,7 +122956,7 @@ bpw
 bqV
 bsF
 bxO
-bvX
+eyF
 bxt
 bEa
 byP
@@ -122969,7 +122975,7 @@ bTP
 bFC
 bZn
 cbi
-bFC
+slK
 cey
 cgm
 cfv
@@ -123207,7 +123213,7 @@ aYg
 bup
 bvB
 bxK
-bvX
+eyF
 bxs
 bDZ
 bxq
@@ -123226,7 +123232,7 @@ bFC
 bFC
 bFC
 bFC
-bFC
+slK
 cex
 cgj
 bGt
@@ -123464,7 +123470,7 @@ bpt
 bqS
 bvC
 bxY
-bvX
+eyF
 bxo
 bEd
 bFf
@@ -123483,7 +123489,7 @@ bFC
 aaa
 aaa
 aaa
-bFC
+slK
 ceB
 cgj
 cfv
@@ -123721,8 +123727,8 @@ bpx
 bqX
 bsC
 bxU
-bvX
-bvX
+eyF
+eyF
 bEb
 bFe
 bBB
@@ -123740,7 +123746,7 @@ aaa
 aaa
 aaa
 aaa
-bFC
+slK
 ceA
 cgn
 cfv
@@ -123979,7 +123985,7 @@ bqY
 bsF
 bxZ
 bvY
-bvX
+eyF
 bvX
 bvX
 bvX
@@ -123997,7 +124003,7 @@ aaa
 aaa
 aaa
 aaa
-bFC
+slK
 ceD
 cgj
 cfv

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -79,6 +79,9 @@
 /area/aisat/entrance{
 	name = "\improper AI Satellite Atmospherics"
 	})
+"aaq" = (
+/turf/simulated/wall,
+/area/teleporter)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -422,7 +425,7 @@
 /turf/simulated/floor/plating,
 /area/security/range)
 "adj" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -683,7 +686,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/prisonlockers)
 "aeh" = (
@@ -691,7 +694,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/prisonlockers)
 "aei" = (
@@ -1183,7 +1186,7 @@
 	},
 /area/security/brig)
 "afU" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -3165,7 +3168,7 @@
 /area/security/hos)
 "alK" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "alL" = (
@@ -3207,7 +3210,7 @@
 /area/security/brig)
 "alN" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
@@ -3314,7 +3317,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/warden)
 "alV" = (
@@ -3465,7 +3468,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "amr" = (
@@ -3592,7 +3595,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/warden)
 "amE" = (
@@ -3940,7 +3943,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "any" = (
@@ -4890,7 +4893,7 @@
 /area/security/seceqstorage)
 "apm" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "apn" = (
@@ -5020,7 +5023,7 @@
 /area/security/seceqstorage)
 "apD" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/seceqstorage)
 "apE" = (
@@ -5129,7 +5132,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "apS" = (
@@ -5287,7 +5290,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/warden)
 "aqx" = (
@@ -5300,7 +5303,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/warden)
 "aqy" = (
@@ -5332,7 +5335,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "aqB" = (
@@ -5350,7 +5353,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "aqC" = (
@@ -5363,7 +5366,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/main)
 "aqD" = (
@@ -5572,7 +5575,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
@@ -5936,7 +5939,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/evidence)
 "arP" = (
@@ -5958,7 +5961,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/evidence)
 "arR" = (
@@ -6869,7 +6872,7 @@
 	},
 /area/security/brig)
 "atS" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -6966,7 +6969,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/seceqstorage)
 "auj" = (
@@ -7117,7 +7120,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
@@ -7126,7 +7129,7 @@
 /area/security/lobby)
 "auE" = (
 /obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/processing)
 "auF" = (
@@ -7146,7 +7149,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
@@ -7163,7 +7166,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
@@ -8857,7 +8860,7 @@
 /turf/simulated/floor/plating,
 /area/security/execution)
 "ayC" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -9153,9 +9156,6 @@
 	id = "Processing"
 	},
 /turf/simulated/floor/plating,
-/area/security/processing)
-"aza" = (
-/turf/simulated/wall/r_wall,
 /area/security/processing)
 "azb" = (
 /obj/machinery/access_button{
@@ -9720,9 +9720,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
-"aAm" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/courtroom)
 "aAp" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -10167,7 +10164,7 @@
 /turf/space,
 /area/space)
 "aBn" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
 "aBo" = (
@@ -10328,7 +10325,7 @@
 /turf/simulated/floor/grass,
 /area/security/permabrig)
 "aBN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
@@ -10762,7 +10759,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "aCL" = (
@@ -11093,7 +11090,7 @@
 	},
 /area/crew_quarters/dorms)
 "aDw" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarport)
 "aDx" = (
 /obj/structure/sign/vacuum/external{
@@ -11760,9 +11757,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"aFd" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/abandonedbar)
 "aFh" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12025,9 +12019,6 @@
 "aFI" = (
 /turf/simulated/wall,
 /area/crew_quarters/arcade)
-"aFJ" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/dorms)
 "aFK" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -12097,7 +12088,7 @@
 /area/maintenance/auxsolarport)
 "aFT" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarport)
 "aFU" = (
 /obj/structure/table,
@@ -12517,7 +12508,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "aGT" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarstarboard)
 "aGU" = (
 /obj/structure/cable{
@@ -12608,7 +12599,7 @@
 /area/maintenance/fsmaint)
 "aHg" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/fpmaint2)
 "aHh" = (
 /obj/machinery/door/airlock/engineering{
@@ -12621,10 +12612,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
-"aHi" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
 /area/maintenance/fpmaint2)
 "aHj" = (
 /obj/machinery/economy/vending/cigarette,
@@ -12773,9 +12760,6 @@
 	icon_state = "darkblue"
 	},
 /area/crew_quarters/courtroom)
-"aHE" = (
-/turf/simulated/wall/r_wall,
-/area/security/detectives_office)
 "aHF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12956,7 +12940,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aIe" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/clownoffice)
 "aIf" = (
@@ -12982,7 +12966,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aIh" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/mimeoffice)
 "aIi" = (
@@ -13683,7 +13667,7 @@
 /area/maintenance/fpmaint2)
 "aJH" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/auxsolarstarboard)
 "aJI" = (
 /obj/structure/closet/emcloset,
@@ -14178,9 +14162,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"aLd" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/secondary/entry)
 "aLe" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -14713,7 +14694,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
@@ -15879,7 +15860,7 @@
 	},
 /area/civilian/barber)
 "aPf" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/arcade)
 "aPg" = (
@@ -17218,7 +17199,7 @@
 	},
 /area/crew_quarters/dorms)
 "aSl" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep)
 "aSm" = (
@@ -17277,12 +17258,6 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
-"aSt" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/fpmaint2)
-"aSu" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/fpmaint)
 "aSv" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -17328,7 +17303,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aSA" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/gateway)
 "aSB" = (
 /obj/structure/cable{
@@ -17963,7 +17938,7 @@
 	id_tag = "imnotmakingyoulubepissoff";
 	name = "Chemistry Privacy Shutter"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -18422,9 +18397,6 @@
 /area/hallway/secondary/garden)
 "aVi" = (
 /turf/simulated/wall,
-/area/storage/primary)
-"aVj" = (
-/turf/simulated/wall/r_wall,
 /area/storage/primary)
 "aVk" = (
 /obj/structure/closet/secure_closet/freezer/money,
@@ -22746,7 +22718,7 @@
 	},
 /area/hallway/primary/port)
 "beP" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/garden)
 "beQ" = (
@@ -22757,7 +22729,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/garden)
 "beR" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "beS" = (
@@ -22788,7 +22760,7 @@
 /area/crew_quarters/dorms)
 "beU" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "beV" = (
@@ -22905,7 +22877,7 @@
 /area/crew_quarters/dorms)
 "bfe" = (
 /obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/gateway)
 "bff" = (
 /obj/machinery/door/airlock/maintenance{
@@ -23459,7 +23431,7 @@
 	},
 /area/chapel/main)
 "bgg" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/chapel/office)
 "bgi" = (
@@ -23774,7 +23746,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bgT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/mrchangs)
 "bgU" = (
@@ -25051,7 +25023,7 @@
 	},
 /area/chapel/main)
 "bjB" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "bjD" = (
@@ -25116,7 +25088,7 @@
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/hallway/secondary/entry)
 "bjR" = (
 /obj/effect/spawner/window/reinforced,
@@ -26004,7 +25976,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/civilian/pet_store)
 "blO" = (
@@ -26385,7 +26357,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bmy" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "bmz" = (
@@ -26935,7 +26907,7 @@
 /turf/simulated/wall,
 /area/storage/tools)
 "bnT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/tools)
 "bnU" = (
@@ -28236,9 +28208,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/library)
-"bqN" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/primary/central/nw)
 "bqO" = (
 /obj/machinery/computer/prisoner{
 	req_access = null;
@@ -28852,7 +28821,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bsv" = (
@@ -28966,7 +28935,7 @@
 	},
 /area/hallway/primary/central/ne)
 "bsL" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/hallway/primary/central/ne)
 "bsM" = (
 /obj/machinery/light_switch{
@@ -28980,7 +28949,7 @@
 /turf/simulated/floor/wood,
 /area/civilian/pet_store)
 "bsN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "bsO" = (
@@ -29180,10 +29149,6 @@
 /obj/item/camera_film,
 /turf/simulated/floor/wood,
 /area/library)
-"btk" = (
-/obj/structure/sign/poster/official/random,
-/turf/simulated/wall/r_wall,
-/area/hallway/secondary/exit)
 "btl" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
@@ -30214,7 +30179,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvX" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/turret_protected/ai_upload)
 "bvY" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -30312,7 +30277,7 @@
 "bwg" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bwh" = (
@@ -32058,7 +32023,7 @@
 	},
 /area/crew_quarters/locker/locker_toilet)
 "bzR" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id_tag = "heads_meeting";
@@ -32371,10 +32336,6 @@
 /obj/machinery/door/window/eastleft{
 	name = "Mail";
 	req_access_txt = "50"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment{
@@ -33540,7 +33501,7 @@
 	},
 /area/turret_protected/ai_upload)
 "bDX" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bDY" = (
@@ -33758,9 +33719,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
-"bEA" = (
-/turf/simulated/wall/r_wall,
-/area/assembly/robotics)
 "bEB" = (
 /obj/structure/closet/crate,
 /obj/structure/cable{
@@ -33782,9 +33740,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"bED" = (
-/turf/simulated/wall/r_wall,
-/area/toxins/lab)
 "bEE" = (
 /obj/machinery/door/window/eastright{
 	name = "Coroner";
@@ -34159,7 +34114,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFC" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/engine/gravitygenerator)
 "bFD" = (
 /obj/machinery/ai_status_display{
@@ -34544,9 +34499,6 @@
 	icon_state = "whitehall"
 	},
 /area/medical/reception)
-"bGr" = (
-/turf/simulated/wall/r_wall,
-/area/assembly/chargebay)
 "bGt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34775,13 +34727,6 @@
 "bHc" = (
 /obj/structure/disposaloutlet{
 	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -35172,7 +35117,7 @@
 /area/hallway/secondary/entry)
 "bHY" = (
 /obj/structure/sign/radiation/rad_area,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Engineering";
 	name = "Engineering Security Doors"
@@ -35226,7 +35171,7 @@
 	},
 /area/assembly/chargebay)
 "bIh" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id_tag = "imnotmakingyoulubepissoff";
@@ -35290,7 +35235,7 @@
 	},
 /area/toxins/lab)
 "bIq" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/reception)
 "bIs" = (
@@ -35351,7 +35296,7 @@
 	},
 /area/medical/genetics)
 "bIB" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bID" = (
@@ -36050,9 +35995,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"bKw" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/port)
 "bKx" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -36112,7 +36054,7 @@
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/port)
 "bKG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -36290,9 +36232,6 @@
 	icon_state = "dark"
 	},
 /area/engine/gravitygenerator)
-"bLd" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/captain/bedroom)
 "bLe" = (
 /obj/machinery/suit_storage_unit/captain,
 /turf/simulated/floor/wood,
@@ -36456,7 +36395,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "bLI" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "bLJ" = (
@@ -37246,7 +37185,7 @@
 	},
 /area/assembly/robotics)
 "bNK" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/biostorage)
 "bNL" = (
@@ -37702,7 +37641,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bOF" = (
@@ -37730,7 +37669,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bOJ" = (
@@ -37757,7 +37696,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bON" = (
@@ -37778,7 +37717,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bOQ" = (
@@ -38565,7 +38504,7 @@
 	},
 /area/medical/chemistry)
 "bQQ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/paramedic)
 "bQR" = (
@@ -38905,7 +38844,7 @@
 	},
 /area/assembly/chargebay)
 "bRV" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/hallway/primary/central/sw)
 "bRW" = (
@@ -38938,7 +38877,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	name = "Privacy Shutters";
@@ -39115,7 +39054,7 @@
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/sleeper)
 "bSv" = (
@@ -39535,7 +39474,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
 "bTe" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "bTf" = (
@@ -39711,7 +39650,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	name = "Privacy Shutters";
@@ -39781,7 +39720,7 @@
 	},
 /area/medical/chemistry)
 "bTJ" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/server)
 "bTK" = (
 /obj/structure/cable{
@@ -39904,7 +39843,7 @@
 	},
 /area/assembly/chargebay)
 "bTZ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/genetics_cloning)
 "bUa" = (
@@ -41329,7 +41268,7 @@
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "bXD" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/sleeper)
 "bXF" = (
@@ -41383,7 +41322,7 @@
 	},
 /area/medical/cryo)
 "bXN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "bXO" = (
@@ -41575,7 +41514,7 @@
 	},
 /area/hallway/primary/central/se)
 "bYd" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/sign/chemistry,
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
@@ -45205,9 +45144,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery2)
-"chr" = (
-/turf/simulated/wall/r_wall,
-/area/medical/cmo)
 "chs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45261,9 +45197,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
-"chA" = (
-/turf/simulated/wall/r_wall,
-/area/medical/medbay2)
 "chB" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/mask/gas,
@@ -47979,7 +47912,7 @@
 /turf/simulated/wall,
 /area/medical/surgeryobs)
 "cpy" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "viroshutters";
 	name = "Privacy Shutters";
@@ -48006,9 +47939,6 @@
 	id = "med2"
 	},
 /turf/simulated/floor/plating,
-/area/medical/biostorage)
-"cpC" = (
-/turf/simulated/wall/r_wall,
 /area/medical/biostorage)
 "cpD" = (
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -48327,7 +48257,7 @@
 /turf/simulated/floor/wood,
 /area/blueshield)
 "cqM" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/cmostore)
 "cqN" = (
 /obj/machinery/holosign_switch{
@@ -49643,7 +49573,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "ctu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/explab)
 "ctv" = (
@@ -50287,7 +50217,7 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cvB" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/controlroom)
 "cvC" = (
@@ -50329,7 +50259,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/construction)
 "cvL" = (
@@ -50566,7 +50496,7 @@
 /area/maintenance/incinerator)
 "cwy" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/incinerator)
 "cwz" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -50928,7 +50858,7 @@
 	},
 /area/maintenance/aft)
 "cxz" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/construction)
 "cxA" = (
@@ -51041,9 +50971,6 @@
 "cxN" = (
 /turf/simulated/wall,
 /area/toxins/xenobiology)
-"cxO" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/aft)
 "cxP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -52655,7 +52582,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cBP" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio4";
 	name = "Chamber 4 Containment Blast Doors"
@@ -52707,7 +52634,7 @@
 	},
 /area/construction)
 "cCc" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
 	name = "Testing Lab Shutters";
@@ -54264,7 +54191,7 @@
 	},
 /area/hallway/primary/aft)
 "cGK" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/control)
 "cGL" = (
 /obj/structure/rack,
@@ -54819,7 +54746,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "cHU" = (
@@ -54885,7 +54812,7 @@
 	},
 /area/maintenance/aft)
 "cIb" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -54977,7 +54904,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "atmos";
 	name = "Atmos Blast Door"
@@ -55020,7 +54947,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cIs" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio5";
 	name = "Chamber 5 Containment Blast Doors"
@@ -55273,7 +55200,7 @@
 	},
 /area/hallway/primary/central/ne)
 "cJa" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "atmos";
 	name = "Atmos Blast Door"
@@ -55644,11 +55571,11 @@
 /area/maintenance/apmaint2)
 "cKe" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/assembly_line)
 "cKf" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/assembly_line)
 "cKg" = (
@@ -56162,7 +56089,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cLM" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -56324,7 +56251,7 @@
 	},
 /area/maintenance/aft)
 "cMj" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -56503,7 +56430,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
 "cMI" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -56583,7 +56510,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
 "cMQ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio7";
 	name = "Chamber 7 Containment Blast Doors"
@@ -56656,7 +56583,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cNa" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio7";
 	name = "Chamber 7 Containment Blast Doors"
@@ -57135,7 +57062,7 @@
 /area/maintenance/apmaint2)
 "cOy" = (
 /obj/structure/sign/securearea,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Engineering";
 	name = "Engineering Security Doors"
@@ -57267,12 +57194,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"cOT" = (
-/turf/simulated/wall/r_wall,
-/area/atmos/distribution)
 "cOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/distribution)
 "cOV" = (
 /obj/structure/table,
@@ -57285,7 +57209,7 @@
 /area/assembly/assembly_line)
 "cOW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos/distribution)
 "cOY" = (
 /obj/structure/rack{
@@ -57674,7 +57598,7 @@
 	},
 /area/engine/engineering)
 "cPZ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cQa" = (
@@ -57820,9 +57744,6 @@
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"cQy" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/apmaint2)
 "cQB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -57913,7 +57834,7 @@
 	},
 /area/atmos)
 "cQN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Engineering";
 	name = "Engineering Security Doors"
@@ -58252,12 +58173,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "cRA" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/portsolar)
-"cRB" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
-/area/maintenance/apmaint2)
 "cRC" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -58469,7 +58386,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRY" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -58967,7 +58884,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "cTl" = (
 /obj/item/radio/intercom{
@@ -59532,7 +59449,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "cUy" = (
 /turf/simulated/floor/plasteel{
@@ -59608,7 +59525,7 @@
 	},
 /area/atmos/distribution)
 "cUT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "cUV" = (
@@ -59929,7 +59846,7 @@
 	dir = 6
 	},
 /obj/structure/sign/nosmoking_2,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVM" = (
@@ -59937,7 +59854,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVN" = (
@@ -59954,14 +59871,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVR" = (
@@ -60721,7 +60638,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cYh" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	name = "Research and Development Lab Shutters";
@@ -60782,7 +60699,7 @@
 	id_tag = "Biohazard";
 	name = "Biohazard Shutter"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "cYq" = (
@@ -60967,7 +60884,7 @@
 /area/atmos)
 "cYU" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/engine/engine_smes)
 "cYV" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
@@ -61191,7 +61108,7 @@
 /area/toxins/lab)
 "cZF" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/engine/engine_smes)
 "cZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61229,7 +61146,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/hardsuitstorage)
 "cZS" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/atmos)
 "cZT" = (
 /obj/structure/chair/office/light{
@@ -62710,7 +62627,7 @@
 /area/atmos)
 "deE" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/starboardsolar)
 "deF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -63119,7 +63036,7 @@
 /area/maintenance/starboardsolar)
 "dfx" = (
 /obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/storage)
 "dfy" = (
 /obj/structure/chair/stool{
@@ -63962,7 +63879,7 @@
 /turf/simulated/floor/plasteel,
 /area/storage/office)
 "dim" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/storage/office)
 "din" = (
@@ -64608,7 +64525,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "djQ" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/starboardsolar)
 "djR" = (
 /obj/machinery/light/small,
@@ -67527,7 +67444,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/prisonlockers)
 "dsN" = (
@@ -68964,6 +68881,10 @@
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
+"eqv" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/chapel/main)
 "eqQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -69256,7 +69177,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "eFY" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "eGo" = (
@@ -69339,6 +69260,10 @@
 /obj/item/phone/pos,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"eJn" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry)
 "eJr" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -70672,7 +70597,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/assembly_line)
 "fJa" = (
@@ -70690,7 +70615,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "fJu" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "fJX" = (
@@ -71167,7 +71092,7 @@
 	},
 /area/toxins/hallway)
 "gbw" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio3";
 	name = "Chamber 3 Containment Blast Doors"
@@ -71712,7 +71637,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "gyS" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio4";
@@ -71964,6 +71889,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"gHN" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/security/warden)
 "gIn" = (
 /obj/item/lighter/random,
 /turf/simulated/floor/wood{
@@ -72798,7 +72731,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/sign/electricshock{
 	pixel_x = -32
 	},
@@ -74261,7 +74194,7 @@
 	},
 /area/toxins/mixing)
 "ilj" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio4";
 	name = "Chamber 4 Containment Blast Doors"
@@ -74351,7 +74284,7 @@
 /area/medical/virology)
 "inQ" = (
 /obj/structure/sign/biohazard,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/toxins/xenobiology)
 "inV" = (
 /obj/structure/cable{
@@ -74507,7 +74440,7 @@
 	},
 /area/maintenance/asmaint2)
 "ivZ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio6";
 	name = "Chamber 6 Containment Blast Doors"
@@ -74779,9 +74712,12 @@
 	},
 /area/crew_quarters/dorms)
 "iHE" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/medical/surgeryobs)
+"iHS" = (
+/turf/simulated/wall,
+/area/security/securearmoury)
 "iHY" = (
 /obj/machinery/camera{
 	c_tag = "Virology Monkey Pen"
@@ -75364,7 +75300,7 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "jnE" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Robotics Lab Shutters";
 	id_tag = "robotics"
@@ -75502,7 +75438,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "jtc" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio2";
 	name = "Chamber 2 Containment Blast Doors"
@@ -75812,7 +75748,7 @@
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "jEQ" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio3";
@@ -76106,6 +76042,10 @@
 /obj/structure/falsewall,
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
+"jTB" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "jTS" = (
 /obj/structure/bed/roller,
 /obj/item/organ/internal/kidneys/vox,
@@ -77237,7 +77177,7 @@
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
 "kPH" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -77279,7 +77219,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "kSv" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -79113,7 +79053,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "muq" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio3";
 	name = "Chamber 3 Containment Blast Doors"
@@ -79685,7 +79625,7 @@
 /area/maintenance/apmaint)
 "mQX" = (
 /obj/structure/barricade/wooden,
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "mRD" = (
@@ -79884,6 +79824,10 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/medbay2)
+"naS" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/crew_quarters/dorms)
 "naU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80895,7 +80839,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "nQT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80956,6 +80900,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"nWk" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "nXc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
@@ -81203,9 +81151,6 @@
 	icon_state = "whitehall"
 	},
 /area/maintenance/aft)
-"ogI" = (
-/turf/simulated/wall/r_wall,
-/area/medical/chemistry)
 "ogJ" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -82168,6 +82113,10 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
+"oRP" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "oSt" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -82194,6 +82143,10 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
+"oSz" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/quartermaster/storage)
 "oSF" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
@@ -82948,7 +82901,7 @@
 	},
 /area/medical/surgery1)
 "pvT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/curtain,
 /turf/simulated/floor/plating,
 /area/medical/virology)
@@ -83256,7 +83209,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "pKi" = (
@@ -83707,9 +83660,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/assembly/assembly_line)
+"qdH" = (
+/obj/effect/spawner/window,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
 "qdO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84620,7 +84581,7 @@
 	},
 /area/assembly/chargebay)
 "qKN" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -84720,6 +84681,9 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/starboard/east)
+"qPj" = (
+/turf/simulated/wall,
+/area/bridge)
 "qPt" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/disposalpipe/segment{
@@ -84867,7 +84831,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "qXs" = (
@@ -85187,7 +85151,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "rjh" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -85809,7 +85773,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "rSo" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
@@ -86284,7 +86248,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "smP" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -87133,6 +87097,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
+"sWI" = (
+/turf/simulated/wall,
+/area/maintenance/incinerator)
 "sXh" = (
 /obj/machinery/economy/vending/autodrobe,
 /turf/simulated/floor/plasteel{
@@ -87306,7 +87273,7 @@
 	},
 /area/engine/engine_smes)
 "tdd" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio2";
 	name = "Chamber 2 Containment Blast Doors"
@@ -87396,7 +87363,7 @@
 	},
 /area/security/permabrig)
 "tif" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio6";
 	name = "Chamber 6 Containment Blast Doors"
@@ -87426,8 +87393,13 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"tkC" = (
+/obj/structure/cable,
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/security/warden)
 "tlj" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio5";
 	name = "Chamber 5 Containment Blast Doors"
@@ -87649,7 +87621,7 @@
 /area/maintenance/asmaint2)
 "tzm" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/incinerator)
 "tzW" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -88608,6 +88580,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"ufE" = (
+/turf/simulated/wall,
+/area/security/evidence)
 "ugg" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -89257,7 +89232,7 @@
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "uHT" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/toxins/server)
 "uHX" = (
@@ -89370,6 +89345,9 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/secondary/exit)
+"uLY" = (
+/turf/simulated/wall,
+/area/maintenance/storage)
 "uMa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89744,7 +89722,7 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/hallway)
 "vfc" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
@@ -89807,6 +89785,10 @@
 	icon_state = "showroomfloor"
 	},
 /area/medical/surgery)
+"vfF" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "vfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -90440,6 +90422,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
+"vCz" = (
+/obj/structure/sign/vacuum/external,
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/quartermaster/storage)
 "vCM" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -91318,7 +91305,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "wkX" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio4";
@@ -91340,7 +91327,7 @@
 /turf/simulated/floor/carpet,
 /area/maintenance/asmaint)
 "wmr" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
@@ -91574,6 +91561,10 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"wvP" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "wvT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -91615,7 +91606,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "wyf" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -92013,7 +92004,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "wQM" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/structure/sign/lifestar,
 /turf/simulated/floor/plating,
 /area/medical/cryo)
@@ -93384,6 +93375,10 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
+"ycd" = (
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/toxins/hallway)
 "ycf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93568,11 +93563,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/security/prisonlockers)
 "yiF" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	name = "Testing Lab Shutters";
@@ -102631,7 +102626,7 @@ aSd
 aPI
 aSd
 aab
-aLd
+aMs
 aaa
 aaa
 aVV
@@ -102884,11 +102879,11 @@ aaa
 aMs
 aMs
 aMs
-aLd
+aMs
 aWe
 aSd
 aMs
-aLd
+aMs
 aaa
 aVV
 aVV
@@ -102898,11 +102893,11 @@ aVV
 aVV
 aVV
 aaa
-aLd
+aMs
 aMs
 aSd
 aSd
-aLd
+aMs
 aaa
 aaa
 aaa
@@ -103159,7 +103154,7 @@ aSd
 aSd
 blB
 boP
-aLd
+aMs
 aaa
 aaa
 aaa
@@ -103171,7 +103166,7 @@ aaa
 aaa
 aaa
 aaa
-aLd
+aMs
 aaa
 aaa
 aaa
@@ -103679,7 +103674,7 @@ aaa
 aaa
 aaa
 aaa
-aLd
+aMs
 aaa
 aaa
 aaa
@@ -103912,7 +103907,7 @@ aaa
 aMs
 aMs
 aMs
-aLd
+aMs
 aRa
 aME
 aTo
@@ -104940,7 +104935,7 @@ aab
 aMs
 aNw
 aNw
-aLd
+aMs
 aPT
 aMD
 aSd
@@ -105729,7 +105724,7 @@ aSd
 bpX
 bmS
 bgR
-aLd
+aMs
 aSd
 aSd
 aOQ
@@ -105972,17 +105967,17 @@ aGn
 aPY
 aSf
 aRT
-aLd
-aLd
-aLd
+aMs
+aMs
+aMs
 aSd
 aSd
 aSd
 aSd
 aSd
-aLd
-aLd
-aLd
+aMs
+aMs
+aMs
 bqe
 aSf
 bsl
@@ -106001,7 +105996,7 @@ bBg
 bLs
 bmS
 bMb
-aLd
+aMs
 aaa
 aaa
 aaa
@@ -106751,10 +106746,10 @@ aVc
 aVc
 bgk
 bhE
-aSd
-aSd
-aSd
-aSd
+eJn
+eJn
+eJn
+eJn
 bre
 bgG
 bqr
@@ -107245,7 +107240,7 @@ aAd
 aDw
 aDw
 aDw
-aSt
+aGn
 aHM
 aIJ
 aKW
@@ -107502,7 +107497,7 @@ aAd
 aDu
 aEC
 aFQ
-aSt
+aGn
 aHU
 aHS
 aJZ
@@ -108273,7 +108268,7 @@ aAd
 aDw
 aDw
 aFT
-aHi
+aPc
 aHS
 aHS
 aKa
@@ -109597,7 +109592,7 @@ bJt
 rEZ
 bnK
 gaF
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -109871,7 +109866,7 @@ aaa
 aaa
 cng
 qiN
-cng
+wvP
 twG
 cqs
 csj
@@ -110111,7 +110106,7 @@ bvs
 bvs
 bvs
 bDQ
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -110128,7 +110123,7 @@ aaa
 aaa
 cng
 qiN
-cng
+wvP
 rSD
 cqs
 csj
@@ -110336,7 +110331,7 @@ aLu
 aLr
 aGn
 aGn
-aII
+jTB
 aGn
 aGn
 aRB
@@ -110368,7 +110363,7 @@ bvs
 bwP
 bvs
 hvS
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -110625,7 +110620,7 @@ bvs
 bEW
 bvs
 bMg
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -111106,7 +111101,7 @@ aHl
 aLx
 aGn
 aGn
-aII
+jTB
 aGn
 aGn
 aGn
@@ -111139,7 +111134,7 @@ bJx
 bKq
 bvs
 jdz
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -111166,7 +111161,7 @@ cgQ
 cgQ
 cqs
 lNi
-cwx
+sWI
 cyo
 czP
 cAX
@@ -111402,7 +111397,7 @@ aaa
 bPT
 bRI
 sft
-bPT
+vCz
 sft
 bUg
 bPT
@@ -111423,13 +111418,13 @@ vdx
 cgQ
 cqs
 lNi
-cwx
+sWI
 cyn
 czH
 cBm
 czJ
 cDV
-cwx
+sWI
 amh
 aaa
 aaa
@@ -111680,13 +111675,13 @@ mmE
 heN
 coL
 fWy
-cwx
+sWI
 cyb
 czQ
 cBa
 cCt
 cDL
-cwx
+sWI
 aab
 aab
 cNF
@@ -111916,7 +111911,7 @@ bKB
 bKB
 bRI
 bTr
-bKB
+oSz
 bTr
 bUg
 bKB
@@ -111943,7 +111938,7 @@ czJ
 cBb
 cCz
 cDX
-cwx
+sWI
 ayi
 aab
 cpz
@@ -112200,7 +112195,7 @@ czK
 cBc
 aag
 cDZ
-cwx
+sWI
 aaa
 aab
 cNM
@@ -112451,13 +112446,13 @@ cqz
 gYs
 ctN
 mKg
-cwx
+sWI
 cye
 czK
 cBd
 czJ
 cBb
-cwx
+sWI
 ayi
 aab
 aaa
@@ -112714,7 +112709,7 @@ czR
 cBn
 cCD
 cDO
-cwx
+sWI
 ayi
 aab
 aab
@@ -112965,13 +112960,13 @@ gzN
 cgQ
 coL
 fmg
-cwx
+sWI
 cwy
-cwx
-cwx
+sWI
+sWI
 cCC
-cwx
-cwx
+sWI
+sWI
 cLi
 cLi
 cLi
@@ -113423,16 +113418,16 @@ aGn
 aGn
 aMA
 aRl
-aSu
-aSt
-aSt
-aVj
-aVj
-aVj
-aVj
-aVj
-aVj
-aVj
+aMA
+aGn
+aGn
+aVi
+aVi
+aVi
+aVi
+aVi
+aVi
+aVi
 bdq
 blP
 bjP
@@ -115251,10 +115246,10 @@ byw
 bFq
 bxb
 bxb
-bKB
+oSz
 bVl
 bWO
-bKB
+oSz
 bYM
 bYM
 jdi
@@ -115993,16 +115988,16 @@ aMA
 aMA
 aMA
 aRl
-aSu
-aSu
-aSu
-aSu
-aSu
-aSu
-aSu
-aSu
-aSu
-aSu
+aMA
+aMA
+aMA
+aMA
+aMA
+aMA
+aMA
+aMA
+aMA
+aMA
 bgE
 bmf
 bkr
@@ -116576,7 +116571,7 @@ qJc
 cOx
 aaa
 aaa
-cQy
+cLi
 cTb
 cUf
 cVn
@@ -116832,8 +116827,8 @@ uUa
 qJc
 cOx
 cOx
-cQy
-cRB
+cLi
+cWk
 cTc
 cNB
 cNB
@@ -117537,8 +117532,8 @@ aMA
 aVD
 aMA
 bac
-aSu
-aSu
+aMA
+aMA
 aSA
 aSA
 aSA
@@ -117763,7 +117758,7 @@ qBH
 azV
 afa
 wsT
-agk
+qdH
 aoh
 tXE
 hgU
@@ -118037,10 +118032,10 @@ ayG
 aqW
 aAR
 aDH
-aqI
-aAm
-aAm
-aAm
+auc
+aEl
+aEl
+aEl
 aKh
 aLM
 aMZ
@@ -118294,10 +118289,10 @@ ayQ
 azH
 aAT
 aDJ
-aqI
+auc
 aGr
 aHx
-aAm
+aEl
 aEl
 aEl
 aEl
@@ -118551,7 +118546,7 @@ aIo
 aIo
 aCK
 aDI
-aAm
+aEl
 aGq
 aHw
 aIW
@@ -119147,13 +119142,13 @@ cLd
 cKb
 cNB
 cPj
-rgM
-rgM
-rgM
-rgM
-rgM
+gLG
+gLG
+gLG
+gLG
+gLG
 cVb
-rgM
+gLG
 dar
 dts
 cYq
@@ -119404,7 +119399,7 @@ cLf
 cKb
 cNB
 cPj
-rgM
+gLG
 cUk
 cVh
 cWz
@@ -119607,7 +119602,7 @@ bkv
 bmb
 aaa
 aaa
-bqN
+blZ
 bsp
 bwN
 bAA
@@ -119661,7 +119656,7 @@ cLn
 cKb
 cNB
 cPj
-rgM
+gLG
 cUj
 cVi
 cWy
@@ -119864,7 +119859,7 @@ bpp
 bmb
 aaa
 aaa
-bmc
+qPj
 bsu
 bwS
 bwg
@@ -119918,7 +119913,7 @@ cLf
 cKb
 cNB
 gSd
-rgM
+gLG
 dsI
 iUF
 gCE
@@ -120121,7 +120116,7 @@ bkv
 bmb
 aaa
 aaa
-bmc
+qPj
 bdi
 bwR
 bkR
@@ -120175,7 +120170,7 @@ cOE
 cKb
 cNB
 cPj
-rgM
+gLG
 dsH
 mJT
 fTF
@@ -120432,7 +120427,7 @@ cOQ
 cKb
 cEM
 cPh
-rgM
+gLG
 dsK
 uVt
 cSl
@@ -120646,7 +120641,7 @@ bBw
 bBw
 bJH
 bKJ
-bxm
+bxl
 bMD
 bOq
 bQo
@@ -120689,7 +120684,7 @@ cLD
 cKb
 cNB
 cPj
-rgM
+gLG
 dsK
 uVt
 uVt
@@ -120946,7 +120941,7 @@ cNG
 cKb
 cNB
 cPj
-rgM
+gLG
 dsL
 uVt
 cSp
@@ -121153,25 +121148,25 @@ bqP
 bsw
 bxj
 bvU
-bxm
+bxl
 byN
 bzS
 bBx
 bCD
 bEc
-bxm
-bxm
-bxm
-bxm
-bMG
-bMG
-bMG
-bMG
-bMG
-bMG
-bMG
-bMG
-bMG
+bxl
+bxl
+bxl
+bxl
+bQo
+bQo
+bQo
+bQo
+bQo
+bQo
+bQo
+bQo
+bQo
 cdY
 cgb
 ciS
@@ -121203,7 +121198,7 @@ cNK
 cKb
 cLi
 cPj
-rgM
+gLG
 dsK
 uVt
 dsY
@@ -121416,7 +121411,7 @@ bvX
 bvX
 bvX
 bvX
-bxm
+bxl
 aab
 aab
 aab
@@ -121460,7 +121455,7 @@ dSM
 eWK
 cCp
 cPl
-rgM
+gLG
 dsK
 uVt
 dsY
@@ -122384,7 +122379,7 @@ adb
 abP
 aiz
 xWL
-afm
+aqv
 amC
 agL
 afl
@@ -122903,7 +122898,7 @@ amE
 anE
 aox
 apk
-apP
+gHN
 agP
 aso
 ake
@@ -123155,10 +123150,10 @@ acK
 ajo
 aeS
 alk
-aiv
+iHS
 amD
 anD
-alW
+tkC
 apS
 apS
 agO
@@ -123689,7 +123684,7 @@ ayT
 azK
 ayR
 aCp
-aHE
+axe
 axe
 aFz
 aFz
@@ -123939,14 +123934,14 @@ awK
 aoq
 arq
 asZ
-aAx
+awK
 aua
 axH
-aAx
+awK
 aoq
 arq
 asZ
-aHE
+axe
 aEo
 aFC
 aGz
@@ -123986,7 +123981,7 @@ bvX
 bvX
 bvX
 bvX
-bxv
+bON
 aab
 aab
 aab
@@ -124177,13 +124172,13 @@ aaa
 aiv
 aqR
 ahR
-aiv
-aiv
-aiv
+iHS
+iHS
+iHS
 ajK
 akt
 aku
-aiv
+iHS
 amH
 anJ
 ahY
@@ -124203,7 +124198,7 @@ ayU
 dof
 azx
 aCr
-aHE
+axe
 aEn
 aFB
 aGy
@@ -124237,24 +124232,24 @@ bqZ
 bsE
 bwU
 bvU
-bxv
+bON
 byS
 bzX
 bBC
 bCM
-bxv
-bxv
-bxv
-bxv
-bLd
-bLd
-bLd
-bLd
-bSi
-bSi
-bSi
-bSi
-bSi
+bON
+bON
+bON
+bON
+bOK
+bOK
+bOK
+bOK
+aaq
+aaq
+aaq
+aaq
+aaq
 bSi
 ceC
 cgj
@@ -124432,15 +124427,15 @@ afX
 afX
 aaa
 aiv
-aiv
-aiv
-akB
+iHS
+iHS
+akW
 acC
-aiv
-aiv
-aiv
-aiv
-aiv
+iHS
+iHS
+iHS
+iHS
+iHS
 amJ
 anJ
 aoD
@@ -124460,7 +124455,7 @@ auQ
 azO
 aro
 aCs
-aHE
+axe
 aEp
 aFD
 aGB
@@ -124503,11 +124498,11 @@ bJN
 bKM
 bLe
 bMN
-bLd
+bOK
 bQv
 bTB
 bUD
-bSi
+aaq
 bVP
 bXx
 bXl
@@ -124696,8 +124691,8 @@ alB
 acL
 adi
 atY
-anH
-anH
+anA
+anA
 aui
 anK
 aoC
@@ -124710,14 +124705,14 @@ awK
 aoq
 aru
 asZ
-aAx
+awK
 awa
 axI
-aAx
+awK
 aoq
 aru
 asZ
-aHE
+axe
 axe
 axe
 aGA
@@ -124764,7 +124759,7 @@ bOx
 bQu
 bTj
 bUB
-bSi
+aaq
 bTO
 bXw
 bXl
@@ -124810,9 +124805,9 @@ cYM
 cNV
 cOb
 fJu
-xfI
-xfI
-xfI
+cYM
+cYM
+cYM
 xfI
 cZM
 xfI
@@ -125017,11 +125012,11 @@ bEh
 bFK
 bHw
 bMP
-bLd
+bOK
 bQz
 bOJ
 bQw
-bSi
+aaq
 bTS
 bXz
 bXl
@@ -125261,7 +125256,7 @@ dnC
 bmi
 aaa
 aaa
-bmc
+qPj
 bdP
 byf
 dLF
@@ -125274,11 +125269,11 @@ bEU
 bFL
 bHx
 bMO
-bLd
+bOK
 bQy
 bOK
 bOK
-bSi
+aaq
 bTR
 bXy
 bXl
@@ -125344,13 +125339,13 @@ jxh
 aaa
 aab
 aaa
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
 aaa
 aaa
 aaa
@@ -125484,7 +125479,7 @@ ayY
 awV
 awf
 axP
-aza
+awV
 aoq
 aBa
 asZ
@@ -125518,7 +125513,7 @@ bkF
 bmi
 aaa
 aaa
-bmc
+qPj
 bsu
 byt
 bwg
@@ -125531,11 +125526,11 @@ bEs
 bEs
 bEs
 bMR
-bLd
+bOK
 bQD
 bOL
 bQx
-bSi
+aaq
 bTV
 bXX
 bXm
@@ -125583,10 +125578,10 @@ tbU
 gAm
 eMw
 dex
-xfI
-xfI
+cYM
+cYM
 ykt
-xfI
+cYM
 mwe
 cSU
 cSU
@@ -125598,16 +125593,16 @@ dcq
 dcq
 dcq
 dcq
-dcq
-dcq
-dcq
-dcq
+uLY
+uLY
+uLY
+uLY
 dgi
-dcq
+uLY
 ddr
 deP
 dgq
-dcq
+uLY
 aaa
 aaa
 aaa
@@ -125788,11 +125783,11 @@ bEk
 bzY
 bLf
 bMQ
-bLd
 bOK
 bOK
 bOK
-bSi
+bOK
+aaq
 dgl
 bXC
 bXn
@@ -125864,7 +125859,7 @@ dgp
 ddr
 ddr
 ddr
-dcq
+uLY
 aaa
 aaa
 aaa
@@ -126098,30 +126093,30 @@ cZS
 cZS
 cZS
 cZS
-dcq
+uLY
 deL
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
-dcq
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
+uLY
 don
-dcq
+uLY
 dfx
 dfR
-dcq
-dcq
-dcq
+uLY
+uLY
+uLY
 dgC
 doL
 dgC
-dcq
+uLY
 aaa
 aaa
 aaa
@@ -126255,10 +126250,10 @@ arv
 ayp
 awi
 axQ
-aAx
-aAx
-aAx
-aAx
+awK
+awK
+awK
+awK
 aAx
 aEu
 aGK
@@ -126367,18 +126362,18 @@ cQZ
 cQZ
 cQZ
 cQZ
-dcq
+uLY
 dok
-dcq
+uLY
 dfu
 dfQ
-dcq
+uLY
 aaa
-dcq
+uLY
 dou
 doI
 dou
-dcq
+uLY
 aaa
 aaa
 aaa
@@ -126624,12 +126619,12 @@ dki
 dkO
 dkO
 cQZ
-dcq
+uLY
 ddr
-dcq
+uLY
 dfC
 dgb
-dcq
+uLY
 aaa
 aaa
 dou
@@ -126881,12 +126876,12 @@ dkh
 bbM
 dlv
 cQZ
-dcq
+uLY
 dfm
-dcq
+uLY
 dfA
 dfT
-dcq
+uLY
 aaa
 aaa
 dou
@@ -127140,7 +127135,7 @@ dkO
 cQZ
 cYz
 aaa
-dcq
+uLY
 dfE
 dgd
 dgc
@@ -127326,11 +127321,11 @@ aUS
 bAg
 bHs
 bkC
-ogI
-ogI
-ogI
-ogI
-ogI
+bOU
+bOU
+bOU
+bOU
+bOU
 bOU
 bOU
 bOU
@@ -127367,7 +127362,7 @@ cep
 cep
 kcQ
 cep
-cOT
+cVE
 cPZ
 cPZ
 cPZ
@@ -127397,10 +127392,10 @@ cQZ
 cQZ
 aab
 aaa
-dcq
+uLY
 dfD
 dgc
-dcq
+uLY
 aaa
 aaa
 aaa
@@ -127532,12 +127527,12 @@ apN
 aqD
 ahE
 asv
-aFL
-aFL
-aFL
-aFL
+ufE
+ufE
+ufE
+ufE
 axC
-aFL
+ufE
 aFL
 axV
 azm
@@ -127583,7 +127578,7 @@ aUS
 bAh
 bHu
 bAh
-ogI
+bOU
 aTT
 bCW
 bDc
@@ -127789,7 +127784,7 @@ aoJ
 apT
 ago
 aiU
-aFL
+ufE
 alS
 apd
 arK
@@ -127840,7 +127835,7 @@ aUS
 bAk
 bHy
 bAk
-ogI
+bOU
 aTS
 fYx
 bBM
@@ -127881,7 +127876,7 @@ ssc
 ssc
 tWL
 cAu
-cOT
+cVE
 cDk
 cOA
 cPs
@@ -128035,7 +128030,7 @@ aaa
 aab
 anA
 acV
-anH
+anA
 akI
 apO
 apO
@@ -128292,7 +128287,7 @@ aaa
 aab
 anA
 anA
-anH
+anA
 akH
 alC
 anV
@@ -128303,7 +128298,7 @@ aHq
 anA
 ahQ
 aiV
-aFL
+ufE
 ama
 apy
 arO
@@ -128395,7 +128390,7 @@ gfi
 sAi
 yhm
 cep
-cOT
+cVE
 cQg
 cOI
 cPD
@@ -128560,7 +128555,7 @@ apQ
 aqG
 ajU
 aiX
-aFL
+ufE
 auI
 apK
 arQ
@@ -128616,7 +128611,7 @@ aTY
 eng
 bGf
 bIh
-ogI
+bOU
 bTM
 bPg
 bQS
@@ -128652,7 +128647,7 @@ hyH
 ssc
 kcQ
 czq
-cOT
+cVE
 cDl
 cOJ
 cPE
@@ -128817,10 +128812,10 @@ kTA
 aqG
 ajJ
 asy
-aFL
+ufE
 amb
 apG
-aFL
+ufE
 apG
 auI
 aFL
@@ -128873,12 +128868,12 @@ aTW
 wuf
 can
 bGq
-ogI
+bOU
 bLx
 bNy
 bQR
 bSt
-ogI
+bOU
 bZH
 cbv
 caA
@@ -128909,7 +128904,7 @@ vfy
 ssc
 cKh
 cLN
-cOT
+cVE
 cQi
 cRa
 cSo
@@ -129130,12 +129125,12 @@ aUP
 tLB
 bGe
 bJA
-ogI
-ogI
-ogI
-ogI
-ogI
-ogI
+bOU
+bOU
+bOU
+bOU
+bOU
+bOU
 bZJ
 cbO
 bWu
@@ -129166,7 +129161,7 @@ rex
 cDf
 gYr
 cLO
-cOT
+cVE
 cQo
 cRd
 cSr
@@ -129423,7 +129418,7 @@ chq
 cDf
 cKj
 cLO
-cOT
+cVE
 cQm
 cRc
 cSq
@@ -129680,7 +129675,7 @@ ahA
 cDf
 cKi
 cLO
-cxO
+chf
 cQp
 oej
 cQp
@@ -129937,7 +129932,7 @@ plV
 cDf
 cKj
 cLO
-cxO
+chf
 cQp
 cQZ
 cSn
@@ -130194,7 +130189,7 @@ wLp
 cDf
 fEv
 uOG
-cxO
+chf
 cQp
 cQZ
 cSu
@@ -130451,7 +130446,7 @@ xBf
 cDf
 fEv
 cLP
-cxO
+chf
 cQp
 cQZ
 cSs
@@ -130708,7 +130703,7 @@ cDf
 cDf
 sWc
 cts
-cxO
+chf
 cQp
 cQZ
 cSw
@@ -130883,17 +130878,17 @@ att
 ava
 avq
 awl
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
 aOI
 aQG
 qFg
@@ -130965,7 +130960,7 @@ ckS
 ckS
 vzf
 xYd
-cxO
+chf
 cQp
 cQZ
 cQZ
@@ -131222,7 +131217,7 @@ czf
 cep
 cjq
 cts
-cxO
+chf
 cNE
 djd
 djd
@@ -131242,13 +131237,13 @@ djd
 djd
 djd
 gNQ
-dgS
+dgT
 fON
 dhL
-dgS
-dgS
-dgS
-dgS
+dgT
+dgT
+dgT
+dgT
 aaa
 aaa
 aab
@@ -131479,33 +131474,33 @@ dgn
 czf
 oEp
 cts
-cxO
-cxO
+chf
+chf
 cAe
 cAe
-cxO
+chf
 cAe
 cAe
-cxO
-cAe
-cAe
-cAe
-cxO
-cxO
+chf
 cAe
 cAe
 cAe
-cxO
-cxO
-cxO
-dgS
-dgS
+chf
+chf
+cAe
+cAe
+cAe
+chf
+chf
+chf
+dgT
+dgT
 cXm
 dcy
 dcV
 ddf
 ddn
-dgS
+dgT
 aaa
 aaa
 aab
@@ -131654,17 +131649,17 @@ awH
 ayg
 aOY
 awl
-aFK
-aFK
-aFK
+naS
+naS
+naS
 gFG
-aFK
-aFK
+naS
+naS
 gFG
-aFK
-aFK
-aFK
-aFK
+naS
+naS
+naS
+naS
 aPk
 ePV
 iGP
@@ -131762,7 +131757,7 @@ vTp
 dcz
 giX
 ddo
-dgS
+dgT
 dgT
 aaa
 aab
@@ -131921,7 +131916,7 @@ sHt
 sHt
 sHt
 sHt
-aFK
+naS
 kiu
 aPm
 aSM
@@ -132178,7 +132173,7 @@ sHt
 sHt
 sHt
 sHt
-aFK
+naS
 kiu
 aPm
 aNQ
@@ -132236,7 +132231,7 @@ cqM
 cqM
 cqM
 cqM
-cpC
+bLK
 pxG
 oGg
 cTx
@@ -132420,11 +132415,11 @@ awl
 awl
 avq
 avq
-atG
-atG
+awl
+awl
 avs
-atG
-atG
+awl
+awl
 sHt
 sHt
 sHt
@@ -132435,7 +132430,7 @@ pwU
 sHt
 sHt
 sHt
-aFK
+naS
 aPm
 aPm
 aSM
@@ -132485,7 +132480,7 @@ bZu
 caP
 ccC
 lzA
-chr
+cfP
 cqM
 gUY
 cqM
@@ -132493,7 +132488,7 @@ gdp
 cmo
 cnJ
 cpd
-cpC
+bLK
 dOo
 oGg
 oRn
@@ -132677,11 +132672,11 @@ atw
 atT
 auK
 bVQ
-atG
+awl
 aup
 avq
 avq
-atG
+awl
 sHt
 sHt
 sHt
@@ -132931,14 +132926,14 @@ aCh
 aqq
 awl
 atu
-atG
+awl
 auA
 axg
 axh
 lQS
 avt
 lQS
-atG
+awl
 sHt
 sHt
 sHt
@@ -133188,20 +133183,20 @@ amL
 aqr
 awl
 awl
-atG
+awl
 axf
 dgk
 axh
 auq
 avp
 auq
-atG
+awl
 aFK
 aFK
 aOI
 gFG
-aFK
-aFK
+naS
+naS
 gFG
 aOI
 aOI
@@ -133280,9 +133275,9 @@ cep
 hVP
 cEx
 chf
-cAe
+nWk
 cmt
-cAe
+nWk
 chf
 chf
 chf
@@ -133513,7 +133508,7 @@ bZw
 caR
 ccF
 cej
-chr
+cfP
 chy
 eAi
 cjv
@@ -133770,7 +133765,7 @@ cfP
 cfP
 cfP
 cfP
-chr
+cfP
 chB
 ciX
 ckD
@@ -134027,8 +134022,8 @@ oZa
 cjF
 ccH
 cek
-chA
-chA
+pAi
+pAi
 cQk
 cQk
 cQk
@@ -135566,7 +135561,7 @@ bVX
 cuQ
 bXQ
 pMM
-cQn
+cQk
 oTy
 ceq
 cQk
@@ -136836,16 +136831,16 @@ oCs
 bHP
 aTH
 cXh
-bGr
-bGr
-bGr
-bGr
-bGr
-bGr
-bGr
-bGr
-bGr
-bGr
+bWj
+bWj
+bWj
+bWj
+bWj
+bWj
+bWj
+bWj
+bWj
+bWj
 cuQ
 tYx
 bGG
@@ -137102,7 +137097,7 @@ bTW
 bUN
 bVA
 bRU
-bGr
+bWj
 cAU
 rCf
 bGG
@@ -137359,8 +137354,8 @@ iNP
 iNP
 ptK
 wCQ
-bGr
-bGr
+bWj
+bWj
 tYx
 cAU
 ceJ
@@ -137607,7 +137602,7 @@ eiq
 bHI
 bwv
 cfy
-bGr
+bWj
 bGc
 bRk
 bLT
@@ -137617,7 +137612,7 @@ bRk
 bSW
 bSJ
 kNY
-bGr
+bWj
 bWn
 chg
 ccW
@@ -137863,8 +137858,8 @@ bau
 bFo
 bHI
 dMJ
-bGr
-bGr
+bWj
+bWj
 qKG
 bLE
 bLT
@@ -137874,7 +137869,7 @@ bLE
 bId
 bSJ
 qQm
-bGr
+bWj
 pMM
 cAU
 cdb
@@ -138131,7 +138126,7 @@ pOl
 hfD
 bSJ
 rwZ
-bGr
+bWj
 pMM
 fQr
 vDR
@@ -138387,11 +138382,11 @@ bPp
 bPp
 bVD
 azq
-bGr
-bGr
+bWj
+bWj
 sBW
-bEA
-bEA
+bIa
+bIa
 cjA
 cuQ
 chU
@@ -138634,7 +138629,7 @@ bau
 pua
 bHI
 cfy
-bGr
+bWj
 bWj
 bIc
 bWe
@@ -138644,11 +138639,11 @@ faK
 bWj
 pgq
 bWe
-bGr
+bWj
 cau
 ccg
 cdC
-bEA
+bIa
 ceK
 cri
 clg
@@ -138905,7 +138900,7 @@ bYl
 cax
 cci
 jpb
-bEA
+bIa
 bYj
 bYj
 bYj
@@ -139451,10 +139446,10 @@ lqd
 cLQ
 oVH
 cBR
-cBR
-cBR
-cBR
-cBR
+cxN
+cxN
+cxN
+cxN
 cZt
 lUp
 lKO
@@ -140943,11 +140938,11 @@ bqg
 boJ
 boJ
 boJ
-aYQ
+eqv
 bvg
 bHI
 cfy
-gLu
+ycd
 bGL
 bPD
 bKi
@@ -140992,7 +140987,7 @@ rKV
 rKV
 mRD
 rKV
-cBR
+cxN
 cBR
 cBR
 gAc
@@ -141249,12 +141244,12 @@ rKV
 cQB
 cRx
 dnY
-cBR
+cxN
 lCQ
 cWr
 kdP
 cNl
-cBR
+cxN
 tlI
 vum
 ojz
@@ -141457,7 +141452,7 @@ bxB
 boJ
 boJ
 boJ
-aYQ
+eqv
 bvg
 bHQ
 wjC
@@ -141511,7 +141506,7 @@ aoo
 vJv
 cWw
 xFt
-cBR
+cxN
 eKA
 ijg
 hra
@@ -141768,7 +141763,7 @@ miN
 xTZ
 qyf
 osm
-cBR
+cxN
 ksj
 mdX
 cga
@@ -141971,16 +141966,16 @@ bmp
 boJ
 boJ
 boJ
-aYQ
+eqv
 bvg
 bHI
 cXh
-gLu
+ycd
 bGD
 bIy
 bKj
 bNC
-bED
+bTb
 bTb
 bTb
 bTb
@@ -142001,9 +141996,9 @@ iZj
 csg
 xdy
 rKV
-gLu
+ycd
 cxS
-gLu
+ycd
 rKV
 qhq
 qhq
@@ -142020,12 +142015,12 @@ rKV
 rKV
 uMj
 rKV
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+cxN
+cxN
+cxN
+cxN
+cxN
+cxN
 mhm
 pAl
 kdh
@@ -142237,7 +142232,7 @@ eER
 vGj
 vGj
 geb
-bED
+bTb
 oyO
 viP
 nin
@@ -142489,12 +142484,12 @@ aYP
 xmi
 bHI
 cXh
-bED
-bED
+bTb
+bTb
 hLG
 cYp
 cYh
-bED
+bTb
 cZp
 cZT
 lXF
@@ -142534,7 +142529,7 @@ cLb
 xDr
 dSD
 fZu
-cBQ
+oRP
 rQO
 ciY
 gjN
@@ -142708,7 +142703,7 @@ aAf
 aAf
 aAf
 aAf
-aFd
+aAf
 aAf
 aGX
 aGX
@@ -142746,7 +142741,7 @@ aYP
 bFH
 bHU
 cXh
-bED
+bTb
 bJr
 bLo
 bNt
@@ -143013,7 +143008,7 @@ cYO
 bRY
 xWj
 cOC
-bED
+bTb
 rKV
 dbx
 rKV
@@ -143270,7 +143265,7 @@ rYr
 bIp
 bUi
 eXy
-bED
+bTb
 cHf
 dbX
 csL
@@ -143527,7 +143522,7 @@ cZk
 daa
 dVQ
 xXO
-bED
+bTb
 bUx
 cga
 csL
@@ -143774,7 +143769,7 @@ bte
 bvh
 bHI
 cXh
-bED
+bTb
 nLa
 bLp
 bNu
@@ -143784,7 +143779,7 @@ ezy
 bIp
 yiu
 tYP
-bED
+bTb
 cKF
 csL
 cga
@@ -144031,17 +144026,17 @@ bEF
 qSF
 bHS
 iBI
-bED
-bED
-bED
-bED
-bED
-bED
-bED
+bTb
+bTb
+bTb
+bTb
+bTb
+bTb
+bTb
 bUT
-bED
-bED
-bED
+bTb
+bTb
+bTb
 auB
 dMM
 gpq
@@ -147368,11 +147363,11 @@ bzO
 bmm
 bBl
 gOd
-bjR
+vfF
 iek
 oWE
 gOd
-bjR
+vfF
 iek
 enR
 bmm
@@ -147882,11 +147877,11 @@ bEG
 buT
 iya
 gOd
-bjR
+vfF
 iek
 mmt
 gOd
-bjR
+vfF
 iek
 ijt
 bmm
@@ -148905,16 +148900,16 @@ bmn
 bmL
 bol
 buE
-bEG
-btk
-bEG
+bEF
+bAK
+bEF
 bqn
 bAE
-bjR
-bjR
-bjR
-bjR
-bjR
+vfF
+vfF
+vfF
+vfF
+vfF
 bAE
 jfJ
 bAE
@@ -149167,11 +149162,11 @@ btp
 bol
 bjR
 boI
-bjR
+vfF
 tnJ
 pXs
 eWC
-bjR
+vfF
 xir
 bjR
 xir

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -73,7 +73,10 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 		var/obj/item/stack/rods/V  = W
 		var/obj/item/stack/sheet/rglass/RG = new (user.loc)
 		RG.add_fingerprint(user)
-		V.use(1)
+		if(V.get_amount() < 5)
+			to_chat(user, "<b>There is not enough rods in this stack. You need 5 rods.</b>")
+			return
+		V.use(5)
 		var/obj/item/stack/sheet/glass/G = src
 		src = null
 		var/replace = (user.get_inactive_hand()==G)
@@ -103,7 +106,7 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list (
 	desc = "Glass which seems to have rods or something stuck in them."
 	singular_name = "reinforced glass sheet"
 	icon_state = "sheet-rglass"
-	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT/2, MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT, MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 70, ACID = 100)
 	resistance_flags = ACID_PROOF
 	origin_tech = "materials=2"

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -73,10 +73,9 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 		var/obj/item/stack/rods/V  = W
 		var/obj/item/stack/sheet/rglass/RG = new (user.loc)
 		RG.add_fingerprint(user)
-		if(V.get_amount() < 5)
+		if(!V.use(5))
 			to_chat(user, "<b>There is not enough rods in this stack. You need 5 rods.</b>")
 			return
-		V.use(5)
 		var/obj/item/stack/sheet/glass/G = src
 		src = null
 		var/replace = (user.get_inactive_hand()==G)

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -48,6 +48,10 @@
 	clawfootstep = FOOTSTEP_LAVA
 	heavyfootstep = FOOTSTEP_LAVA
 
+/turf/simulated/floor/indestructible/arrivals_shuttle
+	name = "shuttle floor"
+	icon_state = "titanium"
+
 /turf/simulated/floor/indestructible/necropolis/Initialize(mapload)
 	. = ..()
 	if(prob(12))

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -48,6 +48,21 @@
 /turf/simulated/wall/indestructible/mech_melee_attack(obj/mecha/M)
 	return
 
+/turf/simulated/wall/indestructible/arrivals_shuttle
+	name = "wall"
+	desc = "A light-weight titanium wall used in shuttles."
+	icon = 'icons/turf/walls/plastinum_wall.dmi'
+	icon_state = "plastinum_wall-0"
+	base_icon_state = "plastinum_wall"
+	flags_2 = CHECK_RICOCHET_2
+	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
+	smoothing_groups = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE)
+	canSmoothWith = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS, SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE)
+
+/turf/simulated/wall/indestructible/arrivals_shuttle/nodiagonal
+	icon_state = "map-shuttle_nd"
+	smoothing_flags = SMOOTH_BITMASK
+
 /turf/simulated/wall/indestructible/necropolis
 	name = "necropolis wall"
 	desc = "A seemingly impenetrable wall."
@@ -153,6 +168,16 @@
 	icon_state = null
 	underlays += mutable_appearance('icons/obj/structures.dmi', "grille") //add a grille underlay
 	underlays += mutable_appearance('icons/turf/floors.dmi', "plating") //add the plating underlay, below the grille
+
+/turf/simulated/wall/indestructible/fakeglass/arrivals_shuttle
+	name = "shuttle window"
+	desc = "A reinforced, air-locked pod window."
+	icon = 'icons/obj/smooth_structures/windows/shuttle_window.dmi'
+	icon_state = "shuttle_window-0"
+	base_icon_state = "shuttle_window"
+	smoothing_groups = list(SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE, SMOOTH_GROUP_TITANIUM_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE, SMOOTH_GROUP_TITANIUM_WALLS)
+	edge_overlay_file = null
 
 /turf/simulated/wall/indestructible/fakeglass/smooth_icon()
 	..()

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -209,7 +209,7 @@
 	desc = "Metal + Glass"
 	id = "rglass"
 	build_type = AUTOLATHE | SMELTER
-	materials = list(MAT_METAL = 1000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
+	materials = list(MAT_METAL = 5000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
 	build_path = /obj/item/stack/sheet/rglass
 	category = list("initial","Construction")
 	maxstack = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Updates all maps to include more regular windows.
Increases rod cost of rglass windows from 1 to 5 rods (does this ened to be more?)
Adjusts mapping standards to reflect new window use. (Fixes and clarifies some things there too)

- [ ] Consider slightly buffing rglass and glass window health values.

Gateway is no longer reinforced as it is now only and always beach

Standardises arrival shuttle, the front fell off.
Arrivals shuttle is now indestructable, this will mean players have a safe refuge every time they spawn in. No more meteor riddled shuttles.
![image](https://user-images.githubusercontent.com/12197162/203419829-be865a90-ee81-46d6-8c5f-9fd645693f2a.png)

Updates mapping contribution guidelines to reflect these, bumped minimum acceptable SDMM version to 2.
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, we use rglass almost everywhere. Now that windows match walls in style it can look quite out of place when rglass is used in non-secure areas.
This means that all non-secure areas use regular glass.
Rglass windows are still used on:

- External (to space) windows
- Transitions between unsecure and secure boundaries where no easily-accessible secondary security mechanism is available
- Places where rwalls are used (generally matches above criteria)

Other changes have been made to remove rwalls from areas that don't need them, secure areas generally only have a "perimiter" of rwalls and the walls within are regular walls.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changeling
:cl:
tweak: Most reinforced glass window instances in non-secure areas replaced with regular glass windows
tweak: Reinforced glass now costs 5 rods to make, not 1
tweak: The arrivals shuttle is now make of indestructable materials to protect new spawns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
