### PR TITLE
Clean up of AStar procs, rework one into an independant adjacent turf proc

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -372,8 +372,8 @@
 /turf/proc/burn_down()
 	return
 
-/// Returns the adjacent turfs, and can check for density or cardinal directions only instead of all 8
-/turf/proc/AdjacentTurfs(check_density = FALSE, cardinal_only = FALSE)
+/// Returns the adjacent turfs. Can check for density or cardinal directions only instead of all 8, or just dense turfs entirely. dense_only takes precedence over open_only.
+/turf/proc/AdjacentTurfs(open_only = FALSE, cardinal_only = FALSE, dense_only = FALSE)
 	var/list/L = new()
 	var/turf/T
 	var/list/directions = cardinal_only ? GLOB.alldirs : GLOB.cardinal
@@ -381,7 +381,9 @@
 		T = get_step(src, dir)
 		if(!istype(T))
 			continue
-		if(check_density && T.density)
+		if(dense_only && !T.density)
+			continue
+		if((open_only && T.density) && !dense_only)
 			continue
 		L.Add(T)
 	return L

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -372,106 +372,22 @@
 /turf/proc/burn_down()
 	return
 
-/////////////////////////////////////////////////////////////////////////
-// Navigation procs
-// Used for A-star pathfinding
-////////////////////////////////////////////////////////////////////////
-
-///////////////////////////
-//Cardinal only movements
-///////////////////////////
-
-// Returns the surrounding cardinal turfs with open links
-// Including through doors openable with the ID
-/turf/proc/CardinalTurfsWithAccess(obj/item/card/id/ID)
-	var/list/L = new()
-	var/turf/simulated/T
-
-	for(var/dir in GLOB.cardinal)
-		T = get_step(src, dir)
-		if(istype(T) && !T.density)
-			if(!LinkBlockedWithAccess(src, T, ID))
-				L.Add(T)
-	return L
-
-// Returns the surrounding cardinal turfs with open links
-// Don't check for ID, doors passable only if open
-/turf/proc/CardinalTurfs()
-	var/list/L = new()
-	var/turf/simulated/T
-
-	for(var/dir in GLOB.cardinal)
-		T = get_step(src, dir)
-		if(istype(T) && !T.density)
-			if(!CanAtmosPass(T))
-				L.Add(T)
-	return L
-
-///////////////////////////
-//All directions movements
-///////////////////////////
-
-// Returns the surrounding simulated turfs with open links
-// Including through doors openable with the ID
-/turf/proc/AdjacentTurfsWithAccess(obj/item/card/id/ID = null, list/closed)//check access if one is passed
-	var/list/L = new()
-	var/turf/simulated/T
-	for(var/dir in GLOB.alldirs2) //arbitrarily ordered list to favor non-diagonal moves in case of ties
-		T = get_step(src, dir)
-		if(T in closed) //turf already proceeded in A*
-			continue
-		if(istype(T) && !T.density)
-			if(!LinkBlockedWithAccess(src, T, ID))
-				L.Add(T)
-	return L
-
-//Idem, but don't check for ID and goes through open doors
-/turf/proc/AdjacentTurfs(list/closed)
-	var/list/L = new()
-	var/turf/simulated/T
-	for(var/dir in GLOB.alldirs2) //arbitrarily ordered list to favor non-diagonal moves in case of ties
-		T = get_step(src, dir)
-		if(T in closed) //turf already proceeded by A*
-			continue
-		if(istype(T) && !T.density)
-			if(!CanAtmosPass(T))
-				L.Add(T)
-	return L
-
-// check for all turfs, including space ones
-/turf/proc/AdjacentTurfsSpace(obj/item/card/id/ID = null, list/closed)//check access if one is passed
+/// Returns the adjacent turfs, and can check for density or cardinal directions only instead of all 8
+/turf/proc/AdjacentTurfs(check_density = FALSE, cardinal_only = FALSE)
 	var/list/L = new()
 	var/turf/T
-	for(var/dir in GLOB.alldirs2) //arbitrarily ordered list to favor non-diagonal moves in case of ties
+	var/list/directions = cardinal_only ? GLOB.alldirs : GLOB.cardinal
+	for(var/dir in directions)
 		T = get_step(src, dir)
-		if(T in closed) //turf already proceeded by A*
+		if(!istype(T))
 			continue
-		if(istype(T) && !T.density)
-			if(!ID)
-				if(!CanAtmosPass(T))
-					L.Add(T)
-			else
-				if(!LinkBlockedWithAccess(src, T, ID))
-					L.Add(T)
+		if(check_density && T.density)
+			continue
+		L.Add(T)
 	return L
 
-//////////////////////////////
-//Distance procs
-//////////////////////////////
-
-//Distance associates with all directions movement
 /turf/proc/Distance(turf/T)
 	return get_dist(src, T)
-
-//  This Distance proc assumes that only cardinal movement is
-//  possible. It results in more efficient (CPU-wise) pathing
-//  for bots and anything else that only moves in cardinal dirs.
-/turf/proc/Distance_cardinal(turf/T)
-	if(!src || !T)
-		return 0
-	return abs(src.x - T.x) + abs(src.y - T.y)
-
-////////////////////////////////////////////////////
 
 /turf/acid_act(acidpwr, acid_volume)
 	. = TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -376,7 +376,7 @@
 /turf/proc/AdjacentTurfs(open_only = FALSE, cardinal_only = FALSE, dense_only = FALSE)
 	var/list/L = new()
 	var/turf/T
-	var/list/directions = cardinal_only ? GLOB.alldirs : GLOB.cardinal
+	var/list/directions = cardinal_only ? GLOB.cardinal : GLOB.alldirs
 	for(var/dir in directions)
 		T = get_step(src, dir)
 		if(!istype(T))

--- a/code/modules/fish/fishtank.dm
+++ b/code/modules/fish/fishtank.dm
@@ -377,7 +377,7 @@
 		if("tank")										//Fishtank: Wets it's own tile and the 4 adjacent tiles (cardinal directions)
 			if(istype(T))
 				T.MakeSlippery()
-				for(var/turf/simulated/ST in T.CardinalTurfs())
+				for(var/turf/simulated/ST in T.AdjacentTurfs(check_density = TRUE, cardinal_only = TRUE))
 					ST.MakeSlippery()
 		if("wall")										//Wall-tank: Wets it's own tile and the surrounding 8 tiles (3x3 square)
 			for(var/turf/simulated/ST in spiral_range_turfs(1, loc))

--- a/code/modules/fish/fishtank.dm
+++ b/code/modules/fish/fishtank.dm
@@ -377,7 +377,7 @@
 		if("tank")										//Fishtank: Wets it's own tile and the 4 adjacent tiles (cardinal directions)
 			if(istype(T))
 				T.MakeSlippery()
-				for(var/turf/simulated/ST in T.AdjacentTurfs(check_density = TRUE, cardinal_only = TRUE))
+				for(var/turf/simulated/ST in T.AdjacentTurfs(open_only = TRUE, cardinal_only = TRUE))
 					ST.MakeSlippery()
 		if("wall")										//Wall-tank: Wets it's own tile and the surrounding 8 tiles (3x3 square)
 			for(var/turf/simulated/ST in spiral_range_turfs(1, loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cleans up some remnant AStar procs that weren't removed in the JPS PR. `AdjacentTurfs` is reworked into a more general proc that returns a list of turfs.

## Why It's Good For The Game
Outside of cleaning up old procs, having a proc that returns either all adjacent turfs, cardinal or all dirs, with or without density is useful.

## Testing
Messed around with a fishtank. Also did some test with possible future PR prospects.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
