### PR TITLE
Makes Simple Mobs unable to be Converted

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -39,8 +39,8 @@ GLOBAL_LIST_EMPTY(all_cults)
 		return FALSE //can't convert machines, that's ratvar's thing
 	if(isguardian(mind.current))
 		var/mob/living/simple_animal/hostile/guardian/G = mind.current
-		if(!iscultist(G.summoner))
-			return FALSE //can't convert it unless the owner is converted
+		if(iscultist(G.summoner))
+			return TRUE //can't convert it unless the owner is converted
 	if(isgolem(mind.current))
 		return FALSE
 	if(isanimal(mind.current))

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -43,6 +43,8 @@ GLOBAL_LIST_EMPTY(all_cults)
 			return FALSE //can't convert it unless the owner is converted
 	if(isgolem(mind.current))
 		return FALSE
+	if(isanimal(mind.current))
+		return FALSE
 	return TRUE
 
 /datum/game_mode/cult


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->  Adds a check to see if the convertee is a simplemob, if they are they cannot be turned into a Cultist.  

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->  Just like how Golems were added to the list of non-convertables, simplemobs like Slimes were on it too.  I do not know what happened to break it or disable that, but this should fix it.  

It's considered not intended by many Admins and often will end up with the mobs being deleted, and while I'd say you haven't truly lived until you've seen a Xenobiologist push out 20+ cult slimes with other random simplemobs of murderbone death -- it's preferable to avoid simplemob murderbone armies in the future under the same reasons Golems were not allowed to be churned out for conversion.  (Sorry for all of those who were murdered by 3+ slimes to never be converted *chuckle)

## Testing
<!-- How did you test the PR, if at all? -->  I was unable to convert random mobs. This didn't prevent me from adding sacrifices to the Revive Rune list so you can still churn out dozens of free full revives as a Cultist Xenobiologist by sac'ing your slime army for infinite healing.  

## Changelog
:cl:
tweak: Added Simple Mobs to the check list of non-convertees, as it used to apparently be in the past.  
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
