### PR TITLE
Fixes a table runtime

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -53,6 +53,8 @@
 
 #define isstorage(A) (istype(A, /obj/item/storage))
 
+#define isstack(I) (istype(I, /obj/item/stack))
+
 GLOBAL_LIST_INIT(pointed_types, typecacheof(list(
 	/obj/item/pen,
 	/obj/item/screwdriver,

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -27,7 +27,10 @@
 
 ///Try to make a table with the item used to attack. FALSE if you can't make a table and should attack. TRUE does not necessarily mean a table was made.
 /obj/structure/table_frame/proc/try_make_table(obj/item/stack/stack, mob/user)
-	if(!stack?.table_type)
+	if(!isstack(stack))
+		return FALSE
+
+	if(!stack.table_type)
 		return FALSE
 
 	if(stack.get_amount() < 1)

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -27,7 +27,7 @@
 
 ///Try to make a table with the item used to attack. FALSE if you can't make a table and should attack. TRUE does not necessarily mean a table was made.
 /obj/structure/table_frame/proc/try_make_table(obj/item/stack/stack, mob/user)
-	if(!isstack(stack))
+	if(!istype(stack))
 		return FALSE
 
 	if(!stack.table_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds a `isstack` define for easily checking if an obj is a stack or not
fixes all items being passed on to the entire proc rather than just stacks

## Why It's Good For The Game
runtimes bad

## Testing
compiled and ran

## Changelog
NPFC