### PR TITLE
Replaces some ore box, sleeper, and body scanner verbs with click combinations 

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -468,6 +468,7 @@
 /obj/machinery/sleeper/AltClick(mob/user)
 	if(issilicon(user))
 		eject()
+		return
 	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	eject()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -6,6 +6,7 @@
 
 /obj/machinery/sleeper
 	name = "sleeper"
+	desc = "Injects chemicals into the bloodstream of the occupant, can remove chemicals from the bloodstream of the occupant through dialysis."
 	icon = 'icons/obj/cryogenic2.dmi'
 	icon_state = "sleeper-open"
 	var/base_icon = "sleeper"
@@ -30,6 +31,11 @@
 
 	light_color = LIGHT_COLOR_CYAN
 
+/obj/machinery/sleeper/examine(mob/user)
+	. = ..()
+	if(Adjacent(user))
+		. += "<span class='notice'>You can <b>Alt-Click</b> to eject the current occupant.</span>"
+
 /obj/machinery/sleeper/detailed_examine()
 	return "The sleeper allows you to clean the blood by means of dialysis, and to administer medication in a controlled environment.<br>\
 			<br>\
@@ -39,7 +45,7 @@
 			<br>\
 			You can also inject common medicines directly into their bloodstream.\
 			<br>\
-			Right-click the cell and click 'Eject Occupant' to remove them. You can enter the cell yourself by right clicking and selecting 'Enter Sleeper'. \
+			Alt-Click the sleeper to remove them. You can enter the cell yourself by right clicking and selecting 'Enter Sleeper'. \
 			Note that you cannot control the sleeper while inside of it."
 
 /obj/machinery/sleeper/power_change()
@@ -459,19 +465,16 @@
 	else
 		to_chat(user, "There's no occupant in the sleeper!")
 
-/obj/machinery/sleeper/verb/eject()
-	set name = "Eject Sleeper"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.default_can_use_topic(src) != STATUS_INTERACTIVE)
+/obj/machinery/sleeper/AltClick(mob/user)
+	if(issilicon(user))
+		eject()
+	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
-	if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
-		return
+	eject()
 
+/obj/machinery/sleeper/proc/eject(mob/user)
 	go_out()
 	add_fingerprint(usr)
-	return
 
 /obj/machinery/sleeper/verb/remove_beaker()
 	set name = "Remove Beaker"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -1,5 +1,6 @@
 /obj/machinery/bodyscanner
 	name = "body scanner"
+	desc = "A sophisticated device which reports most internal and external injuries."
 	icon = 'icons/obj/cryogenic2.dmi'
 	icon_state = "bodyscanner-open"
 	density = TRUE
@@ -11,13 +12,17 @@
 	var/mob/living/carbon/human/occupant
 	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/mindshield, /obj/item/implant/tracking, /obj/item/implant/health)
 
+/obj/machinery/bodyscanner/examine(mob/user)
+	. = ..()
+	if(Adjacent(user))
+		. += "<span class='notice'>You can <b>Alt-Click</b> to eject the current occupant.</span>"
+
 /obj/machinery/bodyscanner/detailed_examine()
 	return "The advanced scanner detects and reports internal injuries such as bone fractures, internal bleeding, and organ damage. \
 			This is useful if you are about to perform surgery.<br>\
 			<br>\
 			Click your target and drag them onto the scanner to place them inside. Click the body scanner in order to operate it. \
-			Right-click the scanner and click 'Eject Occupant' to remove them. You can enter the scanner yourself in a similar way, using the 'Enter Body Scanner' \
-			verb."
+			Alt-Click to remove them, or use the eject button in the interface."
 
 
 /obj/machinery/bodyscanner/Destroy()
@@ -167,15 +172,16 @@
 		return FALSE //maybe they should be able to get out with cuffs, but whatever
 	go_out()
 
-/obj/machinery/bodyscanner/verb/eject()
-	set src in oview(1)
-	set category = "Object"
-	set name = "Eject Body Scanner"
-
-	if(usr.incapacitated())
+/obj/machinery/bodyscanner/AltClick(mob/user)
+	if(issilicon(user))
+		eject()
+	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
+	eject()
+
+/obj/machinery/bodyscanner/proc/eject(mob/user)
 	go_out()
-	add_fingerprint(usr)
+	add_fingerprint(user)
 
 /obj/machinery/bodyscanner/proc/go_out()
 	if(!occupant)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -175,6 +175,7 @@
 /obj/machinery/bodyscanner/AltClick(mob/user)
 	if(issilicon(user))
 		eject()
+		return
 	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	eject()

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -78,26 +78,24 @@
 		O.forceMove(loc)
 		CHECK_TICK
 
+/obj/structure/ore_box/examine(mob/user)
+	. = ..()
+	if(Adjacent(user))
+		. += "<span class='notice'>You can <b>Alt-Shift-Click</b> to empty the ore box.</span>"
+
 /obj/structure/ore_box/onTransitZ()
 	return
 
-/obj/structure/ore_box/verb/empty_box()
-	set name = "Empty Ore Box"
-	set category = "Object"
-	set src in view(1)
-
-	if(usr.incapacitated())
+/obj/structure/ore_box/AltShiftClick(mob/user)
+	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		to_chat(user, "You cannot interact with the ore box.")
 		return
 
-	if(!Adjacent(usr))
-		to_chat(usr, "You cannot reach the ore box.")
-		return
+	add_fingerprint(user)
 
-	add_fingerprint(usr)
-
-	if(contents.len < 1)
-		to_chat(usr, "<span class='warning'>The ore box is empty.</span>")
+	if(length(contents) < 1)
+		to_chat(user, "<span class='warning'>The ore box is empty.</span>")
 		return
 
 	dump_box_contents()
-	to_chat(usr, "<span class='notice'>You empty the ore box.</span>")
+	to_chat(user, "<span class='notice'>You empty the ore box.</span>")


### PR DESCRIPTION
## What Does This PR Do
Adds a desc to both the body scanner and the sleeper
Removes some wrong information from the detailed examine on the body scanner
Replaces the "empty box" verb with an alt-shift-click keybind
Replaces the "eject" verb with an alt-click keybind

## Why It's Good For The Game
The fact you'd rather just go into the UI for these and hit the button rather than using what should be an easier and quicker method ain't great. The future is now, old verbs

## Testing
Compiled and ran 

## Changelog
:cl:
tweak: "empty box" verb is now an alt-shift-click keybind
tweak: "eject" verb is now an alt-click keybind
spellcheck: The sleeper and body scanner now have proper descriptions 
spellcheck: Removed mention of a previously removed verb
/:cl:
