### PR TITLE
Fixes Griefsky runtiming upon death

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/griefsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/griefsky.dm
@@ -59,10 +59,6 @@
 	access_card.access += J.get_access()
 	prev_access = access_card.access
 
-/mob/living/simple_animal/bot/secbot/griefsky/Destroy()
-	QDEL_NULL(weapon)
-	return ..()
-
 /mob/living/simple_animal/bot/secbot/griefsky/UnarmedAttack(atom/A) //like secbots its only possible with admin intervention
 	if(!on)
 		return

--- a/code/modules/mob/living/simple_animal/bot/griefsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/griefsky.dm
@@ -8,7 +8,7 @@
 	window_name = "Automatic Security Unit v3.0"
 
 	var/spin_icon = "griefsky-c"  // griefsky and griefsky junior have dif icons
-	var/weapon = /obj/item/melee/energy/sword
+	var/weapon = /obj/item/melee/energy/sword/saber
 	var/block_chance = 50   //block attacks
 	var/reflect_chance = 80 // chance to reflect projectiles
 	var/dmg = 30 //esword dmg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
#19151 -- Removes a qdel called way earlier than it needs to be.  It was completely deleting Griefsky (He wouldn't drop anything at all) before a proper qdel call later.  Changes the weapon subtype from energy/sword to sword/saber to allow you to actually get combinable energy swords from it.  You got cyborg eswords before.  

## Why It's Good For The Game
When Griefsky dies it's nice to actually have him drop some stuff rather than vanish from existence, and have that stuff be the right stuff.

## Testing
Spawned in Griefsky, toolboxed him to death and my god there was actually a random number of eswords left over, some oil and components to boot!  You also get actual energy sabers, not cyborg energy swords. 

## Changelog
:cl:
fix: Fixed a griefsky runtime, you get some of your swords back.  
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
