### PR TITLE
Reticence now deals stamina damage

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -289,7 +289,7 @@
 	fire_sound = 'sound/weapons/gunshots/gunshot_silenced.ogg'
 	icon_state = "mecha_mime"
 	equip_cooldown = 15
-	projectile = /obj/item/projectile/bullet/mime
+	projectile = /obj/item/projectile/bullet/mime/nonlethal
 	projectiles = 20
 	projectile_energy_cost = 50
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -223,6 +223,10 @@
 			for(var/obj/item/mecha_parts/mecha_equipment/weapon/honker in chassis.equipment)
 				honker.set_ready_state(0)
 
+/obj/item/projectile/bullet/mime/nonlethal
+	damage = 0 /// We deal no normal damage...
+	stamina = 40 /// ...Rather a large amount of stamina damage. Used in the mime mecha
+
 /obj/item/projectile/bullet/mime/fake
 	damage = 0
 	nodamage = TRUE


### PR DESCRIPTION
## What Does This PR Do
The Reticence's gun once again deals stamina damage rather than brute damage
All other traits are untouched
40 brute -> 40 stamina 
## Why It's Good For The Game
The silly little mime mech shouldn't be murdering people left and right, especially if the pilot doesn't know that the silly little mime mech is very, very lethal.
The whole gimmick of it draining the charge of the honk mech is kind of null if it just kills them.
I've been told this is also unintended, and that fox didn't mean for this to deal brute. Makes sense as it turns a fun item that a mime can use into something that isn't going to ever end well for them.
You can still easily kill people with this as a tot, it has combat mecha punches, but a nonantag mime isn't gonna get a nasty surprise. 

## Testing
skrell murder :>

## Changelog
:cl:
tweak: Mime mech's primary weapon now deals stamina damage again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
