### PR TITLE
You can no longer redirect the mining / labour shuttle when it is moving

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -743,15 +743,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Labor Shuttle Airlock"
 	},
-/obj/docking_port/mobile/lockdown{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp";
-	name = "labor camp shuttle";
-	rebuildable = 1;
-	width = 9
-	},
+/obj/docking_port/mobile/labour,
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -2881,15 +2873,7 @@
 	id_tag = "s_docking_airlock";
 	req_access_txt = "48"
 	},
-/obj/docking_port/mobile/lockdown{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "mining";
-	name = "mining shuttle";
-	rebuildable = 1;
-	width = 7
-	},
+/obj/docking_port/mobile/mining,
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -750,7 +750,8 @@
 	id = "laborcamp";
 	name = "labor camp shuttle";
 	rebuildable = 1;
-	width = 9
+	width = 9;
+	uses_lockdown = 1
 	},
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{
@@ -2888,7 +2889,8 @@
 	id = "mining";
 	name = "mining shuttle";
 	rebuildable = 1;
-	width = 7
+	width = 7;
+	uses_lockdown = 1
 	},
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -743,15 +743,14 @@
 	id_tag = "s_docking_airlock";
 	name = "Labor Shuttle Airlock"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/lockdown{
 	dir = 8;
 	dwidth = 2;
 	height = 5;
 	id = "laborcamp";
 	name = "labor camp shuttle";
 	rebuildable = 1;
-	width = 9;
-	uses_lockdown = 1
+	width = 9
 	},
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{
@@ -2882,15 +2881,14 @@
 	id_tag = "s_docking_airlock";
 	req_access_txt = "48"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/lockdown{
 	dir = 8;
 	dwidth = 3;
 	height = 5;
 	id = "mining";
 	name = "mining shuttle";
 	rebuildable = 1;
-	width = 7;
-	uses_lockdown = 1
+	width = 7
 	},
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -205,6 +205,12 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/proc/moveShuttle(shuttleId, dockId, timed, mob/user)
 	var/obj/docking_port/mobile/M = getShuttle(shuttleId)
 	var/obj/docking_port/stationary/D = getDock(dockId)
+	//check if the shuttle is on lockdown
+	if(M.lockeddown)
+		return 3
+	if(M.uses_lockdown)
+		M.lockeddown = TRUE
+		addtimer(VARSET_CALLBACK(M, lockeddown, FALSE), 15 SECONDS)
 	if(!M)
 		return 1
 	M.last_caller = user // Save the caller of the shuttle for later logging

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -228,6 +228,10 @@
 
 	var/obj/docking_port/stationary/destination
 	var/obj/docking_port/stationary/previous
+	/// Does this shuttle use the lockdown system?
+	var/uses_lockdown = FALSE
+	/// If this variable is true, shuttle is on lockdown, and other requests can not be processed
+	var/lockeddown = FALSE
 
 /obj/docking_port/mobile/Initialize(mapload)
 	. = ..()
@@ -832,8 +836,10 @@
 				return TRUE
 			if(1)
 				to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")
-			else
+			if(2)
 				to_chat(usr, "<span class='notice'>Unable to comply.</span>")
+			if(3)
+				atom_say("Shuttle has already received a pending movement request. Please wait until.")
 
 
 /obj/machinery/computer/shuttle/emag_act(mob/user)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -735,7 +735,24 @@
 			dst = destination
 		. += " towards [dst ? dst.name : "unknown location"] ([timeLeft(600)]mins)"
 
-/obj/docking_port/mobile/lockdown
+/obj/docking_port/mobile/labour
+	dir = 8
+	dwidth = 2
+	height = 5
+	id = "laborcamp"
+	name = "labor camp shuttle"
+	rebuildable = TRUE
+	width = 9
+	uses_lockdown = TRUE
+
+/obj/docking_port/mobile/mining
+	dir = 8
+	dwidth = 3
+	height = 5
+	id = "mining"
+	name = "mining shuttle"
+	rebuildable = TRUE
+	width = 7
 	uses_lockdown = TRUE
 
 /obj/machinery/computer/shuttle

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -735,6 +735,9 @@
 			dst = destination
 		. += " towards [dst ? dst.name : "unknown location"] ([timeLeft(600)]mins)"
 
+/obj/docking_port/mobile/lockdown
+	uses_lockdown = TRUE
+
 /obj/machinery/computer/shuttle
 	name = "Shuttle Console"
 	icon_screen = "shuttle"
@@ -839,7 +842,7 @@
 			if(2)
 				to_chat(usr, "<span class='notice'>Unable to comply.</span>")
 			if(3)
-				atom_say("Shuttle has already received a pending movement request. Please wait until.")
+				atom_say("Shuttle has already received a pending movement request. Please wait until the movement request is processed.")
 
 
 /obj/machinery/computer/shuttle/emag_act(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Adds 2 new variables to mobile docking ports.
uses_lockdown and lockeddown
Only the mining shuttle and labour shuttle have this.
When a shuttle with this variable uses_lockdown an order from a shuttle console, it locks down the shuttle for 15 seconds, in that no more orders can be recived. This is enough time for the shuttle to reach the destination, and unseated people to get off the shuttle before it is called again.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ends the pain that is shuttle wars, where a person on the shuttle, is fighting to have the shuttle go to / from lavaland, while the ai / officer / antag is spamming the shuttle console like no tomorow to keep it from going somewhere. This can go on for minutes as people click, which is fun for no one, can also be used to just call it the moment it docks at lavaland / base, so as they make a break for the door they get stunned as the shuttle comes back. This is silly, and should not happen.

Now with this PR, it is simply whoever uses the console first, and the shuttle can not be held hostage at CC

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed the mining and labour camp shuttles worked as expected.

## Changelog
:cl:
tweak: Mining and labour camp shuttles can not receive an order for 15 seconds after being told to move.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
