### PR TITLE
Gives Alien Queen (and Empress) bold text in Alien Hivemind

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -499,6 +499,14 @@
 	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
+/datum/language/xenos/broadcast(mob/living/speaker, message, speaker_mask)
+	if(isalien(speaker))
+		var/mob/living/carbon/alien/humanoid/alienspeaker = speaker
+		if(alienspeaker.loudspeaker)
+			..(speaker, "<font size=3><b>[message]</b></font>")
+			return
+	..(speaker, message)
+
 /datum/language/terrorspider
 	name = "Spider Hivemind"
 	desc = "Terror spiders have a limited ability to commune over a psychic hivemind, similar to xenomorphs."

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -503,9 +503,8 @@
 	if(isalien(speaker))
 		var/mob/living/carbon/alien/humanoid/alienspeaker = speaker
 		if(alienspeaker.loudspeaker)
-			..(speaker, "<font size=3><b>[message]</b></font>")
-			return
-	..(speaker, message)
+			return ..(speaker, "<font size=3><b>[message]</b></font>")
+	return ..()
 
 /datum/language/terrorspider
 	name = "Spider Hivemind"

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -17,6 +17,7 @@
 	status_flags = CANPARALYSE|CANPUSH
 	var/heal_rate = 5
 	var/large = FALSE
+	var/loudspeaker = FALSE
 	var/heat_protection = 0.5
 	var/leaping = FALSE
 	ventcrawler = 2

--- a/code/modules/mob/living/carbon/alien/humanoid/empress.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/empress.dm
@@ -5,6 +5,7 @@
 	health = 700
 	icon_state = "alienq_s"
 	status_flags = CANPARALYSE
+	loudspeaker = TRUE
 	mob_size = MOB_SIZE_LARGE
 	bubble_icon = "alienroyal"
 	large = 1

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -5,6 +5,7 @@
 	health = 250
 	icon_state = "alienq_s"
 	status_flags = CANPARALYSE
+	loudspeaker = TRUE
 	heal_rate = 5
 	large = 1
 	ventcrawler = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Gives the Alien Queen bold text in Alien Hivemind so Aliens can hear them better. Also gives this feature to Empress, even if that one's admin-spawn only.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The Queen should be able to be heard by her brood if she needs to speak, and this should hopefully give her more of a sense of authority. This same effect is had by Terror Spiders.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/71326864/203562763-4fc158d5-e685-42b2-a852-c454e4a52306.png)
![image](https://user-images.githubusercontent.com/71326864/203562836-ed039619-b8d0-4528-aee7-cae28764be68.png)
![image](https://user-images.githubusercontent.com/71326864/203562908-be6d70b3-f9c1-452c-82b8-c9367e04c983.png)
## Testing
<!-- How did you test the PR, if at all? -->
See above.
## Changelog
:cl:
tweak: Alien Queens and Empresses now have bold text in Alien Hivemind speech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
