### PR TITLE
Allows wet leather to be dried in lava

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -121,9 +121,15 @@ GLOBAL_LIST_INIT(xeno_recipes, list (
 	var/wetness = 30 //Reduced when exposed to high temperautres
 	var/drying_threshold_temperature = 500 //Kelvin to start drying
 
+/obj/item/stack/sheet/wetleather/burn()
+	visible_message("<span class='notice'>[src] finishes drying!</span>")
+	new /obj/item/stack/sheet/leather(loc)
+	qdel(src)
+
 /obj/item/stack/sheet/leather
 	name = "leather"
 	desc = "The by-product of mob grinding."
+	resistance_flags = LAVA_PROOF | FIRE_PROOF //So it doesn't burn when drying via lava
 	singular_name = "leather piece"
 	icon_state = "sheet-leather"
 	item_state = "sheet-leather"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
As it says on the tin. Wet leather can now be chucked into lava to turn it into leather after it finishes burning, same as goliath meat can cook in lava. As a result, leather is now fireproof and lavaproof.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Ash Walkers being able to actually get leather from Goliath Hide is nice. You may ask the question "Wait, why don't they just use the Drying Rack? They can make it from just a bit of wood!". The answer is that this drying rack, composed entirely of wood, requires power to work. I assume the player character is rather skilled in magical carpentry and converts some of that wood to an electricity-based cooking system. I digress - this ultimately lets Ash Walkers make leather in an interesting way by cooking it on lava, and thus allows them to access the tribal crafting items that require leather.
There WAS some odd existing check for leather drying which I've left in as I'm not sure if the drying rack is dependent on it or not, if it's not then I'm happy to remove that in favour of this method or leave it in. It seems to check if the ambient temperature is high enough to dry the leather on its own.
## Testing
<!-- How did you test the PR, if at all? -->
Spawned in, grabbed some goliath hide, stripped it with a knife, yote a bucket of water on it, chucked it in lava. Got confused when the leather burned to a crisp after drying, realized it needed resistances to lava and fire, fixed that, did it again, all good. Drip is now able to be acquired as an ashie.
## Changelog
:cl:
tweak: Wet leather can now be dried in lava
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
