### PR TITLE
Fixes the jungle shuttle causing issues

### DIFF
--- a/_maps/map_files/shuttles/emergency_jungle.dmm
+++ b/_maps/map_files/shuttles/emergency_jungle.dmm
@@ -356,6 +356,7 @@
 /obj/docking_port/mobile/emergency{
 	dwidth = 11;
 	height = 18;
+	timid = 1;
 	width = 29
 	},
 /turf/simulated/floor/grass,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sets timid to 1 on the jungle shuttle docking

## Why It's Good For The Game
Not breaking the game is very cool!
Shuttles should be shuttles, and shouldn't break species/tgui/huds

We really, /really/, should have this written down somewhere more obvious
## Testing
Compiled and ran

## Changelog
NPFC - Should fix admins accidentally breaking the game with it for real now
