### PR TITLE
Adds var back which fixes double mouseblob bursting

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -164,6 +164,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	gold_core_spawnable = NO_SPAWN
+	var/bursted = FALSE
 
 /mob/living/simple_animal/mouse/blobinfected/Initialize(mapload)
 	. = ..()
@@ -176,10 +177,13 @@
 
 /mob/living/simple_animal/mouse/blobinfected/death(gibbed)
 	. = ..(gibbed)
-	if(.) // Avoids a double burst due to the gib call in burst
+	if(.) // Only burst if they actually died
 		burst(gibbed)
 
 /mob/living/simple_animal/mouse/blobinfected/proc/burst(gibbed)
+	if(bursted)
+		return // Avoids double bursting in some situations
+	bursted = TRUE
 	var/turf/T = get_turf(src)
 	if(!is_station_level(T.z) || isspaceturf(T))
 		to_chat(src, "<span class='userdanger'>You feel ready to burst, but this isn't an appropriate place!  You must return to the station!</span>")


### PR DESCRIPTION
## What Does This PR Do
Brings back the old `bursted` var that I removed (on accident). Dying doesn't set the `stat` var instantly. This is why you can get multiple `death` calls in this case due to the `gib` call in the `burst` proc.

## Why It's Good For The Game
Fixes a bug

## Testing
Let the timer run out on a mouse blob

## Changelog
:cl:
fix: Actually fixes mouse blobs from bursting twice
/:cl: