### PR TITLE
Tweaks the Hardstun (Weaken) from Cult Doors to a Knockdown

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -545,7 +545,7 @@
 			var/atom/throwtarget
 			throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
 			SEND_SOUND(L, pick(sound('sound/hallucinations/turn_around1.ogg', 0, 1, 50), sound('sound/hallucinations/turn_around2.ogg', 0, 1, 50)))
-			L.Weaken(4 SECONDS)
+			L.KnockDown(4 SECONDS)
 			L.throw_at(throwtarget, 5, 1,src)
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cult doors will no longer hard stun you, instead knocking you down as punishment for touching the door (as a non cultist).

## Why It's Good For The Game
Hardstuns are something Paradise has been moving away from in terms of design. Doors hardstunning you is a bit too punishing and while I do agree there should be some sort of consequence, I think a simple knockdown suffices. Not as painful, but still noticeable and not a position you wanna be in.


## Testing
spawned door, ran in, knockdowned

## Changelog
:cl: Octus
tweak: Cult Doors no longer weaken, instead they simply knock you down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
