### PR TITLE
Restores mapmerge CLI scripts

### DIFF
--- a/tools/mapmerge2/BackupMaps.bat
+++ b/tools/mapmerge2/BackupMaps.bat
@@ -1,0 +1,12 @@
+@echo off
+cd ../../_maps/
+
+for /R %%f in (*.dmm) do copy "%%f" "%%f.backup"
+
+cls
+echo All dmm files in _maps directories have been backed up
+echo Now you can make your changes...
+echo ---
+echo Remember to run mapmerge.bat just before you commit your changes!
+echo ---
+pause

--- a/tools/mapmerge2/RunMapmerge.bat
+++ b/tools/mapmerge2/RunMapmerge.bat
@@ -1,0 +1,5 @@
+@echo off
+set MAPROOT=../../_maps/
+set TGM=1
+python mapmerge.py
+pause

--- a/tools/mapmerge2/mapmerge.py
+++ b/tools/mapmerge2/mapmerge.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
 import shutil
 from collections import defaultdict
-from . import frontend
-from .dmm import *
+
+# Import hacks to make this work as a normal script again
+try:
+    from . import frontend
+except:
+    import frontend
+
+try:
+    from .dmm import *
+except:
+    from dmm import *
 
 def merge_map(new_map, old_map, delete_unused=False):
     if new_map.key_length != old_map.key_length:
@@ -88,7 +97,7 @@ def main(settings):
         shutil.copyfile(fname, fname + ".before")
         old_map = DMM.from_file(fname + ".backup")
         new_map = DMM.from_file(fname)
-        merge_map(new_map, old_map).to_file(fname, settings.tgm)
+        merge_map(new_map, old_map).to_file(fname, tgm=settings.tgm)
 
 if __name__ == '__main__':
     main(frontend.read_settings())


### PR DESCRIPTION
## What Does This PR Do
Restores the CLI scripts for mapmerge. Sometimes you need to run these independantly, and the precommit hook being a forced action you cant control ends up breaking things for no good reaosn.

## Why It's Good For The Game
I hate mapping.

## Testing
Made an edit, did a manual mapmerge, diff was as expected

## Changelog
N/A