### PR TITLE
Gravity generator is now more radioactive to people when turning on or off

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -350,7 +350,9 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 
 
 /obj/machinery/gravity_generator/main/proc/pulse_radiation()
-	radiation_pulse(src, 200)
+	radiation_pulse(src, 600, 2)
+	for(var/mob/living/L in view(7, src)) //Windows kinda make it a non threat, no matter how much I amp it up, so let us cheat a little
+		radiation_pulse(get_turf(L), 600, 2)
 
 /**
   * Shake everyone on the z level and play an alarm to let them know that gravity was enagaged/disenagaged.


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

The gravity generator irradiates itself a bit more, and irradiates allmobs in it's view (won't go through walls, or xray on a vampire that can see it), when turning off or on. Does not irradiate when just on normally.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It's supposed to be radioactive, it has signs and rad suit lockers for god sake. I don't want it SM level as people will cheese it, nor should it create work for the server for being radioactive passively. So we cheat and place radiation on people that can see it.
It probably should be more radiation, it's not really contaminating the person that much, but hey, it's a start.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed people actually get irradiated by the gravity generator now

## Changelog
:cl:
tweak: Gravity generator now irradiates people more reliably.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
