### PR TITLE
Fix varedited areas on space bar.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -41,63 +41,45 @@
 /area/ruin/space/powered)
 "am" = (
 /turf/simulated/wall,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "ap" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aq" = (
 /obj/structure/table,
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "ar" = (
 /obj/structure/table,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "as" = (
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "at" = (
 /obj/structure/table,
 /obj/item/toy/figure/crew/bartender,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "au" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "av" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aw" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "ax" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -110,16 +92,12 @@
 	req_access_txt = "25"
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "az" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aA" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/wall/mineral/titanium,
@@ -137,61 +115,45 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aE" = (
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aF" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aG" = (
 /obj/machinery/light/small,
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aH" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aI" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
 	amount = 10
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aJ" = (
 /turf/simulated/wall,
 /area/ruin/space/powered)
 "aK" = (
 /obj/structure/table,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aL" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/beer,
 /obj/item/reagent_containers/glass/rag,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aM" = (
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
@@ -200,144 +162,102 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aN" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aO" = (
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aP" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aQ" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aR" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/wall,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aS" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aT" = (
 /turf/simulated/floor/plating,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aU" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aV" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aW" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aX" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aY" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "aZ" = (
 /obj/item/radio/beacon,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "ba" = (
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bb" = (
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bc" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bd" = (
 /obj/machinery/economy/vending/snack,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "be" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bf" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Bathroom"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bg" = (
 /obj/structure/urinal{
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bh" = (
 /obj/structure/sink{
 	dir = 4;
@@ -347,26 +267,20 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bi" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bj" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bk" = (
 /obj/structure/toilet{
 	dir = 4
@@ -375,23 +289,17 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bl" = (
 /obj/machinery/door/airlock{
 	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bm" = (
 /obj/structure/glowshroom,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered{
-	name = "Space Bar"
-	})
+/area/ruin/space/powered/bar)
 "bn" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -59,6 +59,10 @@
 	icon_state = "green"
 	there_can_be_many = TRUE
 
+// Space Bar
+/area/ruin/space/powered/bar
+	name = "\improper Space Bar"
+
 //DERELICT (USSP station and USSP Teleporter)
 /area/ruin/space/derelict
 	name = "\improper Derelict Station"


### PR DESCRIPTION
## What Does This PR Do
Removes varedited area on Space Bar.

Part of #20018, fixes for which I'm splitting into separate PRs because I'm not going to attempt to manage one PR that touches five different maps if I don't absolutely have to.

## Why It's Good For The Game
Varedited areas bad.

## Testing
Started server, joined, observed, flew to Space Bar. Ensured bar was powered, and VVed object locs. Checked no runtimes were logged.

No visual changes.