### PR TITLE
Fix escape with identity objectives not syncing to their linked assassinate objectives after the target cryos

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -824,3 +824,7 @@
 // /obj/machinery/door/airlock signals
 #define COMSIG_AIRLOCK_OPEN "airlock_open"
 #define COMSIG_AIRLOCK_CLOSE "airlock_close"
+
+// /datum/objective signals
+///from datum/objective/proc/find_target()
+#define COMSIG_OBJECTIVE_TARGET_FOUND "objective_target_found"

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -151,11 +151,8 @@
 		var/mob/living/carbon/human/H = kill_objective.target?.current
 
 		if(!(locate(/datum/objective/escape) in owner.get_all_objectives()) && H && !HAS_TRAIT(H, TRAIT_GENELESS))
-			var/datum/objective/escape/escape_with_identity/identity_theft = new
+			var/datum/objective/escape/escape_with_identity/identity_theft = new(assassinate = kill_objective)
 			identity_theft.owner = owner
-			identity_theft.target = kill_objective.target
-			identity_theft.target_real_name = kill_objective.target.current.real_name
-			identity_theft.explanation_text = "Escape on the shuttle or an escape pod with the identity of [identity_theft.target_real_name], the [identity_theft.target.assigned_role] while wearing [identity_theft.target.p_their()] identification card."
 			objectives += identity_theft
 
 	if(!(locate(/datum/objective/escape) in owner.get_all_objectives()))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If a changeling has an assassinate and escape with identity objective, the target cryos, and a new one is found, the assassinate objective is updated, but the escape with identity objective still registers as having the old target. 

Now the escape with identity target will know when it's linked assassinate objective finds a new target and update its own accordingly.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The escape with identity objective and it's linked assassinate objective should not have a mismatched target after their previous target goes to cryo. Less work on admins having to re-sync targets.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded up a few different accounts and used a changeling with an assassinate and escape with identity objective, and had the target go to cryo.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fix steal identity objectives not syncing to their linked assassinate objectives after the target cryos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
