### PR TITLE
Cyborg recharge station no longer works while unpowered

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -64,7 +64,7 @@
 	consumable_recharge_coeff = max(1, recharge_speed / 200)
 
 /obj/machinery/recharge_station/process()
-	if(!(NOPOWER|BROKEN))
+	if(stat & (NOPOWER|BROKEN))
 		return
 
 	if(occupant)
@@ -117,11 +117,11 @@
 	..(severity)
 
 /obj/machinery/recharge_station/update_icon_state()
-	if(NOPOWER|BROKEN)
-		if(occupant)
+	if(occupant)
+		if(!(stat & (NOPOWER|BROKEN)))
 			icon_state = "borgcharger1"
 		else
-			icon_state = "borgcharger0"
+			icon_state = "borgcharger2"
 	else
 		icon_state = "borgcharger0"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Cyborg recharge station no longer continues to work after its broken/without power.
Cyborg recharge station now updates its icon properly and makes use of occupied/without power icon (borgcharger2).
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/19964
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![cyborg_recharging_station](https://user-images.githubusercontent.com/77684085/209021184-6119d900-8d86-4bf5-bd18-c97026eee430.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Tested the recharge station while inside, outside, with and without power.
## Changelog
:cl:
fix: Cyborg recharge station icons have been fixed
fix: Cyborg recharge station no longer works while unpowered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
