### PR TITLE
Parry-capable shields/weapons list which attack types they're able to parry when examined

### DIFF
--- a/code/datums/components/parry.dm
+++ b/code/datums/components/parry.dm
@@ -120,4 +120,5 @@
 		return (COMPONENT_BLOCK_SUCCESSFUL | COMPONENT_BLOCK_PERFECT)
 
 /datum/component/parry/proc/on_parent_examined(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
 	examine_list += examine_text

--- a/code/datums/components/parry.dm
+++ b/code/datums/components/parry.dm
@@ -14,16 +14,20 @@
 	var/parry_cooldown
 	///Do we wish to mute the parry sound?
 	var/no_parry_sound
+	/// Text to be shown to users who examine the parent. Will list which type of attacks it can parry.
+	var/examine_text
 
 /datum/component/parry/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(equipped))
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(dropped))
 	RegisterSignal(parent, COMSIG_ITEM_HIT_REACT, PROC_REF(attempt_parry))
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_parent_examined))
 
 /datum/component/parry/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ITEM_EQUIPPED)
 	UnregisterSignal(parent, COMSIG_ITEM_DROPPED)
 	UnregisterSignal(parent, COMSIG_ITEM_HIT_REACT)
+	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
 	var/obj/item/I = parent
 	if(ismob(I.loc))
 		UnregisterSignal(I.loc, COMSIG_LIVING_RESIST)
@@ -41,6 +45,20 @@
 		parryable_attack_types = _parryable_attack_types
 	else
 		parryable_attack_types = list(_parryable_attack_types)
+
+	// From the attack type defines in `code\__DEFINES\combat.dm`.
+	var/static/list/attack_types_english = list(
+		1 = "melee attacks",
+		2 = "unarmed attacks",
+		3 = "projectiles",
+		4 = "thrown projectiles",
+		5 = "leap attacks"
+	)
+	var/list/attack_list = list()
+	for(var/attack_type in parryable_attack_types)
+		attack_list += attack_types_english[attack_type]
+
+	examine_text = "<span class='notice'>It's able to <b>parry</b> [english_list(attack_list)].</span>"
 
 /datum/component/parry/proc/equipped(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
@@ -101,5 +119,5 @@
 			return COMPONENT_BLOCK_SUCCESSFUL
 		return (COMPONENT_BLOCK_SUCCESSFUL | COMPONENT_BLOCK_PERFECT)
 
-
-
+/datum/component/parry/proc/on_parent_examined(datum/source, mob/user, list/examine_list)
+	examine_list += examine_text

--- a/code/datums/components/parry.dm
+++ b/code/datums/components/parry.dm
@@ -46,13 +46,12 @@
 	else
 		parryable_attack_types = list(_parryable_attack_types)
 
-	// From the attack type defines in `code\__DEFINES\combat.dm`.
 	var/static/list/attack_types_english = list(
-		1 = "melee attacks",
-		2 = "unarmed attacks",
-		3 = "projectiles",
-		4 = "thrown projectiles",
-		5 = "leap attacks"
+		MELEE_ATTACK = "melee attacks",
+		UNARMED_ATTACK = "unarmed attacks",
+		PROJECTILE_ATTACK = "projectiles",
+		THROWN_PROJECTILE_ATTACK = "thrown projectiles",
+		LEAP_ATTACK = "leap attacks"
 	)
 	var/list/attack_list = list()
 	for(var/attack_type in parryable_attack_types)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## What Does This PR Do
Requested by @hal9000PR. **(Implementation pending)**

Parry-capable shields/weapons will list which attack types they're able to parry when examined (melee, projectile, unarmed, etc.)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Images of changes
![image](https://user-images.githubusercontent.com/42044220/212243413-4e6632cf-cf3c-4bce-8bfb-a9239216886d.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned parry-capable objects and examined them.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Parry-capable shields/weapons list which attack types they're able to parry when examined (melee, projectile, unarmed, etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
