### PR TITLE
Large object transparency component uses the proper mouse opacity value

### DIFF
--- a/code/datums/components/largeobjecttransparency.dm
+++ b/code/datums/components/largeobjecttransparency.dm
@@ -11,6 +11,8 @@
 	var/target_alpha
 	//if this is supposed to prevent clicks if it's transparent.
 	var/toggle_click
+	//The atom's mouse opacity, so it's restored to its default
+	var/initial_mouse_opacity
 	var/list/registered_turfs
 	var/amounthidden = 0
 
@@ -21,13 +23,14 @@
 	y_offset = _y_offset
 	x_size = _x_size
 	y_size = _y_size
+	var/atom/at = parent
 	if(isnull(_initial_alpha))
-		var/atom/at = parent
 		initial_alpha = at.alpha
 	else
 		initial_alpha = _initial_alpha
 	target_alpha = _target_alpha
 	toggle_click = _toggle_click
+	initial_mouse_opacity = at.mouse_opacity
 	registered_turfs = list()
 
 
@@ -102,4 +105,4 @@
 	var/atom/parent_atom = parent
 	animate(parent_atom, alpha = initial_alpha, 0.5 SECONDS)
 	if(toggle_click)
-		parent_atom.mouse_opacity = MOUSE_OPACITY_OPAQUE
+		parent_atom.mouse_opacity = initial_mouse_opacity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the large object transparency component to remember the atom's mouse opacity, instead of setting a fixed value.

## Why It's Good For The Game
Fixes objects that use the component suddenly having their entire bounding box be mouse clickable when they shouldn't.

## Images of changes
https://user-images.githubusercontent.com/80771500/203431247-f71bdb64-425e-476a-ac2b-6c5971d14243.mp4

## Testing
Spawned a tree, walked behind it and then away from it, hovered the mouse near it.

## Changelog
:cl:
fix: Trees don't become suddenly clickable in a box around them when someone has walked behind one and away afterwards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
