### PR TITLE
Shoving nerds into lockers

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -75,3 +75,7 @@
 	if(loc && (isturf(loc) || istype(loc, /obj/structure/morgue) || istype(loc, /obj/structure/crematorium)))
 		if(!open())
 			to_chat(user, "<span class='notice'>It won't budge!</span>")
+
+/obj/structure/closet/body_bag/shove_impact(mob/living/target, mob/living/attacker)
+	// no, you can't shove people into a body bag
+	return FALSE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -386,6 +386,7 @@
 /obj/structure/closet/shove_impact(mob/living/target, mob/living/attacker)
 	if(opened)
 		target.forceMove(src)
+		visible_message("<span class='danger'>[attacker] shoves [target] into [src]!</span>", "<span class='warning'>You hear a thud, and something clangs shut.</span>")
 		close()
 		return TRUE
 	return ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -383,6 +383,12 @@
 	// Its okay to silently teleport mobs out of lockers, since the only thing affected is their contents list.
 	return
 
+/obj/structure/closet/shove_impact(mob/living/target, mob/living/attacker)
+	if(opened)
+		target.forceMove(src)
+		close()
+		return TRUE
+	return ..()
 
 /obj/structure/closet/bluespace
 	name = "bluespace closet"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -386,9 +386,17 @@
 /obj/structure/closet/shove_impact(mob/living/target, mob/living/attacker)
 	if(opened)
 		target.forceMove(src)
-		visible_message("<span class='danger'>[attacker] shoves [target] into [src]!</span>", "<span class='warning'>You hear a thud, and something clangs shut.</span>")
+		visible_message("<span class='danger'>[attacker] shoves [target] inside [src]!</span>", "<span class='warning'>You hear a thud, and something clangs shut.</span>")
 		close()
+		add_attack_logs(attacker, target, "shoved into [src]")
 		return TRUE
+
+	if(can_open())
+		open()
+		visible_message("<span class='danger'>[attacker] shoves [target] against [src], knocking it open!</span>")
+		target.KnockDown(3 SECONDS)
+		return TRUE
+
 	return ..()
 
 /obj/structure/closet/bluespace

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -1,4 +1,4 @@
-/obj/structure/closet/secure_closete
+/obj/structure/closet/secure_closet
 	name = "secure locker"
 	desc = "It's an immobile card-locked storage unit."
 	icon = 'icons/obj/closet.dmi'

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -1,4 +1,4 @@
-/obj/structure/closet/secure_closet
+/obj/structure/closet/secure_closete
 	name = "secure locker"
 	desc = "It's an immobile card-locked storage unit."
 	icon = 'icons/obj/closet.dmi'

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -149,6 +149,9 @@
 		add_fingerprint(user)
 		toggle(user, by_hand = TRUE)
 
+/obj/structure/closet/crate/shove_impact(mob/living/target, mob/living/attacker)
+	return FALSE
+
 // Called when a crate is delivered by MULE at a location, for notifying purposes
 /obj/structure/closet/crate/proc/notifyRecipient(destination)
 	var/list/msg = list("[capitalize(name)] has arrived at [destination].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Lets you shove people into lockers. If you shove them against an (openable) locker, it'll open. If you shove them against an open locker, it'll close on them. You can finally live out your high school dreams in space station 13.

Idea from https://github.com/tgstation/tgstation/pull/60000.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Another aspect for environmental combat. This one is more funny than impactful, though might slow you down for a bit. It's also funny!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/212011932-04e9ca56-9934-4cfb-a9da-e42b104badbe.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Shoved some nerds (vulps) into lockers. Verified that things which are technically lockers but not really (body bags, crates) didn't work.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: You can now shove people inside of open lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
