### PR TITLE
Fixes an ATM runtime 

### DIFF
--- a/code/modules/economy/economy_machinery/atm.dm
+++ b/code/modules/economy/economy_machinery/atm.dm
@@ -124,6 +124,8 @@
 
 ///ensures proper GC of money account
 /obj/machinery/economy/atm/proc/clear_account()
+	if(!authenticated_account) // In some situations there will be no authenticated account, such as removing your ID without inputting account information
+		return
 	UnregisterSignal(authenticated_account, COMSIG_PARENT_QDELETING)
 	authenticated_account = null
 


### PR DESCRIPTION
## What Does This PR Do
Fixes this runtime
```
Runtime in _component.dm,220: Cannot read null.comp_lookup
proc name: UnregisterSignal (/datum/proc/UnregisterSignal)
usr: *REDACTED USER*
usr.loc: The floor (143,130,2) (/turf/simulated/floor/plasteel)
src: Nanotrasen automatic teller ma... (/obj/machinery/economy/atm)
```

It was passing a null value onto clear_account if you just ejected your ID without logging in.
added a sanity check to prevent this

## Why It's Good For The Game
runtimes bad

## Testing
let the GC debugger smash it's head into the wall for 15 minutes and used an excessive amount of breakpoints

## Changelog
NPFC