### PR TITLE
Fixes the Thunderdome

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -294,7 +294,7 @@
 	message_admins("[key_name_admin(owner)] tried making Thunderdome Teams with One-Click-Antag")
 
 	//Generates a list of candidates from active ghosts.
-	var/list/thunderdome_candidates = shuffle(SSghost_spawns.poll_candidates("Participate in a Thunderdome match?",,, 30 SECONDS, TRUE,, TRUE, FALSE))
+	var/list/thunderdome_candidates = shuffle(SSghost_spawns.poll_candidates("Participate in a Thunderdome match?", poll_time = 30 SECONDS, ignore_respawnability = TRUE, flash_window = TRUE, check_antaghud = FALSE))
 	if(length(thunderdome_candidates) < 2) // One person thunderdome ain't great
 		log_admin("[key_name(owner)] tried making Thunderdome Teams with One-Click-Antag, but not enough people signed up.")
 		message_admins("[key_name_admin(owner)] tried making Thunderdome Teams with One-Click-Antag, but not enough people signed up.")
@@ -310,20 +310,20 @@
 		switch(team_to_assign_to)
 			if("Green")
 				var/turf/possible_spawn_loc_red = pick_n_take(red_spawn_locations)
-				var/mob/living/carbon/human/newMember = new(get_turf(possible_spawn_loc_red))
-				S.copy_to(newMember)
-				newMember.dna.ready_dna(newMember)
+				var/mob/living/carbon/human/new_thunderdome_member = new(get_turf(possible_spawn_loc_red))
+				S.copy_to(new_thunderdome_member)
+				new_thunderdome_member.dna.ready_dna(new_thunderdome_member)
 				thunderdome_candidates.Remove(candidate_to_spawn)
-				newMember.key = candidate_to_spawn.key
-				to_chat(newMember, "You are a member of the <font color='green'><b>GREEN</b></font> Thunderdome team! Gear up and help your team destroy the red team!")
-				newMember.mind.offstation_role = TRUE
+				new_thunderdome_member.key = candidate_to_spawn.key
+				to_chat(new_thunderdome_member, "You are a member of the <font color='green'><b>GREEN</b></font> Thunderdome team! Gear up and help your team destroy the red team!")
+				new_thunderdome_member.mind.offstation_role = TRUE
 				team_to_assign_to = "Red"
 			if("Red")
 				var/turf/possible_spawn_loc_blue = pick_n_take(blue_spawn_locations)
-				var/mob/living/carbon/human/newMember = new(get_turf(possible_spawn_loc_blue))
-				S.copy_to(newMember)
-				newMember.dna.ready_dna(newMember)
-				newMember.key = candidate_to_spawn.key
-				to_chat(newMember, "You are a member of the <font color='red'><b>RED</b></font> Thunderdome team! Gear up and help your team destroy the green team!")
-				newMember.mind.offstation_role = TRUE
+				var/mob/living/carbon/human/new_thunderdome_member = new(get_turf(possible_spawn_loc_blue))
+				S.copy_to(new_thunderdome_member)
+				new_thunderdome_member.dna.ready_dna(new_thunderdome_member)
+				new_thunderdome_member.key = candidate_to_spawn.key
+				to_chat(new_thunderdome_member, "You are a member of the <font color='red'><b>RED</b></font> Thunderdome team! Gear up and help your team destroy the green team!")
+				new_thunderdome_member.mind.offstation_role = TRUE
 				team_to_assign_to = "Green"

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -286,69 +286,44 @@
 	return 0
 
 /datum/admins/proc/makeThunderdomeTeams() // Not strictly an antag, but this seemed to be the best place to put it.
-
-	var/list/mob/candidates = list()
-	var/mob/theghost = null
-	var/time_passed = world.time
-
+	var/max_thunderdome_players = 10
+	var/team_to_assign_to = "Green"
+	var/list/red_spawn_locations = GLOB.tdome1.Copy()
+	var/list/blue_spawn_locations = GLOB.tdome2.Copy()
 	log_admin("[key_name(owner)] tried making Thunderdome Teams with One-Click-Antag")
-	message_admins("[key_name_admin(owner)] tried making Thunderdone Teams with One-Click-Antag")
+	message_admins("[key_name_admin(owner)] tried making Thunderdome Teams with One-Click-Antag")
 
 	//Generates a list of candidates from active ghosts.
-	for(var/mob/G in GLOB.respawnable_list)
-		spawn(0)
-			switch(alert(G,"Do you wish to be considered for a Thunderdome match about to start?","Please answer in 30 seconds!","Yes","No"))
-				if("Yes")
-					if((world.time-time_passed)>300)//If more than 30 game seconds passed.
-						return
-					candidates += G
-				if("No")
-					return
-				else
-					return
-
-	sleep(300) //Debug.
-
-	for(var/mob/dead/observer/G in candidates)
-		if(!G.key)
-			candidates.Remove(G)
-
-	if(candidates.len)
-		var/teamOneMembers = 5
-		var/teamTwoMembers = 5
+	var/list/thunderdome_candidates = shuffle(SSghost_spawns.poll_candidates("Participate in a Thunderdome match?",,, 30 SECONDS, TRUE,, TRUE, FALSE))
+	if(length(thunderdome_candidates) < 2) // One person thunderdome ain't great
+		log_admin("[key_name(owner)] tried making Thunderdome Teams with One-Click-Antag, but not enough people signed up.")
+		message_admins("[key_name_admin(owner)] tried making Thunderdome Teams with One-Click-Antag, but not enough people signed up.")
+		return FALSE
+	// Time to set up our team structure
+	if(length(thunderdome_candidates) > max_thunderdome_players)
+		thunderdome_candidates.Cut(max_thunderdome_players)
+	for(var/mob/dead/observer/candidate_to_spawn in thunderdome_candidates)
+		if(!candidate_to_spawn || !candidate_to_spawn.key || !candidate_to_spawn.client)
+			continue
 		var/datum/character_save/S = new
 		S.randomise()
-		for(var/obj/effect/landmark/L in GLOB.tdome1)
-			if(!teamOneMembers)
-				break
-			var/mob/living/carbon/human/newMember = new(get_turf(L))
-			S.copy_to(newMember)
-			newMember.dna.ready_dna(newMember)
-			while((!theghost || !theghost.client) && candidates.len)
-				theghost = pick(candidates)
-				candidates.Remove(theghost)
-			if(!theghost)
-				qdel(newMember)
-				break
-			newMember.key = theghost.key
-			teamOneMembers--
-			to_chat(newMember, "You are a member of the <font color='green'><b>GREEN</b></font> Thunderdome team! Gear up and help your team destroy the red team!")
-
-		for(var/obj/effect/landmark/L in GLOB.tdome2)
-			if(!teamTwoMembers)
-				break
-			var/mob/living/carbon/human/newMember = new(get_turf(L))
-			S.copy_to(newMember)
-			newMember.dna.ready_dna(newMember)
-			while((!theghost || !theghost.client) && candidates.len)
-				theghost = pick(candidates)
-				candidates.Remove(theghost)
-			if(!theghost)
-				qdel(newMember)
-				break
-			newMember.key = theghost.key
-			teamTwoMembers--
-			to_chat(newMember, "You are a member of the <font color='red'><b>RED</b></font> Thunderdome team! Gear up and help your team destroy the green team!")
-	else
-		return 0
-	return 1
+		switch(team_to_assign_to)
+			if("Green")
+				var/turf/possible_spawn_loc_red = pick_n_take(red_spawn_locations)
+				var/mob/living/carbon/human/newMember = new(get_turf(possible_spawn_loc_red))
+				S.copy_to(newMember)
+				newMember.dna.ready_dna(newMember)
+				thunderdome_candidates.Remove(candidate_to_spawn)
+				newMember.key = candidate_to_spawn.key
+				to_chat(newMember, "You are a member of the <font color='green'><b>GREEN</b></font> Thunderdome team! Gear up and help your team destroy the red team!")
+				newMember.mind.offstation_role = TRUE
+				team_to_assign_to = "Red"
+			if("Red")
+				var/turf/possible_spawn_loc_blue = pick_n_take(blue_spawn_locations)
+				var/mob/living/carbon/human/newMember = new(get_turf(possible_spawn_loc_blue))
+				S.copy_to(newMember)
+				newMember.dna.ready_dna(newMember)
+				newMember.key = candidate_to_spawn.key
+				to_chat(newMember, "You are a member of the <font color='red'><b>RED</b></font> Thunderdome team! Gear up and help your team destroy the green team!")
+				newMember.mind.offstation_role = TRUE
+				team_to_assign_to = "Green"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the thunderdome adminsecret
Sets people spawned via the thunderdome to an offstation role
Thunderdome no longer uses an alert, uses a ghostpoll now 

## Why It's Good For The Game
Working code is a good thing, the thunderdome is pretty cool

## Testing
Compiled and ran with two clients 
## Changelog
:cl:
fix: [ADMIN] The thunderdome secret now functions 
/:cl:
