### PR TITLE
Plasma cutter only delimbs in low pressure

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -210,6 +210,13 @@
 	sharp = TRUE
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 
+/obj/item/projectile/plasma/prehit(atom/target)
+	. = ..()
+	if(!lavaland_equipment_pressure_check(get_turf(target)))
+		name = "weakened [name]"
+		dismemberment = 0
+		sharp = FALSE
+
 /obj/item/projectile/plasma/on_hit(atom/target)
 	. = ..()
 	if(ismineralturf(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Plasma cutters and advanced plasma cutters will no longer delimb when in a pressurized area, but when they are in low pressure such as lavaland or space they will still be able to delimb
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Plasma cutters are a great mining tool and a nice reference to the dead space series with their ability to cut off limbs like, unfortunately this means people could use them to delimb and even decapitate people extremely quickly, a single 357 shot followed up with a plasma cutter shot will most of the time instantly delimb. Seeing as it is mainly intended for lavaland by making it only work in low pressures like lavaland we get to keep the neat reference without harming the balance. It also means it can be used in space to decapitate otherwise nearly impossible to catch changelings.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Booted up private server
Spawned skrell, plasma cutter, and advanced plasma cutter
Shot skrell once with pulse to make it easy to decapitate
Fired at it with plasma cutter and advanced plasma cutter, it did not decapitate it
Took skrell into space and shot them with plasma cutter and advanced plasma cutter, it did decapitate it
Checked chat logs to make sure projectiles were correctly labelled as weakened where appropriate, they were.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Plasma cutters and advanced plasma cutters can now only delimb in low pressure.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
