### PR TITLE
Fixes fultons being able to send you into a nullspace like state

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -118,6 +118,10 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 				if(floor.density)
 					continue
 				flooring_near_beacon += floor
+			var/turf/user_loc = get_turf(user)
+			if(!length(flooring_near_beacon))
+				to_chat(user, "<span class='notice'>Your fulton pack slowly brings you back down, it seems that the linked beacon has stopped functioning!</span>")
+				flooring_near_beacon = user_loc
 			holder_obj.forceMove(pick(flooring_near_beacon))
 			animate(holder_obj, pixel_z = 10, time = 50)
 			sleep(50)

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -118,10 +118,9 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 				if(floor.density)
 					continue
 				flooring_near_beacon += floor
-			var/turf/user_loc = get_turf(user)
 			if(!length(flooring_near_beacon))
 				to_chat(user, "<span class='notice'>Your fulton pack slowly brings you back down, it seems that the linked beacon has stopped functioning!</span>")
-				flooring_near_beacon = user_loc
+				flooring_near_beacon = get_turf(user)
 			holder_obj.forceMove(pick(flooring_near_beacon))
 			animate(holder_obj, pixel_z = 10, time = 50)
 			sleep(50)


### PR DESCRIPTION
## What Does This PR Do
fixes #20020 

## Why It's Good For The Game
Hell is not a great place to be.
Playing the game is generally preferred over not playing the game

## Testing
Got acquainted with the Brazilian wildlife, chat message properly showed up and I got set down in the correct location

## Changelog
:cl:
fix: fixes fultons sending you into an immobile state if the beacon selected was removed
/:cl:
