### PR TITLE
Re-enables shuttle gibbing

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -602,7 +602,6 @@
 					A.unlock()
 
 /obj/docking_port/mobile/proc/roadkill(list/L0, list/L1, dir)
-	var/list/hurt_mobs = list()
 	for(var/i in 1 to L0.len)
 		var/turf/T0 = L0[i]
 		var/turf/T1 = L1[i]
@@ -621,17 +620,11 @@
 				if(isliving(AM))
 					var/mob/living/L = AM
 					L.stop_pulling()
-					if(L.anchored)
-						L.gib()
-					else
-						if(!(L in hurt_mobs))
-							hurt_mobs |= L
-							L.visible_message("<span class='warning'>[L] is hit by \
-									a hyperspace ripple[L.anchored ? "":" and is thrown clear"]!</span>",
+					L.visible_message("<span class='warning'>[L] is hit by \
+									a hyperspace ripple!</span>",
 									"<span class='userdanger'>You feel an immense \
 									crushing pressure as the space around you ripples.</span>")
-							L.Paralyse(20 SECONDS)
-							L.ex_act(2)
+					L.gib()
 
 			// Move unanchored atoms
 			if(!AM.anchored)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Turns shuttle gibbing on to deal with those pesky clings in an emergency.

## Why It's Good For The Game
Alternative to https://github.com/ParadiseSS13/Paradise/pull/19878

Re-enables shuttle gibbing, if I remember correctly shuttle gibbing was disabled a very long time ago and was one of those changes that I just never agreed with. There are plenty of valid reasons why you'd need to gib someone and your only option is a shuttle as risky as it is to gib someone with a shuttle.

I think this is a better alternative than making the cremator indestructible.

Speaking from a more logical standpoint I think having a shuttle bluespace warp onto you is grounds for immediately exploding into a fine mist of blood.

## Images of changes

[Unknown 2022.12.08-07.45 1-1.webm](https://user-images.githubusercontent.com/92271472/206450645-9c450f97-d4f2-495d-bbc4-1fcd9e44606c.webm)

## Testing
See video

## Changelog
:cl: Bmon
tweak: Shuttles now gib mobs that stand under it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
