### PR TITLE
Resting offset fix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -41,7 +41,7 @@
 #define LYING_DOWN 1
 
 ///How much a mob's sprite should be moved when they're lying down
-#define PIXEL_Y_OFFSET_LYING -6
+#define PIXEL_Y_OFFSET_LYING -3
 
 #define LEFT 1
 #define RIGHT 2

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -41,7 +41,7 @@
 #define LYING_DOWN 1
 
 ///How much a mob's sprite should be moved when they're lying down
-#define PIXEL_Y_OFFSET_LYING -3
+#define PIXEL_Y_OFFSET_LYING -6
 
 #define LEFT 1
 #define RIGHT 2

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -12,8 +12,7 @@
 			final_pixel_y = pixel_y
 		else //if(lying != 0)
 			if(lying_prev == 0) //Standing to lying
-				pixel_y = pixel_y
-				final_pixel_y = pixel_y + PIXEL_Y_OFFSET_LYING
+				final_pixel_y = PIXEL_Y_OFFSET_LYING
 				if(dir & (EAST|WEST)) //Facing east or west
 					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
 	if(resize != RESIZE_DEFAULT_SIZE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes the code handling laying offset which was erroneously doubling itself from the base offset of -6 to -12. This is because TG uses a `base_pixel_y ` whereas on Paradise we don't and math just didn't work as it was.

The block of code in question on TG would normally have `pixel_y = base_pixel_y` and then add
`final_pixel_y(= pixel_y)  = base_pixel_y + PIXEL_Y_OFFSET_LYING(defined as -6)`  to add up to -6.

On Paradise this was `pixel_y = pixel_y` and then add `final_pixel_y(= pixel_y) = pixel_y + PIXEL_Y_OFFSET_LYING(defined as -6)` meaning it was duplicating itself and adding the same number twice leaving us with -12 where it should be -6.

This is my understanding of this bug, I kind of have a shakey knowledge of DM in the first place but everything seems to be working now.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It's a bug fix.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![rest](https://user-images.githubusercontent.com/92271472/206872547-ac11a19d-089d-4dd8-9de7-834d801a16ba.png)

![rest 2](https://user-images.githubusercontent.com/92271472/206872554-add06f0a-bbb4-4540-a38b-e58558450d3a.png)

## Testing
<!-- How did you test the PR, if at all? -->
In game
## Changelog
:cl: Bmon
fix: The resting offset has been fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
