### PR TITLE
Wrong chute in clown ruin now has a 50% chance of sending failures in lava instead of safety

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -81,12 +81,6 @@
 	},
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
-"ai" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/ruin/powered/clownplanet)
 "aj" = (
 /obj/effect/decal/cleanable/pie_smudge,
 /obj/structure/disposalpipe/segment{
@@ -290,6 +284,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "ay" = (
@@ -350,6 +348,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
 	},
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
@@ -559,6 +560,9 @@
 	dir = 4;
 	invisibility = 101
 	},
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
 /turf/simulated/floor/plating,
 /area/ruin/powered/clownplanet)
 "aQ" = (
@@ -569,6 +573,9 @@
 /obj/structure/table,
 /obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet/escape,
 /obj/item/pen/multi,
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "white"
@@ -581,6 +588,9 @@
 	},
 /obj/structure/table,
 /obj/item/flashlight/lamp/bananalamp,
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "white"
@@ -687,6 +697,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -820,7 +834,6 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/clownplanet)
 "bo" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -830,6 +843,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
@@ -845,6 +861,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/junction/y,
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "bq" = (
@@ -885,24 +902,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/powered/clownplanet)
-"bt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-y"
-	},
-/turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "bu" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -1100,11 +1099,61 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/clownplanet)
+"lY" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/simulated/mineral/clown/volcanic,
+/area/ruin/powered/clownplanet)
 "pv" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/clownplanet)
+"qo" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/simulated/floor/lubed,
+/area/ruin/powered/clownplanet)
+"qS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/simulated/floor/lubed,
+/area/ruin/powered/clownplanet)
+"sL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/light,
 /area/ruin/powered/clownplanet)
 "ye" = (
 /turf/simulated/floor/plating/lava/smooth,
@@ -1115,6 +1164,29 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/noslip/lavaland,
 /area/lavaland/surface/outdoors/explored)
+"EG" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/simulated/wall/r_wall,
+/area/ruin/powered/clownplanet)
+"HG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/light,
+/area/ruin/powered/clownplanet)
+"HQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/simulated/wall/r_wall,
+/area/ruin/powered/clownplanet)
 "KX" = (
 /obj/item/grown/bananapeel{
 	color = "#2F3000";
@@ -1123,6 +1195,12 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
+"Lp" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/simulated/floor/light,
+/area/ruin/powered/clownplanet)
 "LH" = (
 /obj/machinery/disposal/deliveryChute{
 	desc = "The following is engraved upon the chute: A FATE WORSE THAN DEATH LIES WITHIN";
@@ -1145,6 +1223,19 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/clownplanet)
+"Tc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "white"
+	},
+/area/ruin/powered/clownplanet)
 "TD" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -1159,6 +1250,26 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/r_wall,
+/area/ruin/powered/clownplanet)
+"WZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "Xm" = (
 /obj/item/clothing/head/cone,
@@ -1732,7 +1843,7 @@ eX
 TD
 ch
 ch
-ai
+ch
 ay
 an
 an
@@ -1743,7 +1854,7 @@ af
 av
 bl
 bo
-bt
+ay
 bx
 cc
 bM
@@ -1766,18 +1877,18 @@ eX
 cc
 cc
 ye
-aL
-as
-am
-am
-an
-an
-an
-ar
+cc
+aO
+qS
+qS
+WZ
+WZ
+WZ
+qo
 aC
 av
 bp
-aL
+aA
 bv
 cc
 bL
@@ -1800,17 +1911,17 @@ Mv
 cc
 ye
 ye
-aL
-as
+ab
+ay
 am
 aD
 an
 an
 aL
-cc
-cc
+ac
+EG
 aK
-cc
+aL
 bD
 cc
 bB
@@ -1844,7 +1955,7 @@ aL
 aV
 bb
 bm
-cc
+aL
 bu
 aA
 bB
@@ -1871,14 +1982,14 @@ cc
 aL
 aw
 aB
-aL
-am
-aL
+HQ
+qS
+HQ
 aQ
-aN
-bc
-bc
-bf
+Tc
+HG
+sL
+lY
 cc
 aK
 br
@@ -1903,15 +2014,15 @@ cc
 ye
 aq
 ao
-ar
-aL
+aC
+HQ
 aP
-am
-aL
+qS
+HQ
 aR
-aN
-bc
-bc
+Tc
+Lp
+HG
 bq
 ch
 bw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the disposals in the clown ruin so taking the wrong chute has a 50/50 chance of either sending them into lava, or right at the start to try again.

## Why It's Good For The Game
Due to quirks of the disposal system, before or even after the switch to destination lists, the clown ruins would never send people into lava for their failure. This is disappointing to the Honkmother, so now people will burn. Half the time. The Mother knows mercy.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![BLOODFORTHEHONKMOTHER](https://user-images.githubusercontent.com/80771500/211218323-eee17803-6402-4fab-93ef-9ef191a02ba7.png)

https://user-images.githubusercontent.com/80771500/211218331-c66743b3-1cbe-4019-a6b2-3d1e79a32b1e.mp4

## Testing
_go down chutes, put clown.ogg on repeat_

## Changelog
:cl:
tweak: THE TRIAL OF HONKITUDE is funnier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
