### PR TITLE
aliens can be properly bola'd

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -12,16 +12,6 @@
 		l_store = null
 		update_inv_pockets()
 
-/mob/living/carbon/alien/humanoid/update_inv_legcuffed()
-	clear_alert("legcuffed")
-	if(!legcuffed)
-		return
-	throw_alert("legcuffed", /obj/screen/alert/restrained/legcuffed, new_master = legcuffed)
-	if(m_intent != MOVE_INTENT_WALK)
-		m_intent = MOVE_INTENT_WALK
-		if(hud_used && hud_used.move_intent)
-			hud_used.move_intent.icon_state = "walking"
-
 /mob/living/carbon/alien/humanoid/attack_ui(slot_id)
 	var/obj/item/W = get_active_hand()
 	if(W)

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -12,6 +12,16 @@
 		l_store = null
 		update_inv_pockets()
 
+/mob/living/carbon/alien/humanoid/update_inv_legcuffed()
+	clear_alert("legcuffed")
+	if(!legcuffed)
+		return
+	throw_alert("legcuffed", /obj/screen/alert/restrained/legcuffed, new_master = legcuffed)
+	if(m_intent != MOVE_INTENT_WALK)
+		m_intent = MOVE_INTENT_WALK
+		if(hud_used && hud_used.move_intent)
+			hud_used.move_intent.icon_state = "walking"
+
 /mob/living/carbon/alien/humanoid/attack_ui(slot_id)
 	var/obj/item/W = get_active_hand()
 	if(W)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -727,6 +727,16 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		toggle_move_intent()
 		update_inv_legcuffed()
 
+/mob/living/carbon/update_inv_legcuffed()
+	clear_alert("legcuffed")
+	if(!legcuffed)
+		return
+	throw_alert("legcuffed", /obj/screen/alert/restrained/legcuffed, new_master = legcuffed)
+	if(m_intent != MOVE_INTENT_WALK)
+		m_intent = MOVE_INTENT_WALK
+		if(hud_used && hud_used.move_intent)
+			hud_used.move_intent.icon_state = "walking"
+
 /mob/living/carbon/show_inv(mob/user)
 	user.set_machine(src)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -734,7 +734,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	throw_alert("legcuffed", /obj/screen/alert/restrained/legcuffed, new_master = legcuffed)
 	if(m_intent != MOVE_INTENT_WALK)
 		m_intent = MOVE_INTENT_WALK
-		if(hud_used && hud_used.move_intent)
+		if(hud_used?.move_intent)
 			hud_used.move_intent.icon_state = "walking"
 
 /mob/living/carbon/show_inv(mob/user)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1045,14 +1045,9 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 /mob/living/carbon/human/update_inv_legcuffed()
 	remove_overlay(LEGCUFF_LAYER)
-	clear_alert("legcuffed")
+	. = ..()
 	if(legcuffed)
 		overlays_standing[LEGCUFF_LAYER] = mutable_appearance('icons/mob/mob.dmi', legcuffed.cuffed_state, layer = -LEGCUFF_LAYER)
-		throw_alert("legcuffed", /obj/screen/alert/restrained/legcuffed, new_master = legcuffed)
-		if(m_intent != MOVE_INTENT_WALK)
-			m_intent = MOVE_INTENT_WALK
-			if(hud_used && hud_used.move_intent)
-				hud_used.move_intent.icon_state = "walking"
 	apply_overlay(LEGCUFF_LAYER)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Aliens can now be properly bola'd 

## Why It's Good For The Game
Aliens can be bola'd but they won't get set to walk intent current, or have an alert show up.
Both of these above things happening is good. 

## Testing
Compiled, ran, tossed a bola

## Changelog
:cl:
tweak: Aliens are now set to walk intent after being bola'd
/:cl:
