### PR TITLE
Adds special reinforced catwalk

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -91,6 +91,14 @@
 		C.deconstruct()
 	..()
 
+/obj/structure/lattice/catwalk/mining
+	name = "reinforced catwalk"
+	desc = "A heavily reinforced catwalk used to build bridges in hostile environments. It doesn't look like anything could make this budge."
+	resistance_flags = INDESTRUCTIBLE
+
+/obj/structure/lattice/catwalk/mining/deconstruction_hints(mob/user)
+	return
+
 /obj/structure/lattice/catwalk/clockwork
 	name = "clockwork catwalk"
 	icon = 'icons/obj/smooth_structures/catwalk_clockwork.dmi'

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -202,7 +202,7 @@
 // Removes all signs of lattice on the pos of the turf -Donkieyo
 /turf/proc/RemoveLattice()
 	var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-	if(L)
+	if(L && !(L.resistance_flags & INDESTRUCTIBLE))
 		qdel(L)
 
 /turf/proc/dismantle_wall(devastated = FALSE, explode = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds special reinforced catwalk for use in the mining outpost, this catwalk cannot be destroyed by wire cutters. 
Tweaks lattice removal on turf change to exclude invulnerable lattice, as currently mapped in lattice is destroyed on mapload.
(Regular catwalk is due to changes in https://github.com/ParadiseSS13/Paradise/pull/12345) 
This catwalk is not constructable by players. It is not the same as TG's heatproof support lattice.

(Ironically I added this the same way as TG did, without even realising they had the same thing)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Allows us to place catwalks on lavaland in the map editor
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://user-images.githubusercontent.com/12197162/205159137-f82d7215-8e34-4a89-ad63-a61c91e5256e.png)
(previously this just deleted the catwalk that was here and it was regular volcanic floor)
<!-- How did you test the PR, if at all? -->

## No player facing changes, these are not user-accessible and not currently mapped in. But will be added in https://github.com/ParadiseSS13/Paradise/pull/19769

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
