### PR TITLE
CE's blueprints can now see wires

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -341,3 +341,7 @@
 	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."
 
 /obj/item/areaeditor/blueprints/ce
+
+/obj/item/areaeditor/blueprints/ce/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_SHOW_WIRE_INFO, ROUNDSTART_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the SHOW_WIRE_INFO trait to the CE's blueprints and /only/ the CEs blueprints 
(also probably should mention this was an idea from charlie I just randomly remembered)

## Why It's Good For The Game
The CE's blueprints right now are kind of a weird traitor item. Taking a photo of it can also be done for a steal objective which is really cool, but you're not really given a reason not to do so as the utility of the item just is not applicable to an antagonist. The ability to see wires, while small, presents a choice on how you're going to steal the item.
This is also useful for CE players who aren't too keen on playing the wire minigame startshift, or just might want a reminder.

## Testing
Compiled and ran

## Changelog
:cl:
tweak: CE's blueprints now can view wire info while in hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
