### PR TITLE
Creates full stacks of all sheets and minerals

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -113,6 +113,9 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list (
 	point_value = 4
 	table_type = /obj/structure/table/glass/reinforced
 
+/obj/item/stack/sheet/rglass/fifty
+	amount = 50
+
 /obj/item/stack/sheet/rglass/New(loc, amount)
 	recipes = GLOB.reinforced_glass_recipes
 	..()

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -152,6 +152,9 @@ GLOBAL_LIST_INIT(pglass_recipes, list (
 	point_value = 19
 	table_type = /obj/structure/table/glass/plasma
 
+/obj/item/stack/sheet/plasmaglass/fifty
+	amount = 50
+
 /obj/item/stack/sheet/plasmaglass/New(loc, amount)
 	recipes = GLOB.pglass_recipes
 	..()
@@ -196,6 +199,9 @@ GLOBAL_LIST_INIT(prglass_recipes, list (
 	point_value = 23
 	table_type = /obj/structure/table/glass/reinforced/plasma
 
+/obj/item/stack/sheet/plasmarglass/fifty
+	amount = 50
+
 /obj/item/stack/sheet/plasmarglass/New(loc, amount)
 	recipes = GLOB.prglass_recipes
 	..()
@@ -216,6 +222,9 @@ GLOBAL_LIST_INIT(titaniumglass_recipes, list(
 	merge_type = /obj/item/stack/sheet/titaniumglass
 	full_window = /obj/structure/window/full/shuttle
 	table_type = /obj/structure/table/glass/reinforced/titanium
+
+/obj/item/stack/sheet/titaniumglass/fifty
+	amount = 50
 
 /obj/item/stack/sheet/titaniumglass/New(loc, amount)
 	recipes = GLOB.titaniumglass_recipes
@@ -238,6 +247,10 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	full_window = /obj/structure/window/full/plastitanium
 	table_type = /obj/structure/table/glass/reinforced/plastitanium
 
+/obj/item/stack/sheet/plastitaniumglass/fifty
+	amount = 50
+
 /obj/item/stack/sheet/plastitaniumglass/New(loc, amount)
 	recipes = GLOB.plastitaniumglass_recipes
 	..()
+

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -156,6 +156,9 @@ GLOBAL_LIST_INIT(snow_recipes, list(
 	sheettype = "sandstone"
 	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
 
+/obj/item/stack/sheet/mineral/sandstone/fifty
+	amount = 50
+
 /obj/item/stack/sheet/mineral/sandstone/New()
 	..()
 	recipes = GLOB.sandstone_recipes
@@ -227,6 +230,9 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 	materials = list(MAT_URANIUM=MINERAL_MATERIAL_AMOUNT)
 	point_value = 20
 
+/obj/item/stack/sheet/mineral/uranium/fifty
+	amount = 50
+
 /obj/item/stack/sheet/mineral/uranium/New()
 	..()
 	recipes = GLOB.uranium_recipes
@@ -286,6 +292,9 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 	materials = list(MAT_GOLD=MINERAL_MATERIAL_AMOUNT)
 	point_value = 20
 
+/obj/item/stack/sheet/mineral/gold/fifty
+	amount = 50
+
 /obj/item/stack/sheet/mineral/gold/New()
 	..()
 	recipes = GLOB.gold_recipes
@@ -300,6 +309,9 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 	merge_type = /obj/item/stack/sheet/mineral/silver
 	materials = list(MAT_SILVER=MINERAL_MATERIAL_AMOUNT)
 	point_value = 20
+
+/obj/item/stack/sheet/mineral/silver/fifty
+	amount = 50
 
 /obj/item/stack/sheet/mineral/silver/New()
 	..()
@@ -375,39 +387,6 @@ GLOBAL_LIST_INIT(titanium_recipes, list(
 	amount = 50
 
 
-/*
- * Plastitanium
- */
-/obj/item/stack/sheet/mineral/plastitanium
-	name = "plastitanium"
-	icon_state = "sheet-plastitanium"
-	item_state = "sheet-plastitanium"
-	singular_name = "plastitanium sheet"
-	force = 5
-	throwforce = 5
-	w_class = WEIGHT_CLASS_NORMAL
-	throw_speed = 1
-	throw_range = 3
-	sheettype = "plastitanium"
-	merge_type = /obj/item/stack/sheet/mineral/plastitanium
-	materials = list(MAT_TITANIUM=2000, MAT_PLASMA=2000)
-	point_value = 45
-
-GLOBAL_LIST_INIT(plastitanium_recipes, list(
-	new /datum/stack_recipe("plas-titanium tile", /obj/item/stack/tile/mineral/plastitanium, 1, 4, 20),
-	new /datum/stack_recipe("Kidan Warrior Statue", /obj/structure/statue/plastitanium/kidanstatue, 5, time = 2.5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
-	))
-
-/obj/item/stack/sheet/mineral/plastitanium/New(loc, amount=null)
-	recipes = GLOB.plastitanium_recipes
-	..()
-
-/obj/item/stack/sheet/mineral/enruranium
-	name = "enriched uranium"
-	icon_state = "sheet-enruranium"
-	origin_tech = "materials=6"
-	materials = list(MAT_URANIUM=3000)
-
 //Alien Alloy
 /obj/item/stack/sheet/mineral/abductor
 	name = "alien alloy"
@@ -443,6 +422,10 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list(
 /obj/item/stack/sheet/mineral/adamantine/New(loc, amount = null)
 	recipes = GLOB.adamantine_recipes
 	..()
+
+
+/obj/item/stack/sheet/mineral/adamantine/fifty
+	amount = 50
 
 /*
  * Snow

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -405,8 +405,9 @@ GLOBAL_LIST_INIT(titanium_recipes, list(
 	materials = list(MAT_TITANIUM=2000, MAT_PLASMA=2000)
 	point_value = 45
 
-/obj/item/stack/sheet/mineral/plastinium/fifty
+/obj/item/stack/sheet/mineral/plastitanium/fifty
 	amount = 50
+
 
 GLOBAL_LIST_INIT(plastitanium_recipes, list(
 	new /datum/stack_recipe("plas-titanium tile", /obj/item/stack/tile/mineral/plastitanium, 1, 4, 20),

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -387,6 +387,37 @@ GLOBAL_LIST_INIT(titanium_recipes, list(
 	amount = 50
 
 
+/*
+ * Plastitanium
+ */
+/obj/item/stack/sheet/mineral/plastitanium
+	name = "plastitanium"
+	icon_state = "sheet-plastitanium"
+	item_state = "sheet-plastitanium"
+	singular_name = "plastitanium sheet"
+	force = 5
+	throwforce = 5
+	w_class = WEIGHT_CLASS_NORMAL
+	throw_speed = 1
+	throw_range = 3
+	sheettype = "plastitanium"
+	merge_type = /obj/item/stack/sheet/mineral/plastitanium
+	materials = list(MAT_TITANIUM=2000, MAT_PLASMA=2000)
+	point_value = 45
+
+/obj/item/stack/sheet/mineral/plastinium/fifty
+	amount = 50
+
+GLOBAL_LIST_INIT(plastitanium_recipes, list(
+	new /datum/stack_recipe("plas-titanium tile", /obj/item/stack/tile/mineral/plastitanium, 1, 4, 20),
+	new /datum/stack_recipe("Kidan Warrior Statue", /obj/structure/statue/plastitanium/kidanstatue, 5, time = 2.5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
+	))
+
+/obj/item/stack/sheet/mineral/plastitanium/New(loc, amount=null)
+	recipes = GLOB.plastitanium_recipes
+	..()
+
+
 //Alien Alloy
 /obj/item/stack/sheet/mineral/abductor
 	name = "alien alloy"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -180,6 +180,9 @@ GLOBAL_LIST_INIT(plasteel_recipes, list(
 	point_value = 23
 	table_type = /obj/structure/table/reinforced
 
+/obj/item/stack/sheet/plasteel/fifty
+	amount = 50
+
 /obj/item/stack/sheet/plasteel/New(loc, amount=null)
 	recipes = GLOB.plasteel_recipes
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds full 50 sized stacks of the following materials to the admin spawn menu and to mappers:

- Reinforced glass
- Sandstone
- Uranium
- Gold
- Silver
- Adamantine
- Plasteel
- Plasmaglass
- Reinforced plasmaglass
- Titanium glass
- Plastitanium glass
- Plastitanium

Removes enruranium sheets, since they don't have sprites and aren't used anywhere.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Being able to spawn stacks of fifty instead of having to varedit or click 50 times is nice.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned stacks of 50 for every material, looked at them.
<!-- How did you test the PR, if at all? -->

## Changelog
This doesn't affect players.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
