### PR TITLE
Fixes a runtime when using a mindslave implant

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_traitor.dm
+++ b/code/game/objects/items/weapons/implants/implant_traitor.dm
@@ -11,7 +11,7 @@
 
 /obj/item/implant/traitor/implant(mob/living/carbon/human/mindslave_target, mob/living/carbon/human/user)
 	// Check `activated` here so you can't just keep taking it out and putting it back into other people.
-	if(!..() || activated || !istype(mindslave_target) || !istype(user)) // Both the target and the user need to be human.
+	if(activated || !istype(mindslave_target) || !istype(user)) // Both the target and the user need to be human.
 		return FALSE
 
 	// If the target is catatonic or doesn't have a mind, return.
@@ -24,7 +24,6 @@
 		mindslave_target.visible_message(
 			"<span class='warning'>[mindslave_target] seems to resist the bio-chip!</span>", \
 			"<span class='warning'>You feel a strange sensation in your head that quickly dissipates.</span>")
-		removed(mindslave_target)
 		qdel(src)
 		return FALSE
 
@@ -32,7 +31,6 @@
 	if(mindslave_target == user)
 		to_chat(user, "<span class='notice'>Making yourself loyal to yourself was a great idea! Perhaps even the best idea ever! Actually, you just feel like an idiot.</span>")
 		user.adjustBrainLoss(20)
-		removed(mindslave_target)
 		qdel(src)
 		return FALSE
 
@@ -40,7 +38,7 @@
 	mindslave_target.mind.add_antag_datum(new /datum/antagonist/mindslave(user.mind))
 	mindslave_UID = mindslave_target.mind.UID()
 	log_admin("[key_name_admin(user)] has mind-slaved [key_name_admin(mindslave_target)].")
-	return TRUE
+	return ..()
 
 /obj/item/implant/traitor/removed(mob/target)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime that happens when mindslave implanting a non-viable target, such as ones with mindshield a implant. 

Issue is that since the parent call of `implant()` happened so soon, `removed()` needed to be called, but that resulted in the runtime below, due to `mindslave_UID` not being set yet. However the parent call does not need to happen immediately so I've moved it to the end of the proc.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fixes:
```
[2022-11-28T03:28:45] Runtime in implant_traitor.dm,48: Cannot execute null.remove antag datum().
   proc name: removed (/obj/item/implant/traitor/removed)
   usr: Lorde Buttersworth (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (121,131,2) (/turf/simulated/floor/wood)
   src: Mindslave Bio-chip (/obj/item/implant/traitor)
   src.loc: null
   call stack:
   Mindslave Bio-chip (/obj/item/implant/traitor): removed(Ishmael \'Ish\' Martinez (/mob/living/carbon/human))
   Mindslave Bio-chip (/obj/item/implant/traitor): implant(Ishmael \'Ish\' Martinez (/mob/living/carbon/human), Lorde Buttersworth (/mob/living/carbon/human))
   the bio-chip implanter (Mindsl... (/obj/item/implanter/traitor): attack(Ishmael \'Ish\' Martinez (/mob/living/carbon/human), Lorde Buttersworth (/mob/living/carbon/human))
   Ishmael \'Ish\' Martinez (/mob/living/carbon/human): attackby(the bio-chip implanter (Mindsl... (/obj/item/implanter/traitor), Lorde Buttersworth (/mob/living/carbon/human), "icon-x=19;icon-y=17;vis-x=16;v...")
   Ishmael \'Ish\' Martinez (/mob/living/carbon/human): attackby(the bio-chip implanter (Mindsl... (/obj/item/implanter/traitor), Lorde Buttersworth (/mob/living/carbon/human), "icon-x=19;icon-y=17;vis-x=16;v...")
   the bio-chip implanter (Mindsl... (/obj/item/implanter/traitor): melee attack chain(Lorde Buttersworth (/mob/living/carbon/human), Ishmael \'Ish\' Martinez (/mob/living/carbon/human), "icon-x=19;icon-y=17;vis-x=16;v...")
   Lorde Buttersworth (/mob/living/carbon/human): ClickOn(Ishmael \'Ish\' Martinez (/mob/living/carbon/human), "icon-x=19;icon-y=17;vis-x=16;v...")
   Ishmael \'Ish\' Martinez (/mob/living/carbon/human): Click(the floor (121,130,2) (/turf/simulated/floor/wood), "mapwindow.map", "icon-x=19;icon-y=17;vis-x=16;v...")
```
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes a runtime that happens when mindslave implanting a non-viable target, such as ones with mindshield a implant. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
