### PR TITLE
Bartenders Spawn with an EFTPOS

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -153,7 +153,7 @@
 	pda = /obj/item/pda/bar
 	backpack_contents = list(
 		/obj/item/toy/russian_revolver = 1,
-		/obj/item/eftpos=1)
+		/obj/item/eftpos = 1)
 
 /datum/outfit/job/bartender/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -152,8 +152,8 @@
 	id = /obj/item/card/id/bartender
 	pda = /obj/item/pda/bar
 	backpack_contents = list(
-		/obj/item/toy/russian_revolver = 1
-	)
+		/obj/item/toy/russian_revolver = 1,
+		/obj/item/eftpos=1)
 
 /datum/outfit/job/bartender/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the bartender an EFTPOS scanner to have the option of charging for drinks.
## Why It's Good For The Game
Payed drinks > Free drinks, MAKE THAT MONEY PLAYAH
*In all seriousness, it helps people use the economy more and its part of SoP. Seems nobody ever gave them the one tool that makes charging people a fucking breeze.*

## Testing
booted server, charged myself 0 credits, that stonks baby

## Changelog
:cl:
tweak: Bartenders spawn with an EFTPOS on roundstart now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
