### PR TITLE
Cryocell Fixes

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -161,13 +161,13 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/process()
 	..()
-	if(!occupant)
+	if(!on || !occupant)
 		return
 
 	if(auto_eject_prefs & AUTO_EJECT_DEAD && occupant.stat == DEAD)
 		auto_eject(AUTO_EJECT_DEAD)
 		return
-	if(auto_eject_prefs & AUTO_EJECT_HEALTHY && !occupant.has_organic_damage() && !occupant.has_mutated_organs())
+	if(auto_eject_prefs & AUTO_EJECT_HEALTHY && !(occupant.has_organic_damage() || occupant.has_mutated_organs()))
 		auto_eject(AUTO_EJECT_HEALTHY)
 		return
 
@@ -389,7 +389,7 @@
 				running_bob_animation = FALSE
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/process_occupant()
-	if(!occupant && air_contents.total_moles() < 10)
+	if(air_contents.total_moles() < 10)
 		return
 
 	if(occupant.stat == DEAD || !(occupant.has_organic_damage() || occupant.has_mutated_organs())) // Why waste energy on dead or healthy people

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -435,9 +435,6 @@
 
 	occupant = null
 	update_icon(UPDATE_OVERLAYS)
-	// eject trash the occupant dropped
-	for(var/atom/movable/A in contents - component_parts - list(beaker))
-		A.forceMove(get_step(loc, SOUTH))
 
 /obj/machinery/atmospherics/unary/cryo_cell/force_eject_occupant(mob/target)
 	go_out()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -427,9 +427,12 @@
 /obj/machinery/atmospherics/unary/cryo_cell/proc/go_out()
 	if(!occupant)
 		return
-	occupant.forceMove(get_step(loc, SOUTH))	//this doesn't account for walls or anything, but i don't forsee that being a problem.
-	if(occupant.bodytemperature < 261 && occupant.bodytemperature >= 70) //Patch by Aranclanos to stop people from taking burn damage after being ejected
-		occupant.bodytemperature = 261
+
+	occupant.forceMove(get_step(loc, SOUTH)) // Doesn't account for walls
+
+	if(occupant.bodytemperature < occupant.dna.species.cold_level_1) // Hacky fix for people taking burn damage after being ejected
+		occupant.bodytemperature = occupant.dna.species.cold_level_1
+
 	occupant = null
 	update_icon(UPDATE_OVERLAYS)
 	// eject trash the occupant dropped

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -16,14 +16,14 @@
 	max_integrity = 350
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 30, ACID = 30)
 	var/temperature_archived
+	var/current_heat_capacity = 50
+
 	var/mob/living/carbon/occupant = null
-	var/obj/item/reagent_containers/glass/beaker = null
 	/// Holds two bitflags, AUTO_EJECT_DEAD and AUTO_EJECT_HEALTHY. Used to determine if the cryo cell will auto-eject dead and/or completely healthy patients.
 	var/auto_eject_prefs = AUTO_EJECT_HEALTHY | AUTO_EJECT_DEAD
-
+	var/obj/item/reagent_containers/glass/beaker = null
 	var/last_injection
 	var/injection_cooldown = 34 SECONDS
-	var/current_heat_capacity = 50
 	var/efficiency
 
 	var/running_bob_animation = FALSE // This is used to prevent threads from building up if update_icons is called multiple times
@@ -404,11 +404,8 @@
 		var/stun_time = (max(5 / efficiency, (1 / occupant.bodytemperature) * 2000 / efficiency)) STATUS_EFFECT_CONSTANT
 		occupant.Sleeping(stun_time)
 
-		if(air_contents.oxygen > 2)
-			if(occupant.getOxyLoss())
-				occupant.adjustOxyLoss(-6)
-		else
-			occupant.adjustOxyLoss(-1.2)
+		var/heal_mod = air_contents.oxygen < 2 ? 0.2 : 1
+		occupant.adjustOxyLoss(-6 * heal_mod)
 
 	if(beaker && world.time >= last_injection + injection_cooldown)
 		// Take 1u from the beaker mix, react and inject 10x the amount

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -392,7 +392,7 @@
 	if(!occupant && air_contents.total_moles() < 10)
 		return
 
-	if(occupant.stat == DEAD || (occupant.health >= 100 && !occupant.has_mutated_organs()))  //Why waste energy on dead or healthy people
+	if(occupant.stat == DEAD || !(occupant.has_organic_damage() || occupant.has_mutated_organs())) // Why waste energy on dead or healthy people
 		occupant.bodytemperature = T0C
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -403,7 +403,6 @@
 	if(occupant.bodytemperature < T0C)
 		var/stun_time = (max(5 / efficiency, (1 / occupant.bodytemperature) * 2000 / efficiency)) STATUS_EFFECT_CONSTANT
 		occupant.Sleeping(stun_time)
-		occupant.Paralyse(stun_time)
 
 		if(air_contents.oxygen > 2)
 			if(occupant.getOxyLoss())

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -170,12 +170,12 @@ I use this to standardize shadowling dethrall code
 	return O.parent_organ
 
 /mob/living/carbon/human/has_organic_damage()
-	var/odmg = 0
-	for(var/obj/item/organ/external/O in bodyparts)
-		if(O.is_robotic())
-			odmg += O.brute_dam
-			odmg += O.burn_dam
-	return (health < (100 - odmg))
+	var/robo_damage = 0
+	for(var/obj/item/organ/external/E in bodyparts)
+		if(E.is_robotic())
+			robo_damage += E.brute_dam
+			robo_damage += E.burn_dam
+	return health < maxHealth - robo_damage
 
 /mob/living/carbon/human/proc/handle_splints() //proc that rebuilds the list of splints on this person, for ease of processing
 	splinted_limbs.Cut()

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -120,24 +120,28 @@
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
+
 	var/external_temp
 	if(istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 		var/obj/machinery/atmospherics/unary/cryo_cell/C = M.loc
-		external_temp = C.temperature_archived
+		external_temp = C.air_contents.temperature
 	else
 		var/turf/T = get_turf(M)
 		external_temp = T.temperature
+
 	if(external_temp < TCRYO)
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)
 		update_flags |= M.adjustBruteLoss(-12, FALSE)
 		update_flags |= M.adjustFireLoss(-12, FALSE)
+
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/head/head = H.get_organ("head")
 			if(head)
 				head.status &= ~ORGAN_DISFIGURED
+
 	return ..() | update_flags
 
 /datum/reagent/medicine/rezadone


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes cryocells:
1. being fully functional when not actually turned on*
2. using a weird looping cycle counter instead of a proper cooldown for beaker injections**
3. improperly stopping burn damage when some cold-sensitive races exit the cryocell
4. not using a mob's `maxHealth`, instead always assuming max health of 100
  \- also happens to fix the same issue for Medbots
5. not ignoring robotic limb damage like most other medical equipment (trapping the occupant until released by someone)
6. applying two very similar knockout status effects for no reason
7. giving Cryoxadone outdated cryocell temperature in some cases

\* - Now, the only thing they do while powered off is cool down the occupant, without knocking them out. To have the cryocell passively heal respiratory damage or inject chemicals, you need to turn it on. Making them not cool down the occupant would require a bigger refactor since cryocells are technically atmos objects, and can't easily be stopped from affecting people inside them. Making them still knock you out would be a bit hacky, and raises the question of "why the fuck is falling unconscious when severely cold not a generic behavior instead of only happening in cryocells".
\*\* - Previously, the cryocells used a counter looping between 0 and 17, incrementing each time it processed as long as there's an occupant, doing an injection if the counter is at 0. This counter would never reset, so you could have a situation where you slap a patient into the cryocell at counter = 1, and have to wait half a minute before the cryocell would actually treat the patient, making them weirdly unresponsive. Now they simply check if "current time >= last injection time + cooldown", which properly passes even when no occupant is inside.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs are bad, making important departmental machines more responsive is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Got a monkey, augmented one of its arms to be robotic
- Punched the monke to dent the robotic limb, and to slightly injure another bodypart
- Stuffed the monkey into the cryocell, noticed it doesn't do anything besides lowering the monkey's body temperature (1.)
- Turned the cryocell on, noticed the cryocell inject beaker chemicals and begin treatment as well as putting the monkey to sleep
- Noticed the cryocell properly eject the monkey couple seconds later, once the minor organic damage was treated (5., 4.)
- Waited a few minutes
- Punched one of the monkey's organic limbs again, stuffed it into the cryocell, turned it on
- Noticed the cryocell inject the monkey and begin treatment immediately instead of up to half a minute later (2.)
​
- Stuffed a Unathi into the cryocell
- Waited until its body temperature reaches <280K, ejected
- Noticed the Unathi did not suffer any burn damage (3.)

6. is not a noticeable fix, as both of the Sleeping and Paralysis status effects were applied with the same duration.
7. is fixed twice over, as it mainly manifested when using the cryocell without turning it on (its archived temperature, which Cryoxadone used, only updates while cryocell is turned on). Cryoxadone now uses up-to-date cryocell temperature, and beaker injections only happen while the cryocell is on.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Cryocells now must actually be turned on to function
fix: Cryocell injection cooldown now always counts down, instead of pausing when there's no occupant
tweak: Cryocells now ignore damaged robotic limbs
fix: Cryocells no longer cause minor burn damage to cold-sensitive species on exit
fix: Fixed cryocells never ejecting monkeys even with "Auto-eject healthy" setting on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
