### PR TITLE
Reduces blobs "split" spawn time 

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -106,9 +106,9 @@
 	if(!new_overmind)
 		// sendit
 		if(is_offspring)
-			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob offspring?", ROLE_BLOB, TRUE, source = src)
+			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob offspring?", ROLE_BLOB, TRUE, 10 SECONDS, source = src)
 		else
-			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob?", ROLE_BLOB, TRUE, source = src)
+			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob?", ROLE_BLOB, TRUE, 10 SECONDS, source = src)
 
 		if(length(candidates))
 			C = pick(candidates)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reduces the blob core "split" spawn time to 10 seconds (initial spawns from mice and such aren't affected)

## Why It's Good For The Game
Long wait times are all well and good provided you're not in active combat, blobs will almost always be in active combat, so the extra wait time comes up /a lot/
A 10 second wait time is more than enough time to sign up and play, 30 seconds just screws over the blob

## Testing
Compiled ran, things worked fine

## Changelog
:cl:
tweak: blob split cores now only take 10 seconds to accept a candidate 
/:cl:

