### PR TITLE
Clears an undeleted DB query on switch_server()

### DIFF
--- a/code/game/verbs/switch_server.dm
+++ b/code/game/verbs/switch_server.dm
@@ -20,6 +20,7 @@
 
 		servers_outer[dbq1.item[1]][dbq1.item[2]] = dbq1.item[3] // This should assoc load our data
 
+	qdel(dbq1) //clear our query
 	// Format the server names into an assoc list of K: name V: port
 	var/list/formatted_servers = list()
 	for(var/server in servers_outer)


### PR DESCRIPTION
## What Does This PR Do
Qdel's a db query for the server switching var when its no longer needed
a query should be deleted after its no longer being used

no player facing changes

## Testing
I compiled without runtimes