### PR TITLE
Nuke disc respawn checks its surroundings for an open space if someone winds up building a wall over it

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -594,14 +594,13 @@ GLOBAL_VAR(bomb_set)
 /obj/item/disk/nuclear/proc/find_respawn()
 	var/list/possible_spawns = GLOB.nukedisc_respawn
 	while(length(possible_spawns))
-		var/turf/current_spawn = pick(possible_spawns)
+		var/turf/current_spawn = pick_n_take(possible_spawns)
 		if(!current_spawn.density)
 			return current_spawn
 		// Someone built a wall over it, check the surroundings
 		var/list/open_turfs = current_spawn.AdjacentTurfs(open_only = TRUE)
 		if(length(open_turfs))
 			return pick(open_turfs)
-		possible_spawns.Remove(current_spawn)
 
 #undef NUKE_INTACT
 #undef NUKE_COVER_OFF

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -599,7 +599,7 @@ GLOBAL_VAR(bomb_set)
 			return current_spawn
 		// Someone built a wall over it, check the surroundings
 		var/list/open_turfs = current_spawn.AdjacentTurfs(open_only = TRUE)
-		if(open_turfs)
+		if(length(open_turfs))
 			return pick(open_turfs)
 		possible_spawns.Remove(current_spawn)
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -579,16 +579,29 @@ GLOBAL_VAR(bomb_set)
 		STOP_PROCESSING(SSobj, src)
 		return ..()
 
-	if(length(GLOB.nukedisc_respawn))
+	var/turf/new_spawn = find_respawn()
+	if(new_spawn)
 		GLOB.poi_list.Remove(src)
-		var/obj/item/disk/nuclear/NEWDISK = new(pick(GLOB.nukedisc_respawn))
+		var/obj/item/disk/nuclear/NEWDISK = new(new_spawn)
 		transfer_fingerprints_to(NEWDISK)
 		message_admins("[src] has been destroyed at ([diskturf.x], [diskturf.y], [diskturf.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[diskturf.x];Y=[diskturf.y];Z=[diskturf.z]'>JMP</a>). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[NEWDISK.x];Y=[NEWDISK.y];Z=[NEWDISK.z]'>JMP</a>).")
 		log_game("[src] has been destroyed in ([diskturf.x], [diskturf.y], [diskturf.z]). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z]).")
 		return QDEL_HINT_HARDDEL_NOW
 	else
-		error("[src] was supposed to be destroyed, but we were unable to locate a nukedisc_respawn landmark to spawn a new one.")
+		error("[src] was supposed to be destroyed, but we were unable to locate a nukedisc_respawn landmark or open surroundings to spawn a new one.")
 	return QDEL_HINT_LETMELIVE // Cancel destruction unless forced.
+
+/obj/item/disk/nuclear/proc/find_respawn()
+	var/list/possible_spawns = GLOB.nukedisc_respawn
+	while(length(possible_spawns))
+		var/turf/current_spawn = pick(possible_spawns)
+		if(!current_spawn.density)
+			return current_spawn
+		// Someone built a wall over it, check the surroundings
+		var/list/open_turfs = current_spawn.AdjacentTurfs(open_only = TRUE)
+		if(open_turfs)
+			return pick(open_turfs)
+		possible_spawns.Remove(current_spawn)
 
 #undef NUKE_INTACT
 #undef NUKE_COVER_OFF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a proc respawn checking on the nuke disc. Should the picked spawn be in a wall due to player intervention, it'll check for open turfs in all directions. If it somehow fails to find one (Space is valid as some spawns are mapped in space), it will pick from the list of other spawns and try again.

Failing to find an open space will cause it to fail like if it couldn't find a spawn. All spawns being dense is a possible very rare edge case, so it could be tweaked to spawn regardless and notify the hitch specifically.

## Why It's Good For The Game
The disc respawning in a wall occured on Cere and was originally assumed to be a mapping mistake, but it was a player-made wall. It's more consistent to have it slightly nudge the spawn to be in the open as none of the mapped respawns are in walls specifically.

## Images of changes
https://user-images.githubusercontent.com/80771500/211175649-b49ff38d-0df7-4ba2-adee-59ac10341035.mp4

## Testing
Added a single respawn point to test_tiny, and checked the disc behavior with or without a wall on it.

## Changelog
:cl:
tweak: Restricted nuclear disc respawn will check for nearby open spots if a player builds a wall over a spawn point
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
