### PR TITLE
Borgs can no longer be locked / blown at round end

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -156,6 +156,9 @@
 	if(!is_authenticated(usr))
 		to_chat(usr, "<span class='warning'>Access denied.</span>")
 		return
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		to_chat(usr, "<span class='warning'>Access denied, borgs are no longer your stations property.</span>")
+		return
 	switch(action)
 		if("arm") // Arms the emergency self-destruct system
 			if(issilicon(usr))

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -157,7 +157,7 @@
 		to_chat(usr, "<span class='warning'>Access denied.</span>")
 		return
 	if(SSticker.current_state == GAME_STATE_FINISHED)
-		to_chat(usr, "<span class='warning'>Access denied, borgs are no longer your stations property.</span>")
+		to_chat(usr, "<span class='warning'>Access denied, borgs are no longer your station's property.</span>")
 		return
 	switch(action)
 		if("arm") // Arms the emergency self-destruct system


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

If the round is over, the borg console no longer responds to commands, preventing all borgs being blown at round end because RD / AI / Captain felt like it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

People should (mostly) enjoy round end, all of one job being blown to a brain sucks just because someone felt like it. (also looking at you monkey all button.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed button did not work after round ended

## Changelog
:cl:
tweak: You can no longer blow up all borgs when shuttle docks at cc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
