### PR TITLE
Adds a cargo crate spawning tool for admins

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -733,6 +733,63 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	log_admin("[key_name(usr)] spawned [chosen] at ([usr.x],[usr.y],[usr.z])")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Spawn Atom") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/create_crate(object as text)
+	set category = "Event"
+	set desc = "Spawn an crate from a supplypack datum. Append a period to the text in order to exclude subtypes of paths matching the input."
+	set name = "Create Crate"
+
+	if(!check_rights(R_SPAWN))
+		return
+
+	var/list/types = list()
+	for(var/typepath in subtypesof(/datum/supply_packs))
+		var/datum/supply_packs/P = typepath
+		if(initial(P.name) == "HEADER")
+			continue // To filter out group headers
+		types += P
+
+	var/list/matches = list()
+
+	var/include_subtypes = TRUE
+	if(copytext(object, -1) == ".")
+		include_subtypes = FALSE
+		object = copytext(object, 1, -1)
+
+	if(include_subtypes)
+		for(var/path in types)
+			if(findtext("[path]", object))
+				matches += path
+	else
+		var/needle_length = length(object)
+		for(var/path in types)
+			if(copytext("[path]", -needle_length) == object)
+				matches += path
+
+	if(!length(matches))
+		return
+
+	var/chosen
+	if(length(matches) == 1)
+		chosen = matches[1]
+	else
+		chosen = input("Select an supply crate type", "Create Crate", matches[1]) as null|anything in matches
+
+	if(!chosen)
+		return
+
+	var/datum/supply_packs/the_pack = new chosen(get_turf(usr))
+	if(!istype(the_pack))
+		to_chat(usr, "<span class='userdanger'>Something went wrong with spawning [the_pack], it wasnt a supply_packs path it was [the_pack.type].</span>")
+	var/obj/structure/closet/crate/crate = the_pack.create_package(get_turf(usr))
+	crate.admin_spawned = TRUE
+	for(var/atom/A in crate.contents)
+		A.admin_spawned = TRUE
+	qdel(the_pack)
+
+	log_admin("[key_name(usr)] created a crate [chosen] at ([usr.x],[usr.y],[usr.z])")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Create Crate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+
 /datum/admins/proc/show_traitor_panel(mob/M in GLOB.mob_list)
 	set category = "Admin"
 	set desc = "Edit mobs's memory and role"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -733,63 +733,6 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	log_admin("[key_name(usr)] spawned [chosen] at ([usr.x],[usr.y],[usr.z])")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Spawn Atom") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/datum/admins/proc/create_crate(object as text)
-	set category = "Event"
-	set desc = "Spawn an crate from a supplypack datum. Append a period to the text in order to exclude subtypes of paths matching the input."
-	set name = "Create Crate"
-
-	if(!check_rights(R_SPAWN))
-		return
-
-	var/list/types = list()
-	for(var/typepath in subtypesof(/datum/supply_packs))
-		var/datum/supply_packs/P = typepath
-		if(initial(P.name) == "HEADER")
-			continue // To filter out group headers
-		types += P
-
-	var/list/matches = list()
-
-	var/include_subtypes = TRUE
-	if(copytext(object, -1) == ".")
-		include_subtypes = FALSE
-		object = copytext(object, 1, -1)
-
-	if(include_subtypes)
-		for(var/path in types)
-			if(findtext("[path]", object))
-				matches += path
-	else
-		var/needle_length = length(object)
-		for(var/path in types)
-			if(copytext("[path]", -needle_length) == object)
-				matches += path
-
-	if(!length(matches))
-		return
-
-	var/chosen
-	if(length(matches) == 1)
-		chosen = matches[1]
-	else
-		chosen = input("Select an supply crate type", "Create Crate", matches[1]) as null|anything in matches
-
-	if(!chosen)
-		return
-
-	var/datum/supply_packs/the_pack = new chosen(get_turf(usr))
-	if(!istype(the_pack))
-		to_chat(usr, "<span class='userdanger'>Something went wrong with spawning [the_pack], it wasnt a supply_packs path it was [the_pack.type].</span>")
-	var/obj/structure/closet/crate/crate = the_pack.create_package(get_turf(usr))
-	crate.admin_spawned = TRUE
-	for(var/atom/A in crate.contents)
-		A.admin_spawned = TRUE
-	qdel(the_pack)
-
-	log_admin("[key_name(usr)] created a crate [chosen] at ([usr.x],[usr.y],[usr.z])")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Create Crate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-
 /datum/admins/proc/show_traitor_panel(mob/M in GLOB.mob_list)
 	set category = "Admin"
 	set desc = "Edit mobs's memory and role"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -115,7 +115,8 @@ GLOBAL_LIST_INIT(admin_verbs_event, list(
 GLOBAL_LIST_INIT(admin_verbs_spawn, list(
 	/datum/admins/proc/spawn_atom,		/*allows us to spawn instances*/
 	/client/proc/respawn_character,
-	/client/proc/admin_deserialize
+	/client/proc/admin_deserialize,
+	/datum/admins/proc/create_crate
 	))
 GLOBAL_LIST_INIT(admin_verbs_server, list(
 	/client/proc/reload_admins,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -116,7 +116,7 @@ GLOBAL_LIST_INIT(admin_verbs_spawn, list(
 	/datum/admins/proc/spawn_atom,		/*allows us to spawn instances*/
 	/client/proc/respawn_character,
 	/client/proc/admin_deserialize,
-	/datum/admins/proc/create_crate
+	/client/proc/create_crate
 	))
 GLOBAL_LIST_INIT(admin_verbs_server, list(
 	/client/proc/reload_admins,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1236,8 +1236,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 	var/datum/supply_packs/the_pack = new chosen(get_turf(usr))
-	if(!istype(the_pack))
-		to_chat(usr, "<span class='userdanger'>Something went wrong with spawning [the_pack], it wasnt a supply_packs path it was [the_pack.type].</span>")
 	var/obj/structure/closet/crate/crate = the_pack.create_package(get_turf(usr))
 	crate.admin_spawned = TRUE
 	for(var/atom/A in crate.contents)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1193,7 +1193,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /client/proc/create_crate(object as text)
 	set name = "Create Crate"
-	set desc = "Spawn an crate from a supplypack datum. Append a period to the text in order to exclude subtypes of paths matching the input."
+	set desc = "Spawn a crate from a supplypack datum. Append a period to the text in order to exclude subtypes of paths matching the input."
 	set category = "Event"
 
 	if(!check_rights(R_SPAWN))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1199,12 +1199,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_SPAWN))
 		return
 
-	var/list/types = list()
-	for(var/typepath in subtypesof(/datum/supply_packs))
-		var/datum/supply_packs/P = typepath
-		if(initial(P.name) == "HEADER")
-			continue // To filter out group headers
-		types += P
+	var/list/types = SSeconomy.supply_packs
 
 	var/list/matches = list()
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1226,17 +1226,15 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!length(matches))
 		return
 
-	var/chosen
-	if(length(matches) == 1)
-		chosen = matches[1]
-	else
-		chosen = input("Select a supply crate type", "Create Crate", matches[1]) as null|anything in matches
-
+	var/chosen = input("Select a supply crate type", "Create Crate", matches[1]) as null|anything in matches
 	if(!chosen)
 		return
+	var/datum/supply_packs/the_pack = new chosen()
 
-	var/datum/supply_packs/the_pack = new chosen(get_turf(usr))
-	var/obj/structure/closet/crate/crate = the_pack.create_package(get_turf(usr))
+	var/spawn_location = get_turf(usr)
+	if(!spawn_location)
+		return
+	var/obj/structure/closet/crate/crate = the_pack.create_package(spawn_location)
 	crate.admin_spawned = TRUE
 	for(var/atom/A in crate.contents)
 		A.admin_spawned = TRUE

--- a/code/modules/supply/supply_order.dm
+++ b/code/modules/supply/supply_order.dm
@@ -27,10 +27,13 @@
 		return
 
 	//create the crate
-	var/obj/structure/closet/crate/crate = new object.containertype(_loc)
-	crate.name = "[object.containername] [comment ? "([comment])":"" ]"
-	if(object.access)
-		crate.req_access = list(text2num(object.access))
+	var/obj/structure/closet/crate/crate = object.create_package(_loc)
+
+	// var/obj/structure/closet/crate/crate = new object.containertype(_loc)
+	if(comment)
+		crate.name = "[crate.name] ([comment])"
+	// if(object.access)
+	// 	crate.req_access = list(text2num(object.access))
 
 	//create the manifest slip
 	var/obj/item/paper/manifest/slip = new
@@ -52,24 +55,8 @@
 	slip.info += "[packagesAmt] PACKAGES IN THIS SHIPMENT<br>"
 	slip.info += "CONTENTS:<br><ul>"
 
-	//we now create the actual contents
-	var/list/contains = list()
-	if(istype(object, /datum/supply_packs/misc/randomised))
-		var/datum/supply_packs/misc/randomised/SO = object
-		contains = list()
-		if(length(object.contains))
-			for(var/j in 1 to SO.num_contained)
-				contains += pick(object.contains)
-	else
-		contains = object.contains
-
-	for(var/typepath in contains)
-		if(!typepath)
-			continue
-		var/atom/A = new typepath(crate)
-		if(object.amount && A.vars.Find("amount") && A:amount)
-			A:amount = object.amount
-		slip.info += "<li>[A.name]</li>"	//add the item to the manifest (even if it was misplaced)
+	for(var/atom/A in crate.contents)
+		slip.info += "<li>[A.name]</li>"
 
 	if(istype(crate, /obj/structure/closet/critter)) // critter crates do not actually spawn mobs yet and have no contains var, but the manifest still needs to list them
 		var/obj/structure/closet/critter/CritCrate = crate

--- a/code/modules/supply/supply_order.dm
+++ b/code/modules/supply/supply_order.dm
@@ -29,11 +29,8 @@
 	//create the crate
 	var/obj/structure/closet/crate/crate = object.create_package(_loc)
 
-	// var/obj/structure/closet/crate/crate = new object.containertype(_loc)
 	if(comment)
 		crate.name = "[crate.name] ([comment])"
-	// if(object.access)
-	// 	crate.req_access = list(text2num(object.access))
 
 	//create the manifest slip
 	var/obj/item/paper/manifest/slip = new

--- a/code/modules/supply/supply_pack.dm
+++ b/code/modules/supply/supply_pack.dm
@@ -33,7 +33,7 @@
 		ui_manifest += "[initial(AM.name)]"
 	manifest += "</ul>"
 
-/datum/supply_packs/proc/create_package(spawn_location)
+/datum/supply_packs/proc/create_package(/atom/spawn_location)
 	var/obj/structure/closet/crate/crate = new containertype(spawn_location)
 
 	crate.name = containername

--- a/code/modules/supply/supply_pack.dm
+++ b/code/modules/supply/supply_pack.dm
@@ -33,7 +33,7 @@
 		ui_manifest += "[initial(AM.name)]"
 	manifest += "</ul>"
 
-/datum/supply_packs/proc/create_package(atom/spawn_location)
+/datum/supply_packs/proc/create_package(turf/spawn_location)
 	var/obj/structure/closet/crate/crate = new containertype(spawn_location)
 
 	crate.name = containername

--- a/code/modules/supply/supply_pack.dm
+++ b/code/modules/supply/supply_pack.dm
@@ -45,8 +45,9 @@
 		if(!typepath)
 			continue
 		var/atom/A = new typepath(crate)
-		if(amount && A.vars.Find("amount") && A:amount) // This is sketchy as hell
-			A:amount = amount
+		if(isstack(A))
+			var/obj/item/stack/mats = A
+			mats.amount = amount
 
 	return crate
 

--- a/code/modules/supply/supply_pack.dm
+++ b/code/modules/supply/supply_pack.dm
@@ -32,3 +32,29 @@
 		//Add the name to the UI manifest
 		ui_manifest += "[initial(AM.name)]"
 	manifest += "</ul>"
+
+/datum/supply_packs/proc/create_package(spawn_location)
+	var/obj/structure/closet/crate/crate = new containertype(spawn_location)
+
+	crate.name = containername
+	if(access)
+		crate.req_access = list(text2num(access))
+
+	//we now create the actual contents
+	for(var/typepath in generate_items())
+		if(!typepath)
+			continue
+		var/atom/A = new typepath(crate)
+		if(amount && A.vars.Find("amount") && A:amount) // This is sketchy as hell
+			A:amount = amount
+
+	return crate
+
+/datum/supply_packs/proc/generate_items()
+	return contains
+
+/datum/supply_packs/misc/randomised/generate_items()
+	. = list()
+	if(length(contains))
+		for(var/j in 1 to num_contained)
+			. += pick(contains)

--- a/code/modules/supply/supply_pack.dm
+++ b/code/modules/supply/supply_pack.dm
@@ -33,7 +33,7 @@
 		ui_manifest += "[initial(AM.name)]"
 	manifest += "</ul>"
 
-/datum/supply_packs/proc/create_package(/atom/spawn_location)
+/datum/supply_packs/proc/create_package(atom/spawn_location)
 	var/obj/structure/closet/crate/crate = new containertype(spawn_location)
 
 	crate.name = containername


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Allows admins to use the new "Create Crate" command, allowing them to summon any cargo crate at their current location. Its based heavily on the spawn_atom command.

This is different than spawning crates from the game panel, these crates will be copies of those you can order from cargo, which will be full of goodies.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Admins shouldnt need to manually put together crates like these if they want to send them

## Testing
<!-- How did you test the PR, if at all? -->
Spawned different types of crates. Unlocked, locked, critter crates, water tank crates, mule crates. All worked as expected. Buying crates from cargo worked as intended also, including manifests.

## Changelog
:cl:
add: [ADMIN] The "Create-Crate" tool will now let you spawn supply crates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
