### PR TITLE
Removes the part of apc losing malf points on apc deconstruction I missed

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1394,8 +1394,6 @@
 		terminal = null
 
 /obj/machinery/power/apc/proc/set_broken()
-	if(malfai && operating)
-		malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10,0,1000)
 	stat |= BROKEN
 	operating = FALSE
 	if(occupier)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
In pr #16192 I made it so malf AI did not lose points when it's apc was destroyed.

However, I was dumb, and presumably only tested it by deleting the APC. If I looked in the file more, or tested by attacking the apc, I would find out that when the apc is damaged to breaking (set_broken() gets called), Malf AI also loses points there.

As such, this pr removes the second check that should have been caught 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A: Finishing something a merged pr should have done:
B: The text from the last pr: 
After discussing with a maintainer, it was decided that malf AI should be tweaked to prevent a malf AI from gaining all its points from space built APCs. We are aware however, with the limited APCs on station and off station, so with this PR it is tweaked that if crew deconstructs APCs the malf AI has hacked, they will no longer loose points, meaning once the AI starts going loud with the APC hacking, crew will not be able to destroy APCs the malf AI has hacked to subtract points from them.

For those wondering if command will start deconstructing and repairing the APC on the bridge so the AI can't malfhack it when it turns out the AI is malf, you could already cut the AI control wire to prevent this.

## Testing
<!-- How did you test the PR, if at all? -->
Shot the apc to the point where it broke
Confirmed no points were lost.

## Changelog
:cl:
tweak:  Malf AI no longer looses points when Malfhacked APCs are destroyed. For real this time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
