### PR TITLE
Nerfs the WT-550's size.

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -116,6 +116,7 @@
 	desc = "An outdated personal defense weapon utilized by law enforcement. The WT-550 Automatic Rifle fires 4.6x30mm rounds."
 	icon_state = "wt550"
 	item_state = "wt550"
+	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_sound = 'sound/weapons/gunshots/gunshot_rifle.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
@@ -127,6 +128,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 25
 	knife_y_offset = 12
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/projectile/automatic/wt550/update_icon_state()
 	icon_state = "wt550[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""]"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -128,7 +128,6 @@
 	can_bayonet = TRUE
 	knife_x_offset = 25
 	knife_y_offset = 12
-	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/projectile/automatic/wt550/update_icon_state()
 	icon_state = "wt550[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The WT-550 now cannot fit into normal backpacks as it has been made bulky. ~~It also needs two hands to fire.~~

## Why It's Good For The Game
This weapon is nuts. You can carry multiple in your backpack, ~~dual wield them for double fire output at **40 SHOTS** before needing to reload~~, and can carry multiple mags for quick reloading. Its a very common thing for security or antags to carry more than one WT because they have no limits on storage due to being normal sized. This change's goal is to make ballistics have some cons compared to lasers and also try to balance the gun, as its genuinely superior to lazers in most situations which I feel is a case of pretty bad powercreep.

## Testing
booted server, checked size and tried to fire with two wt's. testing passed

## Changelog
:cl: OctusGit
tweak: The WT is now bulky
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
