### PR TITLE
Mining borgs now have melee armor.

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -208,6 +208,19 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 			use(1)
 		else
 			to_chat(user, "<span class='warning'>You can't improve [D] any further!</span>")
+	else if(isrobot(target))
+		var/mob/living/silicon/robot/R = target
+		if(istype(R.module, /obj/item/robot_module/miner))
+			var/datum/armor/current_armor = R.armor
+			if(current_armor.getRating(MELEE) < 60)
+				R.armor = current_armor.setRating(melee_value = min(current_armor.getRating(MELEE) + 10, 60))
+				to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against melee attacks.</span>")
+				use(1)
+			else
+				to_chat(user, "<span class='warning'>You can't improve [R] any further!</span>")
+		else
+			to_chat(user, "<span class='warning'>[R]'s armor can not be improved!</span>")
+
 
 /obj/item/stack/sheet/animalhide/ashdrake
 	name = "ash drake hide"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -542,6 +542,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	add_language("Robot Talk", TRUE)
 	if("lava" in weather_immunities) // Remove the lava-immunity effect given by a printable upgrade
 		weather_immunities -= "lava"
+	armor = getArmor(arglist(initial(armor)))
 
 	status_flags |= CANPUSH
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -493,6 +493,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	modtype = selected_module
 	designation = selected_module
 	module.add_languages(src)
+	module.add_armor(src)
 	module.add_subsystems_and_actions(src)
 	if(!static_radio_channels)
 		radio.config(module.channels)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -5,6 +5,7 @@
 	w_class = 100
 	item_state = "electronic"
 	flags = CONDUCT
+	var/module_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 
 	/// Has the AI hacked the borg module, allowing access to the malf AI exclusive item.
 	var/malfhacked = FALSE
@@ -85,7 +86,9 @@
 	QDEL_LIST(special_rechargables)
 	return ..()
 
-
+/obj/item/robot_module/Initialize(mapload)
+	. = ..()
+	module_armor = getArmor(arglist(module_armor))
 /**
  * Searches through the various module lists for the given `item_type`, deletes and removes the item from all supplied lists, if the item is found.
  *
@@ -262,6 +265,11 @@
 	R.add_language("Orluum", 0)
 	R.add_language("Clownish", 0)
 	R.add_language("Tkachi", 0)
+
+///Adds armor to a cyborg. Normaly resets it to 0 across the board, unless the module has an armor defined.
+/obj/item/robot_module/proc/add_armor(mob/living/silicon/robot/R)
+	R.armor = module_armor
+
 
 /// Adds anything in `subsystems` to the robot's verbs, and grants any actions that are in `module_actions`.
 /obj/item/robot_module/proc/add_subsystems_and_actions(mob/living/silicon/robot/R)
@@ -539,6 +547,7 @@
 /obj/item/robot_module/miner
 	name = "miner robot module"
 	module_type = "Miner"
+	module_armor = list(MELEE = 20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 	module_actions = list(/datum/action/innate/robot_sight/meson)
 	custom_removals = list("KA modkits")
 	basic_modules = list(

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -257,7 +257,7 @@
 		armor_protection = armor.getRating(damage_flag)
 	if(armor_protection)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
 		armor_protection = clamp((armor_protection * ((100 - armour_penetration_percentage) / 100)) - armour_penetration_flat, min(armor_protection, 0), 100)
-	return round(damage_amount * (100 - armor_protection)*0.01, DAMAGE_PRECISION)
+	return round(damage_amount * (100 - armor_protection) * 0.01, DAMAGE_PRECISION)
 
 /mob/living/silicon/apply_effect(effect = 0, effecttype = STUN, blocked = 0)
 	return FALSE //The only effect that can hit them atm is flashes and they still directly edit so this works for now

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -247,11 +247,8 @@
 
 ///returns the damage value of the attack after processing the silicons's various armor protections
 /mob/living/silicon/proc/run_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration_flat = 0, armour_penetration_percentage = 0)
-	switch(damage_type)
-		if(BRUTE)
-		if(BURN)
-		else
-			return 0
+	if(damage_type != BRUTE && damage_type != BURN)
+		return 0
 	var/armor_protection = 0
 	if(damage_flag)
 		armor_protection = armor.getRating(damage_flag)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -6,6 +6,12 @@
 	weather_immunities = list("ash")
 	mob_biotypes = MOB_ROBOTIC
 	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2
+
+	// You can define armor as a list in datum definition (e.g. `armor = list("fire" = 80, "brute" = 10)`),
+	// which would be converted to armor datum during initialization.
+	// Setting `armor` to a list on an *existing* object would inevitably runtime. Use `getArmor()` instead.
+	var/datum/armor/armor
+
 	var/syndicate = FALSE
 	var/const/MAIN_CHANNEL = "Main Frequency"
 	var/lawchannel = MAIN_CHANNEL // Default channel on which to state laws
@@ -49,6 +55,12 @@
 		diag_hud.add_to_hud(src)
 	diag_hud_set_status()
 	diag_hud_set_health()
+	if(islist(armor))
+		armor = getArmor(arglist(armor))
+	else if(!armor)
+		armor = getArmor()
+	else if(!istype(armor, /datum/armor))
+		stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize()")
 
 
 /mob/living/silicon/med_hud_set_health()
@@ -211,18 +223,41 @@
 
 
 /mob/living/silicon/bullet_act(obj/item/projectile/Proj)
-
-
 	if(!Proj.nodamage)
+		var/damage = run_armor(Proj.damage, Proj.damage_type, Proj.flag, 0, Proj.armour_penetration_flat, Proj.armour_penetration_percentage)
 		switch(Proj.damage_type)
 			if(BRUTE)
-				adjustBruteLoss(Proj.damage)
+				adjustBruteLoss(damage)
 			if(BURN)
-				adjustFireLoss(Proj.damage)
+				adjustFireLoss(damage)
 
 	Proj.on_hit(src,2)
 
 	return 2
+
+/mob/living/silicon/attacked_by(obj/item/I, mob/living/user, def_zone)
+	send_item_attack_message(I, user)
+	if(I.force)
+		var/bonus_damage = 0
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			bonus_damage = H.physiology.melee_bonus
+		var/damage = run_armor(I.force + bonus_damage, I.damtype, MELEE, 0, I.armour_penetration_flat, I.armour_penetration_percentage)
+		apply_damage(damage, I.damtype, def_zone)
+
+///returns the damage value of the attack after processing the silicons's various armor protections
+/mob/living/silicon/proc/run_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration_flat = 0, armour_penetration_percentage = 0)
+	switch(damage_type)
+		if(BRUTE)
+		if(BURN)
+		else
+			return 0
+	var/armor_protection = 0
+	if(damage_flag)
+		armor_protection = armor.getRating(damage_flag)
+	if(armor_protection)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
+		armor_protection = clamp((armor_protection * ((100 - armour_penetration_percentage) / 100)) - armour_penetration_flat, min(armor_protection, 0), 100)
+	return round(damage_amount * (100 - armor_protection)*0.01, DAMAGE_PRECISION)
 
 /mob/living/silicon/apply_effect(effect = 0, effecttype = STUN, blocked = 0)
 	return FALSE //The only effect that can hit them atm is flashes and they still directly edit so this works for now

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -10,6 +10,7 @@
 			if(prob(8))
 				flash_eyes(affect_silicon = 1)
 			add_attack_logs(M, src, "Alien attacked")
+			damage = run_armor(damage, BRUTE, MELEE)
 			adjustBruteLoss(damage)
 			updatehealth()
 		else
@@ -22,6 +23,7 @@
 	. = ..()
 	if(.)
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
+		damage = run_armor(damage, M.melee_damage_type, MELEE, 0, M.armour_penetration_flat, M.armour_penetration_percentage)
 		switch(M.melee_damage_type)
 			if(BRUTE)
 				adjustBruteLoss(damage)
@@ -47,7 +49,8 @@
 			to_chat(user, "<span class='warning'>You don't want to hurt [src]!</span>")
 			return FALSE
 		..(user, TRUE)
-		adjustBruteLoss(rand(10, 15))
+		var/damage = run_armor(rand(10, 15), BRUTE, MELEE)
+		adjustBruteLoss(damage)
 		playsound(loc, "punch", 25, 1, -1)
 		visible_message("<span class='danger'>[user] has punched [src]!</span>", "<span class='userdanger'>[user] has punched [src]!</span>")
 		return TRUE

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -49,8 +49,7 @@
 			to_chat(user, "<span class='warning'>You don't want to hurt [src]!</span>")
 			return FALSE
 		..(user, TRUE)
-		var/damage = run_armor(rand(10, 15), BRUTE, MELEE)
-		adjustBruteLoss(damage)
+		adjustBruteLoss(run_armor(rand(10, 15), BRUTE, MELEE))
 		playsound(loc, "punch", 25, 1, -1)
 		visible_message("<span class='danger'>[user] has punched [src]!</span>", "<span class='userdanger'>[user] has punched [src]!</span>")
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Silicons now have armor.
By default, it is zero across the board.
Mining borgs now have 20% melee armor and nothing else.
This maxes at 60% armor after 4 plates.
This armor is lost on module reset.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Considering we are on lavaland, and mining borgs kinda don't have armor when everything hits like a truck, and while miners get meds and legion cores, and all mining cyborgs get is the worlds slowest self repair system, maybe they should have melee armor.
So this pr does it.
Yes, this makes mining cyborgs *slightly* more robust for melee attacks for say, malf AI.
However, they usually die by lasers or flash into baton, which is perma stun, so this will not be an issue.

Theoretically one could now give gamma borgs armor equivlent to ERT armor, but that is out of this prs scope, and honestly should probably have a little less armor? For someone else to look at.

Armor has not been converted on syndicate borgs from flat brute / burn resist, as it would make them take more damage on emp / more damage from armor peircing rounds, but it could be done. if requested.


## Testing
<!-- How did you test the PR, if at all? -->
Ensured melee and bullet attacks were affected by armor, as well as mob attacks, xeno attacks, and hulk attacks.
Ensured armor upgraded correctly.
Ensure armor got reset by module reset.

## Changelog
:cl:
add: Mining cyborgs now have melee armor.
add: Mining cyborgs can have there melee armor improved when someone applies golaith plates to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
