### PR TITLE
fixes morph button icons not getting updated

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -139,7 +139,7 @@
  */
 /mob/living/simple_animal/hostile/morph/proc/add_food(amount)
 	gathered_food += amount
-	for(var/datum/action/spell_action/action in src.actions)
+	for(var/datum/action/spell_action/action in actions)
 		action.UpdateButtonIcon()
 
 

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -139,8 +139,8 @@
  */
 /mob/living/simple_animal/hostile/morph/proc/add_food(amount)
 	gathered_food += amount
-	for(var/obj/effect/proc_holder/spell/morph_spell/MS in mind.spell_list)
-		MS.updateButtonIcon()
+	for(var/datum/action/spell_action/action in src.actions)
+		action.UpdateButtonIcon()
 
 
 /mob/living/simple_animal/hostile/morph/proc/assume()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Morph actions are now updated when food is eaten

## Why It's Good For The Game
Bugfix, plus people not knowing when they can use their spell is bad

## Testing
Compiled, ran, proc'd the proc, and unwelded some vents

## Changelog
:cl:
fix: Morph actions now update when that morph gains/loses food
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
