### PR TITLE
Fixes a surgery runtime 

### DIFF
--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -138,16 +138,15 @@
 
 /datum/component/surgery_initiator/proc/get_available_surgeries(mob/user, mob/living/target)
 	var/list/available_surgeries = list()
-
 	for(var/datum/surgery/surgery in GLOB.surgeries_list)
 		if(surgery.abstract && !istype(surgery, forced_surgery))  // no choosing abstract surgeries, though they can be forced
 			continue
+		if(!is_type_in_list(target, surgery.target_mobtypes))
+			continue
 		if(!target.can_run_surgery(surgery, user))
 			continue
-		for(var/path in surgery.target_mobtypes)
-			if(istype(target, path))
-				available_surgeries += surgery
-				break
+
+		available_surgeries |= surgery
 
 	return available_surgeries
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #19394, an issue introduced in the surgery refactor. Turns out that mobtypes were being checked a bit too late in the surgery chain, which caused trouble with some surgeries that made certain assumptions in their `can_start` procs (I'm looking at you, Alien Organ Manipulation).

Big thanks to @GDNgit for helping work through this issue and trying to fix it earlier.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This isn't a huge runtime, but it's a good (and annoying) one to knock off.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, performed the action that used to runtime, and saw that it now does not.
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
