### PR TITLE
Fixes countdowns being out of movement sync with their atom

### DIFF
--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -17,6 +17,7 @@
 /obj/effect/countdown/Initialize(mapload)
 	. = ..()
 	attach(loc)
+	RegisterSignal(attached_to, COMSIG_MOVABLE_MOVED, PROC_REF(countdown_on_move))
 
 /obj/effect/countdown/examine(mob/user)
 	. = ..()
@@ -37,14 +38,16 @@
 		STOP_PROCESSING(SSfastprocess, src)
 		started = FALSE
 
+/// Get the value from our atom
 /obj/effect/countdown/proc/get_value()
-	// Get the value from our atom
 	return
+
+/obj/effect/countdown/proc/countdown_on_move()
+	forceMove(get_turf(attached_to))
 
 /obj/effect/countdown/process()
 	if(!attached_to || QDELETED(attached_to))
 		qdel(src)
-	forceMove(get_turf(attached_to))
 	var/new_val = get_value()
 	if(new_val == displayed_text)
 		return

--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -43,11 +43,14 @@
 	return
 
 /obj/effect/countdown/proc/countdown_on_move()
+	SIGNAL_HANDLER
 	forceMove(get_turf(attached_to))
 
 /obj/effect/countdown/process()
 	if(!attached_to || QDELETED(attached_to))
 		qdel(src)
+	if(!isturf(attached_to.loc)) // When in crates, lockers, etc. countdown_on_move wont be called. This is our backup
+		forceMove(get_turf(attached_to))
 	var/new_val = get_value()
 	if(new_val == displayed_text)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->When an atom with a countdown (like an SM shard) moves, the countdown moves with it.
Unfortunately, when the crates holding stuff like this, they wont update in real time. This is because the move signal isnt sent. So they will revert to their old fashion of lagging slightly behind.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->It looks better

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
From this...
![image](https://user-images.githubusercontent.com/91113370/212807366-3ddcba6e-a9a4-4375-9ece-c34c355dfd77.png)
to this
![dreamseeker_BQzTVFTme4](https://user-images.githubusercontent.com/91113370/212807387-fb76fc05-9a76-4291-8e32-0b67489e8fcf.gif)


## Testing
<!-- How did you test the PR, if at all? -->
See gif above, also tested inside crates which used the fallback instead

## Changelog
:cl:
fix: Countdowns over bombs and the SM integrity counter will now stay on top of the object when moved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
