### PR TITLE
Fix varedited areas on Lavaland.

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1260,9 +1260,7 @@
 /area/lavaland/surface/outdoors)
 "cQ" = (
 /turf/simulated/wall/r_wall,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "cR" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -1984,9 +1982,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/bluegrid,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "ei" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2739,9 +2735,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "fx" = (
 /obj/machinery/light{
 	dir = 4
@@ -2792,9 +2786,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/bluegrid,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "fC" = (
 /obj/structure/chair{
 	dir = 4
@@ -3121,9 +3113,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "gi" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3443,9 +3433,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "gM" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -5292,9 +5280,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "AE" = (
 /turf/simulated/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -5513,9 +5499,7 @@
 	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/mine/maintenance{
-	name = "Mining Station Communicatiosns"
-	})
+/area/mine/comms)
 "El" = (
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/plasteel{

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -51,6 +51,9 @@
 /area/mine/abandoned
 	name = "Abandoned Mining Station"
 
+/area/mine/comms
+	name = "Mining Station Communications"
+
 /area/mine/living_quarters
 	name = "Mining Station Port Wing"
 	icon_state = "mining_living"
@@ -79,6 +82,7 @@
 
 /area/mine/laborcamp
 	name = "Labor Camp"
+	icon_state = "brig"
 
 /area/mine/laborcamp/security
 	name = "Labor Camp Security"

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -553,15 +553,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/trader_station/sol
 	name = "Jupiter Station 6"
 
-//Labor camp
-/area/mine/laborcamp
-	name = "Labor Camp"
-	icon_state = "brig"
-
-/area/mine/laborcamp/security
-	name = "Labor Camp Security"
-	icon_state = "security"
-
 //STATION13
 
 /area/atmos


### PR DESCRIPTION
## What Does This PR Do
Removes varedited areas on Lavaland.

Also removes duplicate area defs for some labor camp areas.

Part of #20018, fixes for which I'm splitting into separate PRs because I'm not going to attempt to manage one PR that touches five different maps if I don't absolutely have to.

## Why It's Good For The Game
Varedited areas bad.

## Testing
Started server, joined, observed, flew to Lavaland and VVed object locs. Checked no runtimes were logged.

No visual changes.