### PR TITLE
[Fix] Vendor access - Undo my change, and set scan_id to TRUE by default

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -100,7 +100,7 @@
 	var/shoot_chance = 2
 
 	/// If true, enforce access checks on customers. Disabled by messing with wires.
-	var/scan_id
+	var/scan_id = TRUE
 	/// Holder for a coin inserted into the vendor
 	var/obj/item/coin/coin
 	var/datum/wires/vending/wires
@@ -648,12 +648,6 @@
 		return
 
 	vend_ready = FALSE // From this point onwards, vendor is locked to performing this transaction only, until it is resolved.
-
-	if(!allowed(user))
-		to_chat(user, "<span class='warning'>Access denied. Unable to process transaction.</span>")
-		flick(icon_deny, src)
-		vend_ready = TRUE
-		return
 
 	if(!ishuman(user) || R.price <= 0)
 		// Either the purchaser is not human, or the item is free.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sets vendors to have `scan_id` set to TRUE by default, and undoes the change I added to the `try_vend` proc as there was already an access check... It's just that the wire wasn't set up properly and was working backwards for things other than smartfridges.

Making all vendors check for IDs doesn't break anything as `0` access vendors still work from other checks.

## Why It's Good For The Game
Fixes #19853

## Testing
Spawned as a non-med, tried to buy something from the medbay. Pulsed the `scan_id` wire and tried again with success.

## Changelog
:cl:
fix: Fix vendor access checks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
