### PR TITLE
White soap bars are now createable via chemistry

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -240,10 +240,7 @@
 /datum/chemical_reaction/soapification/gib
 	name = "Gib Soapification"
 	id = "gib_soapification"
-	result = null
 	required_reagents = list("liquidgibs" = 10, "lye"  = 10) // requires two scooped gib tiles
-	min_temp = T0C + 100
-	result_amount = 1
 
 /datum/chemical_reaction/soapification/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Creates a new chemical recipe, 10 units of lye and 10 units of corn oil heated to 373K will create a standard white soap bar at the reaction site.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's always important to keep labs squeaky clean. This will make soap more mass produce-able, but miners could already buy them for 200 points. This also requires cooperation from botany to actually get the corn oil.

## Testing
<!-- How did you test the PR, if at all? -->
I made some soap with my new recipe, and make gibsoap to make sure I didn't accidentally break that in the process.
## Changelog
:cl:
add: 10 units each of lye and corn oil will now make a bar of soap when heated to 373K.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
