### PR TITLE
Fixes external airlock buttons

### DIFF
--- a/code/game/machinery/airlock_control/airlock_button.dm
+++ b/code/game/machinery/airlock_control/airlock_button.dm
@@ -45,16 +45,17 @@ GLOBAL_LIST_EMPTY(all_airlock_access_buttons)
 /obj/machinery/access_button/attack_hand(mob/user)
 	add_fingerprint(user)
 
-	if(!powered(power_channel))
+	var/obj/machinery/airlock_controller/C = locateUID(controller_uid)
+	if(!C)
+		to_chat(user, "<span class='warning'>Could not communicate with controller.</span>")
+		return
+
+	if(!C.powered(C.power_channel))
+		to_chat(user, "<span class='warning'>No response from controller, possibly offline.</span>")
 		return
 
 	if(!allowed(user) && !user.can_advanced_admin_interact())
 		to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
-
-	var/obj/machinery/airlock_controller/C = locateUID(controller_uid)
-	if(!C)
-		to_chat(user, "<span class='warning'>Could not communicate with controller.</span>")
 		return
 
 	C.handle_button(assigned_command)


### PR DESCRIPTION
## What Does This PR Do
Currently some external airlock buttons are mapped to space. This is a problem because they dont work due to never having power. I had 2 options

1. Map the station areas out to the buttons
2. Make the buttons feed off the controller power

This PR does the second

## Why It's Good For The Game
Bugs bad

## Testing
![loU9x8iClz](https://user-images.githubusercontent.com/25063394/212472158-c607e224-e968-4bcb-80ba-b9594376b15d.gif)

## Changelog
:cl: AffectedArc07
fix: Fixed some external airlock buttons not working
/:cl:
