### PR TITLE
Removes Clingtot

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -32,7 +32,7 @@
 	var/list/possible_traitors = get_players_for_role(ROLE_TRAITOR)
 
 	for(var/datum/mind/candidate in possible_traitors)
-		if(candidate.special_role == SPECIAL_ROLE_VAMPIRE) // no traitor vampires
+		if(candidate.special_role == SPECIAL_ROLE_VAMPIRE || candidate.special_role == SPECIAL_ROLE_CHANGELING) // no traitor vampires or changelings
 			possible_traitors.Remove(candidate)
 
 	// stop setup if no possible traitors


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds Changelings to the check that prevents Vampires from also rolling Traitor, making it impossible to roll both Changeling and Traitor at the same time.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This has been quite some time coming, especially with the buffs Changeling has seen recently - Changelings are now antagonists that can stand on their own without needing 20TC of traitor gear, and Clingtots were honestly kinda a pain for balancing either Changeling or Traitor. Besides, the concept of dual-antagonists seems to be flawed from the start - the player was given double the powers/equipment of a normal antagonist and double the amount of objectives, which didn't really make it harder so much as it gave them an excuse to cause even more chaos with their augmented abilities.
## Testing
<!-- How did you test the PR, if at all? -->
It built, which is about all I can test on my own. May be worth a testmerge to ensure it's working as intended.
## Changelog
:cl:
tweak: You can no longer roll both Changeling and Traitor simultaneously
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
