### PR TITLE
Update flash.dm

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -40,6 +40,12 @@
 				overcharged = TRUE
 				add_overlay("overcharge")
 
+//Check if the user is blind
+/obj/item/flash/proc/blind_check(mob/user)
+	if(user && !user.hasTrait("blind")) {
+		to_chat(user, "<span class='notice'>You do not feel anything from the [src] as you are blind.</span>")
+	}
+
 /obj/item/flash/screwdriver_act(mob/living/user, obj/item/I)
 	if(!can_overcharge)
 		return


### PR DESCRIPTION
Having a look at the issue #18831 This should provide the fix :)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
Fixes #18831 - This will check to see if the user that is being flashed is blind. There is currently no check for this and the user will be 'flashed' even if they are blind.
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
Added one proc to check if the user affected by the flash is blind. If they are, they get a message to say they are not affected by the flash as they are blind. Maybe this is not the best approach, but it is a start.
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fix - Ensures blind people do not get affected by flashes.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Logged into the game on my client and tested it and it works

## Changelog
:cl: AllFartAndNoPoo

fix: Fixed issue #18831 Blind people are still affected by flashes

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
