### PR TITLE
Fixes 3 Economy Bugs

### DIFF
--- a/code/game/jobs/departments.dm
+++ b/code/game/jobs/departments.dm
@@ -100,6 +100,10 @@
 		"Research Director",
 		"Scientist",
 		"Xenobiologist",
+		"Xenoarcheologist",
+		"Anomalist",
+		"Plasma Researcher",
+		"Chemical Researcher",
 		"Geneticist",	//Part of both medical and science
 		"Roboticist",
 	)
@@ -143,7 +147,8 @@
 		"Head of Personnel",
 		"Quartermaster",
 		"Cargo Technician",
-		"Shaft Miner"
+		"Shaft Miner",
+		"Spelunker"
 	)
 	head_of_staff = "Head of Personnel"
 
@@ -157,6 +162,10 @@
 		"Chief Engineer",
 		"Station Engineer",
 		"Life Support Specialist",
+		"Atmospheric Technician",
+		"Maintenance Technician",
+		"Engine Technician",
+		"Electrician",
 	)
 	head_of_staff = "Chief Engineer"
 
@@ -169,6 +178,8 @@
 	department_roles = list(
 		"Chief Medical Officer",
 		"Medical Doctor",
+		"Surgeon",
+		"Nurse",
 		"Geneticist",
 		"Psychiatrist",
 		"Chemist",

--- a/code/game/objects/items/weapons/cash.dm
+++ b/code/game/objects/items/weapons/cash.dm
@@ -14,12 +14,11 @@
 	max_amount = MAX_STACKABLE_CASH
 	merge_type = /obj/item/stack/spacecash
 
-/obj/item/stack/spacecash/Initialize(mapload, uncompensated = TRUE)
+/obj/item/stack/spacecash/Initialize(mapload)
 	. = ..()
-	if(uncompensated)
-		SSeconomy.space_credits_created += amount
+	SSeconomy.space_credits_created += amount
 	SSeconomy.total_space_cash += amount
-	update_icon()
+	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/stack/spacecash/Destroy()
 	SSeconomy.total_space_cash -= amount
@@ -28,11 +27,14 @@
 
 /obj/item/stack/spacecash/merge(obj/item/stack/S)
 	. = ..()
-	update_icon()
+	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/stack/spacecash/change_stack(mob/living/user)
 	. = ..()
-	update_icon()
+	var/obj/item/stack/spacecash/new_dosh = .
+	if(istype(new_dosh))
+		new_dosh.update_icon(UPDATE_ICON_STATE)
+	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/stack/spacecash/update_icon_state()
 	name = "[amount == max_amount ? "10000" : amount] Credit[amount > 1 ? "s" : ""]"

--- a/code/modules/supply/supply_console.dm
+++ b/code/modules/supply/supply_console.dm
@@ -397,9 +397,9 @@
 			SSeconomy.request_list -= order
 			return
 		// If we arent public, were cargo access. CANCELLATIONS FOR EVERYONE
-		if(order.requires_cargo_approval && (ACCESS_CARGO in C.access))
+		if(order.requires_cargo_approval && (issilicon(user) || (ACCESS_CARGO in C?.access)))
 			SSeconomy.request_list -= order
-		else if(order.requires_head_approval && (order.ordered_by_department.has_account_access(C.access)))
+		else if(order.requires_head_approval && (issilicon(user) || order.ordered_by_department.has_account_access(C?.access)))
 			SSeconomy.request_list -= order
 		else
 			return //how did we get here?


### PR DESCRIPTION
## What Does This PR Do
Fixes 
Partially Resolves. #19779 Adds alt roundstart job titles to department datums
Fixes #20093 Properly updates icons in money stack code
Fixes #19921 AI no longer runtimes when denying crates

## Why It's Good For The Game
Bugs bad

## Testing
Compiled and ran on test server

- Alt-click transferred space cash and it updated properly
- Tried out a couple alt job role names on my ID and it showed correct dept accounts
- Denied a crate as the AI

## Changelog
:cl:
fix: Alt job titles can now properly access dept account on supply console
fix: Alt-click'ing money now properly updates the new stacks icon
fix: AI's can now properly deny cargo crates
/:cl:

