### PR TITLE
Allows the Long-Distance Cloning Machine to use Outfits

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -50,8 +50,24 @@
 	icon_state = "borgcharger1(old)"
 	anchored = TRUE
 	density = TRUE
+	/// An outfit for ghosts to spawn with
+	var/datum/outfit/selected_outfit
 
 /obj/structure/respawner/attack_ghost(mob/dead/observer/user)
+	if(check_rights(R_EVENT))
+		var/outfit_pick = alert(user, "Do you want to pick an outfit or respawn?", "Pick an Outfit?", "Pick outfit", "Respawn", "Cancel")
+		if(outfit_pick == "Cancel")
+			return
+		if(outfit_pick == "Pick outfit")
+			var/new_outfit = user.client.robust_dress_shop()
+			if(!new_outfit)
+				return
+			if(new_outfit == "Naked")
+				selected_outfit = null
+				return
+			selected_outfit = new_outfit
+			return
+
 	var/response = alert(user, "Are you sure you want to spawn here?\n(If you do this, you won't be able to be cloned!)", "Respawn?", "Yes", "No")
 	if(response == "Yes")
 		user.forceMove(get_turf(src))
@@ -59,6 +75,8 @@
 		message_admins("[key_name_admin(user)] was incarnated by a respawner machine.")
 		var/mob/living/carbon/human/new_human = user.incarnate_ghost()
 		new_human.mind.offstation_role = TRUE // To prevent them being an antag objective
+		if(selected_outfit)
+			new_human.equipOutfit(selected_outfit)
 
 /obj/structure/ghost_beacon
 	name = "ethereal beacon"

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -62,6 +62,8 @@
 			var/new_outfit = user.client.robust_dress_shop()
 			if(!new_outfit)
 				return
+			log_admin("[key_name(user)] changed a respawner machine's outfit to [new_outfit].")
+			message_admins("[key_name(user)] changed a respawner machine's outfit to [new_outfit].")
 			if(new_outfit == "Naked")
 				selected_outfit = null
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Allows people with event permissions to set outfits on ghost clone respawners, which will be equipped when the person spawns.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->This allows for admins to equip a large amount of people for stuff like fun events, or general shenanigans with ghosts.

## Testing
<!-- How did you test the PR, if at all? -->
Changed the outfit, spawned in as ghost. Tried spawning as naked and it spawned me as naked.

## Changelog
Just admin-side stuff

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
