### PR TITLE
Fix #20049 Upgraded protolathe no longer has issues with reagent costs

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -441,7 +441,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		enough_materials = FALSE
 	else
 		for(var/R in being_built.reagents_list)
-			if(!machine.reagents.has_reagent(R, being_built.reagents_list[R]) * coeff)
+			if(!machine.reagents.has_reagent(R, being_built.reagents_list[R] * coeff))
 				atom_say("Not enough reagents to complete prototype.")
 				enough_materials = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
The upgrade coefficient now multiplies the reagent amount properly when checking if the protolathe has enough reagents.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/20049

## Testing
<!-- How did you test the PR, if at all? -->
- Inserted all materials necessary for the Vortex arm implant
- Upgrade the protolathe (4 rating)
- Could start the printing with 20 blood instead of 50
## Changelog
:cl:
fix: Upgraded protolathe no longer has issues with reagent costs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
