### PR TITLE
hide_attacklogs areas actually hide attack logs

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -317,15 +317,14 @@
 	var/loglevel = ATKLOG_MOST
 	if(!isnull(custom_level))
 		loglevel = custom_level
+	var/area/A = get_area(MT)
+	if(A && A.hide_attacklogs)
+		loglevel = ATKLOG_ALL
 	else if(istype(MT))
 		if(istype(MU))
 			if(!MU.ckey && !MT.ckey) // Attacks between NPCs are only shown to admins with ATKLOG_ALL
 				loglevel = ATKLOG_ALL
 			else if(!MU.ckey || !MT.ckey || (MU.ckey == MT.ckey)) // Player v NPC combat is de-prioritized. Also no self-harm, nobody cares
-				loglevel = ATKLOG_ALMOSTALL
-		else
-			var/area/A = get_area(MT)
-			if(A && A.hide_attacklogs)
 				loglevel = ATKLOG_ALMOSTALL
 	else
 		loglevel = ATKLOG_ALL // Hitting an object. Not a mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
hide_attacklogs set the log priority to ALL rather than ALMOST_ALL
(removes just a wee bit of else spam too)

## Why It's Good For The Game
admins that don't wanna see logs shouldn't need to see logs

## Testing
compiled, ran, beat a skrell to death
## Changelog
:cl:
tweak: [ADMIN] hidden attack log areas actually hide their logs now
/:cl:
