### PR TITLE
Limits Telegun to Current Z-Level (Unless a Beacon is Emagged)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -356,10 +356,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/telegun
 	name = "Telegun"
-	desc = "An extremely high-tech energy gun that utilizes bluespace technology to teleport away living targets. Select the target beacon on the telegun itself; projectiles will send targets to the beacon locked onto."
+	desc = "An extremely high-tech energy gun that utilizes bluespace technology to teleport away living targets. Select the target beacon on the telegun itself; projectiles will send targets to the beacon locked onto. Can only send targets to beacons in-sector unless they are emagged!"
 	reference = "TG"
 	item = /obj/item/gun/energy/telegun
-	cost = 12
+	cost = 10
 	job = list("Research Director")
 
 //Roboticist

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -20,11 +20,14 @@
 
 	for(var/obj/item/radio/beacon/R in GLOB.beacons)
 		var/turf/T = get_turf(R)
+		var/turf/M = get_turf(user)
 		if(!T)
 			continue
 		if(!is_teleport_allowed(T.z))
 			continue
-		if(R.syndicate)
+		if(T.z == M.z)
+			continue
+		if(T.z != M.z && R.syndicate)
 			continue
 		var/tmpname = T.loc.name
 		if(areaindex[tmpname])

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -27,7 +27,7 @@
 			continue
 		if(T.z != M.z)
 			continue
-		if(t.z =! M.z && !R.syndicate)
+		if(T.z =! M.z && !R.syndicate)
 			continue
 		var/tmpname = T.loc.name
 		if(areaindex[tmpname])

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -25,7 +25,7 @@
 			continue
 		if(!is_teleport_allowed(T.z))
 			continue
-		if(T.z == M.z)
+		if(T.z != M.z)
 			continue
 		if(t.z =! M.z && !R.syndicate)
 			continue

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -2,7 +2,7 @@
 
 /obj/item/gun/energy/telegun
 	name = "teleporter gun"
-	desc = "An extremely high-tech bluespace energy gun capable of teleporting targets to far off locations."
+	desc = "An extremely high-tech bluespace energy gun capable of teleporting targets to Bluespace Beacons."
 	icon_state = "telegun"
 	item_state = "ionrifle"
 	origin_tech = "combat=6;materials=7;powerstorage=5;bluespace=5;syndicate=4"
@@ -25,9 +25,7 @@
 			continue
 		if(!is_teleport_allowed(T.z))
 			continue
-		if(T.z != M.z)
-			continue
-		if(T.z != M.z && R.syndicate)
+		if(T.z != M.z && !R.emagged)
 			continue
 		var/tmpname = T.loc.name
 		if(areaindex[tmpname])

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -27,7 +27,7 @@
 			continue
 		if(T.z != M.z)
 			continue
-		if(T.z =! M.z && !R.syndicate)
+		if(T.z != M.z && R.syndicate)
 			continue
 		var/tmpname = T.loc.name
 		if(areaindex[tmpname])

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -27,7 +27,7 @@
 			continue
 		if(T.z == M.z)
 			continue
-		if(T.z != M.z && R.syndicate)
+		if(t.z =! M.z && !R.syndicate)
 			continue
 		var/tmpname = T.loc.name
 		if(areaindex[tmpname])

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -240,7 +240,7 @@
 	damage = 0
 	nodamage = 1
 	alwayslog = TRUE
-	var/teleport_target = null
+	var/obj/item/radio/beacon/teleport_target = null
 
 /obj/item/projectile/energy/teleport/New(loc, tele_target)
 	..(loc)
@@ -249,7 +249,7 @@
 
 /obj/item/projectile/energy/teleport/on_hit(atom/target, blocked = 0)
 	if(isliving(target))
-		if(teleport_target.z == target.z)
+		if(get_turf(teleport_target) == target.z || teleport_target.emagged)
 			do_teleport(target, teleport_target, 0)//teleport what's in the tile to the beacon
 		else
 			do_teleport(target, target, 15) //Otherwise it just warps you off somewhere.

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -249,7 +249,7 @@
 
 /obj/item/projectile/energy/teleport/on_hit(atom/target, blocked = 0)
 	var/turf/target_turf = get_turf(teleport_target)
-	if(isliving(target))
+	if(isliving(target) && istype(target_turf))
 		if(target_turf.z == target.z || teleport_target.emagged)
 			do_teleport(target, teleport_target, 0)//teleport what's in the tile to the beacon
 		else

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -249,7 +249,7 @@
 
 /obj/item/projectile/energy/teleport/on_hit(atom/target, blocked = 0)
 	if(isliving(target))
-		if(teleport_target)
+		if(teleport_target.z == target.z)
 			do_teleport(target, teleport_target, 0)//teleport what's in the tile to the beacon
 		else
 			do_teleport(target, target, 15) //Otherwise it just warps you off somewhere.

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -248,8 +248,9 @@
 		teleport_target = tele_target
 
 /obj/item/projectile/energy/teleport/on_hit(atom/target, blocked = 0)
+	var/turf/target_turf = get_turf(teleport_target)
 	if(isliving(target))
-		if(get_turf(teleport_target) == target.z || teleport_target.emagged)
+		if(target_turf.z == target.z || teleport_target.emagged)
 			do_teleport(target, teleport_target, 0)//teleport what's in the tile to the beacon
 		else
 			do_teleport(target, target, 15) //Otherwise it just warps you off somewhere.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that the Telegun only teleports to beacons that are on its z-level. This can be extended to any beacon if you emag the target beacon. If you manage to walk off z-level and back on to set the beacon to space it will instead teleport you somewhere within 15 tiles as it would if you didnt have a beacon set.

Also reduces the Telegun's cost by two to make up for the change.

## Why It's Good For The Game
One-click permakilling Security/targets is cringe. This allows you to do silly things without perma-ending someone.

## Testing
Sent many vox on a wild space adventure.

## Changelog
:cl:
tweak: Tweaked the Telegun's targeting to only choose beacons on your current z-level unless theyre emagged.
tweak: Telegun cost reduced to 10TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
