### PR TITLE
Fixes janicart and mop bucket overlays not updating properly

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -37,6 +37,7 @@
 	I.forceMove(src)
 	updateUsrDialog()
 	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+	update_icon(UPDATE_OVERLAYS)
 	return
 
 /obj/structure/janitorialcart/on_reagent_change()
@@ -48,12 +49,11 @@
 	if(!I.is_robot_module())
 		if(istype(I, /obj/item/mop))
 			var/obj/item/mop/m=I
-			if(m.reagents.total_volume < m.reagents.maximum_volume && reagents.total_volume)
+			if(m.reagents.total_volume < m.reagents.maximum_volume)
 				m.wet_mop(src, user)
 				return
 			if(!mymop)
 				m.janicart_insert(user, src)
-				update_icon(UPDATE_OVERLAYS)
 			else
 				to_chat(user, fail_msg)
 
@@ -61,28 +61,24 @@
 			if(!mybag)
 				var/obj/item/storage/bag/trash/t=I
 				t.janicart_insert(user, src)
-				update_icon(UPDATE_OVERLAYS)
 			else
 				to_chat(user, fail_msg)
 		else if(istype(I, /obj/item/reagent_containers/spray/cleaner))
 			if(!myspray)
+				myspray = I
 				put_in_cart(I, user)
-				myspray=I
-				update_icon(UPDATE_OVERLAYS)
 			else
 				to_chat(user, fail_msg)
 		else if(istype(I, /obj/item/lightreplacer))
 			if(!myreplacer)
 				var/obj/item/lightreplacer/l=I
 				l.janicart_insert(user,src)
-				update_icon(UPDATE_OVERLAYS)
 			else
 				to_chat(user, fail_msg)
 		else if(istype(I, /obj/item/caution))
 			if(signs < max_signs)
-				put_in_cart(I, user)
 				signs++
-				update_icon(UPDATE_OVERLAYS)
+				put_in_cart(I, user)
 			else
 				to_chat(user, "<span class='notice'>[src] can't hold any more signs.</span>")
 		else if(istype(I, /obj/item/crowbar))

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -48,11 +48,12 @@
 	if(!I.is_robot_module())
 		if(istype(I, /obj/item/mop))
 			var/obj/item/mop/m=I
-			if(m.reagents.total_volume < m.reagents.maximum_volume)
+			if(m.reagents.total_volume < m.reagents.maximum_volume && reagents.total_volume)
 				m.wet_mop(src, user)
 				return
 			if(!mymop)
 				m.janicart_insert(user, src)
+				update_icon(UPDATE_OVERLAYS)
 			else
 				to_chat(user, fail_msg)
 
@@ -60,6 +61,7 @@
 			if(!mybag)
 				var/obj/item/storage/bag/trash/t=I
 				t.janicart_insert(user, src)
+				update_icon(UPDATE_OVERLAYS)
 			else
 				to_chat(user, fail_msg)
 		else if(istype(I, /obj/item/reagent_containers/spray/cleaner))
@@ -73,6 +75,7 @@
 			if(!myreplacer)
 				var/obj/item/lightreplacer/l=I
 				l.janicart_insert(user,src)
+				update_icon(UPDATE_OVERLAYS)
 			else
 				to_chat(user, fail_msg)
 		else if(istype(I, /obj/item/caution))

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -30,11 +30,12 @@
 /obj/structure/mopbucket/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/mop))
 		var/obj/item/mop/M = W
-		if(M.reagents.total_volume < M.reagents.maximum_volume)
+		if(M.reagents.total_volume < M.reagents.maximum_volume && reagents.total_volume)
 			M.wet_mop(src, user)
 			return
 		if(!stored_mop)
 			M.mopbucket_insert(user, src)
+			update_icon(UPDATE_OVERLAYS)
 			return
 		to_chat(user, "<span class='notice'>Theres already a mop in the mopbucket.</span>")
 		return

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -30,7 +30,7 @@
 /obj/structure/mopbucket/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/mop))
 		var/obj/item/mop/M = W
-		if(M.reagents.total_volume < M.reagents.maximum_volume && reagents.total_volume)
+		if(M.reagents.total_volume < M.reagents.maximum_volume)
 			M.wet_mop(src, user)
 			return
 		if(!stored_mop)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -35,7 +35,6 @@
 			return
 		if(!stored_mop)
 			M.mopbucket_insert(user, src)
-			update_icon(UPDATE_OVERLAYS)
 			return
 		to_chat(user, "<span class='notice'>Theres already a mop in the mopbucket.</span>")
 		return
@@ -45,6 +44,7 @@
 	user.drop_item()
 	I.forceMove(src)
 	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+	update_icon(UPDATE_OVERLAYS)
 	return
 
 /obj/item/mop/proc/mopbucket_insert(mob/user, obj/structure/mopbucket/J)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixed janicart and mop bucket overlays for mop, trashbag and light replacer not updating properly when inserted.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Overlays not updating when they should is bad
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/77684085/213077200-a8055594-3be4-4245-abc4-9f49aee2f4af.mp4


## Testing
<!-- How did you test the PR, if at all? -->
- See video above
## Changelog
:cl:
fix: Fixed janicart and mop bucket overlays not updating properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
