### PR TITLE
Added pie cannon and spirit board to Sol Trader items

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -340,6 +340,7 @@
 	lootcount = 1
 	loot = list(
 				/obj/machinery/disco = 20,
+				/obj/structure/spirit_board = 20,
 				/obj/mecha/combat/durand/old = 20
 				)
 
@@ -377,6 +378,7 @@
 				// Clown
 				/obj/item/grenade/clusterbuster/honk = 100,
 				/obj/item/bikehorn/golden = 100,
+				/obj/item/gun/throw/piecannon = 100,
 
 				// Bartender
 				/obj/item/storage/box/bartender_rare_ingredients_kit = 100,

--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -80,5 +80,5 @@
 	return 1
 
 /obj/structure/spirit_board/wrench_act(mob/living/user, obj/item/I)
-	if(default_unfasten_wrench(user, I, time = 4 SECONDS))
-		return TRUE
+	. = TRUE
+	default_unfasten_wrench(user, I, time = 4 SECONDS)

--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -12,7 +12,7 @@
 
 /obj/structure/spirit_board/examine(mob/user)
 	. = ..()
-	. += "[initial(desc)] The planchette is sitting at \"[planchette]\"."
+	. += "The planchette is sitting at \"[planchette]\"."
 
 /obj/structure/spirit_board/attack_hand(mob/user as mob)
 	if(..())
@@ -78,3 +78,7 @@
 		return 0
 
 	return 1
+
+/obj/structure/spirit_board/wrench_act(mob/living/user, obj/item/I)
+	if(default_unfasten_wrench(user, I, time = 4 SECONDS))
+		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Added pie cannon (service gear) and spirit board (largeitem) to Sol Trader items.
Spirit board now can be fastened and the redundant examine text has been removed.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The pie cannon is only available to the honk squad currently and it could fit into the sol traders service gear.
The spirit board is fun and chaotic. With the various requirements to use it, combined with the fact that Sol Traders arrival is only approved during green alert, could allow for a fun usage by the crew without the worry of ghosts reporting antags (and its not that better at it than simply using camera obscura + cranyon letters).
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![pie_time](https://user-images.githubusercontent.com/77684085/210849188-077b952b-66c4-4899-bf86-82b7b09ae85d.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Compiled and tried to fasten it with a wrench
## Changelog
:cl:
add: Added pie cannon and spirit board to Sol Traders items
tweak: Spirit board now can be fastened
spellcheck: Spirit board redundant examine text has been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
