### PR TITLE
Crewmembers missing one of their foot now spawns with a cane

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -1826,9 +1826,8 @@
 	if(!l_foot && !r_foot)
 		var/obj/structure/chair/wheelchair/W = new /obj/structure/chair/wheelchair(character.loc)
 		W.buckle_mob(character, TRUE)
-	else
-		if(!l_foot || !r_foot)
-			character.put_in_r_hand(new /obj/item/cane)
+	else if(!l_foot || !r_foot)
+		character.put_in_r_hand(new /obj/item/cane)
 
 	character.underwear = underwear
 	character.undershirt = undershirt

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -1828,8 +1828,7 @@
 		W.buckle_mob(character, TRUE)
 	else
 		if(!l_foot || !r_foot)
-			var/obj/item/cane/C = new /obj/item/cane
-			character.put_in_r_hand(C)
+			character.put_in_r_hand(new /obj/item/cane)
 
 	character.underwear = underwear
 	character.undershirt = undershirt

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -1826,6 +1826,10 @@
 	if(!l_foot && !r_foot)
 		var/obj/structure/chair/wheelchair/W = new /obj/structure/chair/wheelchair(character.loc)
 		W.buckle_mob(character, TRUE)
+	else
+		if(!l_foot || !r_foot)
+			var/obj/item/cane/C = new /obj/item/cane
+			character.put_in_r_hand(C)
 
 	character.underwear = underwear
 	character.undershirt = undershirt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
A cane will be spawned in the right hand if you are lacking one foot on arrival.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Crewmembers without both legs do get a wheelchair upon arrival, those without one foot should get the same treatment, saving them the time and money from buying a cane at the vendor.
## Testing
<!-- How did you test the PR, if at all? -->
- Joined the round with characters without one of both their feets.
## Changelog
:cl:
tweak: Crewmembers missing one of their foot now spawns with a cane
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
