### PR TITLE
Removes the Speed-boost from Cling Epi OD

### DIFF
--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -362,6 +362,8 @@
 					/obj/item/clothing/head/wizard/clown = 1,
 					/obj/item/clothing/mask/gas/clownwiz = 1,
 					/obj/item/clothing/shoes/clown_shoes/magical = 1,
+					/obj/item/dnainjector/comic = 1,
+					/obj/item/implanter/sad_trombone = 1,
 					/obj/item/clothing/suit/wizrobe/mime = 1,
 					/obj/item/clothing/head/wizard/mime = 1,
 					/obj/item/clothing/mask/gas/mime/wizard = 1,

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -362,8 +362,6 @@
 					/obj/item/clothing/head/wizard/clown = 1,
 					/obj/item/clothing/mask/gas/clownwiz = 1,
 					/obj/item/clothing/shoes/clown_shoes/magical = 1,
-					/obj/item/dnainjector/comic = 1,
-					/obj/item/implanter/sad_trombone = 1,
 					/obj/item/clothing/suit/wizrobe/mime = 1,
 					/obj/item/clothing/head/wizard/mime = 1,
 					/obj/item/clothing/mask/gas/mime/wizard = 1,

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -23,7 +23,7 @@
 	user.setStaminaLoss(0)
 	user.SetKnockDown(0)
 	user.reagents.add_reagent("synaptizine", 15)
-	user.reagents.add_reagent("stimulative_agent", 1)
+	user.reagents.add_reagent("stimulative_cling", 1)
 
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -937,7 +937,10 @@
 	id = "stimulative_cling"
 
 /datum/reagent/medicine/stimulative_agent/changeling/on_mob_add(mob/living/L)
-	return 
+	return
+
+/datum/reagent/medicine/stimulative_agent/changeling/on_mob_delete(mob/living/L)
+	return
 
 /datum/reagent/medicine/insulin
 	name = "Insulin"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -937,7 +937,7 @@
 	id = "stimulative_cling"
 
 /datum/reagent/medicine/stimulative_agent/changeling/on_mob_add(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_GOTTAGOFAST, id)
+	return 
 
 /datum/reagent/medicine/insulin
 	name = "Insulin"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -933,6 +933,12 @@
 		M.AdjustLoseBreath(2 SECONDS)
 	return list(0, update_flags)
 
+/datum/reagent/medicine/stimulative_agent/changeling
+	id = "stimulative_cling"
+
+/datum/reagent/medicine/stimulative_agent/changeling/on_mob_add(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_GOTTAGOFAST, id)
+
 /datum/reagent/medicine/insulin
 	name = "Insulin"
 	id = "insulin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
The Stimulative Agent given to clings upon popping their Epi OD ability has been changed to a subtype (Stimulative Cling) which has all the same effects without the speedboost. On health scanners it is identical to Stimulative Agent so you can't automatically know it's a Changeling using the ability.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Giving Changelings Stimulative Agent when Synaptizine got reworked from anti-stun to anti-confusion was a good way to give them a decent buff at the time, as they were still in a very weak state and this was an ability they could only reasonable use once in quite a while - it got them up and out of danger rapidly, but strained muscles still had a role in being longer term speed boosts. However, with the 3x to chemical regen rate, this ability is now much more spammable and as such has taken the place of strained muscles for speed as a Changeling. With the tripled chem regen, this ability no longer needs this crutch, as Changelings already do have a speed-boost ability which they _should_ use if they want speed.
## Testing
<!-- How did you test the PR, if at all? -->
Changed it, ensured it still acted as an anti-stun but did not give speed boost.
## Changelog
:cl:
tweak: Changeling Epinephrine Overdose will no longer increase the player's speed
/:cl:
There's probably some better way to make the stimulative subtype not give movement speed than my code solution so definitely tell me if so.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
