### PR TITLE
Fixes a mecha sleeper runtime

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -213,6 +213,9 @@
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/process()
 	if(..())
 		return
+	if(!chassis)
+		STOP_PROCESSING(SSobj, src)
+		return
 	if(!chassis.has_charge(energy_drain))
 		set_ready_state(1)
 		log_message("Deactivated.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes the below runtime
```
Runtime in medical_tools.dm,216: Cannot execute null.has charge().
proc name: process (/obj/item/mecha_parts/mecha_equipment/medical/sleeper/process)
src: the mounted sleeper (/obj/item/mecha_parts/mecha_equipment/medical/sleeper)
src.loc: the floor (111,95,2) (/turf/simulated/floor/plasteel)
call stack:
the mounted sleeper (/obj/item/mecha_parts/mecha_equipment/medical/sleeper): process(20)
Objects (/datum/controller/subsystem/processing/obj): fire(0)
Objects (/datum/controller/subsystem/processing/obj): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game
runtimes bad

## Testing
-1 OXY and checking SSobj debug
## Changelog
NPFC

