### PR TITLE
The cyborg chameleon projector can now transform into every (crew) cyborg type

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -209,15 +209,15 @@
 	if(active)
 		to_chat(user, "<span class='notice'>You reconfigure [src].</span>")
 		activate(user)
+		return
+	to_chat(user, "<span class='notice'>You activate [src].</span>")
+	apply_wibbly_filters(user)
+	if(do_after(user, 50, target = user) && user.cell.use(activationCost))
+		activate(user)
 	else
-		to_chat(user, "<span class='notice'>You activate [src].</span>")
-		apply_wibbly_filters(user)
-		if(do_after(user, 50, target = user) && user.cell.use(activationCost))
-			activate(user)
-		else
-			to_chat(user, "<span class='warning'>The chameleon field fizzles.</span>")
-			do_sparks(3, FALSE, user)
-		remove_wibbly_filters(user)
+		to_chat(user, "<span class='warning'>The chameleon field fizzles.</span>")
+		do_sparks(3, FALSE, user)
+	remove_wibbly_filters(user)
 
 /obj/item/borg_chameleon/process()
 	if(S)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -180,7 +180,7 @@
 	var/active = FALSE
 	var/activationCost = 300
 	var/activationUpkeep = 50
-	var/disguise = "landmate"
+	var/image/disguise
 	var/mob/living/silicon/robot/syndicate/saboteur/S
 
 /obj/item/borg_chameleon/Destroy()
@@ -208,14 +208,13 @@
 /obj/item/borg_chameleon/proc/toggle(mob/living/silicon/robot/syndicate/saboteur/user)
 	if(active)
 		playsound(src, 'sound/effects/pop.ogg', 100, 1, -6)
-		to_chat(user, "<span class='notice'>You deactivate [src].</span>")
-		deactivate(user)
+		to_chat(user, "<span class='notice'>You reconfigure [src].</span>")
+		activate(user)
 	else
 		to_chat(user, "<span class='notice'>You activate [src].</span>")
 		apply_wibbly_filters(user)
 		if(do_after(user, 50, target = user) && user.cell.use(activationCost))
 			playsound(src, 'sound/effects/bamf.ogg', 100, 1, -6)
-			to_chat(user, "<span class='notice'>You are now disguised as a Nanotrasen engineering cyborg.</span>")
 			activate(user)
 		else
 			to_chat(user, "<span class='warning'>The chameleon field fizzles.</span>")
@@ -230,21 +229,57 @@
 		return PROCESS_KILL
 
 /obj/item/borg_chameleon/proc/activate(mob/living/silicon/robot/syndicate/saboteur/user)
+	var/static/list/module_options = list(
+		"Engineering" = image('icons/mob/robots.dmi', "engi-radial"),
+		"Janitor" = image('icons/mob/robots.dmi', "jan-radial"),
+		"Medical" = image('icons/mob/robots.dmi', "med-radial"),
+		"Mining" = image('icons/mob/robots.dmi', "mining-radial"),
+		"Service" = image('icons/mob/robots.dmi', "serv-radial"),
+		"Cancel Cloaking" = image('icons/mob/screen_gen.dmi', "x"))
+	var/selected_module = show_radial_menu(user, user, module_options, radius = 42)
+	if(!selected_module)
+		return
+	var/examine_text = "you shouldn't see this"
+	switch(selected_module)
+		if("Mining")
+			examine_text = "miner robot module"
+		if("Service")
+			examine_text = "service robot module"
+		if("Medical")
+			examine_text = "medical robot module"
+		if("Janitor")
+			examine_text = "janitorial robot module"
+		if("Engineering")
+			examine_text = "engineering robot module"
+		if("Cancel Cloaking")
+			deactivate(user)
+			return
+	var/module_sprites = user.get_module_sprites(selected_module)
+	var/selected_sprite = show_radial_menu(user, user, module_sprites, radius = 42)
+	if(!selected_sprite)
+		return
+	disguise = module_sprites[selected_sprite]
+	var/list/name_check = splittext(selected_sprite, "-")
+	user.custom_panel = trim(name_check[1])
 	START_PROCESSING(SSobj, src)
 	S = user
-	user.base_icon = disguise
-	user.icon_state = disguise
+	user.icon = disguise.icon
+	user.icon_state = disguise.icon_state
 	user.cham_proj = src
+	user.module.name = examine_text
 	user.bubble_icon = "robot"
 	active = TRUE
 	user.update_icons()
+	to_chat(user, "<span class='notice'>You are now disguised as a Nanotrasen [selected_module] cyborg.</span>")
 
 /obj/item/borg_chameleon/proc/deactivate(mob/living/silicon/robot/syndicate/saboteur/user)
 	STOP_PROCESSING(SSobj, src)
 	S = user
-	user.base_icon = initial(user.base_icon)
+	user.icon = initial(user.icon)
 	user.icon_state = initial(user.icon_state)
+	user.module.name = initial(user.module.name)
 	user.bubble_icon = "syndibot"
+	user.custom_panel = null
 	active = FALSE
 	user.update_icons()
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -207,14 +207,12 @@
 
 /obj/item/borg_chameleon/proc/toggle(mob/living/silicon/robot/syndicate/saboteur/user)
 	if(active)
-		playsound(src, 'sound/effects/pop.ogg', 100, 1, -6)
 		to_chat(user, "<span class='notice'>You reconfigure [src].</span>")
 		activate(user)
 	else
 		to_chat(user, "<span class='notice'>You activate [src].</span>")
 		apply_wibbly_filters(user)
 		if(do_after(user, 50, target = user) && user.cell.use(activationCost))
-			playsound(src, 'sound/effects/bamf.ogg', 100, 1, -6)
 			activate(user)
 		else
 			to_chat(user, "<span class='warning'>The chameleon field fizzles.</span>")
@@ -270,6 +268,7 @@
 	user.bubble_icon = "robot"
 	active = TRUE
 	user.update_icons()
+	playsound(src, 'sound/effects/bamf.ogg', 100, 1, -6)
 	to_chat(user, "<span class='notice'>You are now disguised as a Nanotrasen [selected_module] cyborg.</span>")
 
 /obj/item/borg_chameleon/proc/deactivate(mob/living/silicon/robot/syndicate/saboteur/user)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -223,8 +223,8 @@
 	if(S)
 		if(!S.cell || !S.cell.use(activationUpkeep))
 			disrupt(S)
-	else
-		return PROCESS_KILL
+		return
+	return PROCESS_KILL
 
 /obj/item/borg_chameleon/proc/activate(mob/living/silicon/robot/syndicate/saboteur/user)
 	var/static/list/module_options = list(
@@ -268,7 +268,7 @@
 	user.bubble_icon = "robot"
 	active = TRUE
 	user.update_icons()
-	playsound(src, 'sound/effects/bamf.ogg', 100, 1, -6)
+	playsound(src, 'sound/effects/bamf.ogg', 100, TRUE, -6)
 	to_chat(user, "<span class='notice'>You are now disguised as a Nanotrasen [selected_module] cyborg.</span>")
 
 /obj/item/borg_chameleon/proc/deactivate(mob/living/silicon/robot/syndicate/saboteur/user)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -212,7 +212,7 @@
 		return
 	to_chat(user, "<span class='notice'>You activate [src].</span>")
 	apply_wibbly_filters(user)
-	if(do_after(user, 50, target = user) && user.cell.use(activationCost))
+	if(do_after(user, 5 SECONDS, target = user) && user.cell.use(activationCost))
 		activate(user)
 	else
 		to_chat(user, "<span class='warning'>The chameleon field fizzles.</span>")

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -651,7 +651,7 @@
 
 // Sydicate engineer/sabotuer cyborg module.
 /obj/item/robot_module/syndicate_saboteur
-	name = "engineering robot module" //to disguise in examine
+	name = "saboteur robot module" // Disguises are handled in the actual cyborg projector
 	module_type = "Malf"
 	basic_modules = list(
 		/obj/item/flash/cyborg,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The cyborg chameleon projector can now transform into every (crew) cyborg type, rather than just the landmate cyborg
All things you would expect to change (Desc and icon) change upon use.
While already cloaking, it takes no time to change a disguise again
Instead of using the cloaker again to change back to normal, you hit the Cancel button
(The examine text for the saboborg has also been renamed to "saboteur module" but that's minor and it was only like that in the first place because you could only turn into an engineering borg)
## Why It's Good For The Game
The current iteration of this item sucks, like wholesale just not useful
You're locked into one module sprite, so you're 100% getting metachecked via a shove or a disabler beam
There's still signs that someone is a saboborg, such as "why is that mediborg holding an esword", but random landmates aren't going to get ioned.
Aside from that, it's just a fun tool. Using this for infiltration is still not gonna be easy, but it will be much more possible.

## Images of changes

https://user-images.githubusercontent.com/96800819/210465988-6614a8b3-b03f-40d8-b766-c831d9cdb59a.mp4


## Testing
Compiled, ran, am real borg you can trust

## Changelog
:cl:
tweak: The cyborg chameleon projector now can transfer into any crew obtainable borg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
