### PR TITLE
Tape gags take longer to resist out of

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -7,7 +7,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.90
 	put_on_delay = 2 SECONDS 
-	var/resist_time = 0 SECONDS // How long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
+	/// How long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
+	var/resist_time = 0 SECONDS
 	var/mute = MUZZLE_MUTE_ALL
 	var/security_lock = FALSE // Requires brig access to remove 0 - Remove as normal
 	var/locked = FALSE //Indicates if a mask is locked, should always start as 0.

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -6,8 +6,7 @@
 	flags_cover = MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.90
-	put_on_delay = 2 SECONDS
-/// How long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
+	put_on_delay = 2 SECONDS // How long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
 	var/resist_time = 0 SECONDS
 	var/mute = MUZZLE_MUTE_ALL
 	var/security_lock = FALSE // Requires brig access to remove 0 - Remove as normal

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -6,8 +6,8 @@
 	flags_cover = MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.90
-	put_on_delay = 2 SECONDS // How long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
-	var/resist_time = 0 SECONDS
+	put_on_delay = 2 SECONDS 
+	var/resist_time = 0 SECONDS // How long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
 	var/mute = MUZZLE_MUTE_ALL
 	var/security_lock = FALSE // Requires brig access to remove 0 - Remove as normal
 	var/locked = FALSE //Indicates if a mask is locked, should always start as 0.

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -7,7 +7,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.90
 	put_on_delay = 2 SECONDS
-	var/resist_time = 0 SECONDS //seconds of how long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
+/// How long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
+	var/resist_time = 0 SECONDS
 	var/mute = MUZZLE_MUTE_ALL
 	var/security_lock = FALSE // Requires brig access to remove 0 - Remove as normal
 	var/locked = FALSE //Indicates if a mask is locked, should always start as 0.

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -6,8 +6,8 @@
 	flags_cover = MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.90
-	put_on_delay = 20
-	var/resist_time = 0 //deciseconds of how long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
+	put_on_delay = 2 SECONDS
+	var/resist_time = 0 SECONDS //seconds of how long you need to gnaw to get rid of the gag, 0 to make it impossible to remove
 	var/mute = MUZZLE_MUTE_ALL
 	var/security_lock = FALSE // Requires brig access to remove 0 - Remove as normal
 	var/locked = FALSE //Indicates if a mask is locked, should always start as 0.
@@ -86,7 +86,7 @@
 	icon_state = "tapegag"
 	item_state = null
 	w_class = WEIGHT_CLASS_TINY
-	resist_time = 150
+	resist_time = 30 SECONDS
 	mute = MUZZLE_MUTE_MUFFLE
 	flags = DROPDEL
 
@@ -112,7 +112,7 @@
 	desc = "A muzzle designed to prevent biting."
 	icon_state = "muzzle_secure"
 	item_state = "muzzle_secure"
-	resist_time = 0
+	resist_time = 0 SECONDS
 	mute = MUZZLE_MUTE_NONE
 	security_lock = TRUE
 	locked = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the time it takes to resist out of a tape gag from 15 to 30 seconds
Also refactors all masks to use seconds instead of deciseconds for resist time.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Having to move people every 10 seconds whilst feeding on them as a vampire is extremely tedious, and actively hinders roleplay. Now vampires can try making the situation a little more interesting by making small talk to their victim instead of having to constantly worry about scream spam. 

Also helps other antagonists and security get some peace and quiet, if they desire it. 

Note that this only helps people who take the time and planning effort acquire tape. Other kidnapping victims can continue to scream away.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Performed and timed various types of self bondage.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Tape gags now take longer to resist out of
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
