### PR TITLE
The drop hotkey is now consistent with the drop verb

### DIFF
--- a/code/datums/keybindings/mob.dm
+++ b/code/datums/keybindings/mob.dm
@@ -25,9 +25,8 @@
 /datum/keybinding/mob/drop_held_object/down(client/C)
 	. = ..()
 	var/obj/item/I = C.mob.get_active_hand()
-	SEND_SIGNAL(C.mob, COMSIG_MOB_WILLINGLY_DROP)
 	if(I)
-		C.mob.drop_item()
+		C.mob.drop_item_v()
 	else
 		to_chat(C, "<span class='warning'>You have nothing to drop in your hand!</span>")
 


### PR DESCRIPTION

## What Does This PR Do
The drop hotkey is now consistent with the drop verb

## Why It's Good For The Game
Two very similar ways to drop an item should function off of the same rules. Prevents some weird interactions like dropping objects in objects.

## Testing
Compiled and ran

## Changelog
:cl:
tweak: The drop hotkey now functions the same as the drop verb
/:cl:

