### PR TITLE
Fixes several issues with the forcemove tool

### DIFF
--- a/code/modules/buildmode/submodes/forcemove.dm
+++ b/code/modules/buildmode/submodes/forcemove.dm
@@ -34,7 +34,7 @@
 		RegisterSignal(selected_atom, COMSIG_PARENT_QDELETING, PROC_REF(on_selected_atom_deleted))
 
 		// Green overlay for selection
-		selected_overlay = image(icon = selected_atom.icon, loc = A, icon_state = selected_atom.icon_state, layer = HUD_PLANE_BUILDMODE)
+		selected_overlay = image(icon = selected_atom.icon, loc = A, icon_state = selected_atom.icon_state)
 		selected_overlay.color = "#15d12d"
 		user.client.images += selected_overlay
 


### PR DESCRIPTION
## What Does This PR Do

In less than 12 hours, my fellow admins broke this tool, so here is a fix PR. 😄 

1. Right-clicking the buildmode button now clears the current selection
2. Changing buildmode will clear the current selection
3. Exiting buildmode will clear the current selection
4. Bolds the selected object's name
5. Adds proper autodoc format

One issue remains, namely, that carbon/human subtypes don't get the green overlay. I tried everything, no clue why, it's _definitely_ not a layering issue.

## Why It's Good For The Game

Less bugs for admins.

## Images of changes

Video of 1, 2, 3:

<details>
  <summary>Video</summary>
  
  https://user-images.githubusercontent.com/33333517/212470535-3d9f00d8-2764-45f4-b5e6-ac82b8e15f90.mp4
  
</details>

Image of 4:

![image](https://user-images.githubusercontent.com/33333517/212470502-94191a7a-75ad-45f4-b450-c9d83f809bb0.png)

## Testing

Made the videos/images above.

## Changelog
:cl:
fix: Fixes the forcemove buildmodes's selection overlay sticking around in several cases. Made the selection text more readable.
/:cl:
