### PR TITLE
Anchorable Large Decor Statues

### DIFF
--- a/code/game/objects/items/decorations.dm
+++ b/code/game/objects/items/decorations.dm
@@ -214,13 +214,17 @@
 //Decorative structures
 ///////
 
-
 /obj/structure/decorative_structures
 	icon = 'icons/obj/decorations.dmi'
 	icon_state = ""
 	density = TRUE
 	anchored = FALSE
 	max_integrity = 100
+
+/obj/structure/decorative_structures/attackby(obj/item/W, mob/living/user, params)
+	add_fingerprint(user)
+	if(default_unfasten_wrench(user, W))
+		return
 
 /obj/structure/decorative_structures/metal
 	flags = CONDUCT

--- a/code/game/objects/items/decorations.dm
+++ b/code/game/objects/items/decorations.dm
@@ -221,10 +221,12 @@
 	anchored = FALSE
 	max_integrity = 100
 
-/obj/structure/decorative_structures/attackby(obj/item/W, mob/living/user, params)
+/obj/structure/decorative_structures/wrench_act(mob/user, obj/item/I)
+	. = TRUE
 	add_fingerprint(user)
-	if(default_unfasten_wrench(user, W))
+	if(!I.tool_use_check(user, 0))
 		return
+	default_unfasten_wrench(user, I, 0)
 
 /obj/structure/decorative_structures/metal
 	flags = CONDUCT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes #19843

Makes the craftable large decoration statues such as the metal angel statue anchorable in place.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A very minor QoL feature that prevents other players from pushing around your display pieces.

## Testing
<!-- How did you test the PR, if at all? -->

Spawn in statues.
Pull them around.
Wrench em in place.
Can't pull them around anymore.
Unwrench em.
Pull them around some more.

## Changelog
:cl:
tweak: Tweaked the large decor statues so that they can be anchored in place with a wrench
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
