### PR TITLE
Hand drill's screwdriver form no longer as a weight class of 1

### DIFF
--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -85,6 +85,7 @@
 	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
 	origin_tech = "materials=2;engineering=2" //done for balance reasons, making them high value for research, but harder to get
 	force = 8 //might or might not be too high, subject to change
+	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 8
 	throw_speed = 2
 	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The hand drill's screwdriver form no longer has a weight class of 1, it now has a weight class of 2 like the jaws of life and the hand drill wrench mode

## Why It's Good For The Game
Attaching a bit to the end of if shouldn't halve its weight 

## Testing
Compiled and ran

## Changelog
:cl:
tweak: The hand drill screwdriver mode now has a weight class of small
/:cl:
