### PR TITLE
Minorly refactors the "gripper" cyborg item and moves the "drop gripped item" to an action button

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -441,6 +441,8 @@
 /datum/action/item_action/remove_badge
 	name = "Remove Holobadge"
 
+/datum/action/item_action/drop_gripped_item
+	name = "Drop gripped item"
 
 // Clown Acrobat Shoes
 /datum/action/item_action/slipping

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -343,7 +343,7 @@
 	if(try_wallmount(I, user, params))
 		return
 	// The magnetic gripper does a separate attackby, so bail from this one
-	if(istype(I, /obj/item/gripper))
+	if(istype(I, /obj/item/gripper_engineering))
 		return
 
 	return ..()

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -5,6 +5,7 @@
 	desc = "A simple grasping tool for synthetic assets."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gripper"
+	actions_types = list(/datum/action/item_action/drop_gripped_item)
 
 	//Has a list of items that it can hold.
 	var/list/can_hold = list(
@@ -44,10 +45,9 @@
 
 
 /obj/item/gripper_medical/afterattack(atom/target, mob/living/user, proximity, params)
-	var/mob/living/carbon/human/pickup_target
 	if(!proximity || !target || !ishuman(target))
 		return
-	pickup_target = target
+	var/mob/living/carbon/human/pickup_target = target
 	if(!IS_HORIZONTAL(pickup_target))
 		return
 	pickup_target.AdjustSleeping(-10 SECONDS)
@@ -66,11 +66,7 @@
 	. = ..()
 	can_hold = typecacheof(can_hold)
 
-/obj/item/gripper_engineering/verb/drop_item_gripped()
-	set name = "Drop Gripped Item"
-	set desc = "Release an item from your magnetic gripper."
-	set category = "Robot Commands"
-
+/obj/item/gripper_engineering/ui_action_click(mob/user)
 	drop_gripped_item()
 
 /obj/item/gripper_engineering/attack_self(mob/user)
@@ -90,7 +86,7 @@
 /obj/item/gripper_engineering/attack(mob/living/carbon/M, mob/living/carbon/user)
 	return
 
-/// Grippers are snowflakey so this is needed to to prevent forceMoving grippers after `if(!user.drop_item())` checks done in certain attackby's. // What does this even MEAN - GDN 
+/// Grippers are snowflakey so this is needed to to prevent forceMoving grippers after `if(!user.drop_item())` checks done in certain attackby's. // What does this even MEAN - GDN
 /obj/item/gripper_engineering/forceMove(atom/destination)
 	return
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -1,6 +1,6 @@
 //Simple borg hand.
 //Limited use.
-/obj/item/gripper
+/obj/item/gripper_engineering // This isn't a drone item, also in engineering cyborg kits
 	name = "magnetic gripper"
 	desc = "A simple grasping tool for synthetic assets."
 	icon = 'icons/obj/device.dmi'
@@ -36,64 +36,65 @@
 	//Item currently being held.
 	var/obj/item/gripped_item = null
 
-/obj/item/gripper/medical
+/obj/item/gripper_medical
 	name = "medical gripper"
 	desc = "A grasping tool used to help patients up once surgery is complete, or to substitute for hands in surgical operations."
-	can_hold = list()
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gripper"
 
-/obj/item/gripper/medical/attack_self(mob/user)
-	return
 
-/obj/item/gripper/medical/afterattack(atom/target, mob/living/user, proximity, params)
-	var/mob/living/carbon/human/H
-	if(!gripped_item && proximity && target && ishuman(target))
-		H = target
-		if(IS_HORIZONTAL(H))
-			H.AdjustSleeping(-10 SECONDS)
-			H.AdjustParalysis(-6 SECONDS)
-			H.AdjustStunned(-6 SECONDS)
-			H.AdjustWeakened(-6 SECONDS)
-			H.AdjustKnockDown(-6 SECONDS)
-			H.stand_up()
-			playsound(user.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			user.visible_message( \
-				"<span class='notice'>[user] shakes [H] trying to wake [H.p_them()] up!</span>",\
-				"<span class='notice'>You shake [H] trying to wake [H.p_them()] up!</span>",\
-				)
+/obj/item/gripper_medical/afterattack(atom/target, mob/living/user, proximity, params)
+	var/mob/living/carbon/human/pickup_target
+	if(!proximity || !target || !ishuman(target))
+		return
+	pickup_target = target
+	if(!IS_HORIZONTAL(pickup_target))
+		return
+	pickup_target.AdjustSleeping(-10 SECONDS)
+	pickup_target.AdjustParalysis(-6 SECONDS)
+	pickup_target.AdjustStunned(-6 SECONDS)
+	pickup_target.AdjustWeakened(-6 SECONDS)
+	pickup_target.AdjustKnockDown(-6 SECONDS)
+	pickup_target.stand_up()
+	playsound(user.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+	user.visible_message( \
+		"<span class='notice'>[user] shakes [pickup_target] trying to wake [pickup_target.p_them()] up!</span>",\
+		"<span class='notice'>You shake [pickup_target] trying to wake [pickup_target.p_them()] up!</span>",\
+		)
 
-/obj/item/gripper/New()
-	..()
+/obj/item/gripper_engineering/Initialize(mapload)
+	. = ..()
 	can_hold = typecacheof(can_hold)
 
-/obj/item/gripper/verb/drop_item_gripped()
+/obj/item/gripper_engineering/verb/drop_item_gripped()
 	set name = "Drop Gripped Item"
 	set desc = "Release an item from your magnetic gripper."
-	set category = "Drone"
+	set category = "Robot Commands"
 
 	drop_gripped_item()
 
-/obj/item/gripper/attack_self(mob/user)
-	if(gripped_item)
-		gripped_item.attack_self(user)
-	else
+/obj/item/gripper_engineering/attack_self(mob/user)
+	if(!gripped_item)
 		to_chat(user, "<span class='warning'>[src] is empty.</span>")
+		return
+	gripped_item.attack_self(user)
 
-/obj/item/gripper/proc/drop_gripped_item(silent = FALSE)
-	if(gripped_item)
-		if(!silent)
-			to_chat(loc, "<span class='warning'>You drop [gripped_item].</span>")
-		gripped_item.forceMove(get_turf(src))
-		gripped_item = null
+/obj/item/gripper_engineering/proc/drop_gripped_item(silent = FALSE)
+	if(!gripped_item)
+		return
+	if(!silent)
+		to_chat(loc, "<span class='warning'>You drop [gripped_item].</span>")
+	gripped_item.forceMove(get_turf(src))
+	gripped_item = null
 
-/obj/item/gripper/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/gripper_engineering/attack(mob/living/carbon/M, mob/living/carbon/user)
 	return
 
-/// Grippers are snowflakey so this is needed to to prevent forceMoving grippers after `if(!user.drop_item())` checks done in certain attackby's.
-/obj/item/gripper/forceMove(atom/destination)
+/// Grippers are snowflakey so this is needed to to prevent forceMoving grippers after `if(!user.drop_item())` checks done in certain attackby's. // What does this even MEAN - GDN 
+/obj/item/gripper_engineering/forceMove(atom/destination)
 	return
 
-/obj/item/gripper/afterattack(atom/target, mob/living/user, proximity, params)
-
+/obj/item/gripper_engineering/afterattack(atom/target, mob/living/user, proximity, params)
 	if(!target || !proximity) //Target is invalid or we are not adjacent.
 		return FALSE
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -116,7 +116,7 @@
 		return 0
 
 /mob/living/silicon/robot/drop_item()
-	var/obj/item/gripper/G = get_active_hand()
+	var/obj/item/gripper_engineering/G = get_active_hand()
 	if(istype(G))
 		G.drop_gripped_item(silent = TRUE)
 		return TRUE // The gripper is special because it has a normal item inside that we can drop.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1536,7 +1536,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 
 /// Used in `robot.dm` when the user presses "Q" by default.
 /mob/living/silicon/robot/proc/on_drop_hotkey_press()
-	var/obj/item/gripper/G = get_active_hand()
+	var/obj/item/gripper_engineering/G = get_active_hand()
 	if(istype(G) && G.gripped_item)
 		G.drop_gripped_item() // if the active module is a gripper, try to drop its held item.
 	else

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -317,7 +317,7 @@
 		/obj/item/stack/medical/ointment/advanced/cyborg,
 		/obj/item/stack/medical/splint/cyborg,
 		/obj/item/stack/nanopaste/cyborg,
-		/obj/item/gripper/medical
+		/obj/item/gripper_medical
 	)
 	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_facid)
 	special_rechargables = list(/obj/item/reagent_containers/spray/cyborg_facid, /obj/item/extinguisher/mini)
@@ -364,7 +364,7 @@
 		/obj/item/analyzer,
 		/obj/item/geiger_counter/cyborg,
 		/obj/item/holosign_creator/engineering,
-		/obj/item/gripper,
+		/obj/item/gripper_engineering,
 		/obj/item/matter_decompiler,
 		/obj/item/painter,
 		/obj/item/areaeditor/blueprints/cyborg,
@@ -380,7 +380,7 @@
 	special_rechargables = list(/obj/item/extinguisher, /obj/item/weldingtool/largetank/cyborg, /obj/item/gun/energy/emitter/cyborg)
 
 /obj/item/robot_module/engineering/handle_death(mob/living/silicon/robot/R, gibbed)
-	var/obj/item/gripper/G = locate(/obj/item/gripper) in modules
+	var/obj/item/gripper_engineering/G = locate(/obj/item/gripper_engineering) in modules
 	if(G)
 		G.drop_gripped_item(silent = TRUE)
 
@@ -636,7 +636,7 @@
 		/obj/item/stack/nanopaste/cyborg/syndicate,
 		/obj/item/gun/medbeam,
 		/obj/item/extinguisher/mini,
-		/obj/item/gripper/medical
+		/obj/item/gripper_medical
 	)
 	special_rechargables = list(/obj/item/extinguisher/mini)
 
@@ -657,7 +657,7 @@
 		/obj/item/multitool/cyborg,
 		/obj/item/t_scanner,
 		/obj/item/analyzer,
-		/obj/item/gripper,
+		/obj/item/gripper_engineering,
 		/obj/item/melee/energy/sword/cyborg,
 		/obj/item/card/emag,
 		/obj/item/borg_chameleon,
@@ -741,7 +741,7 @@
 		/obj/item/wirecutters/cyborg/drone,
 		/obj/item/multitool/cyborg/drone,
 		/obj/item/lightreplacer/cyborg,
-		/obj/item/gripper,
+		/obj/item/gripper_engineering,
 		/obj/item/matter_decompiler,
 		/obj/item/reagent_containers/spray/cleaner/drone,
 		/obj/item/soap,
@@ -764,7 +764,7 @@
 	)
 
 /obj/item/robot_module/drone/handle_death(mob/living/silicon/robot/R, gibbed)
-	var/obj/item/gripper/G = locate(/obj/item/gripper) in modules
+	var/obj/item/gripper_engineering/G = locate(/obj/item/gripper_engineering) in modules
 	if(G)
 		G.drop_gripped_item(silent = TRUE)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -184,7 +184,7 @@
 	if(accept_hand)
 		if(!tool)
 			success = TRUE
-		if(isrobot(user) && istype(tool, /obj/item/gripper/medical))
+		if(isrobot(user) && istype(tool, /obj/item/gripper_medical))
 			success = TRUE
 
 	if(accept_any_item)


### PR DESCRIPTION
## What Does This PR Do
Minorly refactors the "gripper" cyborg item 
moves the "drop gripped item" from the drone tab to an action button
mediborgs no longer get the above verb

## Why It's Good For The Game
only thing the drone tab is used for, used with things that aren't drones so it's silly
mediborgs shouldn't get a verb they can't use'
buttons good verbs bad

## Testing
compiled and did things

## Changelog
:cl:
tweak: "drop gripped item" is now an action button
fix: Mediborgs no longer have an unusable verb
/:cl:

