### PR TITLE
Mop no longer fails to clean when used with 1 unit remaining

### DIFF
--- a/code/game/objects/cleaning.dm
+++ b/code/game/objects/cleaning.dm
@@ -29,10 +29,11 @@
 	if(!do_after(user, cleanspeed, target = src))
 		return FALSE
 
-	cleaner.post_clean(src, user)
-
 	if(!cleaner.can_clean())
+		cleaner.post_clean(src, user)
 		return FALSE
+
+	cleaner.post_clean(src, user)
 
 	to_chat(user, "<span class='notice'>You [text_verb] \the [text_targetname][text_description]</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Mop no longer fails to clean when used with 1 unit remaining.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
 It currently only wets the floor on last use, not cleaning the decals. Its not intended behaviour.

## Testing
<!-- How did you test the PR, if at all? -->
- Used the mop with 1u of water remaining to see if it did clean the blood.
## Changelog
:cl:
fix: Mop no longer fails to clean when used with 1 unit remaining
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
