### PR TITLE
Fixes a flash runtime

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -77,14 +77,14 @@
 
 
 /obj/item/flash/proc/try_use_flash(mob/user = null)
+	if(broken)
+		return FALSE
+
 	if(cooldown >= world.time)
 		to_chat(user, "<span class='warning'>Your [name] is still too hot to use again!</span>")
 		return FALSE
 	cooldown = world.time + cooldown_duration
 	flash_recharge(user)
-
-	if(broken)
-		return FALSE
 
 	playsound(loc, use_sound, 100, 1)
 	flick("[initial(icon_state)]2", src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #18862
the associated code was calling if(broken) after it would check for a cooldown, hit activate it twice without a user (can only be done with an emp) in under the cooldown time and you get a runtime because there's no user.
That logic has been fixed, and the flash's stat is checked first

## Why It's Good For The Game
runtimes bad
I like a clean production log

## Testing
flash + ion rifle
## Changelog
NPFC