### PR TITLE
Prevents Grey Mimes from talking via telepathy

### DIFF
--- a/code/game/dna/mutations/powers.dm
+++ b/code/game/dna/mutations/powers.dm
@@ -929,7 +929,11 @@
 	return new /datum/spell_targeting/telepathic
 
 /obj/effect/proc_holder/spell/remotetalk/cast(list/targets, mob/user = usr)
-	if(!ishuman(user))	return
+	if(!ishuman(user))
+		return
+	if(user.mind?.miming) // Dont let mimes telepathically talk
+		to_chat(user,"<span class='warning'>You can't communicate without breaking your vow of silence.</span>")
+		return
 	var/say = input("What do you wish to say") as text|null
 	if(!say || usr.stat)
 		return

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -338,6 +338,9 @@
 	..(speaker,message,speaker.real_name)
 
 /datum/language/grey/check_can_speak(mob/living/speaker)
+	if(speaker.mind?.miming) // Because its a hivemind, mimes would be able to speak otherwise
+		to_chat(speaker,"<span class='warning'>You can't communicate without breaking your vow of silence.</span>")
+		return FALSE
 	if(ishuman(speaker))
 		var/mob/living/carbon/human/S = speaker
 		var/obj/item/organ/external/rhand = S.get_organ("r_hand")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Grey (the species) mimes will no longer be able to talk through telepathic messages or their species hivemind. This also affects the genetic power to speak into peoples heads.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Greys shouldnt be except from the mime's vow of silence

## Testing
<!-- How did you test the PR, if at all? -->
Spawned as a grey mime.
Tried speaking out loud, failed.
Tried the telepathy spell, failed.
Tried the grey hivemind, failed.
Broke vow of silence
Spoke out loud
Telepathied a skrell
Spoke on grey hivemind

## Changelog
:cl:
fix: Grey Mimes are now bound by their vow of silence for their hivemind and telepathy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
