### PR TITLE
Parrying Hotkey

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -661,6 +661,8 @@
 	#define COMSIG_HUMAN_NO_CHANGE_APPEARANCE (1<<0)
 /// From mob/living/carbon/human/change_head_accessory(): (mob/living/carbon/human/H, head_accessory_style)
 #define COMSIG_HUMAN_CHANGE_HEAD_ACCESSORY "human_change_head_accessory"
+//sent from living mobs when they parry
+#define COMSIG_HUMAN_PARRY "human_parry"
 
 // /datum/species signals
 

--- a/code/datums/components/parry.dm
+++ b/code/datums/components/parry.dm
@@ -26,7 +26,7 @@
 	UnregisterSignal(parent, COMSIG_ITEM_HIT_REACT)
 	var/obj/item/I = parent
 	if(ismob(I.loc))
-		UnregisterSignal(I.loc, COMSIG_LIVING_RESIST)
+		UnregisterSignal(I.loc, COMSIG_HUMAN_PARRY)
 
 /datum/component/parry/Initialize(_stamina_constant = 0, _stamina_coefficient = 0, _parry_time_out_time = PARRY_DEFAULT_TIMEOUT, _parryable_attack_types = ALL_ATTACK_TYPES, _parry_cooldown = 2 SECONDS, _no_parry_sound = FALSE)
 	if(!isitem(parent))
@@ -45,13 +45,13 @@
 /datum/component/parry/proc/equipped(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
 	if(slot in list(slot_l_hand, slot_r_hand))
-		RegisterSignal(user, COMSIG_LIVING_RESIST, PROC_REF(start_parry))
+		RegisterSignal(user, COMSIG_HUMAN_PARRY, PROC_REF(start_parry))
 	else
-		UnregisterSignal(user, COMSIG_LIVING_RESIST)
+		UnregisterSignal(user, COMSIG_HUMAN_PARRY)
 
 /datum/component/parry/proc/dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
-	UnregisterSignal(user, COMSIG_LIVING_RESIST)
+	UnregisterSignal(user, COMSIG_HUMAN_PARRY)
 
 /datum/component/parry/proc/start_parry(mob/living/L)
 	SIGNAL_HANDLER

--- a/code/datums/keybindings/human.dm
+++ b/code/datums/keybindings/human.dm
@@ -42,3 +42,10 @@
 		return
 	var/obj/item/clothing/accessory/holster/H = locate() in M.w_uniform
 	H?.holster_verb()
+
+/datum/keybinding/human/parry
+	name = "Parry"
+
+/datum/keybinding/human/parry/down(client/C)
+	. = ..()
+	SEND_SIGNAL(C.mob, COMSIG_HUMAN_PARRY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Parrying is no longer tied to resist and now has its own hotkey. The key is unbinded and can be changed to any key. (For best results bind it to F)

## Why It's Good For The Game
Parrying sharing resist is bad design, has some very annoying misinput moments, and really needed its own key because hitting B in a fight is awkward.

## Images of changes
![hqdefault](https://user-images.githubusercontent.com/62493359/211949960-a6ce17bb-a042-46ee-988f-c6c56767c666.jpg)
i love ultrakill


## Testing
booted test server, binded parry, parried, damn

## Changelog
:cl: OctusGit SabreML
tweak: Parrying no longer uses resist as a signal, it now has its own designated hotkey and signal for the action.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
