### PR TITLE
Add fail-safes to disposal sort junctions, fix looping

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -82,7 +82,7 @@
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "ai" = (
-/obj/structure/disposalpipe/sortjunction{
+/obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /turf/simulated/wall/r_wall,

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -31076,7 +31076,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -75511,11 +75511,7 @@
 	},
 /area/toxins/hallway)
 "kCk" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	icon_state = "pipe-j2s";
-	name = "Cargo Disposals"
-	},
+/obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "kDl" = (
@@ -80651,6 +80647,19 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
+"oFy" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "oFK" = (
 /obj/machinery/light{
 	dir = 8
@@ -143015,7 +143024,7 @@ ciY
 ciY
 eaT
 kmA
-hyf
+oFy
 ldn
 ldn
 dIQ

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/see_reagents = FALSE // Determines if the cyborg can see reagents
 
 	/// Integer used to determine self-mailing location, used only by drones and saboteur borgs
-	var/mail_destination = 0
+	var/mail_destination = 1
 
 /mob/living/silicon/robot/get_cell()
 	return cell

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1041,16 +1041,15 @@
 /obj/structure/disposalpipe/sortjunction/Initialize(mapload)
 	. = ..()
 	updatedir()
-	if(sort_type_txt && sort_type_txt != "1")
-		var/list/sort_type_str = splittext(sort_type_txt, ";")
-		if(!("1" in sort_type_str)) // Default to disposals if mapped with it along other destinations
-			var/new_sort_type = list()
-			for(var/x in sort_type_str)
-				var/n = text2num(x)
-				if(n)
-					new_sort_type |= n
-			if(length(new_sort_type))
-				sort_type = new_sort_type
+	var/list/sort_type_str = splittext(sort_type_txt, ";")
+	if(length(sort_type_str) && !("1" in sort_type_str)) // Default to disposals if mapped with it along other destinations
+		var/new_sort_type = list()
+		for(var/x in sort_type_str)
+			var/n = text2num(x)
+			if(n)
+				new_sort_type |= n
+		if(length(new_sort_type))
+			sort_type = new_sort_type
 	update_appearance(UPDATE_DESC)
 	update()
 	return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1042,12 +1042,15 @@
 	. = ..()
 	updatedir()
 	if(sort_type_txt && sort_type_txt != "1")
-		sort_type = list()
 		var/list/sort_type_str = splittext(sort_type_txt, ";")
-		for(var/x in sort_type_str)
-			var/n = text2num(x)
-			if(n)
-				sort_type += n
+		if(!("1" in sort_type_str)) // Default to disposals if mapped with it along other destinations
+			var/new_sort_type = list()
+			for(var/x in sort_type_str)
+				var/n = text2num(x)
+				if(n)
+					new_sort_type |= n
+			if(length(new_sort_type))
+				sort_type = new_sort_type
 	update_appearance(UPDATE_DESC)
 	update()
 	return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1048,26 +1048,29 @@
 	return
 
 /obj/structure/disposalpipe/sortjunction/proc/parse_sort_destinations()
+	if(sort_type_txt == "1")
+		return
+
 	var/list/sort_type_str = splittext(sort_type_txt, ";")
 	var/mapping_fail
-	if(sort_type_txt != "1")
-		if(length(sort_type_str)) // Default to disposals if mapped with it along other destinations
-			if("1" in sort_type_str)
-				mapping_fail = "Mutually exclusive sort types in sort_type_txt"
-			else
-				var/new_sort_type = list()
-				for(var/x in sort_type_str)
-					var/n = text2num(x)
-					if(n)
-						new_sort_type |= n
-				if(length(new_sort_type))
-					sort_type = new_sort_type
-				else
-					mapping_fail = "No sort types after parsing sort_type_txt"
+
+	if(length(sort_type_str)) // Default to disposals if mapped with it along other destinations
+		if("1" in sort_type_str)
+			mapping_fail = "Mutually exclusive sort types in sort_type_txt"
 		else
-			mapping_fail = "Sort_type_txt is empty"
-		if(mapping_fail)
-			stack_trace("[src] mapped incorrectly at [x],[y],[z] - [mapping_fail]")
+			var/new_sort_type = list()
+			for(var/x in sort_type_str)
+				var/n = text2num(x)
+				if(n)
+					new_sort_type |= n
+			if(length(new_sort_type))
+				sort_type = new_sort_type
+			else
+				mapping_fail = "No sort types after parsing sort_type_txt"
+	else
+		mapping_fail = "Sort_type_txt is empty"
+	if(mapping_fail)
+		stack_trace("[src] mapped incorrectly at [x],[y],[z] - [mapping_fail]")
 
 /obj/structure/disposalpipe/sortjunction/attackby(obj/item/I, mob/user, params)
 	if(..())

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1041,18 +1041,33 @@
 /obj/structure/disposalpipe/sortjunction/Initialize(mapload)
 	. = ..()
 	updatedir()
-	var/list/sort_type_str = splittext(sort_type_txt, ";")
-	if(length(sort_type_str) && !("1" in sort_type_str)) // Default to disposals if mapped with it along other destinations
-		var/new_sort_type = list()
-		for(var/x in sort_type_str)
-			var/n = text2num(x)
-			if(n)
-				new_sort_type |= n
-		if(length(new_sort_type))
-			sort_type = new_sort_type
+	if(mapload)
+		parse_sort_destinations()
 	update_appearance(UPDATE_DESC)
 	update()
 	return
+
+/obj/structure/disposalpipe/sortjunction/proc/parse_sort_destinations()
+	var/list/sort_type_str = splittext(sort_type_txt, ";")
+	var/mapping_fail
+	if(sort_type_txt != "1")
+		if(length(sort_type_str)) // Default to disposals if mapped with it along other destinations
+			if("1" in sort_type_str)
+				mapping_fail = "Mutually exclusive sort types in sort_type_txt"
+			else
+				var/new_sort_type = list()
+				for(var/x in sort_type_str)
+					var/n = text2num(x)
+					if(n)
+						new_sort_type |= n
+				if(length(new_sort_type))
+					sort_type = new_sort_type
+				else
+					mapping_fail = "No sort types after parsing sort_type_txt"
+		else
+			mapping_fail = "Sort_type_txt is empty"
+		if(mapping_fail)
+			stack_trace("[src] mapped incorrectly at [x],[y],[z] - [mapping_fail]")
 
 /obj/structure/disposalpipe/sortjunction/attackby(obj/item/I, mob/user, params)
 	if(..())

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -8,7 +8,7 @@
 	var/obj/wrapped = null
 	var/init_welded = FALSE
 	var/giftwrapped = FALSE
-	var/sortTag = 0
+	var/sortTag = 1
 
 /obj/structure/bigDelivery/Destroy()
 	var/turf/T = get_turf(src)
@@ -81,7 +81,7 @@
 	icon_state = "deliverycrate2"
 	var/obj/item/wrapped = null
 	var/giftwrapped = FALSE
-	var/sortTag = 0
+	var/sortTag = 1
 
 /obj/item/smallDelivery/ex_act(severity)
 	for(var/atom/movable/AM in contents)
@@ -307,15 +307,11 @@
 													// travels through the pipes.
 	for(var/obj/structure/bigDelivery/O in src)
 		deliveryCheck = 1
-		if(O.sortTag == 0)
-			O.sortTag = 1
 	for(var/obj/item/smallDelivery/O in src)
 		deliveryCheck = 1
-		if(O.sortTag == 0)
-			O.sortTag = 1
 	for(var/obj/item/shippingPackage/O in src)
 		deliveryCheck = 1
-		if(!O.sealed || O.sortTag == 0)		//unsealed or untagged shipping packages will default to disposals
+		if(!O.sealed)		//unsealed shipping packages will default to disposals
 			O.sortTag = 1
 	if(deliveryCheck == 0)
 		H.destinationTag = 1
@@ -367,7 +363,7 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "shippack"
 	var/obj/item/wrapped = null
-	var/sortTag = 0
+	var/sortTag = 1
 	var/sealed = 0
 
 /obj/item/shippingPackage/attackby(obj/item/O, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Since disposals work off a list that starts off at 1, this adds some fail-safes for weird mapping issues and removes hacky tag handling.

Disposals is now mutually exclusive from the rest. Removing all destinations on a junction automatically sets it to Disposals, and adding another destination will remove it from the list.

The sort junction on the clown planet ruin is replaced with a regular junction as you can't tag yourself.

## Why It's Good For The Game
Fixes #20098

## Images of changes
![Disposals2](https://user-images.githubusercontent.com/80771500/210801754-499dd7bc-5ad1-4247-9783-9561f1423976.PNG)

## Testing
Mapped in odd sorting junctions, and checked their vars after init. Sent stuff through disposals from different devices (`flush()` handled tags differently between devices)

## Changelog
:cl:
tweak: Disposals is a mutually exclusive destination for sorting pipes
fix: Fixed disposals looping if a sorting pipe isn't set up properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
