### PR TITLE
Prevents vampires who didn't drain anyone from being tested in the chapel

### DIFF
--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -261,7 +261,7 @@
 			hud.vampire_blood_display.screen_loc = "WEST:6,CENTER-1:15"
 			hud.static_inventory += hud.vampire_blood_display
 			hud.show_hud(hud.hud_version)
-		hud.vampire_blood_display.maptext = "<div align='center' valign='middle'd style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#ce0202'>[bloodusable]</font></div>"
+		hud.vampire_blood_display.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#ce0202'>[bloodusable]</font></div>"
 	handle_vampire_cloak()
 	if(isspaceturf(get_turf(owner.current)))
 		check_sun()
@@ -309,6 +309,8 @@
 
 /datum/antagonist/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.current.health >= 50)
+		if(!bloodtotal && !isspaceturf(get_turf(owner.current)))
+			return
 		switch(owner.current.health)
 			if(75 to 100)
 				to_chat(owner.current, "<span class='warning'>Your skin flakes away...</span>")

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -265,7 +265,7 @@
 	handle_vampire_cloak()
 	if(isspaceturf(get_turf(owner.current)))
 		check_sun()
-	if(istype(area, chapel) && (!isfullpower && total blood > 0))
+	if(istype(get_area(owner.current), /area/chapel) && !get_ability(/datum/vampire_passive/full) && bloodtotal > 0)
 		vamp_burn(7)
 	nullified = max(0, nullified - 2)
 

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -309,8 +309,6 @@
 
 /datum/antagonist/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.current.health >= 50)
-		if(!bloodtotal && !isspaceturf(get_turf(owner.current)))
-			return
 		switch(owner.current.health)
 			if(75 to 100)
 				to_chat(owner.current, "<span class='warning'>Your skin flakes away...</span>")

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -309,6 +309,8 @@
 
 /datum/antagonist/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.current.health >= 50)
+		if(!bloodtotal)
+			return
 		switch(owner.current.health)
 			if(75 to 100)
 				to_chat(owner.current, "<span class='warning'>Your skin flakes away...</span>")

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -309,7 +309,7 @@
 
 /datum/antagonist/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.current.health >= 50)
-		if(!bloodtotal)
+		if(!bloodtotal && !isspaceturf(get_turf(owner.current)))
 			return
 		switch(owner.current.health)
 			if(75 to 100)

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -261,11 +261,11 @@
 			hud.vampire_blood_display.screen_loc = "WEST:6,CENTER-1:15"
 			hud.static_inventory += hud.vampire_blood_display
 			hud.show_hud(hud.hud_version)
-		hud.vampire_blood_display.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#ce0202'>[bloodusable]</font></div>"
+		hud.vampire_blood_display.maptext = "<div align='center' valign='middle'd style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#ce0202'>[bloodusable]</font></div>"
 	handle_vampire_cloak()
 	if(isspaceturf(get_turf(owner.current)))
 		check_sun()
-	if(istype(get_area(owner.current), /area/chapel) && !get_ability(/datum/vampire_passive/full))
+	if(istype(area, chapel) && (!isfullpower && total blood > 0))
 		vamp_burn(7)
 	nullified = max(0, nullified - 2)
 
@@ -309,8 +309,6 @@
 
 /datum/antagonist/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.current.health >= 50)
-		if(!bloodtotal && !isspaceturf(get_turf(owner.current)))
-			return
 		switch(owner.current.health)
 			if(75 to 100)
 				to_chat(owner.current, "<span class='warning'>Your skin flakes away...</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Vampires will no longer suffer any ill effects if they are in the chapel area as long as they didn't obtain any usable blood.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Getting attention from security before you obtained any usable blood will result in a time sentence (or it's lack, depending what did you do to get security attention in the first place) instead of round ending permabrig while you are still locked to only having two abilities (and helps if security is mass testing people in the chapel because another vampire tipped them off about their presence on the station)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Testing
Checked what happens to vampires at specific stages when exposed to chapel and space: vampire with no blood drained, vampire with some blood drained, vampire with specialization, full power vampire and all burned up in space, while only vampire with some blood drained reacted to being in chapel.
No runtimes happened during testing.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Vampires with 0 blood drained no longer react to being in the chapel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
