### PR TITLE
Shoving nerds into disposals

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -176,6 +176,7 @@
 	)
 	target.forceMove(src)
 	add_attack_logs(attacker, target, "Shoved into disposals", !!target.ckey ? null : ATKLOG_ALL)
+	playsound(src, "sound/effects/bang.ogg")
 	return TRUE
 
 // mouse drop another mob or self

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -175,7 +175,7 @@
 		"<span class='warning'>You hear the sound of something being thrown in the trash.</span>"
 	)
 	target.forceMove(src)
-	add_attack_logs(attacker, target, "Shoved into disposals", !!target.ckey ? null : ATKLOG_ALL)
+	add_attack_logs(attacker, target, "Shoved into disposals", target.ckey ? null : ATKLOG_ALL)
 	playsound(src, "sound/effects/bang.ogg")
 	return TRUE
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -168,6 +168,16 @@
 		C.density = TRUE
 		qdel(src)
 
+/obj/machinery/disposal/shove_impact(mob/living/target, mob/living/attacker)
+	target.visible_message(
+		"<span class='warning'>[attacker] shoves [target] inside of [src]!</span>",
+		"<span class='userdanger'>[attacker] shoves you inside of [src]!</span>",
+		"<span class='warning'>You hear the sound of something being thrown in the trash.</span>"
+	)
+	target.forceMove(src)
+	add_attack_logs(attacker, target, "Shoved into disposals", !!target.ckey ? null : ATKLOG_ALL)
+	return TRUE
+
 // mouse drop another mob or self
 //
 /obj/machinery/disposal/MouseDrop_T(mob/living/target, mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a shove interaction for disposals units. It drops you inside the unit, though doesn't automatically flush you, meaning you're free to crawl out, though it could be comboed for some pretty fun BM.
I can see this being useful for getting annoying people out of places they aren't supposed to. You aren't open to a free attack after this like you might be after tabling or walling, so it's a nice "get out of here" interaction.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's a nice shortcut to click-dragging, and it'll be good at getting people out of areas if used effectively. You still need to manually flush.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/212252476-3e34a85a-30a1-4e8f-a3c5-758200fdd164.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See video
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Adds shove interactions to disposals units.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
