### PR TITLE
Prevents BOH storing backpacks / belts of holding, increased rnd level req

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -59,7 +59,7 @@
 	max_combined_w_class = 35
 	resistance_flags = FIRE_PROOF
 	flags_2 = NO_MAT_REDEMPTION_2
-	cant_hold = list(/obj/item/storage/backpack/holding)
+	cant_hold = list(/obj/item/storage/backpack, /obj/item/storage/belt/bluespace)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 60, ACID = 50)
 
 /obj/item/storage/backpack/holding/attackby(obj/item/W, mob/user, params)

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -15,7 +15,7 @@
 	name = "Bag of Holding"
 	desc = "A backpack that opens into a localized pocket of Blue Space."
 	id = "bag_holding"
-	req_tech = list("bluespace" = 7, "materials" = 5, "engineering" = 5, "plasmatech" = 6)
+	req_tech = list("bluespace" = 7, "materials" = 5, "engineering" = 7, "plasmatech" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 3000, MAT_DIAMOND = 1500, MAT_URANIUM = 250, MAT_BLUESPACE = 2000)
 	build_path = /obj/item/storage/backpack/holding
@@ -25,7 +25,7 @@
 	name = "Belt of Holding"
 	desc = "An astonishingly complex belt popularized by a rich blue-space technology magnate."
 	id = "bluespace_belt"
-	req_tech = list("bluespace" = 7, "materials" = 5, "engineering" = 5, "plasmatech" = 6)
+	req_tech = list("bluespace" = 7, "materials" = 5, "engineering" = 6, "plasmatech" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 1500, MAT_DIAMOND = 3000, MAT_URANIUM = 1000)
 	build_path = /obj/item/storage/belt/bluespace


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

BOH can no longer hold belts of holding, or any backpack type, preventing insane storage of items.
Engineering level for boh to 7, 2 prototypes / 1 proto 1 jetpack.
Belt increased to 6, since it is smaller / simpler.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

BOH is strong. This is fine. However, there are situations where one can do stupid things to make it unbalanced. So this pr addresses the main concern of storage, by being able to store backpacks, which are full of items, in the boh, or belts of holding.
Also makes them harder to unlock in rnd, requiring engi 7 for boh and 6 for belt of holding.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed BOH could not hold backpacks, and belts of holding. 
Confirmed BOH could still interact with another boh

## Changelog
:cl:
tweak: Bag of holding can no longer hold backpacks or belts of holding.
tweak: Bag of holding and belts of holding rnd level requirement increased.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
