### PR TITLE
Adds Engineering Storage to Special Operations

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -12151,9 +12151,6 @@
 /obj/machinery/economy/vending/engivend,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"Vq" = (
-/turf,
-/area/shuttle/gamma/space)
 "Vs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/badminbrew,
@@ -31025,7 +31022,7 @@ aN
 aN
 aN
 Db
-Vq
+DB
 HI
 Iq
 JN

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -181,6 +181,11 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
+"aH" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/permits,
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "aK" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -1846,6 +1851,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_sit)
+"hm" = (
+/obj/machinery/door_control/no_emag{
+	pixel_y = 24;
+	req_access_txt = "114";
+	name = "Engineering Storage Shutters";
+	id = "SpecopsEngineering"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/specops)
 "ho" = (
 /obj/item/radio{
 	pixel_x = 5;
@@ -2397,10 +2414,6 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/transport)
-"iW" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/transparent/glass,
-/area/centcom/specops)
 "iX" = (
 /obj/machinery/suit_storage_unit/syndicate/secure,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -4591,10 +4604,6 @@
 /turf/simulated/floor/plasteel,
 /area/tdome/arena)
 "pX" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Diplomatic Office";
-	req_access_txt = "114"
-	},
 /turf/simulated/floor/plasteel/dark/nitrogen,
 /area/centcom/specops)
 "pY" = (
@@ -4975,6 +4984,22 @@
 /obj/item/reagent_containers/food/snacks/grown/mushroom/amanita,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
+"rp" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "rr" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers,
@@ -5518,6 +5543,10 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
+"tq" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "ts" = (
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -7150,6 +7179,13 @@
 	icon_state = "darkyellow"
 	},
 /area/centcom/suppy)
+"Bm" = (
+/obj/machinery/door/poddoor/multi_tile/impassable/three_tile_hor{
+	id_tag = "SpecopsEngineering";
+	name = "Specops Engineering Storage"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "Bo" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -7509,10 +7545,26 @@
 	},
 /area/tdome/tdomeobserve)
 "CH" = (
-/obj/item/flashlight/lamp,
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/simulated/floor/carpet/black,
+/obj/item/stack/sheet/plasteel{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 50
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "CJ" = (
 /obj/machinery/door_control/no_emag{
@@ -7619,7 +7671,14 @@
 	id = "specopsoffice";
 	name = "Privacy Shutters";
 	pixel_x = 6;
-	pixel_y = -3;
+	pixel_y = 10;
+	req_access_txt = "114"
+	},
+/obj/machinery/door_control/no_emag{
+	pixel_x = -6;
+	pixel_y = -17;
+	name = "Engineering Storage";
+	id = "SpecopsEngineering";
 	req_access_txt = "114"
 	},
 /turf/simulated/floor/carpet,
@@ -8489,7 +8548,12 @@
 /turf/simulated/wall/indestructible/fakeglass/brass,
 /area/wizard_station)
 "GO" = (
-/obj/structure/closet/crate/can,
+/obj/machinery/door_control/no_emag{
+	pixel_y = -24;
+	req_access_txt = "114";
+	name = "Engineering Storage Shutters";
+	id = "SpecopsEngineering"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "GP" = (
@@ -8538,14 +8602,13 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "GV" = (
-/obj/structure/table/wood,
-/obj/item/dice/d20{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/dice/d10{
-	pixel_x = -3
-	},
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/cell/bluespace,
+/obj/item/stock_parts/cell/bluespace,
+/obj/item/stock_parts/cell/bluespace,
+/obj/item/stock_parts/cell/bluespace,
+/obj/item/stock_parts/cell/bluespace,
+/obj/item/stock_parts/cell/bluespace,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "GW" = (
@@ -9087,15 +9150,14 @@
 /turf/simulated/floor/plating,
 /area/centcom/specops)
 "Jg" = (
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/carpet/black,
+/obj/item/storage/belt/utility/chief/full,
+/obj/item/storage/belt/utility/chief/full,
+/obj/item/storage/belt/utility/chief/full,
+/obj/item/storage/belt/utility/chief/full,
+/obj/item/storage/belt/utility/chief/full,
+/obj/item/storage/belt/utility/chief/full,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Jh" = (
 /turf/simulated/wall/indestructible/riveted,
@@ -9324,15 +9386,6 @@
 /obj/item/gun/medbeam,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/gamma/space)
-"JS" = (
-/obj/machinery/door_control/no_emag{
-	id = "CCGAMMA";
-	name = "Gamma Lockdown";
-	pixel_y = 32;
-	req_access_txt = "114"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/specops)
 "JU" = (
 /obj/structure/holowindow{
 	dir = 1
@@ -9951,16 +10004,6 @@
 	icon_state = "vault"
 	},
 /area/tdome/tdomeadmin)
-"Mq" = (
-/obj/structure/chair/comfy/black,
-/turf/simulated/floor/transparent/glass,
-/area/centcom/specops)
-"Mr" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/centcom/specops)
 "Ms" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/stripes/end,
@@ -9968,16 +10011,6 @@
 	icon_state = "cafeteria"
 	},
 /area/tdome/tdomeobserve)
-"Mu" = (
-/obj/item/clipboard,
-/obj/structure/table/reinforced,
-/obj/item/detective_scanner,
-/obj/item/storage/box/ids{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/turf/simulated/floor/carpet/black,
-/area/centcom/specops)
 "Mv" = (
 /obj/machinery/recharge_station/upgraded,
 /turf/simulated/floor/plasteel{
@@ -9985,20 +10018,45 @@
 	icon_state = "vault"
 	},
 /area/centcom/specops)
-"Mw" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/centcom/specops)
 "My" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Special Ops.";
-	name = "Special Ops. Monitor";
-	network = list("ERT")
-	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/carpet/black,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd/combat,
+/obj/item/rcd/combat,
+/obj/item/rcd/combat,
+/obj/item/rcd/combat,
+/obj/item/rcd/combat,
+/obj/item/rcd/combat,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Mz" = (
 /obj/effect/turf_decal/stripes/line,
@@ -10149,6 +10207,22 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/evac)
+"Nb" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "Nc" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -10353,14 +10427,8 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
 "NU" = (
-/obj/structure/table/wood,
-/obj/item/storage/pill_bottle/dice,
-/obj/machinery/newscaster/security_unit{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -28
-	},
-/turf/simulated/floor/transparent/glass,
+/obj/machinery/power/port_gen/pacman/super/upgraded,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "NW" = (
 /obj/structure/sign/securearea{
@@ -10406,13 +10474,6 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass,
 /area/centcom/control)
-"Oj" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/item/flash,
-/turf/simulated/floor/carpet/black,
-/area/centcom/specops)
 "Ok" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -10491,6 +10552,22 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/simulated/floor/wood,
 /area/centcom/evac)
+"OA" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "OD" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on,
 /turf/simulated/floor/plasteel{
@@ -10814,10 +10891,14 @@
 /turf/simulated/floor/plating/airless,
 /area/centcom/control)
 "PM" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
+/obj/structure/closet/crate/engineering,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
 	},
-/turf/simulated/floor/transparent/glass,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 50
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "PO" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -11759,13 +11840,6 @@
 "TU" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/evac)
-"TV" = (
-/obj/item/flag/command,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/centcom/specops)
 "TW" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -12073,6 +12147,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/centcom/control)
+"Vo" = (
+/obj/machinery/economy/vending/engivend,
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
+"Vq" = (
+/turf,
+/area/shuttle/gamma/space)
 "Vs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/badminbrew,
@@ -12110,10 +12191,14 @@
 	},
 /area/tdome/tdomeobserve)
 "VC" = (
-/obj/machinery/computer/card/centcom{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
+/obj/structure/table/reinforced,
+/obj/item/rpd/bluespace,
+/obj/item/rpd/bluespace,
+/obj/item/rpd/bluespace,
+/obj/item/rpd/bluespace,
+/obj/item/rpd/bluespace,
+/obj/item/rpd/bluespace,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "VD" = (
 /obj/machinery/door/poddoor/multi_tile/impassable/two_tile_hor{
@@ -13128,18 +13213,6 @@
 /area/shuttle/escape)
 "Zr" = (
 /turf/simulated/wall/indestructible/riveted,
-/area/centcom/specops)
-"Zs" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Gamma Armory";
-	req_access_txt = "114"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "CCGAMMA";
-	name = "Gamma Security"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Zt" = (
 /obj/structure/closet/secure_closet/guncabinet,
@@ -30952,7 +31025,7 @@ aN
 aN
 aN
 Db
-DB
+Vq
 HI
 Iq
 JN
@@ -31983,7 +32056,7 @@ Db
 aN
 aN
 Zr
-Zs
+Zr
 Zr
 Zr
 Zr
@@ -32240,11 +32313,11 @@ aN
 aN
 aN
 Zr
-JS
-Mq
+NU
+NU
 NU
 PM
-NP
+tq
 Zr
 Ji
 Ra
@@ -32497,11 +32570,11 @@ aN
 aN
 aN
 Zr
+aH
 Ra
-Mq
-iW
-PM
-Ae
+Ra
+Ra
+tq
 Zr
 Ji
 Ra
@@ -32754,13 +32827,13 @@ aN
 aN
 aN
 Zr
-Yx
-Yx
-Yx
-Yx
-AV
-VI
-TV
+rp
+Ra
+Ra
+Ra
+Ra
+Bm
+Ji
 Ra
 Xz
 Yj
@@ -33011,10 +33084,10 @@ aN
 aN
 aN
 VI
-gY
-Mr
-Mr
-Yx
+Nb
+Ra
+Ra
+Ra
 Ra
 pX
 Ji
@@ -33269,12 +33342,12 @@ aN
 Db
 Zr
 CH
-Mu
-Oj
-Yx
-AV
-RD
-TV
+Ra
+Ra
+Ra
+Ra
+Ra
+Ji
 Ra
 Xz
 Yj
@@ -33525,13 +33598,13 @@ wK
 aN
 aN
 Zr
-Yw
-Mw
-Yw
-Yx
+Vo
+Ra
+Ra
+Ra
 GO
 Zr
-Ji
+hm
 Ra
 Xz
 RD
@@ -33785,7 +33858,7 @@ Zr
 VC
 My
 Jg
-Yx
+OA
 GV
 Zr
 Ji

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -7182,7 +7182,7 @@
 "Bm" = (
 /obj/machinery/door/poddoor/multi_tile/impassable/three_tile_hor{
 	id_tag = "SpecopsEngineering";
-	name = "Specops Engineering Storage"
+	name = "Special Operations Engineering Storage"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds Engineering Storage to the Special Operations area of Central Command, locked behind admin access blast doors.
Engineering Storage contains the following equipment:

- 12 stacks of metal
- 12 stacks of glass
- 6 stacks of plasteel
- 6 Combat RCDs, along with 30 spare cartridges
- 6 Bluespace rapid pipe dispensers
- 6 full advanced toolbelts
- 6 bluespace power cells
- 12 metal foam grenades
- 3 upgraded S.U.P.E.R.P.A.C.M.A.N.-type Portable Generators
- 60 uranium sheets to power them with
- 2 floodlights
- 1 Engi-Vend
- 1 box of construction permits

This replaces the Diplomatic Office, as it was practically never used, and a functionally identical Administrative Office is located 20 tiles to the south. It also cuts off one of the entrances to the Gamma armory, but that door was also never used, and an alternative entrance to the Gamma armory is available to the west.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Engineering ERTs can sometimes be a bit lackluster, and even gamma engineering ERT only gets a toolbelt and an RCD to fix the station with. If this area is opened by admins, an ERT can have access to all the tools needed to do practically any repairs or improvements to the station, without having to rely on cannibalizing the station to do it. This also makes building-focused admin teams much faster to set up, since they don't have to spawn everything manually anymore.

Note that an admin has to open this, so this has no effect on the round unless an admin deems it necessary.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/18598676/206922013-1e0f4520-b735-41a7-87b0-bc48d6daffca.png)
![image](https://user-images.githubusercontent.com/18598676/206922039-272d2e7c-1df5-4a13-b713-52f4bd34b0ef.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Made sure that the blast doors work and have correct ID access
Made sure the generators have the correct fuel
Made sure the foam grenades work
Tried to follow the mapping guidelines
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Added Special Operations Engineering Storage to Central Command
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
