### PR TITLE
Fixes a disposals runtime and cleans up a touch of disposals grammar 

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -495,7 +495,7 @@
 			update()
 		else
 			for(var/mob/M in viewers(src))
-				M.show_message("\the [I] bounces off of \the [src]'s rim!.", 3)
+				M.show_message("\the [I] bounces off of \the [src]'s rim!", 3)
 		return 0
 	else
 		return ..(mover, target, height)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -257,7 +257,7 @@
 	destination_tagger.ui_interact(user)
 
 /obj/machinery/disposal/deliveryChute
-	name = "Delivery chute"
+	name = "delivery chute"
 	desc = "A chute for big and small packages alike!"
 	density = TRUE
 	icon_state = "intake"
@@ -279,7 +279,7 @@
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
-	if(istype(AM, /obj/item/projectile)	|| isAI(AM))  return
+	if(istype(AM, /obj/item/projectile)	|| isAI(AM) || QDELETED(AM))  return
 	switch(dir)
 		if(NORTH)
 			if(AM.loc.y != loc.y + 1) return

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -279,7 +279,8 @@
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
-	if(istype(AM, /obj/item/projectile)	|| isAI(AM) || QDELETED(AM))  return
+	if(istype(AM, /obj/item/projectile)	|| isAI(AM) || QDELETED(AM))
+		return
 	switch(dir)
 		if(NORTH)
 			if(AM.loc.y != loc.y + 1) return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Disposal chutes are no longer capitalized, an extra period has been removed from the "rim shot" line
Disposals chutes no longer try to transfer Qdeleted items

## Why It's Good For The Game
Runtimes bad
Improper grammar bad

## Testing
Threw items like snowballs and wine bottles into disposals 
## Changelog
:cl:
spellcheck: disposal chutes are no longer capitalized 
/:cl:
