### PR TITLE
Unequip gib victims earlier in the process.

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -61,7 +61,7 @@
 		else
 			destructed_items += I
 
-	QDEL_LIST(destructed_items)
+	QDEL_LIST_CONTENTS(destructed_items)
 
 	imp_in.gib()
 

--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -46,24 +46,22 @@
 	// self-destruct
 	var/current_location = get_turf(imp_in)
 
-	var/destructed_items = list()
+	var/list/destructed_items = list()
 
 	// Iterate over the implantee's contents and take out indestructible
 	// things to avoid having to worry about containers and recursion
 	for(var/obj/item/I in imp_in.get_contents())
-		if(I)
-			if(I == src) // Don't delete ourselves prematurely
-				continue
-			// Drop indestructible items on the ground first, to avoid them
-			// getting deleted when destroying the rest of the items, which we
-			// track in a list to qdel afterwards
-			if(I.resistance_flags & INDESTRUCTIBLE)
-				I.forceMove(current_location)
-			else
-				destructed_items += I
+		if(I == src) // Don't delete ourselves prematurely
+			continue
+		// Drop indestructible items on the ground first, to avoid them
+		// getting deleted when destroying the rest of the items, which we
+		// track in a list to qdel afterwards
+		if(I.resistance_flags & INDESTRUCTIBLE)
+			I.forceMove(current_location)
+		else
+			destructed_items += I
 
-	for(var/I in destructed_items)
-		qdel(I)
+	QDEL_LIST(destructed_items)
 
 	imp_in.gib()
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -14,12 +14,12 @@
 			var/atom/movable/thing = I.remove(src)
 			if(thing)
 				thing.forceMove(get_turf(src))
-				thing.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
+				thing.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1, 3), 5)
 
 	for(var/obj/item/I in get_equipped_items(include_pockets = TRUE))
 		unEquip(I)
 		I.forceMove(get_turf(src))
-		I.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
+		I.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1, 3), 5)
 
 	for(var/obj/item/organ/external/E in bodyparts)
 		if(istype(E, /obj/item/organ/external/chest))

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -16,6 +16,11 @@
 				thing.forceMove(get_turf(src))
 				thing.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 
+	for(var/obj/item/I in get_equipped_items(include_pockets = TRUE))
+		unEquip(I)
+		I.forceMove(get_turf(src))
+		I.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
+
 	for(var/obj/item/organ/external/E in bodyparts)
 		if(istype(E, /obj/item/organ/external/chest))
 			continue

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,7 +17,7 @@
 				thing.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1, 3), 5)
 
 	for(var/obj/item/I in get_equipped_items(include_pockets = TRUE))
-		unEquip(I)
+		unEquip(I, TRUE)
 		I.forceMove(get_turf(src))
 		I.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1, 3), 5)
 


### PR DESCRIPTION
Re-upload of #19626 which GitHub can't tell is open or closed.

## What Does This PR Do
This PR unequips human types on gib, tossing their equipment around randomly in the same way that their organs are. This adds to the list of equipment that may possibly survive an explosion, and ensures indestructible items are not wiped out of reality on gib.

This has several consequences and, depending on how you look at it, balance implications.

## Why It's Good For The Game

1. When a human type is gibbed, their internal and external organs are removed, and 'thrown' about in the area of the gib. This process does not consider certain things. The primary issue here is that objects, even indestructible ones, are simply deleted on gib when the human entity itself is deleted. Their damage resistance is completely ignored. This is a problem.

2. Typically, removing a limb will pop off any relevant worn clothing. Lose a foot, your shoes are removed. These items remain after a gib, but are not affected in the same way that organs are. Organs are tossed about in a random direction anywhere from 1 to 3 tiles away. The clothing simply remains on the same tile, like the person was just raptured. Now, these items will be 
tossed about. It's not a huge thing, but it "feels" better.

The current behavior for nukie bomb implants, where all of their equipment is deleted as a consequence of their gibbing, has been instead moved to the implants themselves, which check for non-destructible items and deletes them before the gib.

There are probably a handful of other places where balance here should be considered. I mentioned some of these in Discord but they may jog someone's memory to consider something I hadn't. I don't know enough about balance/design to think through if these are good things.

- Before this PR, Ei-nath would prevent the wizard from taking the victim's ID. This would no longer be the case.

- PDAs and IDs are in slots that gets them deleted on gib. Now, if characters gib, their IDs, if they don't get caught up in a subsequent explosion, are up for grabs. Or the CE's toolbelt. Or other similar items. Basically, the loot table for explosions strong enough to cause gibbing has been buffed.

## Testing

Some sample CE explosions showing what might remain on a given gib/explosion blast-radius combination.

![17_26_55__Paradise Station 13-](https://user-images.githubusercontent.com/59303604/200198580-7172b0f1-f8e8-4970-83d8-3a91b1c563d9.png)


## Changelog
:cl:
fix: Gibbed players are unequipped entirely. This increases the chances that their items survive larger explosions, but does not guarantee it. Nukie bomb implants will continue to destroy their (non-destructible) equipment.
fix: Indestructible items will no longer be destroyed when in a container worn by a gibbed person, and will properly be affected by explosions.
/:cl: