### PR TITLE
Fixes a surgery runtime

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -71,6 +71,8 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_selected)
+		if(!affected)
+			return FALSE // Yes, we may not have a limb in this area (Example being fixing someones arm by slapping it on)
 		if(!affected.encased) //no bone, problem.
 			return FALSE
 		if(HAS_TRAIT(target, TRAIT_NO_BONES))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #19394 
`Affected` can be null due to getting your external limb removed, this doesn't actually change the intended logic, but random runtimes are bad.
Adds a sanity check to prevent this

## Why It's Good For The ~~Game~~ Production Log

Common runtime has no game impact because it basically does the same thing it does now, but fills up production log and makes it difficult to sift through.

## Testing
Broke some people's arms and attached them back on, broke a machine in half and gave him a new leg, abducted some guy and removed his heart. Sat down and started coding this PR

## Changelog
NPFC
