### PR TITLE
Light tiles now require apcs to provide light power

### DIFF
--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -38,7 +38,7 @@
 	SIGNAL_HANDLER
 	if(power_check() || !on)
 		return
-	extinguish_light()
+	toggle_light(FALSE)
 
 /turf/simulated/floor/light/proc/power_check()
 	var/area/A = get_area(src)
@@ -94,8 +94,6 @@
 		visible_message("<span class='danger'>[src] doesn't react, it seems to be out of power.</span>")
 		return
 	var/area/A = get_area(src)
-	if(!A)
-		return
 	// 0 = OFF
 	// 1 = ON
 	on = light

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -42,8 +42,6 @@
 
 /turf/simulated/floor/light/proc/power_check()
 	var/area/A = get_area(src)
-	if(!A)
-		return FALSE
 	return A.powered(LIGHT)
 
 /turf/simulated/floor/light/attack_hand(mob/user)

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -1,16 +1,16 @@
 /turf/simulated/floor/light
 	name = "\improper light floor"
-	light_range = 5
-	icon_state = "light_on"
+	light_range = 0
+	icon_state = "light_off"
 	floor_tile = /obj/item/stack/tile/light
 	broken_states = list("light_off")
 	/// Are we on
-	var/on = TRUE
+	var/on = FALSE
 	/// Are we broken
 	var/light_broken = FALSE
 	/// Can we modify a colour
 	var/can_modify_colour = TRUE
-	/// Are we draining power, prevents updating the icon drain / generate power
+	/// Are we draining power
 	var/using_power = FALSE
 
 /turf/simulated/floor/light/Initialize(mapload)
@@ -20,24 +20,15 @@
 	var/obj/machinery/power/apc/current_apc = current_area.get_apc()
 	if(current_apc)
 		RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(power_update), override = TRUE)
+	toggle_light(TRUE)
 
 /turf/simulated/floor/light/update_icon_state()
-	var/area/A = get_area(src)
-	if(!A)
-		return
 	if(on)
 		icon_state = "light_on"
 		set_light(5, null, color)
-		if(!using_power)
-			A.addStaticPower(100, STATIC_LIGHT)
-			using_power = TRUE
 	else
 		icon_state = "light_off"
 		set_light(0)
-		if(using_power)
-			A.addStaticPower(-100, STATIC_LIGHT)
-			using_power = FALSE
-
 
 /turf/simulated/floor/light/BeforeChange()
 	toggle_light(FALSE)
@@ -102,10 +93,20 @@
 	if(!on && !power_check())
 		visible_message("<span class='danger'>[src] doesn't react, it seems to be out of power.</span>")
 		return
+	var/area/A = get_area(src)
+	if(!A)
+		return
 	// 0 = OFF
 	// 1 = ON
 	on = light
+	if(!on && using_power)
+		A.addStaticPower(-100, STATIC_LIGHT)
+		using_power = FALSE
+	if(on && !using_power)
+		using_power = TRUE
+		A.addStaticPower(100, STATIC_LIGHT)
 	update_icon()
+
 
 /turf/simulated/floor/light/extinguish_light()
 	toggle_light(FALSE)

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -14,6 +14,7 @@
 /turf/simulated/floor/light/Initialize(mapload)
 	. = ..()
 	update_icon()
+	START_PROCESSING(SSobj, src)
 
 /turf/simulated/floor/light/update_icon_state()
 	if(on)
@@ -25,7 +26,19 @@
 
 /turf/simulated/floor/light/BeforeChange()
 	set_light(0)
+	STOP_PROCESSING(SSobj, src)
 	..()
+
+/turf/simulated/floor/light/process()
+	if(power_check() || !on)
+		return
+	extinguish_light()
+
+/turf/simulated/floor/light/proc/power_check()
+	var/area/A = get_area(src)
+	if(!A)
+		return FALSE
+	return A.powered(LIGHT)
 
 /turf/simulated/floor/light/attack_hand(mob/user)
 	if(!can_modify_colour)
@@ -71,6 +84,9 @@
 		to_chat(user, "<span class='warning'>[src]'s light bulb appears to have burned out.</span>")
 
 /turf/simulated/floor/light/proc/toggle_light(light)
+	if(!on && !power_check())
+		visible_message("<span class='danger'>[src] doesn't react, it seems to be out of power.</span>")
+		return
 	// 0 = OFF
 	// 1 = ON
 	on = light


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Light tiles turn off without apcs having lighting power enable, and can not be turned on without power.
Uses 100 W per tile. A lightbulb with light range of 4 uses 80 w, and this has a range of 5.
Light tiles must be manually turned on if turned off by power outage, do not self turn on, can be changed.

They also use the extinguish message when turned off via power as it is spookier.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Light tiles producing light in maints without requiring area power is not great for upcoming shadow demons. Or placed in space. Shadow demons can not tentacle the tiles either, meaning they can not deal with them.

This PR means that while still very effective vs shadow demons, they still require the apc to be powered. If the APC is depowered or destroyed, the demon will have much more freedom once again.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed tiles worked.
Confirmed tiles turned off with no power
Confirmed tiles would not turn on with no power.
Confirmed message would not output each cycle.

## Changelog
:cl:
tweak: Light tiles now require apcs to provide light power in order to work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
