### PR TITLE
Fixes some vortex arm bugs that were not caught

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -516,11 +516,16 @@
 
 	owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
 	playsound(src, 'sound/weapons/v1_parry.ogg', 100, TRUE)
-	if(isitem(hitby)) //Thrown items
+	if(attack_type == THROWN_PROJECTILE_ATTACK)
+		if(!isitem(hitby))
+			return TRUE
 		var/obj/item/TT = hitby
-		addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), locateUID(TT.thrownby), 15, 15, owner), 0.1 SECONDS) //yeet that shit right back
+		addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), locateUID(TT.thrownby), 10, 4, owner), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finshes the throwing to prevent double embeds
 		return TRUE
-	melee_attack_chain(owner, hitby)
+	if(isitem(hitby))
+		melee_attack_chain(owner, hitby.loc)
+	else
+		melee_attack_chain(owner, hitby)
 	return TRUE
 
 /obj/item/v1_arm_shell


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Attacks the loc of hitby if it is an item, since that is the person with the item, vs trying to hit the item directly

Thrown items should not longer duplicate on embed from vortex arm reflection, as its throwspeed was lowered to a reasonable value, as well as slightly increased callback to ensure no issues happen.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad. Sorry for not catching in testing earlier.

## Testing
<!-- How did you test the PR, if at all? -->
Tested to ensure that humans would get hit by vortex arm on perfect parry
Tested to ensure thrown items no longer duplicate on embed from the arm

## Changelog
:cl:
fix: Vortex arm now melee hits humans on parry, and no longer freaks out when parrying items that embed on target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
