### PR TITLE
Makes it so you no longer weld plating if you're on harm intent

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -117,6 +117,8 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+	if(user.a_intent == INTENT_HARM) // no repairing on harm intent, so you can use the welder in a fight near damaged paneling without welding your eyes out
+		return
 	if(unfastened)
 		to_chat(user, "<span class='warning'>You start removing [src], exposing space after you're done!</span>")
 		if(!I.use_tool(src, user, 50, volume = I.tool_volume * 2)) //extra loud to let people know something's going down


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Exactly as on the tin. If you're on harm intent you will neither attempt to unfasten plating or repair it. Works fine on other intents.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Sometimes, you want to use the welder to absolutely weld the shit out of something, but there's damaged plating in the area and suddenly you have no eyes left because clicking is difficult. This change lets people use welders as weapons in areas that have damaged plating without subjecting themselves to sudden-onset blindness and bright white flashes.
## Testing
<!-- How did you test the PR, if at all? -->
Blew a hole in the station, tried to aggressively weld the damaged plating, nothing happened. Tried to gently weld the damaged plating, success.
## Changelog
:cl:
tweak: You will no longer weld plating if you are on harm intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
