### PR TITLE
Fixes some issues with Deathsquad spawning

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -577,7 +577,7 @@ GLOBAL_VAR(bomb_set)
 		log_game("[src] (unrestricted) has been deleted in ([diskturf ? "[diskturf.x], [diskturf.y] ,[diskturf.z]":"nonexistent location"]). It will not respawn.")
 		GLOB.poi_list.Remove(src)
 		STOP_PROCESSING(SSobj, src)
-		return..()
+		return ..()
 
 	if(length(GLOB.nukedisc_respawn))
 		GLOB.poi_list.Remove(src)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -526,16 +526,24 @@ GLOBAL_VAR(bomb_set)
 	max_integrity = 250
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 30, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	/// Is the disk restricted to the station? If true, also respawns the disk when deleted
+	var/restricted_to_station = TRUE
 
 /obj/item/disk/nuclear/unrestricted
+	name = "unrestricted nuclear authentication disk"
 	desc = "Seems to have been stripped of its safeties, you better not lose it."
+	restricted_to_station = FALSE
 
 /obj/item/disk/nuclear/New()
 	..()
-	START_PROCESSING(SSobj, src)
+	if(restricted_to_station)
+		START_PROCESSING(SSobj, src)
 	GLOB.poi_list |= src
 
 /obj/item/disk/nuclear/process()
+	if(!restricted_to_station)
+		stack_trace("An unrestricted NAD ([src]) was processing.")
+		return PROCESS_KILL
 	if(!check_disk_loc())
 		var/holder = get(src, /mob)
 		if(holder)
@@ -544,6 +552,8 @@ GLOBAL_VAR(bomb_set)
 
  //station disk is allowed on the station level, escape shuttle/pods, CC, and syndicate shuttles/base, reset otherwise
 /obj/item/disk/nuclear/proc/check_disk_loc()
+	if(!restricted_to_station)
+		return TRUE
 	var/turf/T = get_turf(src)
 	var/area/A = get_area(src)
 	if(is_station_level(T.z))
@@ -551,9 +561,6 @@ GLOBAL_VAR(bomb_set)
 	if(A.nad_allowed)
 		return TRUE
 	return FALSE
-
-/obj/item/disk/nuclear/unrestricted/check_disk_loc()
-	return TRUE
 
 /obj/item/disk/nuclear/Destroy(force)
 	var/turf/diskturf = get_turf(src)
@@ -564,6 +571,13 @@ GLOBAL_VAR(bomb_set)
 		GLOB.poi_list.Remove(src)
 		STOP_PROCESSING(SSobj, src)
 		return ..()
+
+	if(!restricted_to_station) // Non-restricted NADs should be allowed to be deleted, otherwise it becomes a restricted NAD when teleported
+		message_admins("[src] (unrestricted) has been deleted in ([diskturf ? "[diskturf.x], [diskturf.y] ,[diskturf.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[diskturf.x];Y=[diskturf.y];Z=[diskturf.z]'>JMP</a>":"nonexistent location"]). It will not respawn.")
+		log_game("[src] (unrestricted) has been deleted in ([diskturf ? "[diskturf.x], [diskturf.y] ,[diskturf.z]":"nonexistent location"]). It will not respawn.")
+		GLOB.poi_list.Remove(src)
+		STOP_PROCESSING(SSobj, src)
+		return..()
 
 	if(length(GLOB.nukedisc_respawn))
 		GLOB.poi_list.Remove(src)

--- a/code/modules/admin/verbs/deathsquad.dm
+++ b/code/modules/admin/verbs/deathsquad.dm
@@ -1,7 +1,5 @@
 //Deathsquad
 
-#define MAX_COMMANDOS 14
-
 GLOBAL_VAR_INIT(deathsquad_sent, FALSE)
 
 /client/proc/send_deathsquad()
@@ -28,12 +26,19 @@ GLOBAL_VAR_INIT(deathsquad_sent, FALSE)
 			log_admin("[key_name(proccaller)] cancelled their Deathsquad.")
 			return
 
-	var/commando_number = input(src, "How many Deathsquad Commandos would you like to send? (Recommended is 6, Max is [MAX_COMMANDOS])", "Specify Commandos") as num|null
+	// Locates commandos spawns
+	var/list/commando_spawn_locations = list()
+	for(var/obj/effect/landmark/spawner/ds/L in GLOB.landmarks_list) //Despite obj/effect/landmark/spawner/ds being in the exact same location and doing the exact same thing as obj/effect/landmark/spawner/ert, switching them breaks it?
+		commando_spawn_locations += L
+
+	var/max_commandos = length(commando_spawn_locations)
+
+	var/commando_number = input(src, "How many Deathsquad Commandos would you like to send? (Recommended is 6, Max is [max_commandos])", "Specify Commandos") as num|null
 	if(!commando_number)
 		message_admins("[key_name_admin(proccaller)] cancelled their Deathsquad.")
 		log_admin("[key_name(proccaller)] cancelled their Deathsquad.")
 		return
-	commando_number = clamp(commando_number, 1, MAX_COMMANDOS)
+	commando_number = clamp(commando_number, 1, max_commandos)
 
 	var/is_leader = TRUE
 	if(GLOB.deathsquad_sent)
@@ -69,11 +74,7 @@ GLOBAL_VAR_INIT(deathsquad_sent, FALSE)
 		to_chat(src, "<span class='userdanger'>Nobody volunteered to join the DeathSquad.</span>")
 		return
 
-	// Spawns commandos and equips them.
-	var/list/commando_spawn_locations = list()
-	for(var/obj/effect/landmark/spawner/ds/L in GLOB.landmarks_list) //Despite obj/effect/landmark/spawner/ds being in the exact same location and doing the exact same thing as obj/effect/landmark/spawner/ert, switching them breaks it?
-		commando_spawn_locations += L
-
+	// Equips the Deathsquad
 	for(var/mob/ghost_mob in commando_ghosts)
 		if(!ghost_mob || !ghost_mob.key || !ghost_mob.client)
 			continue

--- a/code/modules/admin/verbs/deathsquad.dm
+++ b/code/modules/admin/verbs/deathsquad.dm
@@ -57,10 +57,10 @@ GLOBAL_VAR_INIT(deathsquad_sent, FALSE)
 	var/list/commando_ghosts = list()
 	if(alert("Would you like to custom pick your Deathsquad?",, "Yes", "No") == "Yes")
 		var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_deathsquad")
-		commando_ghosts = pollCandidatesWithVeto(src, usr, commando_number, "Join the DeathSquad?",, 21, 60 , TRUE, GLOB.role_playtime_requirements[ROLE_DEATHSQUAD], TRUE, FALSE, source = source)
+		commando_ghosts = pollCandidatesWithVeto(src, usr, commando_number, "Join the DeathSquad?",, 21, 60 SECONDS, TRUE, GLOB.role_playtime_requirements[ROLE_DEATHSQUAD], TRUE, FALSE, source = source)
 	else
 		var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_deathsquad")
-		commando_ghosts = SSghost_spawns.poll_candidates("Join the Deathsquad?",, GLOB.responseteam_age, 60 , TRUE, GLOB.role_playtime_requirements[ROLE_DEATHSQUAD], TRUE, FALSE, source = source)
+		commando_ghosts = SSghost_spawns.poll_candidates("Join the Deathsquad?",, GLOB.responseteam_age, 60 SECONDS, TRUE, GLOB.role_playtime_requirements[ROLE_DEATHSQUAD], TRUE, FALSE, source = source)
 		if(length(commando_ghosts) > commando_number)
 			commando_ghosts.Cut(commando_number + 1) //cuts the ghost candidates down to the amount requested
 	if(!length(commando_ghosts))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Deathsquad will now spawn properly, with the first one chosen actually being the NAD carrier. Players will now actually get to choose organic or cyborg deathsquad (I broke that too...). Unrestricted NADs have been refactored so admins can delete them without the NAD respawning as a normal NAD. 

Unrestricted NADs will now be deleted instead of transforming into a normal NAD. Better not lose it...

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #19866

## Testing
<!-- How did you test the PR, if at all? -->
Spawned deathsquad with 2 accounts, the NAD holder will now always be the first chosen, and other players can now choose to play cyborgs. Unrestricted NADs will now be deleted instead

## Changelog
Nothing player facing, only admin facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
