### PR TITLE
Re-adds Rathen's Secret to the Spellbook

### DIFF
--- a/code/datums/spells/rathens.dm
+++ b/code/datums/spells/rathens.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/rathens
 	name = "Rathen's Secret"
-	desc = "Summons a powerful shockwave around you that tears the appendix out of enemies, and occasionally remove their limbs."
+	desc = "Summons a powerful shockwave around you that tears the appendix out of enemies, and occasionally removes their limbs."
 	base_cooldown = 50 SECONDS
 	clothes_req = TRUE
 	invocation = "APPEN NATH!"

--- a/code/datums/spells/rathens.dm
+++ b/code/datums/spells/rathens.dm
@@ -1,11 +1,11 @@
 /obj/effect/proc_holder/spell/rathens
 	name = "Rathen's Secret"
-	desc = "Summons a powerful shockwave around you that tears the appendix and limbs off of enemies."
-	base_cooldown = 500
+	desc = "Summons a powerful shockwave around you that tears the appendix out of enemies, and occasionally remove their limbs."
+	base_cooldown = 50 SECONDS
 	clothes_req = TRUE
 	invocation = "APPEN NATH!"
 	invocation_type = "shout"
-	cooldown_min = 200
+	cooldown_min = 20 SECONDS
 	action_icon_state = "lungpunch"
 
 /obj/effect/proc_holder/spell/rathens/create_new_targeting()

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -184,6 +184,13 @@
 	category = "Defensive"
 	cost = 1
 
+/datum/spellbook_entry/rathens
+	name = "Rathen's Secret"
+	spell_type = /obj/effect/proc_holder/spell/rathens
+	log_name = "RS"
+	category = "Defensive"
+	cost = 1
+
 /datum/spellbook_entry/repulse
 	name = "Repulse"
 	spell_type = /obj/effect/proc_holder/spell/aoe/repulse


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Readds the spell Rathen's Secret to the spellbook, a 1-cost spell with a 50 second cooldown that forcibly removes the appendixes of anyone near you. If they have no appendix (presumably because you've already used this spell on them), they suffer increased damage from the spell and a longer stun. It also seems to come with a semi-infrequent chance to remove limbs, what fun.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The spell was initially cut from the Wizard's spellbook in https://github.com/ParadiseSS13/Paradise/pull/10364, but from what I can tell in this PR Rathen's was intended to be reworked to just not be so malodorous instead of being removed from the Wizard's spellbook simultaneously. Thus, let's just re-add it so Wizards can have their funny appendicectomy spell.
## Testing
<!-- How did you test the PR, if at all? -->
Eight skrells lost their appendixes (it IS appendixes when referring to the anatomical organ, and appendices when referring to the plural of the book-keeping variety of appendix) in tests to make sure the spell worked properly and didn't runtime. They also lost a few other limbs, but that's not important!
## Changelog
:cl:
add: Wizards can now re-select Rathen's Secret from the spellbook. Happy Appendicectomies!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
