### PR TITLE
Legion cores no longer fix bones / ib on station, unless implanted.

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -344,10 +344,13 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.bodytemperature = H.dna.species.body_temperature
-		for(var/thing in H.bodyparts)
-			var/obj/item/organ/external/E = thing
-			E.fix_internal_bleeding()
-			E.mend_fracture()
+		if(is_mining_level(H.z))
+			for(var/thing in H.bodyparts)
+				var/obj/item/organ/external/E = thing
+				E.fix_internal_bleeding()
+				E.mend_fracture()
+		else
+			to_chat(owner, "<span class='warning'>...But the core was weakened, as it was not close enough to the rest of the legions of the necropolis.</span>")
 	else
 		owner.bodytemperature = BODYTEMP_NORMAL
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Legion cores no longer fix bones / ib on station, unless implanted.
**Everything else is identical.** 
It is still an aheal on implantation. Getting an organ is not without risk. It takes time, and you can have one at a time. The only issue with it is traders with an autoimplanter, but that is unlikely to be available with antags due to most rounds staying on red constantly.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Makes miners more possible to kill as a major event on station.
Makes security struggle less vs a miner on station, constantly fixing bones.
Doesn't make legion cores worse vs bosses.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed IB was not fixed on station and message showed, confirmed IB was fixed on lavaland, confirmed implanted worked as expected.


## Changelog
:cl:
tweak: legion cores no longer fix bones / ib on station, unless implanted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
