### PR TITLE
observers can now view the contents of zipped duffles

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -426,6 +426,9 @@
 	return ..()
 
 /obj/item/storage/backpack/duffel/show_to(mob/user)
+	if(isobserver(user))
+		return ..()
+
 	if(zipped)
 		to_chat(usr, "<span class='notice'>[src] is zipped shut!</span>")
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #20015 

## Why It's Good For The Game
they know

## Testing
It worked
None of us are safe

## Changelog
:cl:
fix: observers can now view the contents of zipped dufflebags
/:cl:
