### PR TITLE
Shoving nerds into deep-fryers (and other kitchen equipment)

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -46,13 +46,32 @@
 /obj/machinery/cooker/proc/setRegents(obj/item/reagent_containers/OldReg, obj/item/reagent_containers/NewReg)
 	OldReg.reagents.trans_to(NewReg, OldReg.reagents.total_volume)
 
+/obj/machinery/cooker/proc/special_attack_grab(obj/item/grab/G, mob/user)
+	if(!G)
+		return FALSE
+	if(!iscarbon(G.affecting))
+		to_chat(user, "<span class='warning'>You can't shove that in there!</span>")
+		return FALSE
+	if(G.state < GRAB_AGGRESSIVE)
+		to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+		return FALSE
+	special_attack(user, G.affecting, TRUE)
+	user.changeNext_move(CLICK_CD_MELEE)
+	if(!isnull(G) && !QDELETED(G))
+		qdel(G)
+
+/obj/machinery/cooker/proc/special_attack(mob/user, mob/living/carbon/target, from_grab = FALSE)
+	if(from_grab)
+		to_chat(user, "<span class='alert'>This is ridiculous. You can not fit [target] in this [src].</span>")
+	return FALSE
+
 // check if you can put it in the machine
 /obj/machinery/cooker/proc/checkValid(obj/item/check, mob/user)
 	if(on)
 		to_chat(user, "<span class='notice'>[src] is still active!</span>")
 		return FALSE
 	if(istype(check, /obj/item/grab))
-		return special_attack(check, user)
+		return special_attack_grab(user, check)
 	if(has_specials && checkSpecials(check))
 		return TRUE
 	if(istype(check, /obj/item/reagent_containers/food/snacks) || emagged)
@@ -190,11 +209,6 @@
 		return
 	if(default_deconstruction_screwdriver(user, openicon, officon, I))
 		return TRUE
-
-
-
-/obj/machinery/cooker/proc/special_attack(obj/item/grab/G, mob/user)
-	return 0
 
 // MAKE SURE TO OVERRIDE THESE ON THE MACHINE IF IT HAS SPECIAL FOOD INTERACTIONS!
 // FAILURE TO OVERRIDE WILL RESULT IN FAILURE TO PROPERLY HANDLE SPECIAL INTERACTIONS!		--FalseIncarnate

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -84,26 +84,30 @@
 		emagged = TRUE
 		return
 
-/obj/machinery/cooker/deepfryer/special_attack(obj/item/grab/G, mob/user)
-	if(ishuman(G.affecting))
-		if(G.state < GRAB_AGGRESSIVE)
-			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-			return 0
-		var/mob/living/carbon/human/C = G.affecting
-		var/obj/item/organ/external/head/head = C.get_organ("head")
-		if(!head)
+/obj/machinery/cooker/deepfryer/special_attack(mob/user, mob/living/carbon/target, from_grab)
+
+	var/obj/item/organ/external/head/head = target.get_organ("head")
+	if(!head)
+		if(from_grab)
 			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-			return 0
-		C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
-						"<span class='userdanger'>[user] dunks your face into [src]!</span>")
-		C.emote("scream")
-		user.changeNext_move(CLICK_CD_MELEE)
-		C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
-		head.disfigure()
-		add_attack_logs(user, G.affecting, "Deep-fried with [src]")
-		qdel(G) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
-		return 0
-	return 0
+		return FALSE  // you'll probably get smacked against it
+	if(from_grab)
+		target.visible_message(
+			"<span class='danger'>[user] dunks [target]'s face into [src]!</span>",
+			"<span class='userdanger'>[user] dunks your face into [src]!</span>",
+			"<span class='danger'>You hear a splash and a loud sizzle.</span>"
+		)
+	else
+		target.visible_message(
+			"<span class='danger'>[user] shoves [target] into [src], sizzling their head!</span>",
+			"<span class='userdanger'>[user] shoves you into [src], and your head burns as it's coated in hot cooking oil!</span>",
+			"<span class='danger'>You hear a splash and a loud sizzle.</span>"
+		)
+	target.emote("scream")
+	target.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
+	head.disfigure()
+	add_attack_logs(user, target, "Deep-fried with [src]")
+	return TRUE
 
 /// Make foam consisting of burning oil.
 /obj/machinery/cooker/deepfryer/proc/make_foam(ice_amount)

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -103,8 +103,10 @@
 			"<span class='userdanger'>[user] shoves you into [src], and your head burns as it's coated in hot cooking oil!</span>",
 			"<span class='danger'>You hear a splash and a loud sizzle.</span>"
 		)
+
+	playsound(src, "sound/machines/kitchen/deep_fryer_emerge.ogg", 100)
 	target.emote("scream")
-	target.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
+	target.apply_damage(from_grab ? 25 : 20, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
 	head.disfigure()
 	add_attack_logs(user, target, "Deep-fried with [src]")
 	return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -51,6 +51,7 @@
 	)
 
 	target.emote("scream")
-	target.adjustFireLoss(30)
+	playsound(src, "sound/machines/kitchen/grill_mid.ogg", 100)
+	target.adjustFireLoss(from_grab ? 30 : 20)
 	add_attack_logs(user, target, "Burned with [src]")
 	return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -44,18 +44,13 @@
 		E += M.rating
 	efficiency = round((E/2), 1) // There's 2 lasers, so halve the effect on the efficiency to keep it balanced
 
-/obj/machinery/kitchen_machine/grill/special_attack(obj/item/grab/G, mob/user)
-	if(ishuman(G.affecting))
-		if(G.state < GRAB_AGGRESSIVE)
-			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-			return 0
-		var/mob/living/carbon/human/C = G.affecting
-		C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s body!</span>", \
-						"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
-		C.emote("scream")
-		user.changeNext_move(CLICK_CD_MELEE)
-		C.adjustFireLoss(30)
-		add_attack_logs(user, G.affecting, "Burned with [src]")
-		qdel(G) //Removes the grip to prevent rapid sears and give you a chance to run
-		return 0
-	return 0
+/obj/machinery/kitchen_machine/grill/special_attack(mob/user, mob/living/carbon/target, from_grab)
+	target.visible_message(
+		"<span class='danger'>[user] [from_grab ? "forces" : "shoves"] [target] onto [src], searing [target]'s body!</span>",
+		"<span class='userdanger'>[user] [from_grab ? "forces" : "shoves"] you onto [src]! It burns!</span>"
+	)
+
+	target.emote("scream")
+	target.adjustFireLoss(30)
+	add_attack_logs(user, target, "Burned with [src]")
+	return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -112,8 +112,9 @@
 			if(!(R.id in GLOB.cooking_reagents[recipe_type]))
 				to_chat(user, "<span class='alert'>Your [O] contains components unsuitable for cookery.</span>")
 				return TRUE
-	else if(istype(O,/obj/item/grab))
-		return special_attack(O, user)
+	else if(istype(O, /obj/item/grab))
+		var/obj/item/grab/G = O
+		return special_attack_grab(G, user)
 	else
 		to_chat(user, "<span class='alert'>You have no idea what you can cook with [O].</span>")
 		return TRUE
@@ -142,8 +143,23 @@
 /obj/machinery/kitchen_machine/attack_ai(mob/user)
 	return FALSE
 
-/obj/machinery/kitchen_machine/proc/special_attack(obj/item/grab/G, mob/user)
-	to_chat(user, "<span class='alert'>This is ridiculous. You can not fit [G.affecting] in this [src].</span>")
+/obj/machinery/kitchen_machine/proc/special_attack_grab(obj/item/grab/G, mob/user)
+	if(!G)
+		return FALSE
+	if(!iscarbon(G.affecting))
+		to_chat(user, "<span class='warning'>You can't shove that in there!</span>")
+		return FALSE
+	if(G.state < GRAB_AGGRESSIVE)
+		to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+		return FALSE
+	special_attack(user, G.affecting, TRUE)
+	user.changeNext_move(CLICK_CD_MELEE)
+	if(!isnull(G) && !QDELETED(G))
+		qdel(G)
+
+/obj/machinery/kitchen_machine/proc/special_attack(mob/user, mob/living/carbon/target, from_grab = FALSE)
+	if(from_grab)
+		to_chat(user, "<span class='alert'>This is ridiculous. You can not fit [target] in this [src].</span>")
 	return FALSE
 
 /********************

--- a/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
@@ -53,14 +53,17 @@
 		target.visible_message("<span class='danger'>[user] bashes [target]'s head in [src]'s door!</span>", \
 						"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
 		target.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
-		target.apply_damage(15, BRUTE, "head")
+		target.apply_damage(20, BRUTE, "head")
 		target.Weaken(4 SECONDS)  // With the weaken, you PROBABLY can't run unless they are slow to grab you again...
 	else
 		target.visible_message(
 			"<span class='danger'>[user] shoves [target] into [src], and the heated metal scalds [target.p_them()]!</span>",
 			"<span class='userdanger'>[user] shoves you into [src], and the heated metal scalds you!</span>"
 		)
+		target.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
+		target.apply_damage(20, BRUTE, "head")
+		target.KnockDown(2 SECONDS)
 	target.emote("scream")
-
+	playsound(src, "sound/machines/kitchen/oven_loop_end.ogg", 100)
 	add_attack_logs(user, target, "Smashed with [src]")
 	return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
@@ -44,24 +44,23 @@
 		E += M.rating
 	efficiency = round((E/2), 1) // There's 2 lasers, so halve the effect on the efficiency to keep it balanced
 
-/obj/machinery/kitchen_machine/oven/special_attack(obj/item/grab/G, mob/user)
-	if(ishuman(G.affecting))
-		if(G.state < GRAB_AGGRESSIVE)
-			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-			return 0
-		var/mob/living/carbon/human/C = G.affecting
-		var/obj/item/organ/external/head/head = C.get_organ("head")
+/obj/machinery/kitchen_machine/oven/special_attack(mob/user, mob/living/target, from_grab)
+	if(from_grab)
+		var/obj/item/organ/external/head/head = target.get_organ("head")
 		if(!head)
 			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-			return 0
-		C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
+			return FALSE
+		target.visible_message("<span class='danger'>[user] bashes [target]'s head in [src]'s door!</span>", \
 						"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
-		C.emote("scream")
-		user.changeNext_move(CLICK_CD_MELEE)
-		C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
-		C.apply_damage(15, BRUTE, "head")
-		C.Weaken(4 SECONDS)
-		add_attack_logs(user, G.affecting, "Smashed with [src]")
-		qdel(G) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
-		return 0
-	return 0
+		target.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
+		target.apply_damage(15, BRUTE, "head")
+		target.Weaken(4 SECONDS)  // With the weaken, you PROBABLY can't run unless they are slow to grab you again...
+	else
+		target.visible_message(
+			"<span class='danger'>[user] shoves [target] into [src], and the heated metal scalds [target.p_them()]!</span>",
+			"<span class='userdanger'>[user] shoves you into [src], and the heated metal scalds you!</span>"
+		)
+	target.emote("scream")
+
+	add_attack_logs(user, target, "Smashed with [src]")
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some shove interactions to the kitchen. If you're familiar with the grab interactions on kitchen equipment, this is mostly the same. Being shoved into cooking equipment deals some brute/burn damage, depending on the machine. It only does this every so often per machine (7 seconds), so you'll have to get creative and can't just keep stunlocking people into them.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
More environmental combat is good! also charlie thought this would be a good idea.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/212250036-aca07cf6-bdd6-4a9c-8a7f-391bd6ee2c5e.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See video
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Getting shoved into kitchen equipment will now hurt you a bit. Watch out!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
