### PR TITLE
Blob can now expand diagonally by moving twice linearly in one move for 10 points.

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -330,7 +330,14 @@
 
 	var/obj/structure/blob/OB = locate() in circlerange(T, 1)
 	if(!OB)
-		to_chat(src, "There is no blob adjacent to you.")
+		var/obj/structure/blob/DB = locate() in range(T, 1)
+		if(!DB)
+			to_chat(src, "There is no blob adjacent to you.")
+			return
+		if(!can_buy(5))
+			return
+		DB.double_expand(T, 0, blob_reagent_datum.color, src)
+		DB.color = blob_reagent_datum.color
 		return
 
 	if(!can_buy(5))

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -179,7 +179,7 @@
 		if(adjacent in circlerange(src, 1))
 			expand(adjacent, 0, overmind.blob_reagent_datum.color, overmind, T)
 			overmind.blob_core.chemical_attack(adjacent)
-			src.color = overmind.blob_reagent_datum.color
+			color = overmind.blob_reagent_datum.color
 			return
 
 /obj/structure/blob/Crossed(mob/living/L, oldloc)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -132,7 +132,7 @@
 	if(iswallturf(loc))
 		loc.blob_act(src) //don't ask how a wall got on top of the core, just eat it
 
-/obj/structure/blob/proc/expand(turf/T = null, prob = 1, a_color, _overmind = null)
+/obj/structure/blob/proc/expand(turf/T = null, prob = 1, a_color, _overmind = null, turf/double_target = null)
 	if(prob && !prob(obj_integrity))
 		return
 	if(isspaceturf(T) && prob(75)) 	return
@@ -153,6 +153,13 @@
 	if(T.Enter(B,src))//Attempt to move into the tile
 		B.density = initial(B.density)
 		B.loc = T
+		if(double_target)
+			if(!overmind.can_buy(5))
+				overmind.last_attack = world.time
+				return
+			B.expand(double_target, 0, overmind.blob_reagent_datum.color, overmind)
+			overmind.blob_core.chemical_attack(T)
+			overmind.last_attack = world.time
 	else
 		T.blob_act()//If we cant move in hit the turf
 		B.loc = null //So we don't play the splat sound, see Destroy()
@@ -166,6 +173,14 @@
 			overmind.blob_reagent_datum.send_message(M)
 		A.blob_act(src)
 	return 1
+
+/obj/structure/blob/proc/double_expand(turf/T = null, prob = 1, a_color, _overmind = null)
+	for(var/turf/adjacent in circlerange(T, 1))
+		if(adjacent in circlerange(src, 1))
+			src.expand(adjacent, 0, overmind.blob_reagent_datum.color, overmind, T)
+			overmind.blob_core.chemical_attack(adjacent)
+			src.color = overmind.blob_reagent_datum.color
+			return
 
 /obj/structure/blob/Crossed(mob/living/L, oldloc)
 	..()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -177,7 +177,7 @@
 /obj/structure/blob/proc/double_expand(turf/T = null, prob = 1, a_color, _overmind = null)
 	for(var/turf/adjacent in circlerange(T, 1))
 		if(adjacent in circlerange(src, 1))
-			src.expand(adjacent, 0, overmind.blob_reagent_datum.color, overmind, T)
+			expand(adjacent, 0, overmind.blob_reagent_datum.color, overmind, T)
 			overmind.blob_core.chemical_attack(adjacent)
 			src.color = overmind.blob_reagent_datum.color
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Blobs can expand diagonally for 10 points.
If a blob is northeast, it try to spread horizontally or vertically for 5 points as normal. If this fails, only 5 points is spent.
If it succeeds, it consumes another 5 points, and now spreads to that originally diagonal tile.
This will not reliably work in space, and naturally bodies in the way will block spreading (but will be attacked)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to attack blob but blob not being able to attack is silly. It makes no sense realistically, only makes "sense" in a land of squares.
This PR lets blob attack diagonally IF the path is not blocked linearly, so no attacks that don't make sense, and without lettting blob cover area diagonally for only 5 points, which would be rapid spreading

## Testing
<!-- How did you test the PR, if at all? -->
Lots of testing to make sure diagonal spread works as intended, attacks as intended, fixing runtimes from incorrect overminds, ect.

## Changelog
:cl:
tweak: Blob can now attack diagonally by spreading lineally twice in 1 move for the full 10 point cost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
