### PR TITLE
Fixes descriptions on two food items

### DIFF
--- a/code/modules/food_and_drinks/food/foods/bread.dm
+++ b/code/modules/food_and_drinks/food/foods/bread.dm
@@ -69,7 +69,7 @@
 
 /obj/item/reagent_containers/food/snacks/sliceable/tofubread
 	name = "tofubread"
-	icon_state = "Like meatbread but for vegetarians. Not guaranteed to give superpowers."
+	desc = "Like meatbread but for vegetarians. Not guaranteed to give superpowers."
 	icon_state = "tofubread"
 	slice_path = /obj/item/reagent_containers/food/snacks/tofubreadslice
 	slices_num = 5
@@ -85,7 +85,7 @@
 
 /obj/item/reagent_containers/food/snacks/sliceable/bread
 	name = "bread"
-	icon_state = "Some plain old Earthen bread."
+	desc = "Some plain old Earthen bread."
 	icon_state = "bread"
 	slice_path = /obj/item/reagent_containers/food/snacks/breadslice
 	slices_num = 6
@@ -219,5 +219,3 @@
 	trash = /obj/item/trash/waffles
 	filling_color = "#E6DEB5"
 	list_reagents = list("nutriment" = 8, "vitamin" = 1)
-
-

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -24,8 +24,8 @@
 
 /obj/item/reagent_containers/food/snacks/soydope
 	name = "soy dope"
-	desc = "Like regular dope, but for the health concious consumer."
 	icon_state = "soydope"
+	desc = "Like regular dope, but for the health concious consumer."
 	trash = /obj/item/trash/plate
 	filling_color = "#C4BF76"
 	list_reagents = list("nutriment" = 2)

--- a/code/modules/food_and_drinks/food/foods/side_dishes.dm
+++ b/code/modules/food_and_drinks/food/foods/side_dishes.dm
@@ -115,4 +115,3 @@
 	list_reagents = list("nutriment" = 3, "vitamin" = 4)
 	filling_color = "#FF5500"
 	tastes = list("parsnip" = 1)
-


### PR DESCRIPTION
## What Does This PR Do
Fixes two descriptions in the bread file (also moves one thing around and removes an extra blank line)

## Why It's Good For The Game
descriptions should exist

## Testing
Compiled, ran, really shouldn't have compiled because these aren't valid icon states

## Changelog
:cl:
spellcheck: bread and tofu bread now have a description as intended
/:cl:
