### PR TITLE
Wallets can no longer hold the hand drill

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -26,6 +26,9 @@
 		/obj/item/reagent_containers/dropper,
 		/obj/item/screwdriver,
 		/obj/item/stamp)
+	cant_hold = list(
+		/obj/item/screwdriver/power
+	)
 	slot_flags = SLOT_ID
 
 	var/obj/item/card/id/front_id = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Wallets can no longer hold the hand drill.
fixes: #20075
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
What is this, some kind of bluespace wallet?
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Try and put a screwdriver in a wallet
It goes in
Try and put a hand drill in a wallet
It does not go in
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Wallets can no longer hold the hand drill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
