### PR TITLE
Fixes alien weed nodes not GCing

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -265,6 +265,7 @@
 		return
 	check_surroundings()
 	START_PROCESSING(SSobj, src)
+	RegisterSignal(linked_node, COMSIG_PARENT_QDELETING, PROC_REF(clear_linked_node))
 
 /obj/structure/alien/weeds/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -273,6 +274,11 @@
 	linked_node = null
 	clear_wall_weed()
 	return ..()
+
+/obj/structure/alien/weeds/proc/clear_linked_node()
+	SIGNAL_HANDLER
+	UnregisterSignal(linked_node, COMSIG_PARENT_QDELETING)
+	linked_node = null
 
 /obj/structure/alien/weeds/attack_alien(mob/living/carbon/alien/humanoid/user)
 	if(user.a_intent != INTENT_HARM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #19327
Alien weed nodes now have their references in other weeds removed on destroy

## Why It's Good For The Game
I like gcing

will make part of #20154 work more consistently 
## Testing
compiled and ran with gc tests enabled

## Changelog
NPFC