### PR TITLE
Janicart and Mop bucket tweaks

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -48,7 +48,7 @@
 	if(!I.is_robot_module())
 		if(istype(I, /obj/item/mop))
 			var/obj/item/mop/m=I
-			if(m.reagents.total_volume < maximum_volume)
+			if(m.reagents.total_volume < m.reagents.maximum_volume)
 				m.wet_mop(src, user)
 				return
 			if(!mymop)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -10,6 +10,7 @@
 	face_while_pulling = FALSE
 	container_type = OPENCONTAINER
 	//copypaste sorry
+	var/maximum_volume = 150
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/storage/bag/trash/mybag	= null
 	var/obj/item/mop/mymop = null
@@ -18,10 +19,9 @@
 	var/signs = 0
 	var/const/max_signs = 4
 
-
 /obj/structure/janitorialcart/Initialize(mapload)
 	. = ..()
-	create_reagents(100)
+	create_reagents(150)
 	GLOB.janitorial_equipment += src
 
 /obj/structure/janitorialcart/Destroy()
@@ -48,7 +48,7 @@
 	if(!I.is_robot_module())
 		if(istype(I, /obj/item/mop))
 			var/obj/item/mop/m=I
-			if(m.reagents.total_volume < m.reagents.maximum_volume)
+			if(m.reagents.total_volume < maximum_volume)
 				m.wet_mop(src, user)
 				return
 			if(!mymop)
@@ -125,7 +125,6 @@
 	popup.set_content(dat)
 	popup.open()
 
-
 /obj/structure/janitorialcart/Topic(href, href_list)
 	if(!in_range(src, usr))
 		return
@@ -166,7 +165,6 @@
 	update_icon(UPDATE_OVERLAYS)
 	updateUsrDialog()
 
-
 /obj/structure/janitorialcart/update_overlays()
 	. = ..()
 	if(mybag)
@@ -182,14 +180,14 @@
 	if(reagents.total_volume > 0)
 		var/image/reagentsImage = image(icon,src,"cart_reagents0")
 		reagentsImage.alpha = 150
-		switch((reagents.total_volume/reagents.maximum_volume)*100)
-			if(1 to 25)
+		switch((reagents.total_volume / maximum_volume) * 100)
+			if(1 to 37)
 				reagentsImage.icon_state = "cart_reagents1"
-			if(26 to 50)
+			if(38 to 75)
 				reagentsImage.icon_state = "cart_reagents2"
-			if(51 to 75)
+			if(76 to 112)
 				reagentsImage.icon_state = "cart_reagents3"
-			if(76 to 100)
+			if(113 to 150)
 				reagentsImage.icon_state = "cart_reagents4"
 		reagentsImage.icon += mix_color_from_reagents(reagents.reagent_list)
 		. += reagentsImage

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -1,36 +1,32 @@
 /obj/structure/mopbucket
-	desc = "Fill it with water, but don't forget a mop!"
 	name = "mop bucket"
+	desc = "Fill it with water, but don't forget a mop!"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "mopbucket"
 	density = TRUE
 	container_type = OPENCONTAINER
 	face_while_pulling = FALSE
 	var/obj/item/mop/stored_mop = null
+	var/maximum_volume = 150
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 
 /obj/structure/mopbucket/Initialize(mapload)
 	. = ..()
-	create_reagents(100)
+	create_reagents(150)
 	GLOB.janitorial_equipment += src
 
 /obj/structure/mopbucket/full/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent("water", 100)
+	reagents.add_reagent("water", 150)
 
 /obj/structure/mopbucket/Destroy()
 	GLOB.janitorial_equipment -= src
 	return ..()
 
-/obj/structure/mopbucket/examine(mob/user)
-	. = ..()
-	if(in_range(user, src))
-		. += "[bicon(src)] [src] contains [reagents.total_volume] units of water left!"
-
 /obj/structure/mopbucket/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/mop))
 		var/obj/item/mop/M = W
-		if(M.reagents.total_volume < M.reagents.maximum_volume)
+		if(M.reagents.total_volume < maximum_volume)
 			M.wet_mop(src, user)
 			return
 		if(!stored_mop)
@@ -38,7 +34,6 @@
 			return
 		to_chat(user, "<span class='notice'>Theres already a mop in the mopbucket.</span>")
 		return
-	return ..()
 
 /obj/structure/mopbucket/proc/put_in_cart(obj/item/mop/I, mob/user)
 	user.drop_item()
@@ -60,14 +55,14 @@
 	if(reagents.total_volume > 0)
 		var/image/reagentsImage = image(icon, src, "mopbucket_reagents0")
 		reagentsImage.alpha = 150
-		switch((reagents.total_volume/reagents.maximum_volume)*100)
-			if(1 to 25)
+		switch((reagents.total_volume / maximum_volume) * 100)
+			if(1 to 37)
 				reagentsImage.icon_state = "mopbucket_reagents1"
-			if(26 to 50)
+			if(38 to 75)
 				reagentsImage.icon_state = "mopbucket_reagents2"
-			if(51 to 75)
+			if(76 to 112)
 				reagentsImage.icon_state = "mopbucket_reagents3"
-			if(76 to 100)
+			if(113 to 150)
 				reagentsImage.icon_state = "mopbucket_reagents4"
 		reagentsImage.icon += mix_color_from_reagents(reagents.reagent_list)
 		. += reagentsImage
@@ -80,5 +75,3 @@
 		stored_mop = null
 		update_icon(UPDATE_OVERLAYS)
 		return
-
-

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -26,7 +26,7 @@
 /obj/structure/mopbucket/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/mop))
 		var/obj/item/mop/M = W
-		if(M.reagents.total_volume < maximum_volume)
+		if(M.reagents.total_volume < M.reagents.maximum_volume)
 			M.wet_mop(src, user)
 			return
 		if(!stored_mop)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -75,3 +75,4 @@
 		stored_mop = null
 		update_icon(UPDATE_OVERLAYS)
 		return
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Increased janicart and mop bucket maximum volume (100u -> 150u).
You will no longer attack the mop bucket while transfering reagents to it.
Mop bucket: redundant examine text (reagent amount being displayed twice) has been removed.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It makes no sense that a mobile reagent container like the bucket (120u) has more volume than heavy, specialized equipment for cleaning (100u).
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![mop_bucket](https://user-images.githubusercontent.com/77684085/212504678-f3fe795a-b837-4fae-8d04-de1a2c1fbf85.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Spawned a mop bucket and janicart.
- I filled it with a bucket to its new maximum capacity.
- Examined the Mop bucket.
## Changelog
:cl:
tweak: Increased janicart and mop bucket maximum volume (100u -> 150u)
fix: You will no longer attack the mop bucket while transfering reagents to it
spellcheck: Mop bucket: redundant examine text has been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
