### PR TITLE
Prevents Syndie Nukes from being moved without the NAD

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -33,6 +33,7 @@ GLOBAL_VAR(bomb_set)
 	var/obj/item/nuke_core/plutonium/core = null
 	var/lastentered
 	var/is_syndicate = FALSE
+	var/requires_NAD_to_unbolt = FALSE // if this is true you cannot unbolt the NAD with tools, only the NAD
 	use_power = NO_POWER_USE
 	var/previous_level = ""
 	var/datum/wires/nuclearbomb/wires = null
@@ -44,6 +45,7 @@ GLOBAL_VAR(bomb_set)
 
 /obj/machinery/nuclearbomb/syndicate
 	is_syndicate = TRUE
+	requires_NAD_to_unbolt = TRUE
 
 /obj/machinery/nuclearbomb/undeployed
 	extended = FALSE
@@ -227,6 +229,9 @@ GLOBAL_VAR(bomb_set)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+	if(requires_NAD_to_unbolt == TRUE)
+		to_chat(user, "<span class='warning'>This device seems to have additional safeguards, and cannot be forcibly moved without using the NAD!</span>")
+		return
 	if(removal_stage == NUKE_INTACT)
 		visible_message("<span class='notice'>[user] starts cutting loose the anchoring bolt covers on [src].</span>",\
 		"<span class='notice'>You start cutting loose the anchoring bolt covers with [I]...</span>",\
@@ -380,6 +385,7 @@ GLOBAL_VAR(bomb_set)
 				if(anchored)
 					visible_message("<span class='warning'>With a steely snap, bolts slide out of [src] and anchor it to the flooring.</span>")
 				else
+					requires_NAD_to_unbolt = FALSE
 					visible_message("<span class='warning'>The anchoring bolts slide back into the depths of [src].</span>")
 			return
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -33,7 +33,8 @@ GLOBAL_VAR(bomb_set)
 	var/obj/item/nuke_core/plutonium/core = null
 	var/lastentered
 	var/is_syndicate = FALSE
-	var/requires_NAD_to_unbolt = FALSE // if this is true you cannot unbolt the NAD with tools, only the NAD
+	/// If this is true you cannot unbolt the NAD with tools, only the NAD
+	var/requires_NAD_to_unbolt = FALSE
 	use_power = NO_POWER_USE
 	var/previous_level = ""
 	var/datum/wires/nuclearbomb/wires = null
@@ -229,7 +230,7 @@ GLOBAL_VAR(bomb_set)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	if(requires_NAD_to_unbolt == TRUE)
+	if(requires_NAD_to_unbolt)
 		to_chat(user, "<span class='warning'>This device seems to have additional safeguards, and cannot be forcibly moved without using the NAD!</span>")
 		return
 	if(removal_stage == NUKE_INTACT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds an additional variable to Syndie nukes which prevents the first step of tool-based unanchoring from being done until the NAD is used to unbolt the nuke. Once the nuke is unbolted, this variable is set to false which means it can be un-anchored by tools so crew can still try to unanchor it and space it if it's actually planted on station.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The nukies game-mode is intended to be crew vs nukies, actually fighting for defense of the station. Instead, some players have figured out that they can entirely circumvent the gamemode by easily breaking into the nukie shuttle (it's poorly defended), and it's genuinely unfair to say that one of the players picked for nukie should have to sit behind on the shuttle and not enjoy the fun of the round just because some people want to cheese the roundtype. This prevents that cheese from being effective (people can still break into the shuttle to steal spare nukie gear), so people can actually enjoy the roundtype itself. This PR was requested by MattTheFicus.
## Testing
<!-- How did you test the PR, if at all? -->
Ensured I could not weld the syndie nuke initially, popped in an NAD, spent 2 minutes figuring out what the variable for the nuke code was, unbolted the nuke, rebolted it, yote the NAD, tried to weld it, succeeded. Confirmed the crew's nuke could be welded normally regardless.
## Changelog
:cl:
tweak: Syndicate Nukes can now only be unbolted with the NAD on the first unbolting. After that, they can be unbolted by tools.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
