### PR TITLE
Prevents cult teleport while prone

### DIFF
--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -513,11 +513,12 @@
 	var/obj/effect/rune/teleport/actual_selected_rune = potential_runes[input_rune_key] //what rune does that key correspond to?
 	if(QDELETED(src) || !user || user.l_hand != src && user.r_hand != src || user.incapacitated() || !actual_selected_rune)
 		return
-	uses--
 
-	if(IS_HORIZONTAL(user))
-		to_chat(user, "<span class='cultitalic'>You cannot cast this spell while on the floor!</span>")
+	if(HAS_TRAIT(user, TRAIT_FLOORED))
+		to_chat(user, "<span class='cultitalic'>You cannot cast this spell while knocked down!</span>")
 		return
+
+	uses--
 
 	var/turf/origin = get_turf(teleportee)
 	var/turf/destination = get_turf(actual_selected_rune)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -515,6 +515,10 @@
 		return
 	uses--
 
+	if(IS_HORIZONTAL(user))
+		to_chat(user, "<span class='cultitalic'>You cannot cast this spell while on the floor!</span>")
+		return
+
 	var/turf/origin = get_turf(teleportee)
 	var/turf/destination = get_turf(actual_selected_rune)
 	INVOKE_ASYNC(actual_selected_rune, TYPE_PROC_REF(/obj/effect/rune, teleport_effect), teleportee, origin, destination)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
As it states on the tin, if you are on the ground for any reason and you try to cast the cult teleport spell, you will be unable to.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Discussing cult balance is a bit of a joke in the community, but I think most will agree that cult at the moment is an exceptionally safe antag for a number of reasons - they can be fully rejuvenated if they die using a revive rune, they can be recalled to a recall rune by their fellow cultists, and at any point they feel like they can use the teleport spell to escape any ill situation. With this change at least, if you baton a cultist they cannot immediately cast this spell to get out risk-free from any combat.
## Testing
<!-- How did you test the PR, if at all? -->
Made sure it worked for both stuns, knockdowns, and intentional resting, has a message to the cultist that it doesn't work while prone and doesn't use up the spell.
## Changelog
:cl:
tweak: Cultists are now unable to use the teleport spell while prone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
