### PR TITLE
Matches Sec. Plasmaman Helmets to Standard Sec. Headgear

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -79,7 +79,7 @@
 	if(!on || !up)
 		set_light(0)
 		return
-	
+
 	set_light(brightness_on)
 
 /obj/item/clothing/head/helmet/space/plasmaman/extinguish_light()
@@ -91,19 +91,21 @@
 	desc = "A plasmaman containment helmet designed for security officers, protecting them from being flashed and burning alive, alongside other undesirables."
 	icon_state = "security_envirohelm"
 	item_state = "security_envirohelm"
-	armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = INFINITY, RAD = 0, FIRE = INFINITY, ACID = 150)
+	armor = list(MELEE = 25, BULLET = 20, LASER = 20, ENERGY = 5, BOMB = 15, BIO = INFINITY, RAD = 0, FIRE = INFINITY, ACID = 150)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security/warden
 	name = "warden's plasma envirosuit helmet"
 	desc = "A plasmaman containment helmet designed for the warden, a pair of white stripes being added to differentiate them from other members of security."
 	icon_state = "warden_envirohelm"
 	item_state = "warden_envirohelm"
+	armor = list(MELEE = 35, BULLET = 20, LASER = 20, ENERGY = 5, BOMB = 15, BIO = INFINITY, RAD = 0, FIRE = INFINITY, ACID = 150)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security/hos
 	name = "security plasma envirosuit helmet"
 	desc = "A plasmaman containment helmet designed for the head of security."
 	icon_state = "hos_envirohelm"
 	item_state = "hos_envirohelm"
+	armor = list(MELEE = 35, BULLET = 20, LASER = 20, ENERGY = 5, BOMB = 15, BIO = INFINITY, RAD = 0, FIRE = INFINITY, ACID = 150)
 
 /obj/item/clothing/head/helmet/space/plasmaman/medical
 	name = "medical plasma envirosuit helmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. --> Tweaks the armor values for Security Envirohelms so that they're up to snuff with the armor that all other species are able to gain from their Security gear.     

## Why It's Good For The Game
Plasmamen cannot wear armored headgear without combustion and death, so they're limited to only their Envirohelmet.  However the Helmets that Plasmamen were wearing are much weaker than the standard Beret and Helmet non-Plasmaman Officers can wear at all times.  Kind of bad for someone who is going to be dealing with Station-Wide Threats, even more so for the Warden and Head of Security roles given they're a more valuable target for many Antagonists.  Turns out that even the basic Plasmaman Sec. Envirohelm had only 5% melee armor compared to a regular Redman's 25% from a basic helmet.  

## Testing
I whack Plasmeme on the head, he take a bit less damage (Still totally ROASTED by fire damage from lasers, 50% burn damage increase gaming, so don't think this makes you safe from being laser gunned to death in .5 seconds -- it's .75 seconds now)  

## Changelog
:cl:
tweak: Adds proper armor to Security Envirohelmets.  
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
