### PR TITLE
hierophant arena walls now decay after the hierophant dies

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -15,6 +15,7 @@ GLOBAL_LIST_INIT(prisoncomputer_list, list())
 GLOBAL_LIST_INIT(celltimers_list, list()) // list of all cell timers
 GLOBAL_LIST_INIT(cell_logs, list())
 GLOBAL_LIST_INIT(navigation_computers, list())
+GLOBAL_LIST_INIT(hierophant_walls, list())
 
 GLOBAL_LIST_INIT(all_areas, list())
 GLOBAL_LIST_INIT(all_unique_areas, list()) // List of all unique areas. AKA areas with there_can_be_many = FALSE

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -89,7 +89,6 @@
 	GLOB.hierophant_walls -= src
 	return ..()
 
-GLOBAL_LIST_INIT(hierophant_walls, list())
 
 /turf/simulated/wall/indestructible/hierophant/proc/collapse()
 	if(prob(15))

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -79,6 +79,25 @@
 	icon = 'icons/turf/walls/hierophant_wall.dmi'
 	icon_state = "wall"
 	smoothing_flags = SMOOTH_CORNERS
+	baseturf = /turf/simulated/floor/indestructible/hierophant/two
+
+/turf/simulated/wall/indestructible/hierophant/Initialize(mapload)
+	. = ..()
+	GLOB.hierophant_walls += src
+
+/turf/simulated/wall/indestructible/hierophant/BeforeChange()
+	GLOB.hierophant_walls -= src
+	return ..()
+
+GLOBAL_LIST_INIT(hierophant_walls, list())
+
+/turf/simulated/wall/indestructible/hierophant/proc/collapse()
+	if(prob(15))
+		visible_message("<span class='warning'>[src] starts to rumble and groan as the lights fade on it, and it begins to collapse to rubble!</span>",\
+		"<span class='warning'>You hear metal groaning and tearing!</span>")
+		new /turf/simulated/floor/indestructible/hierophant/two(src)
+		return
+	addtimer(CALLBACK(src, PROC_REF(collapse)), 10 SECONDS)
 
 /turf/simulated/wall/indestructible/sandstone
 	icon = 'icons/turf/walls/sandstone_wall.dmi'

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(hierophant_walls, list())
 	if(prob(15))
 		visible_message("<span class='warning'>[src] starts to rumble and groan as the lights fade on it, and it begins to collapse to rubble!</span>",\
 		"<span class='warning'>You hear metal groaning and tearing!</span>")
-		new /turf/simulated/floor/indestructible/hierophant/two(src)
+		ChangeTurf(/turf/simulated/floor/indestructible/hierophant/two)
 		return
 	addtimer(CALLBACK(src, PROC_REF(collapse)), 10 SECONDS)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -487,6 +487,13 @@ Difficulty: Hard
 	burst_range = initial(burst_range) + round(anger_modifier * 0.08)
 	beam_range = initial(beam_range) + round(anger_modifier * 0.12)
 
+/mob/living/simple_animal/hostile/megafauna/hierophant/bullet_act(obj/item/projectile/P)
+	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client)
+		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
+			FindTarget(list(P.firer), 1)
+		Goto(P.starting, move_to_delay, 3)
+	..()
+
 //Hierophant overlays
 /obj/effect/temp_visual/hierophant
 	name = "vortex energy"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -405,6 +405,8 @@ Difficulty: Hard
 			stored_nearby += L // store the people to grant the achievements to once we die
 		hierophant_burst(null, get_turf(src), 10)
 		set_stat(CONSCIOUS) // deathgasp wont run if dead, stupid
+		for(var/turf/simulated/wall/indestructible/hierophant/T in GLOB.hierophant_walls)
+			T.collapse()
 		..(/* force_grant = stored_nearby */)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
hierophant arena walls now decay after the hierophant dies, slowly turning to arena turf over time.

If it is better to collapse them all at once I can do that. Probably is, but thought a slow collapse would be cooler.

Hierophant will follow colossus bolts to the source if hit by one in their arena.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Looks cool. Arena collapsing, hierophant is dead, nothing really keeping it up. 
Thematics. 
Nothing else.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed the walls started slowly collapsing. 

## Changelog
:cl:
tweak: The walls in the hierophants arena collapse over time after hierophant is killed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
