### PR TITLE
Adds pepperspray to the SecTech vendor

### DIFF
--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -210,8 +210,15 @@
 	icon_deny = "sec_deny"
 	icon_panel = "wide_vendor"
 	req_access_txt = "1"
-	products = list(/obj/item/restraints/handcuffs = 8, /obj/item/restraints/handcuffs/cable/zipties = 8, /obj/item/grenade/flashbang = 4, /obj/item/flash = 5,
-					/obj/item/reagent_containers/food/snacks/donut = 12, /obj/item/storage/box/evidence = 6, /obj/item/flashlight/seclite = 4, /obj/item/restraints/legcuffs/bola/energy = 7,
+	products = list(/obj/item/restraints/handcuffs = 8,
+					/obj/item/restraints/handcuffs/cable/zipties = 8,
+					/obj/item/grenade/flashbang = 4,
+					/obj/item/flash = 5,
+					/obj/item/reagent_containers/spray/pepper = 5,
+					/obj/item/reagent_containers/food/snacks/donut = 12,
+					/obj/item/storage/box/evidence = 6,
+					/obj/item/flashlight/seclite = 4,
+					/obj/item/restraints/legcuffs/bola/energy = 7,
 					/obj/item/clothing/mask/muzzle/safety = 4)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2, /obj/item/storage/fancy/donut_box = 2, /obj/item/hailer = 5)
 	refill_canister = /obj/item/vending_refill/security


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Adds 5 peppersprayers to each sectech

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->SecTechs have all the supplies of a full secbelt except a baton and pepperspray. Currently, the only way to get peppersprayer is to order a new officer kit, or raid some poor officer's sec belt, or have them be mapped in like on cyberiad.

## Testing
<!-- How did you test the PR, if at all? -->
Peppersprayers was in the vendor

## Changelog
:cl:
add: SecTech vendors now contain 5 peppersprayers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
