### PR TITLE
Fixes epic fail with reinforced glass tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -515,7 +515,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_REINFORCED_TABLES)
 	canSmoothWith = list(SMOOTH_GROUP_REINFORCED_TABLES)
 
-/obj/structure/table/glass/reinforced/deconstruction_hints(mob/user) //look, it was either copy paste these 3 procs, or copy paste all of the glass stuff
+/obj/structure/table/glass/reinforced/deconstruction_hints(mob/user) //look, it was either copy paste these 4 procs, or copy paste all of the glass stuff
 	if(deconstruction_ready)
 		to_chat(user, "<span class='notice'>The top cover has been <i>welded</i> loose and the main frame's <b>bolts</b> are exposed.</span>")
 	else
@@ -535,6 +535,19 @@
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		to_chat(user, "<span class='notice'>You [deconstruction_ready ? "strengthen" : "weaken"] the table.</span>")
 		deconstruction_ready = !deconstruction_ready
+
+/obj/structure/table/glass/reinforced/shove_impact(mob/living/target, mob/living/attacker)
+	if(locate(/obj/structure/table) in get_turf(target))
+		return FALSE
+	var/pass_flags_cache = target.pass_flags
+	target.pass_flags |= PASSTABLE
+	if(target.Move(loc))
+		. = TRUE
+		target.Weaken(4 SECONDS)
+		add_attack_logs(attacker, target, "pushed onto [src]", ATKLOG_ALL)
+	else
+		. = FALSE
+	target.pass_flags = pass_flags_cache
 
 /obj/structure/table/glass/reinforced/check_break(mob/living/M)
 	if(has_gravity(M) && M.mob_size > MOB_SIZE_SMALL && (obj_integrity < (max_integrity / 2))) //big tables for big boys, only breaks under 50% hp

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -515,19 +515,19 @@
 	smoothing_groups = list(SMOOTH_GROUP_REINFORCED_TABLES)
 	canSmoothWith = list(SMOOTH_GROUP_REINFORCED_TABLES)
 
-/obj/structure/table/reinforced/deconstruction_hints(mob/user) //look, it was either copy paste these 3 procs, or copy paste all of the glass stuff
+/obj/structure/table/glass/reinforced/deconstruction_hints(mob/user) //look, it was either copy paste these 3 procs, or copy paste all of the glass stuff
 	if(deconstruction_ready)
 		to_chat(user, "<span class='notice'>The top cover has been <i>welded</i> loose and the main frame's <b>bolts</b> are exposed.</span>")
 	else
 		to_chat(user, "<span class='notice'>The top cover is firmly <b>welded</b> on.</span>")
 
-/obj/structure/table/reinforced/flip(direction)
+/obj/structure/table/glass/reinforced/flip(direction)
 	if(!deconstruction_ready)
 		return FALSE
 	else
 		return ..()
 
-/obj/structure/table/reinforced/welder_act(mob/user, obj/item/I)
+/obj/structure/table/glass/reinforced/welder_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
![2022 12 08-21 34 37](https://media.tenor.com/vauuoXz1mgoAAAAM/epic-fail-falling.gif)


Uses the correct path for the custom reinforced glass table behaviour.
Makes the shoved behaviour work like regular tables, not glass ones.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Glass tables should be deconstructable, and should cause shove stun
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Fixed not being able to deconstruct reinforced glass tables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
