### PR TITLE
SecTech tweaks and availability

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -25582,7 +25582,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/economy/vending/security,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -85955,7 +85955,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/brig)
 "tKm" = (
-/obj/machinery/economy/vending/security,
 /obj/machinery/light{
 	dir = 8
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2883,7 +2883,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/economy/vending/security,
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -212,12 +212,12 @@
 	req_access_txt = "1"
 	products = list(/obj/item/restraints/handcuffs = 8,
 					/obj/item/restraints/handcuffs/cable/zipties = 8,
-					/obj/item/grenade/flashbang = 4,
+					/obj/item/grenade/flashbang = 5,
 					/obj/item/flash = 5,
 					/obj/item/reagent_containers/spray/pepper = 5,
 					/obj/item/storage/box/evidence = 6,
-					/obj/item/flashlight/seclite = 4,
-					/obj/item/restraints/legcuffs/bola/energy = 7,
-					/obj/item/clothing/mask/muzzle/safety = 4)
+					/obj/item/flashlight/seclite = 5,
+					/obj/item/restraints/legcuffs/bola/energy = 10,
+					/obj/item/clothing/mask/muzzle/safety = 5)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2, /obj/item/storage/fancy/donut_box = 2, /obj/item/hailer = 5)
 	refill_canister = /obj/item/vending_refill/security

--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -215,13 +215,9 @@
 					/obj/item/grenade/flashbang = 4,
 					/obj/item/flash = 5,
 					/obj/item/reagent_containers/spray/pepper = 5,
-					/obj/item/reagent_containers/food/snacks/donut = 12,
 					/obj/item/storage/box/evidence = 6,
 					/obj/item/flashlight/seclite = 4,
 					/obj/item/restraints/legcuffs/bola/energy = 7,
 					/obj/item/clothing/mask/muzzle/safety = 4)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2, /obj/item/storage/fancy/donut_box = 2, /obj/item/hailer = 5)
 	refill_canister = /obj/item/vending_refill/security
-
-
-

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -18,7 +18,7 @@
 
 /datum/supply_packs/security/vending/security
 	name = "SecTech Supply Crate"
-	cost = 600
+	cost = 400
 	contains = list(/obj/item/vending_refill/security)
 	containername = "SecTech supply crate"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
All brigs now starts with only one SecTech.
Removed donuts from SecTech (the donut box contraband still remains).
Reduced SecTech supply crate cost (600 -> 400 credits).
Tweaked the following contents amounts:
Flashbang 4 -> 5
Seclite 4 -> 5
Energy Bola 7 -> 10 (enough for the nine officers during highpop + HoS)
Muzzle 4 -> 5
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having donuts in and out of contraband in the same vending machine is redundant. 
Brig has a lot of donuts already and i would rather have it locked behind some effort (contraband).


One SecTech is enough to supply all officers roundstart, two is too much of an abundance that usually only empties out of energy bolas because of how good they are.
The restock cost has been reduced as compensation for this loss and to encourage security to order it.

## Testing
<!-- How did you test the PR, if at all? -->
- Confirmed the changes (vendor missing, donut and price) ingame.
## Changelog
:cl:
tweak: All brigs now starts with only one SecTech
tweak: Removed donuts from SecTech (the donut box contraband still remains)
tweak: SecTech: increased the amount of flashbangs, seclites, muzzle and bolas.
tweak: Reduced SecTech supply crate cost (600 -> 400 credits)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
