### PR TITLE
Attempts to fix cult halo/nukie telecrystal number

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1875,6 +1875,21 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
+// This proc returns every player with a client who is not a ghost or a new_player
+/proc/get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)
+	var/list/living_players = list()
+
+	for(var/mob/M in GLOB.player_list)
+		if(isobserver(M))
+			continue
+		if(exclude_nonhuman && !ishuman(M))
+			continue
+		if(exclude_offstation && M.mind?.offstation_role)
+			continue
+		living_players += M
+
+	return living_players
+
 /proc/make_bit_triplet()
 	var/list/num_sample  = list(1, 2, 3, 4, 5, 6, 7, 8, 9)
 	var/result = 0

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1875,7 +1875,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
-// This proc returns every player with a client who is not a ghost or a new_player
+/// This proc returns every player with a client who is not a ghost or a new_player
 /proc/get_living_players(exclude_nonhuman = FALSE, exclude_offstation = FALSE)
 	var/list/living_players = list()
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1876,7 +1876,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
 // This proc returns every player with a client who is not a ghost or a new_player
-/proc/get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)
+/proc/get_living_players(exclude_nonhuman = FALSE, exclude_offstation = FALSE)
 	var/list/living_players = list()
 
 	for(var/mob/living/M in GLOB.player_list)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1879,9 +1879,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 /proc/get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)
 	var/list/living_players = list()
 
-	for(var/mob/M in GLOB.player_list)
-		if(isobserver(M))
-			continue
+	for(var/mob/living/M in GLOB.player_list)
 		if(exclude_nonhuman && !ishuman(M))
 			continue
 		if(exclude_offstation && M.mind?.offstation_role)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -220,7 +220,8 @@ GLOBAL_LIST_EMPTY(all_cults)
   * Above 100 players, [CULT_RISEN_HIGH] and [CULT_ASCENDANT_HIGH] are used.
   */
 /datum/game_mode/proc/cult_threshold_check()
-	var/players = length(GLOB.player_list)
+	var/list/living_players = get_living_players(TRUE)
+	var/players = length(living_players)
 	var/cultists = get_cultists() // Don't count the starting cultists towards the number of needed conversions
 	if(players >= CULT_POPULATION_THRESHOLD)
 		// Highpop

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_EMPTY(all_cults)
   * Above 100 players, [CULT_RISEN_HIGH] and [CULT_ASCENDANT_HIGH] are used.
   */
 /datum/game_mode/proc/cult_threshold_check()
-	var/list/living_players = get_living_players(TRUE)
+	var/list/living_players = get_living_players(exclude_nonhuman = TRUE, exclude_offstation = TRUE)
 	var/players = length(living_players)
 	var/cultists = get_cultists() // Don't count the starting cultists towards the number of needed conversions
 	if(players >= CULT_POPULATION_THRESHOLD)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -140,9 +140,8 @@
 	return ..()
 
 /datum/game_mode/nuclear/proc/scale_telecrystals()
-	var/danger
 	var/list/living_crew = get_living_players()
-	danger = length(living_crew)
+	var/danger = length(living_crew)
 	while(!ISMULTIPLE(++danger, 10)) //Increments danger up to the nearest multiple of ten
 
 	total_tc += danger * NUKESCALINGMODIFIER

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -140,7 +140,7 @@
 	return ..()
 
 /datum/game_mode/nuclear/proc/scale_telecrystals()
-	var/list/living_crew = get_living_players()
+	var/list/living_crew = get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)
 	var/danger = length(living_crew)
 	while(!ISMULTIPLE(++danger, 10)) //Increments danger up to the nearest multiple of ten
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -141,7 +141,8 @@
 
 /datum/game_mode/nuclear/proc/scale_telecrystals()
 	var/danger
-	danger = GLOB.player_list.len
+	var/list/living_crew = get_living_players()
+	danger = length(living_crew)
 	while(!ISMULTIPLE(++danger, 10)) //Increments danger up to the nearest multiple of ten
 
 	total_tc += danger * NUKESCALINGMODIFIER


### PR DESCRIPTION
## What Does This PR Do

This PR attempts to fix two parts of the game, 1) cultist halo not appearing when 30% of the crew is culted 2) nukies getting more telecrystals than they should.

In both cases, the calculation is based on the connected players who are not sitting in lobby (living or observers). This means that animals, off-station roles, etc. are all counted, not to mention dead people. For this reason, cult halo almost never occurs, as you can have 10 living people with 20 ghosts - if 5 of those 10 are cultists, the halo still does not appear (despite 50% of the crew being culted), because the game counts observers too (`ascend_number = round(0.3 * (players_list - cultists))` which is `7.5` - as it is higher than 5, the halo doesn't happen.)

This PR attempts to make a calculation based on "whichever client minus observers minus offstation roles minus non-humanoids".

Nukies count synthetics, cult halo doesn't.

## Why It's Good For The Game

Cult halo appearing is a vital part of any cult round, without it, the station might find itself completely culted without any warning. The crew needs a heads up when to go valid, lest they get consumed by an old god.

## Testing

I tried to test it locally with five clients but I was unable to, due to how ascension is calculated. :(

If this could be tested on mentorstation beforehand, that'd be great.

## Changelog
:cl:
fix: Cult halo should properly appear when 30% of the LIVING humanoid crewmembers are culted, not the server population's 30%.
fix: Nukies should get telecrystals based on the number of LIVING humanoid crewmembers, not the server population.
/:cl:
