### PR TITLE
Reworks the cyborg hypospray 

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -1,44 +1,58 @@
-#define BORGHYPO_REFILL_VALUE 5
+#define BORGHYPO_REFILL_VALUE 10
 
 /obj/item/reagent_containers/borghypo
 	name = "Cyborg Hypospray"
 	desc = "An advanced chemical synthesizer and injection system, designed for heavy-duty medical equipment."
-	icon = 'icons/obj/hypo.dmi'
 	item_state = "hypo"
+	icon = 'icons/obj/hypo.dmi'
 	icon_state = "borghypo"
 	amount_per_transfer_from_this = 5
-	volume = 30
 	possible_transfer_amounts = null
-	var/mode = 1
+	/// It doesn't matter what reagent is used in the autohypos, so we don't!
+	var/total_reagents = 100
+	var/maximum_reagents = 100
 	var/charge_cost = 50
 	var/charge_tick = 0
-	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
+	var/recharge_time = 2 //Time it takes for shots to recharge (in seconds)
 	var/bypass_protection = 0 //If the hypospray can go through armor or thick material
-
+	var/choosen_reagent = "salglu_solution"
 	var/list/datum/reagents/reagent_list = list()
 	var/list/reagent_ids = list("salglu_solution", "epinephrine", "spaceacillin", "charcoal", "hydrocodone")
-	//var/list/reagent_ids = list("salbutamol", "silver_sulfadiazine", "styptic_powder", "charcoal", "epinephrine", "spaceacillin", "hydrocodone")
+	var/static/list/reagent_icons = list("salglu_solution" = image(icon = 'icons/goonstation/objects/iv.dmi', icon_state = "ivbag"),
+							"epinephrine" = image(icon = 'icons/obj/hypo.dmi', icon_state = "autoinjector"),
+							"spaceacillin" = image(icon = 'icons/obj/decals.dmi', icon_state = "bio"),
+							"charcoal" = image(icon = 'icons/obj/chemical.dmi', icon_state = "pill11"),
+							"hydrocodone" = image(icon = 'icons/obj/chemical.dmi', icon_state = "bottle19"),
+							"styptic_powder" = image(icon = 'icons/obj/chemical.dmi', icon_state = "bandaid_brute"),
+							"salbutamol" = image(icon = 'icons/obj/chemical.dmi', icon_state = "pill8"),
+							"sal_acid" = image(icon = 'icons/obj/chemical.dmi', icon_state = "pill4"),
+							"syndicate_nanites" = image(icon = 'icons/obj/decals.dmi', icon_state = "greencross"),
+							"potass_iodide" = image(icon = 'icons/obj/chemical.dmi', icon_state = "pill17"))
 
 /obj/item/reagent_containers/borghypo/surgeon
 	reagent_ids = list("styptic_powder", "epinephrine", "salbutamol")
+	total_reagents = 60
+	maximum_reagents = 60
 
 /obj/item/reagent_containers/borghypo/crisis
 	reagent_ids = list("salglu_solution", "epinephrine", "sal_acid")
+	total_reagents = 60
+	maximum_reagents = 60
 
 /obj/item/reagent_containers/borghypo/syndicate
 	name = "syndicate cyborg hypospray"
 	desc = "An experimental piece of Syndicate technology used to produce powerful restorative nanites used to very quickly restore injuries of all types. Also metabolizes potassium iodide, for radiation poisoning, and hydrocodone, for field surgery and pain relief."
 	icon_state = "borghypo_s"
 	charge_cost = 20
-	recharge_time = 2
+	recharge_time = 1 // No time to recharge
 	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone")
-	bypass_protection = 1
+	total_reagents = 60
+	maximum_reagents = 60
+	bypass_protection = TRUE
+	choosen_reagent = "syndicate_nanites"
 
 /obj/item/reagent_containers/borghypo/Initialize(mapload)
 	. = ..()
-	for(var/R in reagent_ids)
-		add_reagent(R)
-
 	START_PROCESSING(SSobj, src)
 
 /obj/item/reagent_containers/borghypo/Destroy()
@@ -50,83 +64,58 @@
 	if(charge_tick < recharge_time)
 		return FALSE
 	charge_tick = 0
-
-	if(isrobot(loc))
-		var/mob/living/silicon/robot/R = loc
-		if(R && R.cell)
-			var/datum/reagents/RG = reagent_list[mode]
-			if(!refill_borghypo(RG, reagent_ids[mode], R)) 	//If the storage is not full recharge reagents and drain power.
-				for(var/i in 1 to reagent_list.len)     	//if active mode is full loop through the list and fill the first one that is not full
-					RG = reagent_list[i]
-					if(refill_borghypo(RG, reagent_ids[i], R))
-						break
-	//update_icon()
+	refill_borghypo()
 	return TRUE
 
 // Use this to add more chemicals for the borghypo to produce.
-/obj/item/reagent_containers/borghypo/proc/add_reagent(reagent)
-	reagent_ids |= reagent
-	var/datum/reagents/RG = new(30)
-	RG.my_atom = src
-	reagent_list += RG
-
-	var/datum/reagents/R = reagent_list[reagent_list.len]
-	R.add_reagent(reagent, 30)
-
-/obj/item/reagent_containers/borghypo/proc/refill_borghypo(datum/reagents/RG, reagent_id, mob/living/silicon/robot/R)
-	if(RG.total_volume < RG.maximum_volume)
-		RG.add_reagent(reagent_id, BORGHYPO_REFILL_VALUE)
-		R.cell.use(charge_cost)
-		return TRUE
-	return FALSE
+/obj/item/reagent_containers/borghypo/proc/refill_borghypo(reagent_id, mob/living/silicon/robot/robot)
+	if(istype(robot))
+		robot.cell.use(charge_cost)
+	total_reagents = min((total_reagents + BORGHYPO_REFILL_VALUE), maximum_reagents)
+	return
 
 /obj/item/reagent_containers/borghypo/attack(mob/living/carbon/human/M, mob/user)
-	var/datum/reagents/R = reagent_list[mode]
-	if(!R.total_volume)
+	if(!total_reagents)
 		to_chat(user, "<span class='warning'>The injector is empty.</span>")
 		return
 	if(!istype(M))
 		return
-	if(R.total_volume && M.can_inject(user, TRUE, user.zone_selected, penetrate_thick = bypass_protection))
+	if(total_reagents && M.can_inject(user, TRUE, user.zone_selected, penetrate_thick = bypass_protection))
 		to_chat(user, "<span class='notice'>You inject [M] with the injector.</span>")
 		to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
 
-		R.add_reagent(M)
+		M.reagents.add_reagent(choosen_reagent, 5)
+		total_reagents = (total_reagents - 5)
 		if(M.reagents)
-			var/datum/reagent/injected = GLOB.chemical_reagents_list[reagent_ids[mode]]
+			var/datum/reagent/injected = GLOB.chemical_reagents_list[choosen_reagent]
 			var/contained = injected.name
-			var/trans = R.trans_to(M, amount_per_transfer_from_this)
-			add_attack_logs(user, M, "Injected with [name] containing [contained], transfered [trans] units", injected.harmless ? ATKLOG_ALMOSTALL : null)
-			to_chat(user, "<span class='notice'>[trans] units injected. [R.total_volume] units remaining.</span>")
+			add_attack_logs(user, M, "Injected with [name] containing [contained], transfered [5] units", injected.harmless ? ATKLOG_ALMOSTALL : null)
+			to_chat(user, "<span class='notice'>[5] units injected. [total_reagents] units remaining.</span>")
+
+/obj/item/reagent_containers/borghypo/proc/get_radial_contents()
+	return reagent_icons & reagent_ids
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user)
-	playsound(loc, 'sound/effects/pop.ogg', 50, 0)		//Change the mode
-	mode++
-	if(mode > reagent_list.len)
-		mode = 1
-
+	playsound(loc, 'sound/effects/pop.ogg', 50, 0)
+	var/selected_reagent = show_radial_menu(user, src, get_radial_contents())
+	if(!selected_reagent)
+		return
 	charge_tick = 0 //Prevents wasted chems/cell charge if you're cycling through modes.
-	var/datum/reagent/R = GLOB.chemical_reagents_list[reagent_ids[mode]]
+	var/datum/reagent/R = GLOB.chemical_reagents_list[selected_reagent]
 	to_chat(user, "<span class='notice'>Synthesizer is now producing '[R.name]'.</span>")
-	return
+	choosen_reagent = selected_reagent
 
 /obj/item/reagent_containers/borghypo/examine(mob/user)
 	. = ..()
-	if(get_dist(user, src) <= 2)
-		var/empty = TRUE
+	var/datum/reagent/get_reagent_name = GLOB.chemical_reagents_list[choosen_reagent]
+	. |= "<span class='notice'>It is currently dispensing [get_reagent_name.name]. Contains [total_reagents] units of various reagents.</span>" // We couldn't care less what actual reagent is in the container, just if there IS reagent in it
 
-		for(var/datum/reagents/RS in reagent_list)
-			var/datum/reagent/R = locate() in RS.reagent_list
-			if(R)
-				. += "<span class='notice'>It currently has [R.volume] units of [R.name] stored.</span>"
-				empty = FALSE
-
-		if(empty)
-			. += "<span class='notice'>It is currently empty. Allow some time for the internal syntheszier to produce more.</span>"
 
 /obj/item/reagent_containers/borghypo/basic
 	name = "Basic Medical Hypospray"
 	desc = "A very basic medical hypospray, capable of providing simple medical treatment in emergencies."
 	reagent_ids = list("salglu_solution", "epinephrine")
+	total_reagents = 30
+	maximum_reagents = 30
 
 #undef BORGHYPO_REFILL_VALUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #19341 
Reworks the cyborg hypospray
Instead of functioning off of multiple reagent samples, the entire hypospray now has a total "pool" of reagents 
This is set to 100 for standard, and 60 for the nuclear cyborg
Every 10 seconds, the medical cyborg gains 10 reagents back, and every 2 seconds, the nuclear cyborg gains 10 reagents back
I'm not too sure on the above values, but the suggestion was taken from qwerty
Every time to transfer a chemical, the total "pool" will decrease by that amount transferred. 
All previous chemical choices remain the same

NPFC stuff:
Code has been reworked to be more readable and functional
Reagent hard references removed

Todo: 
- [ ] Document it 
- [ ] Polish the menus 

## Why It's Good For The Game
Radial menus are nice
The current implementation of the cyborg hypospray is pretty dang weird. Everything being in different sections at only recharging one at a time means that you're going to be switching options not to use a chemical you want to use, but to make sure all your chemicals are capped off at maximum. Aside from just being really weird to interact with, the current implementation doesn't accomplish much in terms of limiting resources. It's annoying to use for little reason and making it more intuitive is good. 

## Images of changes
TBA

## Testing
Compiled and ran

## Changelog
:cl:
tweak: The cyborg hypospray has been reworked, now uses a total reagents system rather than separate reagents per chemical
/:cl:
