### PR TITLE
Syndie tool tweaks

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -193,7 +193,7 @@ GLOBAL_VAR(bomb_set)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(auth || (istype(I, /obj/item/screwdriver/nuke)))
+	if(auth || ((istype(I, /obj/item/screwdriver/nuke)) && !is_syndicate))
 		if(!panel_open)
 			panel_open = TRUE
 			to_chat(user, "You unscrew the control panel of [src].")

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -193,7 +193,7 @@ GLOBAL_VAR(bomb_set)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(auth || ((istype(I, /obj/item/screwdriver/nuke)) && !is_syndicate))
+	if(auth || (istype(I, /obj/item/screwdriver/nuke) && !is_syndicate))
 		if(!panel_open)
 			panel_open = TRUE
 			to_chat(user, "You unscrew the control panel of [src].")

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -100,7 +100,7 @@
 						break
 
 /obj/item/multitool/red
-	name = "Suspicious Multitool"
+	name = "suspicious multitool"
 	desc = "A sinister-looking multitool, used for pulsing wires to test which to cut."
 	icon_state = "multitool_syndi"
 	belt_icon = "multitool_syndi"

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -104,7 +104,7 @@
 	throwforce = 18
 
 /obj/item/storage/toolbox/syndicate/populate_contents()
-	new /obj/item/screwdriver(src, "red")
+	new /obj/item/screwdriver/nuke(src)
 	new /obj/item/wrench(src)
 	new /obj/item/weldingtool/largetank(src)
 	new /obj/item/crowbar/red(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

The syndicate screwdriver now spawns in suspicious toolboxes, basically a way for traitors to buy another ultra thin tip screwdriver if they lost their original one. For everyone else, it's just a faster screwdriver kind of like the suspicious multitool.

Speaking of the suspicious multitool, I have removed the capitalization from its name. This is improper for an item.

The syndicate screwdriver no longer interacts with the syndie nuke. This is to prevent easy disarms without the NAD. There was no way to get one on a nukeop round before so this isn't really a big deal.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

As described above. Just adds more of a benefit to buying or finding a suspicious toolbox. Could have sworn this was already a thing though unless I am once again crossing my TG knowledge with Paradise.

This is going to require the headmins or whoever is in charge of spacelaw to sign off on the syndicate screwdriver being removed from the S class contraband list before being merged.

## Testing
<!-- How did you test the PR, if at all? -->
In game
## Changelog
:cl: Bmon
add: Syndicate screwdrivers now spawn in suspicious toolboxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
