### PR TITLE
TM ONLY - Enables tracy profiler

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -6,8 +6,8 @@
 
 // Uncomment the following line to enable Tracy profiling.
 // DO NOT DO THIS UNLESS YOU UNDERSTAND THE IMPLICATIONS
-// Your data directory will grow by about a gigabyte every time you launch the server, as well as introducing potential instabilities over multiple BYOND versions. 
-// #define ENABLE_BYOND_TRACY
+// Your data directory will grow by about a gigabyte every time you launch the server, as well as introducing potential instabilities over multiple BYOND versions.
+#define ENABLE_BYOND_TRACY
 
 
 #ifdef CIBUILDING


### PR DESCRIPTION
Last tracy profile was in august, I want to see what the big tick eaters are now that we have the atmos rework TM'd.

This will not pass CI. This is fine. This is DNM. 