### PR TITLE
Updates darkmodes theming to more closely match Bay

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -924,33 +924,33 @@
 	///// BUTTONS /////
 	SSchangelog.UpdatePlayerChangelogButton(src)
 	/* Rpane */
-	winset(src, "rpane.textb", "background-color=#40628a;text-color=#FFFFFF")
-	winset(src, "rpane.infob", "background-color=#40628a;text-color=#FFFFFF")
-	winset(src, "rpane.wikib", "background-color=#40628a;text-color=#FFFFFF")
-	winset(src, "rpane.forumb", "background-color=#40628a;text-color=#FFFFFF")
-	winset(src, "rpane.rulesb", "background-color=#40628a;text-color=#FFFFFF")
-	winset(src, "rpane.githubb", "background-color=#40628a;text-color=#FFFFFF")
-	winset(src, "rpane.webmap", "background-color=#40628a;text-color=#FFFFFF")
+	winset(src, "rpane.textb", "background-color=#494949;text-color=#a4bad6")
+	winset(src, "rpane.infob", "background-color=#494949;text-color=#a4bad6")
+	winset(src, "rpane.wikib", "background-color=#494949;text-color=#a4bad6")
+	winset(src, "rpane.forumb", "background-color=#494949;text-color=#a4bad6")
+	winset(src, "rpane.rulesb", "background-color=#494949;text-color=#a4bad6")
+	winset(src, "rpane.githubb", "background-color=#494949;text-color=#a4bad6")
+	winset(src, "rpane.webmap", "background-color=#494949;text-color=#a4bad6")
 	/* Outputwindow */
-	winset(src, "outputwindow.saybutton", "background-color=#40628a;text-color=#FFFFFF")
-	winset(src, "outputwindow.mebutton", "background-color=#40628a;text-color=#FFFFFF")
+	winset(src, "outputwindow.saybutton", "background-color=#494949;text-color=#a4bad6")
+	winset(src, "outputwindow.mebutton", "background-color=#494949;text-color=#a4bad6")
 	///// UI ELEMENTS /////
 	/* Mainwindow */
-	winset(src, "mainwindow", "background-color=#272727")
-	winset(src, "mainwindow.mainvsplit", "background-color=#272727")
-	winset(src, "mainwindow.tooltip", "background-color=#272727")
+	winset(src, "mainwindow", "background-color=#171717")
+	winset(src, "mainwindow.mainvsplit", "background-color=#202020")
+	winset(src, "mainwindow.tooltip", "background-color=#171717")
 	/* Outputwindow */
-	winset(src, "outputwindow", "background-color=#1d1d1d")
-	winset(src, "outputwindow.browseroutput", "background-color=#272727")
+	winset(src, "outputwindow", "background-color=#202020")
+	winset(src, "outputwindow.browseroutput", "background-color=#202020")
 	/* Rpane */
-	winset(src, "rpane", "background-color=#1d1d1d")
-	winset(src, "rpane.rpanewindow", "background-color=#1d1d1d")
+	winset(src, "rpane", "background-color=#202020")
+	winset(src, "rpane.rpanewindow", "background-color=#202020")
 	/* Browserwindow */
-	winset(src, "browserwindow", "background-color=#272727")
-	winset(src, "browserwindow.browser", "background-color=#272727")
+	winset(src, "browserwindow", "background-color=#171717")
+	winset(src, "browserwindow.browser", "background-color=#171717")
 	/* Infowindow */
-	winset(src, "infowindow", "background-color=#1d1d1d;text-color=#FFFFFF")
-	winset(src, "infowindow.info", "background-color=#272727;text-color=#FFFFFF;highlight-color=#009900;tab-text-color=#FFFFFF;tab-background-color=#1d1d1d")
+	winset(src, "infowindow", "background-color=#202020;text-color=#a4bad6")
+	winset(src, "infowindow.info", "background-color=#171717;text-color=#a4bad6;highlight-color=#009900;tab-text-color=#a4bad6;tab-background-color=#202020")
 	// NOTIFY USER
 	to_chat(src, "<span class='notice'>Darkmode Enabled</span>")
 

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -295,7 +295,7 @@ em				{font-style: normal;font-weight: bold;}
 h1.alert, h2.alert			{color: #a4bad6;}
 .ghostalert			{color: #cc00c6;font-style: italic; font-weight: bold;}
 .emote				{font-style: italic;}
-.selecteddna			{color: #FFFFFF; 	background-color: #001B1B}
+.selecteddna			{color: #a4bad6; 	background-color: #001B1B}
 
 .attack				{color: #ff0000;}
 .moderate			{color: #CC0000;}
@@ -430,7 +430,7 @@ h1.alert, h2.alert			{color: #a4bad6;}
 span.body .codephrases 		{color: #5555FF;}
 span.body .coderesponses 		{color: #FF3333;}
 
-.announcement h1, .announcement h2 { color: #fff; margin: 8pt 0; line-height: 1.2; }
+.announcement h1, .announcement h2 { color: #a4bad6; margin: 8pt 0; line-height: 1.2; }
 .announcement p { color: #d82020; line-height: 1.3; }
 .announcement.minor h1 { font-size: 180%; }
 .announcement.minor h2 { font-size: 170%; }

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -7,16 +7,20 @@ html, body {
 	padding: 0;
 	margin: 0;
 	height: 100%;
-	color: #fff;
+	color: #a4bad6;
 }
 body {
-	background: #151515;
+	background: #171717;
 	font-family: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 9pt;
+	color: #a4bad6;
 	line-height: 1.2;
 	overflow-x: hidden;
 	overflow-y: scroll;
 	word-wrap: break-word;
+	scrollbar-face-color:#1A1A1A;
+	scrollbar-track-color:#171717;
+	scrollbar-highlight-color:#171717;
 }
 h1, h2, h3, h4, h5, h6 {color: #06f; font-family: Georgia, Verdana, sans-serif;}
 
@@ -68,22 +72,21 @@ font-size: 14px;
 	bottom: 0;
 	right: 0;
 	padding: 8px;
-	background: #ddd;
+	background: #202020;
 	text-decoration: none;
 	font-variant: small-caps;
 	font-size: 1.1em;
 	font-weight: bold;
-	color: #333;
+	color: #a4bad6;
 }
-#newMessages:hover {background: #ccc;}
+#newMessages:hover {background: #171717;}
 #newMessages i {vertical-align: middle; padding-left: 3px;}
 #ping {
 	position: fixed;
 	top: 0;
 	right: 40px;
 	width: 45px;
-	background: #ddd;
-	color: #000;
+	background: #202020;
 	height: 30px;
 	padding: 8px 0 2px 0;
 }
@@ -92,7 +95,6 @@ font-size: 14px;
 	display: block;
 	text-align: center;
 	font-size: 8pt;
-	color: #000;
 	padding-top: 2px;
 }
 #options {
@@ -101,19 +103,19 @@ font-size: 14px;
 	right: 0;
 }
 #options a {
-	background: #ddd;
+	background: #202020;
 	height: 30px;
 	padding: 5px 0;
 	display: block;
-	color: #333;
+	color: #a4bad6;
 	text-decoration: none;
 	line-height: 28px;
 	border-top: 1px solid #b4b4b4;
 }
-#options a:hover {background: #ccc;}
+#options a:hover {background: #202020;}
 #options .toggle {
 	width: 40px;
-	background: #ccc;
+	background: #202020;
 	border-top: 0;
 	float: right;
 	text-align: center;

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -292,7 +292,7 @@ em				{font-style: normal;font-weight: bold;}
 .binaryradio			{color: #1B00FB;font-family: 'Courier New', Courier, monospace;}
 .mommiradio			{color: #6685f5;}
 .alert				{color: #d82020;}
-h1.alert, h2.alert			{color: #FFF;}
+h1.alert, h2.alert			{color: #a4bad6;}
 .ghostalert			{color: #cc00c6;font-style: italic; font-weight: bold;}
 .emote				{font-style: italic;}
 .selecteddna			{color: #FFFFFF; 	background-color: #001B1B}

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -266,7 +266,7 @@ em				{font-style: normal;font-weight: bold;}
 .playerreply			{color: #8800bb;font-weight: bold;}
 .pmsend				{color: #6685f5;}
 .name				{font-weight: bold;}
-.say				{color: #E8EBED}
+.say				{color: #a4bad6}
 .yell				{font-weight: bold;}
 .siliconsay			{font-family: 'Courier New', Courier, monospace;}
 .deadsay				{color: #e2c1ff;}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Updates darkmodes theming to match Bays which is overall a better version of darkmode

Darker bits are a little darker especially up in the status panel, themes better with the chatbox now.

All chat colours have remained unchanged except for the default chat colour which includes say and the announcement colour. Basically, if it was bright ass #FFFFFF white before it's gone and now replaced with a white blue, kind of like the same colour you have here on Github darkmode but a little bluer to compensate for it being on a darker background.

These changes are from Baystation.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Please for the love of all that is good in this codebase my eyes bleed every time I switch on darkmode and am flashbanged by a half white half dark chatbox. I want a darkmode, not an inverted colours mode.
## Images of changes

![parabay](https://user-images.githubusercontent.com/92271472/207766229-632f0fd3-e958-4994-9104-b30765fa4ef2.png)


![image](https://user-images.githubusercontent.com/92271472/207761509-cf6904f9-30bd-489d-9829-641aaae1fa14.png)

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Bmon, BS12
tweak: Goonchat has been tweaked to match BS12's darkmode. No more bright white!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
