### PR TITLE
Tweaks to Vendomat and Artvend

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18688,7 +18688,7 @@
 	},
 /area/storage/tech)
 "bjx" = (
-/obj/machinery/economy/vending/assist,
+/obj/machinery/economy/vending/assist/free,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70154,7 +70154,7 @@
 /area/quartermaster/storage)
 "lCb" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/economy/vending/assist,
+/obj/machinery/economy/vending/assist/free,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "lCt" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -41,7 +41,7 @@
 /turf/simulated/floor/mineral/titanium/purple,
 /area/ruin/space/powered)
 "k" = (
-/obj/machinery/economy/vending/assist,
+/obj/machinery/economy/vending/assist/free,
 /turf/simulated/floor/mineral/titanium/purple,
 /area/ruin/space/powered)
 "l" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -3812,7 +3812,7 @@
 	name = "Derelict Annex"
 	})
 "iH" = (
-/obj/machinery/economy/vending/assist,
+/obj/machinery/economy/vending/assist/free,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"

--- a/_maps/map_files/RandomZLevels/example.dmm
+++ b/_maps/map_files/RandomZLevels/example.dmm
@@ -758,7 +758,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
 "bZ" = (
-/obj/machinery/economy/vending/assist,
+/obj/machinery/economy/vending/assist/free,
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
 "ca" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -53384,7 +53384,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
 "cDY" = (
-/obj/machinery/economy/vending/assist,
+/obj/machinery/economy/vending/assist/free,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cDZ" = (

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -3015,7 +3015,7 @@
 /turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors)
 "fY" = (
-/obj/machinery/economy/vending/assist,
+/obj/machinery/economy/vending/assist/free,
 /turf/simulated/floor/plating,
 /area/mine/cafeteria)
 "fZ" = (

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -1,10 +1,16 @@
 //general-use clothing vendors, wardrobe vendors are in another file
 /obj/machinery/economy/vending/assist
-	products = list(/obj/item/assembly/prox_sensor = 5, /obj/item/assembly/igniter = 3, /obj/item/assembly/signaler = 4,
-						/obj/item/wirecutters = 1, /obj/item/cartridge/signal = 4)
-	contraband = list(/obj/item/flashlight = 5, /obj/item/assembly/timer = 2, /obj/item/assembly/voice = 2, /obj/item/assembly/health = 2)
 	ads_list = list("Only the finest!",  "Have some tools.",  "The most robust equipment.",  "The finest gear in space!")
+	products = list(/obj/item/assembly/prox_sensor = 4, /obj/item/assembly/igniter = 4, /obj/item/assembly/signaler = 4,
+						/obj/item/wirecutters = 2, /obj/item/cartridge/signal = 4)
+	contraband = list(/obj/item/flashlight = 4, /obj/item/assembly/timer = 2, /obj/item/assembly/voice = 2, /obj/item/assembly/health = 2)
+	prices = list(/obj/item/assembly/prox_sensor = 20, /obj/item/assembly/igniter = 20, /obj/item/assembly/signaler = 30,
+					/obj/item/wirecutters = 50, /obj/item/cartridge/signal = 75, /obj/item/flashlight = 40,
+					/obj/item/assembly/timer = 20, /obj/item/assembly/voice = 20, /obj/item/assembly/health = 20)
 	refill_canister = /obj/item/vending_refill/assist
+
+/obj/machinery/economy/vending/assist/free
+	prices = list()
 
 /obj/machinery/economy/vending/boozeomat
 	name = "\improper Booze-O-Mat"
@@ -720,6 +726,7 @@
 	/obj/item/pen/red = 5)
 	contraband = list(/obj/item/toy/crayon/mime = 1,/obj/item/toy/crayon/rainbow = 1)
 	premium = list(/obj/item/poster/random_contraband = 5, /obj/item/pen/fancy = 2)
+	prices = list(/obj/item/stack/cable_coil/random = 20)
 
 /obj/machinery/economy/vending/tool
 	name = "\improper YouTool"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Gives a cost to Artvend cable coils.
Tweaks Vendomat amounts slightly (new standard is 4, increased wirecutter amount to 2) and paid version has been given to the ones located in public areas.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Theres no reason to acquire cables from the tools vendor or cargo since Artvend has big amounts of it for free and in close proximity.
It makes sense that Vendomat should cost money in public areas just like how it is with Tool Vendors.

## Testing
<!-- How did you test the PR, if at all? -->
- Compiled and looked into the new prices and amounts.
## Changelog
:cl:
tweak: Artvend cable coil now has a price
tweak: Vendomat now has a paid version and amounts have been tweaked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
