### PR TITLE
Wizard forcewall now has a 15 second cooldown vs 10 second

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -195,13 +195,13 @@
 	desc = "This spell creates a 3 tile wide unbreakable wall that only you can pass through, and does not need wizard garb. Lasts 30 seconds."
 
 	school = "transmutation"
-	base_cooldown = 150
+	base_cooldown = 15 SECONDS
 	clothes_req = FALSE
 	invocation = "TARCOL MINTI ZHERI"
 	invocation_type = "whisper"
 	sound = 'sound/magic/forcewall.ogg'
 	action_icon_state = "shield"
-	cooldown_min = 50 //25 deciseconds reduction per rank
+	cooldown_min = 5 SECONDS //25 deciseconds reduction per rank
 	var/wall_type = /obj/effect/forcefield/wizard
 
 /obj/effect/proc_holder/spell/forcewall/create_new_targeting()

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -195,13 +195,13 @@
 	desc = "This spell creates a 3 tile wide unbreakable wall that only you can pass through, and does not need wizard garb. Lasts 30 seconds."
 
 	school = "transmutation"
-	base_cooldown = 100
+	base_cooldown = 150
 	clothes_req = FALSE
 	invocation = "TARCOL MINTI ZHERI"
 	invocation_type = "whisper"
 	sound = 'sound/magic/forcewall.ogg'
 	action_icon_state = "shield"
-	cooldown_min = 50 //12 deciseconds reduction per rank
+	cooldown_min = 50 //25 deciseconds reduction per rank
 	var/wall_type = /obj/effect/forcefield/wizard
 
 /obj/effect/proc_holder/spell/forcewall/create_new_targeting()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

base cooldown of forcewall up to 15 seconds from 10

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Greater forcewall, which is now normal force wall, offers a bit too much protection for its cooldown. One could have 3 groups of 3 forcewalls up at once. Effectively being able to permamently 2 or even 3 doors to one room fully sealed, or an area of maints. Practically untouchable, for 1 point.
 Now, one can only have 2 groups of 3 forcewalls at base price. Still strong, but a noticable reduction to control.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
![image](https://user-images.githubusercontent.com/52090703/210027491-67ce2a16-a882-45e1-8866-1a2ea8ee0e71.png)

N/A, just tweaking the numbers

## Changelog
:cl:
tweak: Wizard forcewall now has a 15 second cooldown vs 10 second cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
