### PR TITLE
Receiving two steal objectives no longer makes the second one a Free Objective

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -215,39 +215,42 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/datum/objective/O = new objective_type(explanation_text)
 	O.owner = owner
 
-	if(target_override)
-		O.target = target_override
-		objectives += O
-		return
-
 	if(!O.needs_target)
 		objectives += O
-		return
+		return O
 
-	O.find_target()
-	var/duplicate = FALSE
+	var/found_valid_target = FALSE
 
-	// Steal objectives need snowflake handling here unfortunately.
-	if(istype(O, /datum/objective/steal))
-		var/datum/objective/steal/S = O
-		// Check if it's a duplicate.
-		if("[S.steal_target]" in assigned_targets)
-			S.find_target() // Try again.
-			if("[S.steal_target]" in assigned_targets)
-				S.steal_target = null
-				S.explanation_text = "Free Objective" // Still a duplicate, so just make it a free objective.
-				duplicate = TRUE
-		if(S.steal_target && !duplicate)
-			assigned_targets += "[S.steal_target]"
+	if(target_override)
+		O.target = target_override
+		found_valid_target = TRUE
 	else
-		if("[O.target]" in assigned_targets)
-			O.find_target()
-			if("[O.target]" in assigned_targets)
-				O.target = null
-				O.explanation_text = "Free Objective"
-				duplicate = TRUE
-		if(O.target && !duplicate)
-			assigned_targets += "[O.target]"
+		var/loops = 5
+		// Steal objectives need snowflake handling here unfortunately.
+		if(istype(O, /datum/objective/steal))
+			var/datum/objective/steal/S = O
+			while(loops--)
+				S.find_target()
+				if(S.steal_target && !("[S.steal_target.name]" in assigned_targets))
+					found_valid_target = TRUE
+					break
+		else
+			while(loops--)
+				O.find_target()
+				if(O.target && !("[O.target]" in assigned_targets))
+					found_valid_target = TRUE
+					break
+
+	if(found_valid_target)
+		// This is its own seperate section in case someone passes a `target_override`.
+		if(istype(O, /datum/objective/steal))
+			var/datum/objective/steal/S = O
+			assigned_targets |= "[S.steal_target.name]"
+		else
+			assigned_targets |= "[O.target]"
+	else
+		O.explanation_text = "Free Objective"
+		O.target = null
 
 	objectives += O
 	return O


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cleans up `/datum/antagonist/proc/add_objective`. Fixes code so that receiving two steal objectives no longer makes the second one a Free Objective. This should heavily cut down on/eliminate occurrences of free objectives for the most part.

This whole time, I was checking `if("[S.steal_target]" in assigned_targets)`, but what I failed to notice is that `steal_target` is just a datum, so what was actually happening here is `if("/datum/theft_objective" in assigned_targets)`. As you can see, by the time the 2nd steal objective is added, it automatically detects it as a "duplicate". The fix is to instead check `"[S.steal_target.name]"` so we have something unique to compare.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Testing
Spawned in and gave myself traitor. `add_objective` was able to give me two steal objectives properly. Other objectives still worked fine.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Receiving two steal objectives no longer makes the second one a Free Objective.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
