### PR TITLE
Reduces Taj and Vulp dark sight from 8 tiles to 3

### DIFF
--- a/code/modules/surgery/organs/subtypes/tajaran.dm
+++ b/code/modules/surgery/organs/subtypes/tajaran.dm
@@ -8,12 +8,12 @@
 	name = "tajaran eyeballs"
 	colourblind_matrix = MATRIX_TAJ_CBLIND //The colour matrix and darksight parameters that the mob will recieve when they get the disability.
 	replace_colours = TRITANOPIA_COLOR_REPLACE
-	see_in_dark = 8
+	see_in_dark = 3
 
 /obj/item/organ/internal/eyes/tajaran/farwa //Being the lesser form of Tajara, Farwas have an utterly incurable version of their colourblindness.
 	name = "farwa eyeballs"
 	colourmatrix = MATRIX_TAJ_CBLIND
-	see_in_dark = 8
+	see_in_dark = 3
 	replace_colours = TRITANOPIA_COLOR_REPLACE
 
 /obj/item/organ/internal/heart/tajaran

--- a/code/modules/surgery/organs/subtypes/vulpkanin.dm
+++ b/code/modules/surgery/organs/subtypes/vulpkanin.dm
@@ -8,12 +8,12 @@
 	icon = 'icons/obj/species_organs/vulpkanin.dmi'
 	colourblind_matrix = MATRIX_VULP_CBLIND //The colour matrix and darksight parameters that the mob will recieve when they get the disability.
 	replace_colours = PROTANOPIA_COLOR_REPLACE
-	see_in_dark = 8
+	see_in_dark = 3
 
 /obj/item/organ/internal/eyes/vulpkanin/wolpin //Being the lesser form of Vulpkanin, Wolpins have an utterly incurable version of their colourblindness.
 	name = "wolpin eyeballs"
 	colourmatrix = MATRIX_VULP_CBLIND
-	see_in_dark = 8
+	see_in_dark = 3
 	replace_colours = PROTANOPIA_COLOR_REPLACE
 
 /obj/item/organ/internal/heart/vulpkanin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Reduces the dark sight Tajs and Vulps get from 8 tiles(Full view range) to 3 tiles(One more than humans).

Primal forms dark sight also reduced for both 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Both species essentially have free night vision with a very minor drawback. This PR keeps their dark sight while reducing it so that it is not on the same level as night vision.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

Left new, right old. Both images were taken in full darkness.
![PR1](https://user-images.githubusercontent.com/92271472/209886405-3dda816d-6be0-4dbc-827b-a031481e59b3.png)

## Testing
<!-- How did you test the PR, if at all? -->
In game.
## Changelog
:cl: Bmon
tweak: Tajarans and Vulpkanins have had their dark sight reduced from 8 tiles to 3.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
