### PR TITLE
Re-adds the ablative trenchcoat to the theft pool, reverting #19599

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -130,6 +130,12 @@
 	protected_jobs = list("Chief Medical Officer")
 	location_override = "the Chief Medical Officer's Office"
 
+/datum/theft_objective/ablative
+	name = "an ablative trenchcoat"
+	typepath = /obj/item/clothing/suit/hooded/ablative
+	protected_jobs = list("Head of Security", "Warden")
+	location_override = "the Armory"
+
 /datum/theft_objective/krav
 	name = "the warden's krav maga martial arts gloves"
 	typepath = /obj/item/clothing/gloves/color/black/krav_maga/sec


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Reverts https://github.com/ParadiseSS13/Paradise/pull/19559, re-adding the Ablative Trenchcoat to the list of items that antagonists with steal objectives can steal.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The Ablative Trenchcoat is a unique and powerful item, particularly in the hands of an antagonist (who will see far greater use of it than security as it primarily works on equipment that is held by security, while very few antagonists possess energy weapons that haven't been stolen from sec themselves), on par with other high-value theft items. It was removed from the theft pool in the aforementioned PR so that it could see more use in the hands of antagonists who could now steal it regardless of their objectives. I would argue it has seen **far** too much use in this time, as quite a few players have an attitude of rushing the item regardless of whatever else they have to do because of how much it counters security. This generally forces sec to escalate much more than they should. Antagonists will still be able to steal this off security officers who are using it in the field if they so please, but it means that not every single antag will be able to rush this item and effectively stop caring about energy weapons.
## Testing
<!-- How did you test the PR, if at all? -->
Spawned self as skrell, made self a traitor, confirmed Ablative appeared as a possible theft objective. 
## Changelog
:cl:
tweak: The Ablative Trenchcoat is again a theft objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
