### PR TITLE
Janiborg no longer starts with floor buffer and now can be toggled

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -338,6 +338,10 @@
 /datum/action/item_action/laugh_track
 	name = "Laugh Track"
 
+/datum/action/item_action/floor_buffer
+	name = "Toggle Floor Buffer"
+	desc = "Movement speed is decreased while active."
+
 /datum/action/item_action/adjust
 
 /datum/action/item_action/adjust/New(Target)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -375,8 +375,7 @@
 	var/mob/living/silicon/robot/cyborg
 
 /obj/item/borg/upgrade/floorbuffer/do_install(mob/living/silicon/robot/R)
-	var/obj/item/borg/upgrade/floorbuffer/U = locate() in R
-	if(U)
+	for(var/obj/item/borg/upgrade/floorbuffer/U in R)
 		to_chat(R, "<span class='notice'>A floor buffer unit is already installed!</span>")
 		to_chat(usr, "<span class='notice'>There's no room for another floor buffer unit!</span>")
 		return

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -371,7 +371,8 @@
 	icon_state = "upgrade"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/janitor
-	var/buffer_speed = 1 // How much speed the cyborg loses while the buffer is active
+	/// How much speed the cyborg loses while the buffer is active
+	var/buffer_speed = 1
 	var/mob/living/silicon/robot/cyborg
 
 /obj/item/borg/upgrade/floorbuffer/do_install(mob/living/silicon/robot/R)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -363,3 +363,38 @@
 			msg_cooldown = world.time
 	else
 		deactivate()
+
+/obj/item/borg/upgrade/floorbuffer
+	name = "janitor cyborg floor buffer upgrade"
+	desc = "A floor buffer upgrade kit that can be attached to janitor cyborgs."
+	icon = 'icons/obj/vehicles.dmi'
+	icon_state = "upgrade"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/janitor
+	var/buffer_speed = 1 // How much speed the cyborg loses while the buffer is active
+	var/mob/living/silicon/robot/cyborg
+
+/obj/item/borg/upgrade/floorbuffer/do_install(mob/living/silicon/robot/R)
+	var/obj/item/borg/upgrade/floorbuffer/U = locate() in R
+	if(U)
+		to_chat(R, "<span class='notice'>A floor buffer unit is already installed!</span>")
+		to_chat(usr, "<span class='notice'>There's no room for another floor buffer unit!</span>")
+		return
+	cyborg = R
+	var/datum/action/A = new /datum/action/item_action/floor_buffer(src)
+	A.Grant(R)
+	return TRUE
+
+/obj/item/borg/upgrade/floorbuffer/ui_action_click()
+	if(!cyborg.floorbuffer)
+		cyborg.floorbuffer = TRUE
+		cyborg.speed += buffer_speed
+	else
+		cyborg.floorbuffer = FALSE
+		cyborg.speed -= buffer_speed
+	to_chat(cyborg, "<span class='notice'>The floor buffer is now [cyborg.floorbuffer ? "active" : "deactivated"].</span>")
+
+/obj/item/borg/upgrade/floorbuffer/Destroy()
+	cyborg.floorbuffer = FALSE
+	cyborg = null
+	return ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -107,6 +107,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/magpulse = FALSE
 	var/ionpulse = FALSE // Jetpack-like effect.
 	var/ionpulse_on = FALSE // Jetpack-like effect.
+	var/floorbuffer = FALSE //Does it clean the tile under it?
 
 	var/datum/action/item_action/toggle_research_scanner/scanner = null
 	var/list/module_actions = list()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -107,7 +107,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/magpulse = FALSE
 	var/ionpulse = FALSE // Jetpack-like effect.
 	var/ionpulse_on = FALSE // Jetpack-like effect.
-	var/floorbuffer = FALSE //Does it clean the tile under it?
+	/// Does it clean the tile under it?
+	var/floorbuffer = FALSE
 
 	var/datum/action/item_action/toggle_research_scanner/scanner = null
 	var/list/module_actions = list()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -451,7 +451,7 @@
 /obj/item/robot_module/janitor/proc/on_cyborg_move(mob/living/silicon/robot/R)
 	SIGNAL_HANDLER
 
-	if(R.stat == DEAD || !isturf(R.loc))
+	if(R.stat == DEAD || !isturf(R.loc) || !R.floorbuffer)
 		return
 	var/turf/tile = R.loc
 	for(var/A in tile)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1098,6 +1098,16 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_floorbuffer
+	name = "Cyborg Upgrade (Floor buffer)"
+	id = "borg_upgrade_floorbuffer"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/floorbuffer
+	req_tech = list("materials" = 4, "engineering" = 4)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracking Beacon"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Alternative version of #15864
Janiborgs no longer starts with a floor buffer, its now an upgrade module.
Floor buffer now can be toggled on/off and the movement speed is decreased while active.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Janiborgs are too good at cleaning, most of the time leaving poor organic janitors to stare while they just cleans the room by simply existing.
Janiborgs advanced mop wont be ignored as much with floor buffers no longer being something they start with.
By decreasing their speed while the buffer is active we would be mainly nerfing their combo with vtec, that did turn them into cleaning monsters before.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
WITHOUT VTEC
https://user-images.githubusercontent.com/77684085/211211566-fe9a7245-ba02-478b-857f-fb9f7463ece8.mp4

WITH VTEC
https://user-images.githubusercontent.com/77684085/211211549-b751fe96-e0ea-4914-85a1-0bbeae8a4a7d.mp4

## Testing
<!-- How did you test the PR, if at all? -->
- See videos above
## Changelog
:cl:
tweak: Janiborgs no longer starts with floor buffers, its now an upgrade module
tweak: Floor buffer now can be toggled on/off and the movement speed is decreased while active
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
