### PR TITLE
Clean up MMI radio actions to call the right procs

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -175,7 +175,7 @@
 /obj/item/mmi/proc/become_occupied(new_icon)
 	icon_state = new_icon
 	if(radio)
-		radio_action.ApplyIcon()
+		radio_action.UpdateButtonIcon()
 
 /obj/item/mmi/examine(mob/user)
 	. = ..()
@@ -209,17 +209,9 @@
 	return ..()
 
 /datum/action/generic/configure_mmi_radio/ApplyIcon(obj/screen/movable/action_button/current_button)
-	// A copy/paste of the item action icon code
-	current_button.overlays.Cut()
-	if(target)
-		var/obj/item/I = mmi
-		var/old_layer = I.layer
-		var/old_plane = I.plane
-		I.layer = 21
-		I.plane = HUD_PLANE
-		current_button.overlays += I
-		I.layer = old_layer
-		I.plane = old_plane
+	icon_icon = mmi.icon
+	button_icon_state = mmi.icon_state
+	..()
 
 /obj/item/mmi/emp_act(severity)
 	if(!brainmob)

--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -105,8 +105,6 @@
 		H.mind.transfer_to(brainmob)
 	to_chat(brainmob, "<span class='notice'>You feel slightly disoriented. That's normal when you're just a [ejected_flavor_text].</span>")
 	become_occupied(occupied_icon)
-	if(radio)
-		radio_action.ApplyIcon()
 
 /obj/item/mmi/robotic_brain/attempt_become_organ(obj/item/organ/external/parent, mob/living/carbon/human/H)
 	if(..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The MMI radio actions were calling `ApplyIcon` directly instead of `UpdateButtonIcon`, which would cause runtimes as they weren't otherwise passing the button. This brings it in line with other actions.

`ApplyIcon` is tweaked slightly so it only passes the object's icon and icon state, and lets the parent handle the rest.

## Why It's Good For The Game
Fixes #19933. Nothing playerfacing otherwise.

## Images of changes]
![12](https://user-images.githubusercontent.com/80771500/208259499-b23bafca-a30f-4b64-abf4-ac2acd431255.png)

## Testing
Debrained someone, stuffed them into an MMI, installed a radio. Did the reverse where the radio was installed first then the brain.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
