### PR TITLE
Fixes a "problem" with smoothing

### DIFF
--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -23,7 +23,7 @@ DEFINE_BITFIELD(smoothing_flags, list(
 
 /*smoothing macros*/
 
-#define QUEUE_SMOOTH(thing_to_queue) if(thing_to_queue.smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK)) {SSicon_smooth.add_to_queue(thing_to_queue)}
+#define QUEUE_SMOOTH(thing_to_queue) if((thing_to_queue.smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK)) && thing_to_queue.z) {SSicon_smooth.add_to_queue(thing_to_queue)}
 
 #define QUEUE_SMOOTH_NEIGHBORS(thing_to_queue) for(var/neighbor in orange(1, thing_to_queue)) {var/atom/atom_neighbor = neighbor; QUEUE_SMOOTH(atom_neighbor)}
 

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -152,6 +152,8 @@ DEFINE_BITFIELD(smoothing_junction, list(
 //do not use, use QUEUE_SMOOTH(atom)
 /atom/proc/smooth_icon()
 	smoothing_flags &= ~SMOOTH_QUEUED
+	if(!z)
+		return
 	if(smoothing_flags & SMOOTH_CORNERS)
 		if(smoothing_flags & SMOOTH_DIAGONAL_CORNERS)
 			corners_diagonal_smooth(calculate_adjacencies())

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -152,9 +152,6 @@ DEFINE_BITFIELD(smoothing_junction, list(
 //do not use, use QUEUE_SMOOTH(atom)
 /atom/proc/smooth_icon()
 	smoothing_flags &= ~SMOOTH_QUEUED
-	if(!z) //nullspace are not sending their best
-		stack_trace("[type] called smooth_icon() without being on a z-level")
-		return
 	if(smoothing_flags & SMOOTH_CORNERS)
 		if(smoothing_flags & SMOOTH_DIAGONAL_CORNERS)
 			corners_diagonal_smooth(calculate_adjacencies())

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -180,6 +180,7 @@
 			qdel(AA)
 		alternate_appearances = null
 
+	REMOVE_FROM_SMOOTH_QUEUE(src)
 	QDEL_NULL(reagents)
 	invisibility = INVISIBILITY_MAXIMUM
 	LAZYCLEARLIST(overlays)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the constant debug messages we keep getting about things trying to smooth in nullspace.

```
[2022-12-10T21:43:47] Runtime in stacktrace.dm,14: /obj/structure/window/full/reinforced called smooth_icon() without being on a z-level
[2022-12-10T21:43:47]   proc name: stack trace (/datum/proc/stack_trace)
[2022-12-10T21:43:47]   src: the reinforced window (/obj/structure/window/full/reinforced)
[2022-12-10T21:43:47]   src.loc: null
[2022-12-10T21:43:47]   call stack:
[2022-12-10T21:43:47]   the reinforced window (/obj/structure/window/full/reinforced): stack trace("/obj/structure/window/full/rei...")
[2022-12-10T21:43:47]   the reinforced window (/obj/structure/window/full/reinforced): smooth icon()
[2022-12-10T21:43:47]   the reinforced window (/obj/structure/window/full/reinforced): smooth icon()
[2022-12-10T21:43:47]   Icon Smoothing (/datum/controller/subsystem/icon_smooth): fire(0)
[2022-12-10T21:43:47]   Icon Smoothing (/datum/controller/subsystem/icon_smooth): ignite(0)
[2022-12-10T21:43:47]   Master (/datum/controller/master): RunQueue()
[2022-12-10T21:43:47]   Master (/datum/controller/master): Loop()
[2022-12-10T21:43:47]   Master (/datum/controller/master): StartProcessing(0)
```

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Things keep trying to smooth in nullspace for some reason, since smoothing works on a queue we can't really know why this is happening without spending a lot of time debugging. A better solution is just to remove them from smooth queue on del, refuse to smooth when not on a Z, and only let things get added to the smooth queue when it has a Z level.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Blew things up
<!-- How did you test the PR, if at all? -->

## Changelog
No user facing changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
