### PR TITLE
Sharp burn weapons can now disember

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -262,10 +262,13 @@
 	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner)
-		if(!(limb_flags & CANNOT_DISMEMBER) && brute_dam >= max_damage)
-			if(prob(brute / 2))
-				if(sharp)
+		if(sharp)
+			if(!(limb_flags & CANNOT_DISMEMBER) && brute_dam >= max_damage)
+				if(prob(brute / 2))
 					droplimb(0, DROPLIMB_SHARP)
+			if(!(limb_flags & CANNOT_DISMEMBER) && burn_dam >= max_damage)
+				if(prob(burn / 2))
+					droplimb(0, DROPLIMB_BURN)
 
 	if(owner_old)
 		owner_old.updatehealth("limb receive damage")
@@ -493,6 +496,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	if(!disintegrate)
 		disintegrate = DROPLIMB_SHARP
+	if(disintegrate == DROPLIMB_BURN && istype(src, /obj/item/organ/external/head))
+		disintegrate = DROPLIMB_SHARP //Lets not make sharp burn weapons delete brains.
 
 	switch(disintegrate)
 		if(DROPLIMB_SHARP)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -262,13 +262,11 @@
 	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner)
-		if(sharp)
-			if(!(limb_flags & CANNOT_DISMEMBER) && brute_dam >= max_damage)
-				if(prob(brute / 2))
-					droplimb(0, DROPLIMB_SHARP)
-			if(!(limb_flags & CANNOT_DISMEMBER) && burn_dam >= max_damage)
-				if(prob(burn / 2))
-					droplimb(0, DROPLIMB_BURN)
+		if(sharp && !(limb_flags & CANNOT_DISMEMBER))
+			if(brute_dam >= max_damage && prob(brute / 2))
+				droplimb(0, DROPLIMB_SHARP)
+			if(burn_dam >= max_damage && prob(burn / 2))
+				droplimb(0, DROPLIMB_BURN)
 
 	if(owner_old)
 		owner_old.updatehealth("limb receive damage")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Sharp burn weapons have the same chance to disember as burn weapons, accounting for burn instead of brute, in the form of DROPLIMB_BURN
If a DROPLIMB_BURN is used on head, it changes to DROPLIMB_SHARP, as otherwise it would instantly delete the brain.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Sharp weapons that are burn being cutting edge is cool. Who doesn't want to turn someones arm into ash. Sharp does not have much of a point without being able to delimb, so burn weapons that are sharp (which are rare) could use this.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed burn weapons that were sharp delimbed
Confirm limbs got turned to ash, and heads got cut off.

## Changelog
:cl:
add: Burn weapons that are sharp can now delimb people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
