### PR TITLE
Removes toner cartridge/water tank crates

### DIFF
--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -719,14 +719,14 @@
 	icon_state = "artvend"
 	icon_lightmask = "artvend"
 	icon_panel = "screen_vendor"
-	products = list(/obj/item/stack/cable_coil/random = 10, /obj/item/camera = 4, /obj/item/camera_film = 6,
+	products = list(/obj/item/stack/cable_coil/random = 10, /obj/item/toner = 4, /obj/item/camera = 4, /obj/item/camera_film = 6,
 	/obj/item/storage/photo_album = 2, /obj/item/stack/wrapping_paper = 4, /obj/item/stack/tape_roll = 5, /obj/item/stack/packageWrap = 4,
 	/obj/item/storage/fancy/crayons = 4, /obj/item/hand_labeler = 4, /obj/item/paper = 10,
 	/obj/item/c_tube = 10, /obj/item/pen = 5, /obj/item/pen/blue = 5,
 	/obj/item/pen/red = 5)
 	contraband = list(/obj/item/toy/crayon/mime = 1,/obj/item/toy/crayon/rainbow = 1)
 	premium = list(/obj/item/poster/random_contraband = 5, /obj/item/pen/fancy = 2)
-	prices = list(/obj/item/stack/cable_coil/random = 20)
+	prices = list(/obj/item/stack/cable_coil/random = 20, /obj/item/toner = 40)
 
 /obj/machinery/economy/vending/tool
 	name = "\improper YouTool"

--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -99,17 +99,6 @@
 	cost = 100
 	containername = "bureaucracy crate"
 
-/datum/supply_packs/misc/toner
-	name = "Toner Cartridges Crate"
-	contains = list(/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner)
-	cost = 100
-	containername = "toner cartridges crate"
-
 /datum/supply_packs/misc/artscrafts
 	name = "Arts and Crafts Supplies Crate"
 	contains = list(/obj/item/storage/fancy/crayons,

--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -10,13 +10,6 @@
 	containername = "\improper MULEbot crate"
 	department_restrictions = list(DEPARTMENT_SUPPLY)
 
-/datum/supply_packs/misc/watertank
-	name = "Water Tank Crate"
-	contains = list(/obj/structure/reagent_dispensers/watertank)
-	cost = 50
-	containertype = /obj/structure/largecrate
-	containername = "water tank crate"
-
 /datum/supply_packs/misc/hightank
 	name = "High-Capacity Water Tank Crate"
 	contains = list(/obj/structure/reagent_dispensers/watertank/high)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removed toner cartridge and water tank crates.
ArtVend: Toner cartridges have been added (40 credits).
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Less supply packs bloat.
Water tanks are EVERYWHERE, if someone needs more water they would be ordering the high capacity version that has 100x more volume.
No one needs a crate with SIX toner cartridges and it fits in the ArtVend vending machine.

## Testing
<!-- How did you test the PR, if at all? -->
- Bought toner cartridges at the artvendor
## Changelog
:cl:
del: Removed toner cartridge crate
del: Removed water tank crate
tweak: ArtVend: Toner cartridges have been added
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
