### PR TITLE
Adds the missing pda server key to the rd office in delta and meta

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -71559,6 +71559,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/stamp/rd,
+/obj/item/paper/monitorkey,
 /turf/simulated/floor/plasteel/white,
 /area/crew_quarters/hor)
 "dmd" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -43450,6 +43450,7 @@
 	pixel_y = 10
 	},
 /obj/item/stamp/rd,
+/obj/item/paper/monitorkey,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes #19815
Adds the missing pda server monitor key note to the RD office for both delta and meta.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The RD is supposed to have access to this.
The key being missing likely was an oversight.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

**DELTA:**
![Screenshot (96)](https://user-images.githubusercontent.com/113341203/205057874-c74ab06c-82da-4756-8d11-879b047c1a40.png)

**META:**
![Screenshot (95)](https://user-images.githubusercontent.com/113341203/205057854-241ef30d-313f-4676-a119-bffd5869ecde.png)

## Testing
<!-- How did you test the PR, if at all? -->

Check if the key is indeed missing.
It is.
Add it to both delta and meta RD office.
Check both maps if its there.
Now it is! (see images)

## Changelog
:cl:
fix: Fixed the lack of pda server keys in the RD office on delta and meta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
