### PR TITLE
Fixes hacking the vendor ID scan wire

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -100,7 +100,7 @@
 	var/shoot_chance = 2
 
 	/// If true, enforce access checks on customers. Disabled by messing with wires.
-	var/scan_id
+	var/scan_id = TRUE
 	/// Holder for a coin inserted into the vendor
 	var/obj/item/coin/coin
 	var/datum/wires/vending/wires
@@ -649,7 +649,7 @@
 
 	vend_ready = FALSE // From this point onwards, vendor is locked to performing this transaction only, until it is resolved.
 
-	if(!allowed(user))
+	if(!allowed(user) && scan_id)
 		to_chat(user, "<span class='warning'>Access denied. Unable to process transaction.</span>")
 		flick(icon_deny, src)
 		vend_ready = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the ID scan wire on vendors so that hacking it now actually removes access requirements from a vendor.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The ID scan wire was previously broken, this returns it to its original functionality.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Go up to a vendor with required access
Take item from vendor
Remove ID
Fail to take item from vendor
Hack ID scan wire
Take item from vendor
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix:  Hacking the ID scan wire on vendors now actually disables access requirements on vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
