### PR TITLE
Gives the Gamma Med ERT a toxins medkit

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -382,6 +382,7 @@
 
 	backpack_contents = list(
 		/obj/item/bodyanalyzer/advanced = 1,
+		/obj/item/storage/firstaid/toxin = 1,
 		/obj/item/storage/firstaid/doctor = 1,
 		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/extinguisher/mini = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Gives the Gamma Medical ERT a toxins medkit, as stated in the title. This is to bring it in-line with other ERTs, which have toxins treatment options (Red has a toxins medkit, Amber has a bottle of pills containing salicylic and charcoal). I'm open to changing this to a charcoal pillbottle if that's preferred.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Gamma ERT should be a step up from Red ERT. It should have the same or better options available. Presently, if Gamma Med wants to treat toxins damage on itself, it needs to use combat stims. I know it can use the medigun to heal other people but it really should have the option of using charcoal the good old fashioned way.
## Testing
<!-- How did you test the PR, if at all? -->
Spawned in, confirmed it loaded, confirmed Gamma Med had charcoal, wept tears of joy.
## Changelog
:cl:
tweak: Added a Toxins Medkit to Gamma ERT equipment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
