### PR TITLE
Bartender Traitor's can buy Assassination Shells

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -320,6 +320,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	job = list("Bartender")
 
+/datum/uplink_item/jobspecific/assassinationbullets
+	name = "Assasination Shotgun Shells"
+	desc = "A box containing 6 specialised shrapnel shells laced with a silencing toxin, useful for close range assassination."
+	reference = "ASS"
+	item = /obj/item/storage/box/syndie_kit/assassination
+	cost = 6
+	job = list("Bartender")
+
 //Barber
 
 /datum/uplink_item/jobspecific/safety_scissors //Hue

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -174,6 +174,13 @@
 	for(var/I in 1 to 6)
 		new /obj/item/ammo_casing/shotgun/fakebeanbag(src)
 
+/obj/item/storage/box/syndie_kit/assassination
+	name = "shotgun shells"
+
+/obj/item/storage/box/syndie_kit/assassination/populate_contents()
+	for(var/I in 1 to 6)
+		new /obj/item/ammo_casing/shotgun/assassination(src)
+
 /obj/item/storage/box/syndie_kit/emp
 	name = "boxed EMP kit"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the ability for traitor bartenders to buy assassination shells.
Price - 6TC
Comes with 6 shells in the box.

## Why It's Good For The Game
Bartender exclusive traitor weapons are pretty useless or incredibly niche at who they are effective too (im looking at you booze shells.) These rounds actually give bartenders some synergy with their starting items (The DB) and also provides more options to engaging targets without having to always buy a loud weapon from the uplink. Plus they just feel good to use that it makes sense.

## Testing
Booted server, bought shells, shot Punpun cause he deserved it

## Changelog 
:cl: Octus
tweak: Bartenders now have access to assassination shells in their uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
