### PR TITLE
Vetus balance tweaks, also with a grav anomaly tweak

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -105,8 +105,10 @@
 	. = ..()
 	if(natural_spawn) //So an anomaly in the hallway is assured to have some risk to it, but not make sm / vetus too much pain
 		for(var/I in 1 to 3)
-			if(prob(75)) new /obj/item/stack/rods(loc)
-			if(prob(75)) new /obj/item/shard(loc)
+			if(prob(75)) 
+				new /obj/item/stack/rods(loc)
+			if(prob(75))
+				new /obj/item/shard(loc)
 
 /obj/effect/anomaly/grav/anomalyEffect()
 	..()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -98,7 +98,15 @@
 	icon_state = "shield2"
 	density = FALSE
 	var/boing = FALSE
+	var/knockdown = FALSE
 	aSignal = /obj/item/assembly/signaler/anomaly/grav
+
+/obj/effect/anomaly/grav/Initialize(mapload, new_lifespan, _drops_core = TRUE, natural_spawn = TRUE)
+	. = ..()
+	if(natural_spawn) //So an anomaly in the hallway is assured to have some risk to it, but not make sm / vetus too much pain
+		for(var/I in 1 to 3)
+			if(prob(75)) new /obj/item/stack/rods(loc)
+			if(prob(75)) new /obj/item/shard(loc)
 
 /obj/effect/anomaly/grav/anomalyEffect()
 	..()
@@ -112,7 +120,7 @@
 		if(!M.mob_negates_gravity())
 			step_towards(M,src)
 	for(var/obj/O in range(0, src))
-		if(!O.anchored && O.loc != src) // so it cannot throw the anomaly core
+		if(!O.anchored && O.loc != src && O.move_resist < MOVE_FORCE_OVERPOWERING) // so it cannot throw the anomaly core or super big things
 			var/mob/living/target = locate() in view(4, src)
 			if(target && !target.stat)
 				O.throw_at(target, 5, 10, dodgeable = FALSE)
@@ -129,7 +137,10 @@
 
 /obj/effect/anomaly/grav/proc/gravShock(mob/living/A)
 	if(boing && isliving(A) && !A.stat)
-		A.Weaken(4 SECONDS)
+		if(!knockdown)
+			A.Weaken(4 SECONDS)
+		else
+			A.KnockDown(4 SECONDS) //You know, maybe hard stuns in a megafauna fight are a bad idea.
 		var/atom/target = get_edge_target_turf(A, get_dir(src, get_step_away(A, src)))
 		A.throw_at(target, 5, 1)
 		boing = FALSE
@@ -147,6 +158,7 @@
 	var/zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE
 	var/zap_range = 5
 	var/power = 5000
+	var/knockdown = FALSE
 
 /obj/effect/anomaly/flux/Initialize(mapload, new_lifespan, drops_core = TRUE, _explosive = TRUE)
 	. = ..()
@@ -175,7 +187,10 @@
 	if(canshock && istype(M))
 		canshock = FALSE //Just so you don't instakill yourself if you slam into the anomaly five times in a second.
 		M.electrocute_act(shockdamage, name, flags = SHOCK_NOGLOVES)
-		M.Weaken(explosive ? 6 SECONDS : 3 SECONDS) //Back to being deadly if you touch it, rather than just being able to crawl out of it. Non explosive ones less deadly, since you can't loot them / vetus
+		if(!knockdown)
+			M.Weaken(explosive ? 6 SECONDS : 3 SECONDS) //Back to being deadly if you touch it, rather than just being able to crawl out of it. Non explosive ones less deadly, since you can't loot them
+		else
+			M.KnockDown(3 SECONDS)
 
 /obj/effect/anomaly/flux/detonate()
 	if(explosive)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -103,12 +103,13 @@
 
 /obj/effect/anomaly/grav/Initialize(mapload, new_lifespan, _drops_core = TRUE, event_spawned = TRUE)
 	. = ..()
-	if(natural_spawn) //So an anomaly in the hallway is assured to have some risk to it, but not make sm / vetus too much pain
-		for(var/I in 1 to 3)
-			if(prob(75)) 
-				new /obj/item/stack/rods(loc)
-			if(prob(75))
-				new /obj/item/shard(loc)
+	if(!event_spawned) //So an anomaly in the hallway is assured to have some risk to it, but not make sm / vetus too much pain
+		return
+	for(var/I in 1 to 3)
+		if(prob(75))
+			new /obj/item/stack/rods(loc)
+		if(prob(75))
+			new /obj/item/shard(loc)
 
 /obj/effect/anomaly/grav/anomalyEffect()
 	..()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -101,7 +101,7 @@
 	var/knockdown = FALSE
 	aSignal = /obj/item/assembly/signaler/anomaly/grav
 
-/obj/effect/anomaly/grav/Initialize(mapload, new_lifespan, _drops_core = TRUE, natural_spawn = TRUE)
+/obj/effect/anomaly/grav/Initialize(mapload, new_lifespan, _drops_core = TRUE, event_spawned = TRUE)
 	. = ..()
 	if(natural_spawn) //So an anomaly in the hallway is assured to have some risk to it, but not make sm / vetus too much pain
 		for(var/I in 1 to 3)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -363,13 +363,15 @@ Difficulty: Hard
 				var/obj/effect/anomaly/bluespace/A = new(spot, 150, FALSE)
 				A.mass_teleporting = FALSE
 			if(GRAV)
-				new /obj/effect/anomaly/grav(spot, 150, FALSE)
+				var/obj/effect/anomaly/grav/A = new(spot, 150, FALSE, FALSE)
+				A.knockdown = TRUE
 			if(PYRO)
 				var/obj/effect/anomaly/pyro/A = new(spot, 150, FALSE)
 				A.produces_slime = FALSE
 			if(FLUX)
 				var/obj/effect/anomaly/flux/A = new(spot, 150, FALSE)
 				A.explosive = FALSE
+				A.knockdown = TRUE
 			if(VORTEX)
 				new /obj/effect/anomaly/bhole(spot, 150, FALSE)
 		anomalies++
@@ -516,6 +518,9 @@ Difficulty: Hard
 	beam.forceMove(get_turf(src))
 	return ..()
 
+/mob/living/simple_animal/hostile/megafauna/ancient_robot/mob_negates_gravity() //No more being thrown around like a spastic child by grav anomalies
+	return TRUE
+
 /mob/living/simple_animal/hostile/ancient_robot_leg
 	name = "leg"
 	desc = "Legs with a mounted turret, for shooting and crushing small miners like you."
@@ -526,6 +531,7 @@ Difficulty: Hard
 	faction = list("mining", "boss") // No attacking your leg
 	weather_immunities = list("lava","ash")
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	minbodytemp = 0
 	flying = TRUE
 	check_friendly_fire = 1
 	ranged = TRUE
@@ -548,9 +554,9 @@ Difficulty: Hard
 	stat_attack = DEAD
 	var/range = 3
 	var/mob/living/simple_animal/hostile/megafauna/ancient_robot/core = null
-	var/fake_max_hp = 400
-	var/fake_hp = 400
-	var/fake_hp_regen = 10
+	var/fake_max_hp = 300
+	var/fake_hp = 300
+	var/fake_hp_regen = 2
 	var/transfer_rate = 0.75
 	var/who_am_i = null
 	var/datum/beam/leg_part
@@ -608,7 +614,7 @@ Difficulty: Hard
 	if(regen)
 		fake_hp = min(fake_hp + fake_hp_regen, fake_max_hp)
 	transfer_rate = 0.75 * (fake_hp/fake_max_hp)
-	if(fake_hp >= 300 && !ranged)
+	if(fake_hp >= 25 && !ranged)
 		ranged = TRUE
 		visible_message("<span class='danger'>[src]'s turret pops out of it!</span>")
 	if(get_dist(get_turf(core),get_turf(src)) <= range)
@@ -664,6 +670,9 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/ancient_robot_leg/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	playsound(src, 'sound/effects/meteorimpact.ogg', 60, TRUE, 2, TRUE) //turned way down from bubblegum levels due to 4 legs
+
+/mob/living/simple_animal/hostile/ancient_robot_leg/mob_negates_gravity()
+	return TRUE
 
 /obj/item/projectile/ancient_robot_bullet
 	damage = 8

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -614,7 +614,7 @@ Difficulty: Hard
 	if(regen)
 		fake_hp = min(fake_hp + fake_hp_regen, fake_max_hp)
 	transfer_rate = 0.75 * (fake_hp/fake_max_hp)
-	if(fake_hp >= 25 && !ranged)
+	if(fake_hp >= 250 && !ranged)
 		ranged = TRUE
 		visible_message("<span class='danger'>[src]'s turret pops out of it!</span>")
 	if(get_dist(get_turf(core),get_turf(src)) <= range)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -886,7 +886,7 @@
 				var/obj/effect/anomaly/flux/A = new(L, 300, FALSE)
 				A.explosive = FALSE
 			if(GRAVITATIONAL_ANOMALY)
-				new /obj/effect/anomaly/grav(L, 250, FALSE)
+				new /obj/effect/anomaly/grav(L, 250, FALSE, FALSE)
 			if(PYRO_ANOMALY)
 				new /obj/effect/anomaly/pyro(L, 200, FALSE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Vetus spawned grav and flux anomalies now knockdown, instead of hard stun. 
Vetus no longer dies slowly in space, legs were taking cold damage.
Vetus no longer gets thrown around by grav anomalies, messing up it's charge greatly.
Vetus legs are a bit easier to disable turrets on.
Grav anomalies if spawned via event (or by admins), can spawn with up to 3 shards of glass / rods, so even if it spawns in a hallwy, it is a threat. Vetus and SM uneffected.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

With the benefit of hindsight, *maybe* hard stuns in a megafauna boss fight suck to play against.
Grav anomalies were extra special with vetus, making it's charge very silly, so this makes it immune to the pull and throw of it. You and the ore on the ground however, are still not.
Bluespace still works, as it already is mass teleporting, and is much less of a threat.
Vetus' legs took a bit much damage to disable turrets on, and came back too fast. Now they will stay down for most if not all of the fight, but repair over time still if left alone.
Since I was touching other anomalies, and grav, I made grav anomaly a bit more dangerous if it spawns with nothing to throw around, as it now has a good chance to have some materials spawn with it to throw around.
And finaly, a robot dying to space is bad.

## Testing
<!-- How did you test the PR, if at all? -->
Ensured vetus spawned anomalies did not stun.
Ensured sm / vetus grav anomalies did not spawn with glass and rods.
Ensured grav anomalies spawned with glass and rods otherwise.
Ensured vetus didn't get moved by grav anomalies.
Ensured vetus no longer dies in space.

## Changelog
:cl:
tweak: Vetus' anomalies can no longer hard stun, and grav no longer throws vetus around.
tweak: Vetus' turrets are easier to destroy.
tweak: Grav anomalies spawned by events spawn with some glass shards and rods.
fix: Vetus no longer dies in space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
