### PR TITLE
Plasma pistol no longer requires the user stand still while overloading it

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -360,7 +360,7 @@
 	to_chat(user, "<span class='notice'>You begin to overload [src].</span>")
 	charging = TRUE
 	charge_failure = FALSE
-	addtimer(CALLBACK(src, PROC_REF(overload)), 3 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(overload)), 2.5 SECONDS)
 
 /obj/item/gun/energy/plasma_pistol/proc/overload()
 	if(ishuman(loc) && !charge_failure)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -367,7 +367,7 @@
 		var/mob/living/carbon/C = loc
 		select_fire(C)
 		overloaded = TRUE
-		cell.charge -= 125
+		cell.use(125)
 		playsound(C.loc, 'sound/machines/terminal_prompt_confirm.ogg', 75, 1)
 		atom_say("Overloading successful.")
 		set_light(3) //extra visual effect to make it more noticable to user and victims alike

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -324,6 +324,7 @@
 	var/overloaded = FALSE
 	var/warned = FALSE
 	var/charging = FALSE
+	var/charge_failure = FALSE
 	var/mob/living/carbon/holder = null
 
 /obj/item/gun/energy/plasma_pistol/Initialize(mapload)
@@ -354,19 +355,29 @@
 		to_chat(user, "<span class='warning'>[src] does not have enough charge to be overloaded.</span>")
 		return
 	if(charging)
+		to_chat(user, "<span class='warning'>[src] is already charging!</span>")
 		return
 	to_chat(user, "<span class='notice'>You begin to overload [src].</span>")
 	charging = TRUE
-	if(do_after(user, 2.5 SECONDS, target = src))
-		select_fire(user)
+	charge_failure = FALSE
+	addtimer(CALLBACK(src, PROC_REF(overload)), 3 SECONDS)
+
+/obj/item/gun/energy/plasma_pistol/proc/overload()
+	if(ishuman(loc) && !charge_failure)
+		var/mob/living/carbon/C = loc
+		select_fire(C)
 		overloaded = TRUE
 		cell.charge -= 125
-		playsound(loc, 'sound/machines/terminal_prompt_confirm.ogg', 75, 1)
+		playsound(C.loc, 'sound/machines/terminal_prompt_confirm.ogg', 75, 1)
 		atom_say("Overloading successful.")
 		set_light(3) //extra visual effect to make it more noticable to user and victims alike
-		holder = user
+		holder = C
 		RegisterSignal(holder, COMSIG_CARBON_SWAP_HANDS, PROC_REF(discharge))
+	else
+		atom_say("Overloading failure.")
+		playsound(loc, 'sound/machines/buzz-sigh.ogg', 75, 1)
 	charging = FALSE
+	charge_failure = FALSE
 
 /obj/item/gun/energy/plasma_pistol/proc/reset_overloaded()
 	select_fire()
@@ -390,16 +401,19 @@
 
 /obj/item/gun/energy/plasma_pistol/emp_act(severity)
 	..()
+	charge_failure = TRUE
 	if(prob(100 / severity) && overloaded)
 		discharge()
 
 /obj/item/gun/energy/plasma_pistol/dropped(mob/user)
 	. = ..()
+	charge_failure = TRUE
 	if(overloaded)
 		discharge()
 
 /obj/item/gun/energy/plasma_pistol/equipped(mob/user, slot, initial)
 	. = ..()
+	charge_failure = TRUE
 	if(overloaded)
 		discharge()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Plasma pistol no longer requires the user to stand still while charging.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Plasma pistol is a niche weapon, being able to hit hard and break shields, but having to stand still for 2.5 seconds reduces the practicality of it greatly.
This now only just puts a charge wait of 2.5 seconds between shots, while still keeping the penalties of switching off it. I might make the penalties apply if the gun is dropped / holstered while charging, will see what people think.

Honestly it might still be too large of a charge time.

## Testing
<!-- How did you test the PR, if at all? -->

Confirm charging worked, and that it failed if dropped / holstered.

## Changelog
:cl:
tweak: Plasma pistol no longer requires the user stand still while overloading it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
