### PR TITLE
Batons passive drain a small amount of charge if left on

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -133,8 +133,8 @@
 	cell.update_icon()
 	cell = null
 	turned_on = FALSE
-	STOP_PROCESSING(SSobj, src)
 	update_icon(UPDATE_ICON_STATE)
+	STOP_PROCESSING(SSobj, src)
 
 /obj/item/melee/baton/attack_self(mob/user)
 	if(cell?.charge >= hitcost)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -35,8 +35,8 @@
 
 /obj/item/melee/baton/Destroy()
 	if(cell?.loc == src)
-		STOP_PROCESSING(SSobj, src)
 		QDEL_NULL(cell)
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /**
@@ -133,6 +133,7 @@
 	cell.update_icon()
 	cell = null
 	turned_on = FALSE
+	STOP_PROCESSING(SSobj, src)
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/melee/baton/attack_self(mob/user)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -35,6 +35,7 @@
 
 /obj/item/melee/baton/Destroy()
 	if(cell?.loc == src)
+		STOP_PROCESSING(SSobj, src)
 		QDEL_NULL(cell)
 	return ..()
 
@@ -102,6 +103,7 @@
 		turned_on = FALSE
 		update_icon()
 		playsound(src, "sparks", 75, TRUE, -1)
+		STOP_PROCESSING(SSobj, src)
 
 /obj/item/melee/baton/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/stock_parts/cell))
@@ -138,6 +140,10 @@
 		turned_on = !turned_on
 		to_chat(user, "<span class='notice'>[src] is now [turned_on ? "on" : "off"].</span>")
 		playsound(src, "sparks", 75, TRUE, -1)
+		if(turned_on)
+			START_PROCESSING(SSobj, src)
+		else
+			STOP_PROCESSING(SSobj, src)
 	else
 		if(isrobot(loc))
 			to_chat(user, "<span class='warning'>You do not have enough reserve power to charge [src]!</span>")
@@ -145,9 +151,17 @@
 			to_chat(user, "<span class='warning'>[src] does not have a power source!</span>")
 		else
 			to_chat(user, "<span class='warning'>[src] is out of charge.</span>")
+		STOP_PROCESSING(SSobj, src)
 	update_icon()
 	add_fingerprint(user)
 
+/obj/item/melee/baton/process()
+	cell.use(100)
+	if(!cell.charge)
+		turned_on = FALSE
+		playsound(src, "sparks", 75, TRUE, -1)
+		update_icon()
+		STOP_PROCESSING(SSobj, src)
 
 /obj/item/melee/baton/attack(mob/M, mob/living/user)
 	if(turned_on && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that batons drain 100 units of charge per two seconds

That's about a full baton hit every 20 seconds it is left on doing nothing.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Meant to work with PR https://github.com/ParadiseSS13/Paradise/pull/19957

The Baton is still a very powerful item even after the rework and this at least makes there have to be a deliberate action to use it kind of like the telebaton.

I think this is a needed change for my aforementioned PR but could also work by itself.

Really want to hear what you all think about the drain rate, I think a 100 per two seconds is a good number but am open to change it depending on feedback.

## Testing
<!-- How did you test the PR, if at all? -->
In-game

## Changelog
:cl: Bmon
add: The baton will now slowly run out of charge if left on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
