### PR TITLE
Indestructable toxins test site camera is now viewable from the camera monitor in the toxins launch room on Box.

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -78813,7 +78813,7 @@
 	dir = 8;
 	invuln = 1;
 	name = "Hardened Bomb-Test Security Camera";
-	network = list("Research","SS13")
+	network = list("Toxins","Research","SS13")
 	},
 /turf/simulated/floor/indestructible,
 /area/toxins/test_area)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Add indestructable toxins test site camera to the toxins network on Boxstation so that it may be viewed via the camera monitor in the toxins launch room.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Previously this camera was not on the toxins camera network, despite being in the toxins test site. This camera is rather useful if you want to watch your toxins bomb go off. Now you can actually do so.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Go to toxins launch room
Look at the camera console
Middle camera is there
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Indestructable toxins test site camera is now viewable from the camera monitor in the toxins launch room on Boxstation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
