### PR TITLE
Avoid double bursting for blob mice

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -175,8 +175,9 @@
 	return ..()
 
 /mob/living/simple_animal/mouse/blobinfected/death(gibbed)
-	burst(gibbed)
-	return ..(gibbed)
+	. = ..(gibbed)
+	if(.) // Avoids a double burst due to the gib call in burst
+		burst(gibbed)
 
 /mob/living/simple_animal/mouse/blobinfected/proc/burst(gibbed)
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## What Does This PR Do
Fixes a case where blob mice would burst twice

## Why It's Good For The Game
Fixes a nasty bug

## Testing
Spawned 3 blob mice. Killed one by suicide, another by calling `gib` and the last one by calling `death`.

## Changelog
:cl:
fix: Blob mice now don't burst twice in certain cases
/:cl: