### PR TITLE
Bandolier Buff because its existance is pathetic and im tired of every individual shell being its own seperate slot oh my god

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -484,7 +484,8 @@
 	desc = "A bandolier for holding shotgun ammunition."
 	icon_state = "bandolier"
 	item_state = "bandolier"
-	storage_slots = 8
+	storage_slots = 16
+	max_combined_w_class = 16
 	can_hold = list(/obj/item/ammo_casing/shotgun)
 	display_contents_with_number = TRUE
 
@@ -497,7 +498,7 @@
 		new /obj/item/ammo_casing/shotgun/beanbag(src)
 
 /obj/item/storage/belt/bandolier/update_icon_state()
-	icon_state = "[initial(icon_state)]_[length(contents)]"
+	icon_state = "[initial(icon_state)]_[min(length(contents), 8)]"
 
 /obj/item/storage/belt/bandolier/attackby(obj/item/I, mob/user)
 	var/amount = length(contents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Increases the bandolier capacity from 8 > 16.
Shotgun shells now stack into a single slot for ease of storage management.
That's it.

## Why It's Good For The Game
This belt item is trash, completely outclassed by having your shells in box's inside your backpack. This buff gives it a better niche of being easier to manage your shells, having them all in one place, and also more storage then keeping it in a box. An actual improvement to its entire gimmick overall.

## Images of changes
![dreamseeker_nToB4aDEIN](https://user-images.githubusercontent.com/62493359/210644923-5fa6303f-1378-40e8-98b8-e0de281630df.png)


## Testing
boot server, used new belt, epic

## Changelog
:cl: Octus
tweak: Bandoliers are more useful, their storage capacity has been doubled and storage management is much more convenient to use and manage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
