### PR TITLE
Wallets now show proper jobs on Sechuds and Comms

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -49,6 +49,8 @@
 
 #define is_pen(W) (istype(W, /obj/item/pen) || istype(W, /obj/item/flashlight/pen))
 
+#define is_pda(W) (istype(W, /obj/item/pda))
+
 #define isspacecash(W) (istype(W, /obj/item/stack/spacecash))
 
 #define isstorage(A) (istype(A, /obj/item/storage))

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -223,7 +223,7 @@
 	var/image/holder = hud_list[ID_HUD]
 	holder.icon_state = "hudunknown"
 	if(wear_id)
-		holder.icon_state = "hud[ckey(wear_id.GetJobName())]"
+		holder.icon_state = "hud[ckey(wear_id.get_job_name())]"
 	sec_hud_set_security_status()
 
 

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -20,12 +20,6 @@
 	else
 		return check_access_list(acc)
 
-/obj/item/proc/GetAccess()
-	return list()
-
-/obj/item/proc/GetID()
-	return null
-
 /obj/proc/generate_req_lists()
 	//These generations have been moved out of /obj/New() because they were slowing down the creation of objects that never even used the access system.
 	if(!req_access)
@@ -406,105 +400,8 @@
 /proc/get_all_solgov_jobs()
 	return list("Solar Federation Lieutenant","Solar Federation Specops Lieutenant","Solar Federation Marine","Solar Federation Specops Marine","Solar Federation Representative","Sol Trader","Solar Federation General")
 
-//gets the actual job rank (ignoring alt titles)
-//this is used solely for sechuds
-/obj/proc/GetJobRealName()
-	if(!istype(src, /obj/item/pda) && !istype(src,/obj/item/card/id))
-		return
-
-	var/rank
-	var/assignment
-	if(istype(src, /obj/item/pda))
-		if(src:id)
-			rank = src:id:rank
-			assignment = src:id:assignment
-	else if(istype(src, /obj/item/card/id))
-		rank = src:rank
-		assignment = src:assignment
-
-	if( rank in GLOB.joblist )
-		return rank
-
-	if( assignment in GLOB.joblist )
-		return assignment
-
-	return "Unknown"
-
-
-/proc/GetIdCard(mob/living/carbon/human/H)
-	if(H.wear_id)
-		var/id = H.wear_id.GetID()
-		if(id)
-			return id
-	if(H.get_active_hand())
-		var/obj/item/I = H.get_active_hand()
-		return I.GetID()
-
-/proc/FindNameFromID(mob/living/carbon/human/H)
-	ASSERT(istype(H))
-	var/obj/item/card/id/C = H.get_active_hand()
-	if( istype(C) || istype(C, /obj/item/pda) )
-		var/obj/item/card/id/ID = C
-
-		if( istype(C, /obj/item/pda) )
-			var/obj/item/pda/pda = C
-			ID = pda.id
-		if(!istype(ID))
-			ID = null
-
-		if(ID)
-			return ID.registered_name
-
-	C = H.wear_id
-
-	if( istype(C) || istype(C, /obj/item/pda) )
-		var/obj/item/card/id/ID = C
-
-		if( istype(C, /obj/item/pda) )
-			var/obj/item/pda/pda = C
-			ID = pda.id
-		if(!istype(ID))
-			ID = null
-
-		if(ID)
-			return ID.registered_name
-
 /proc/get_all_job_icons() //For all existing HUD icons
 	return GLOB.joblist + get_all_ERT_jobs() + list("Prisoner")
-
-/obj/proc/GetJobName() //Used in secHUD icon generation
-	var/assignmentName = "Unknown"
-	var/rankName = "Unknown"
-	if(istype(src, /obj/item/pda))
-		var/obj/item/pda/P = src
-		assignmentName = P.ownjob
-		rankName = P.ownrank
-	else if(istype(src, /obj/item/card/id))
-		var/obj/item/card/id/I = src
-		assignmentName = I.assignment
-		rankName = I.rank
-
-
-	var/job_icons = get_all_job_icons()
-	var/centcom = get_all_centcom_jobs()
-	var/solgov = get_all_solgov_jobs()
-
-	if(assignmentName in centcom) //Return with the NT logo if it is a Centcom job
-		return "Centcom"
-	if(rankName in centcom)
-		return "Centcom"
-
-	if(assignmentName in solgov) //Return with the SolGov logo if it is a SolGov job
-		return "solgov"
-	if(rankName in solgov)
-		return "solgov"
-
-	if(assignmentName	in job_icons) //Check if the job has a hud icon
-		return assignmentName
-	if(rankName in job_icons)
-		return rankName
-
-	return "Unknown" //Return unknown if none of the above apply
 
 /proc/get_accesslist_static_data(num_min_region = REGION_GENERAL, num_max_region = REGION_COMMAND)
 	var/list/retval

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -376,7 +376,7 @@
 		return threatcount
 
 	//Agent cards lower threatlevel.
-	var/obj/item/card/id/id = GetIdCard(perp)
+	var/obj/item/card/id/id = perp.GetIdCard()
 	if(id && istype(id, /obj/item/card/id/syndicate))
 		threatcount -= 2
 	// A proper	CentCom id is hard currency.

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -376,7 +376,7 @@
 		return threatcount
 
 	//Agent cards lower threatlevel.
-	var/obj/item/card/id/id = perp.GetIdCard()
+	var/obj/item/card/id/id = perp.get_id_card()
 	if(id && istype(id, /obj/item/card/id/syndicate))
 		threatcount -= 2
 	// A proper	CentCom id is hard currency.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -825,18 +825,14 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/assignmentName = get_ID_assignment(if_no_id = "Unknown")
 	var/rankName = get_ID_rank(if_no_id = "Unknown")
 
-	var/job_icons = get_all_job_icons()
-	var/centcom = get_all_centcom_jobs()
-	var/solgov = get_all_solgov_jobs()
+	var/static/list/job_icons = get_all_job_icons()
+	var/static/list/centcom = get_all_centcom_jobs()
+	var/static/list/solgov = get_all_solgov_jobs()
 
-	if(assignmentName in centcom) //Return with the NT logo if it is a Centcom job
-		return "Centcom"
-	if(rankName in centcom)
+	if((assignmentName in centcom) || (rankName in centcom)) //Return with the NT logo if it is a Centcom job
 		return "Centcom"
 
-	if(assignmentName in solgov) //Return with the SolGov logo if it is a SolGov job
-		return "solgov"
-	if(rankName in solgov)
+	if((assignmentName in solgov) || (rankName in solgov)) //Return with the SolGov logo if it is a SolGov job
 		return "solgov"
 
 	if(assignmentName in job_icons) //Check if the job has a hud icon

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -818,3 +818,48 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 /// Called on cyborg items that need special charging behavior. Override as needed for specific items.
 /obj/item/proc/cyborg_recharge(coeff = 1, emagged = FALSE)
 	return
+
+// Access and Job stuff
+
+/obj/item/proc/GetJobName() //Used in secHUD icon generation
+	var/assignmentName = get_ID_assignment(if_no_id = "Unknown")
+	var/rankName = get_ID_rank(if_no_id = "Unknown")
+
+	var/job_icons = get_all_job_icons()
+	var/centcom = get_all_centcom_jobs()
+	var/solgov = get_all_solgov_jobs()
+
+	if(assignmentName in centcom) //Return with the NT logo if it is a Centcom job
+		return "Centcom"
+	if(rankName in centcom)
+		return "Centcom"
+
+	if(assignmentName in solgov) //Return with the SolGov logo if it is a SolGov job
+		return "solgov"
+	if(rankName in solgov)
+		return "solgov"
+
+	if(assignmentName in job_icons) //Check if the job has a hud icon
+		return assignmentName
+	if(rankName in job_icons)
+		return rankName
+
+	return "Unknown" //Return unknown if none of the above apply
+
+/obj/item/proc/get_ID_assignment(if_no_id = "No id")
+	var/obj/item/card/id/id = GetID()
+	if(istype(id)) // Make sure its actually an ID
+		return id.assignment
+	return if_no_id
+
+/obj/item/proc/get_ID_rank(if_no_id = "No id")
+	var/obj/item/card/id/id = GetID()
+	if(istype(id)) // Make sure its actually an ID
+		return id.rank
+	return if_no_id
+
+/obj/item/proc/GetAccess()
+	return list()
+
+/obj/item/proc/GetID()
+	return null

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -821,7 +821,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 
 // Access and Job stuff
 
-/obj/item/proc/GetJobName() //Used in secHUD icon generation
+/obj/item/proc/get_job_name() //Used in secHUD icon generation
 	var/assignmentName = get_ID_assignment(if_no_id = "Unknown")
 	var/rankName = get_ID_rank(if_no_id = "Unknown")
 

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -31,19 +31,32 @@
 	var/obj/item/card/id/front_id = null
 
 
-/obj/item/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
-	. = ..(W, new_location)
+/obj/item/storage/wallet/remove_from_storage(obj/item/I, atom/new_location)
+	. = ..()
 	if(.)
-		if(W == front_id)
-			front_id = null
-			update_icon(UPDATE_ICON_STATE)
+		if(istype(I, /obj/item/card/id))
+			refresh_ID()
 
-/obj/item/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
-	. = ..(W, prevent_warning)
+/obj/item/storage/wallet/handle_item_insertion(obj/item/I, prevent_warning = FALSE)
+	. = ..()
 	if(.)
-		if(!front_id && istype(W, /obj/item/card/id))
-			front_id = W
-			update_icon(UPDATE_ICON_STATE)
+		if(istype(I, /obj/item/card/id))
+			refresh_ID()
+
+/obj/item/storage/wallet/orient2hud(mob/user)
+	. = ..()
+	refresh_ID()
+
+/obj/item/storage/wallet/proc/refresh_ID()
+	// Locate the first ID in the wallet
+	front_id = (locate(/obj/item/card/id) in contents)
+
+	if(ishuman(loc))
+		var/mob/living/carbon/human/wearing_human = loc
+		if(wearing_human.wear_id == src)
+			wearing_human.sec_hud_set_ID()
+
+	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/storage/wallet/update_icon_state()
 	if(front_id)

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -33,15 +33,13 @@
 
 /obj/item/storage/wallet/remove_from_storage(obj/item/I, atom/new_location)
 	. = ..()
-	if(.)
-		if(istype(I, /obj/item/card/id))
-			refresh_ID()
+	if(. && istype(I, /obj/item/card/id))
+		refresh_ID()
 
 /obj/item/storage/wallet/handle_item_insertion(obj/item/I, prevent_warning = FALSE)
 	. = ..()
-	if(.)
-		if(istype(I, /obj/item/card/id))
-			refresh_ID()
+	if(. && istype(I, /obj/item/card/id))
+		refresh_ID()
 
 /obj/item/storage/wallet/orient2hud(mob/user)
 	. = ..()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -261,8 +261,8 @@
 
 /mob/proc/get_id_card()
 	for(var/obj/item/I in get_all_slots())
-		. = I.GetID()
-		if(istype(.)) // Make sure its an ID card
+		var/obj/item/card/id/id = I.GetID()
+		if(istype(id)) // Make sure its an ID card
 			break
 
 /mob/proc/get_item_by_slot(slot_id)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -262,7 +262,7 @@
 /mob/proc/get_id_card()
 	for(var/obj/item/I in get_all_slots())
 		. = I.GetID()
-		if(.)
+		if(istype(.)) // Make sure its an ID card
 			break
 
 /mob/proc/get_item_by_slot(slot_id)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -261,8 +261,8 @@
 
 /mob/proc/get_id_card()
 	for(var/obj/item/I in get_all_slots())
-		var/obj/item/card/id/id = I.GetID()
-		if(istype(id)) // Make sure its an ID card
+		. = I.GetID()
+		if(.)
 			break
 
 /mob/proc/get_item_by_slot(slot_id)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -430,39 +430,45 @@
 		else
 			return if_no_id
 
-//gets assignment from ID or ID inside PDA or PDA itself
-//Useful when player do something with computers
+//gets assignment from ID, PDA, Wallet, etc.
+//This should not be relied on for authentication, because PDAs show their owner's job, even if an ID is not inserted
 /mob/living/carbon/human/proc/get_assignment(if_no_id = "No id", if_no_job = "No job")
-	var/obj/item/pda/pda = wear_id
-	var/obj/item/card/id/id = wear_id
-	if(istype(pda))
-		if(pda.id && istype(pda.id, /obj/item/card/id))
-			. = pda.id.assignment
-		else
-			. = pda.ownjob
-	else if(istype(id))
-		. = id.assignment
-	else
+	if(!wear_id)
 		return if_no_id
-	if(!.)
-		. = if_no_job
-	return
+	var/obj/item/card/id/id = wear_id.GetID()
+	if(istype(id)) // Make sure its actually an ID
+		if(!id.assignment)
+			return if_no_job
+		return id.assignment
 
-//gets name from ID or ID inside PDA or PDA itself
-//Useful when player do something with computers
+	if(is_pda(wear_id))
+		var/obj/item/pda/pda = wear_id
+		return pda.ownjob
+
+	return if_no_id
+
+//gets name from ID, PDA, Wallet, etc.
+//This should not be relied on for authentication, because PDAs show their owner's name, even if an ID is not inserted
 /mob/living/carbon/human/proc/get_authentification_name(if_no_id = "Unknown")
-	var/obj/item/pda/pda = wear_id
-	var/obj/item/card/id/id = wear_id
-	if(istype(pda))
-		if(pda.id)
-			. = pda.id.registered_name
-		else
-			. = pda.owner
-	else if(istype(id))
-		. = id.registered_name
-	else
+	if(!wear_id)
 		return if_no_id
-	return
+	var/obj/item/card/id/id = wear_id.GetID()
+	if(istype(id) && id.registered_name)
+		return id.registered_name
+
+	if(is_pda(wear_id))
+		var/obj/item/pda/pda = wear_id
+		return pda.owner
+
+	return if_no_id
+
+/mob/living/carbon/human/proc/GetIdCard(mob/living/carbon/human/H)
+	var/obj/item/card/id/id = wear_id.GetID()
+	if(istype(id)) // Make sure its actually an ID
+		return id
+	if(H.get_active_hand())
+		var/obj/item/I = H.get_active_hand()
+		return I.GetID()
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere
 /mob/living/carbon/human/get_visible_name(id_override = FALSE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -462,7 +462,7 @@
 
 	return if_no_id
 
-/mob/living/carbon/human/proc/GetIdCard(mob/living/carbon/human/H)
+/mob/living/carbon/human/get_id_card(mob/living/carbon/human/H)
 	var/obj/item/card/id/id = wear_id.GetID()
 	if(istype(id)) // Make sure its actually an ID
 		return id

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -189,6 +189,11 @@ GLOBAL_LIST_EMPTY(PDAs)
 		id = null
 		playsound(src, 'sound/machines/terminal_eject.ogg', 50, TRUE)
 
+	if(ishuman(loc))
+		var/mob/living/carbon/human/wearing_human = loc
+		if(wearing_human.wear_id == src)
+			wearing_human.sec_hud_set_ID()
+
 /obj/item/pda/verb/verb_remove_id()
 	set category = "Object"
 	set name = "Remove id"
@@ -246,7 +251,11 @@ GLOBAL_LIST_EMPTY(PDAs)
 			id = I
 			user.put_in_hands(old_id)
 			playsound(src, 'sound/machines/pda_button1.ogg', 50, TRUE)
-	return
+
+	if(ishuman(loc))
+		var/mob/living/carbon/human/wearing_human = loc
+		if(wearing_human.wear_id == src)
+			wearing_human.sec_hud_set_ID()
 
 /obj/item/pda/attackby(obj/item/C, mob/user, params)
 	..()
@@ -394,3 +403,13 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/datum/data/pda/utility/flashlight/FL = find_program(/datum/data/pda/utility/flashlight)
 	if(FL && FL.fon)
 		FL.start()
+
+/obj/item/pda/get_ID_assignment(if_no_id = "No id")
+	. = ..()
+	if(. == if_no_id) // We dont have an ID in us, check our cached job
+		return ownjob
+
+/obj/item/pda/get_ID_rank(if_no_id = "No id")
+	. = ..()
+	if(. == if_no_id) // Ditto but rank
+		return ownrank


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Wallets and PDAs now correctly display the job of the ID they have for both comms and sechud. Wallets with multiple IDs will display the first ID. 

PDAs without an ID inserted, will show their cached job (Owner: Blah-name name, **Head of Security** ). This cached job on PDAs is how it has worked for a long time, if this should be removed, I can do so.

This also eliminates the unused procs GetJobRealName and FindNameFromID, because they are terrible code.

It also moves GetIdCard to a carbon/human proc
         
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Wallets not showing IDs is confusing for security, and showing the wrong ID on comms is also confusing.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://cdn.discordapp.com/attachments/626658531311091744/1060277074268536972/image.png)
![image](https://cdn.discordapp.com/attachments/626658531311091744/1060278374519537804/image.png)

## Testing
<!-- How did you test the PR, if at all? -->
No ID - shows no id on sechud, "No id" on comms
Wallet, HOS ID first - HOS sechud, HOS on comms
Wallet, Captain ID first - Captain sechud, Captain on comms
HOS PDA, no ID - HOS sechud, HOS on comms (note, this doesnt grant you HOS access, just makes you look like one)
HOS PDA, HOS ID in PDA - HOS sechud, HOS on comms
HOS PDA, Captain ID in PDA - Captain sechud, Captain on comms

## Changelog
:cl:
tweak: Wallets and PDAs will now consistently show the right ID on sechud and comms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
