### PR TITLE
Fixes a narsie runtime

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -122,6 +122,8 @@
 	var/list/noncultists = list()
 	for(var/mob/living/carbon/food in GLOB.alive_mob_list) //we don't care about constructs or cult-Ians or whatever. cult-monkeys are fair game i guess
 		var/turf/pos = get_turf(food)
+		if(!pos) // The GLOB mob list (alive or dead) can contain null entries, so we gotta check if we're trying to get the turf of something that doesn't exist
+			return
 		if(pos.z != src.z)
 			continue
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #18341 
The cause was due to the playerlist being able to contain null values, not leaving the z level

## Why It's Good For The Game
Runtimes bad

## Testing
Compiled, ran, went postal

## Changelog
NPFC
