### PR TITLE
Removes automender smallhealth

### DIFF
--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -80,7 +80,6 @@
 		if(M.reagents)
 			applying = TRUE
 			update_icon(UPDATE_ICON_STATE)
-			apply_to(M, user, 0.2) // We apply a very weak application up front, then loop.
 			while(do_after(user, 10, target = M))
 				measured_health = M.health
 				apply_to(M, user, 1, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes the small injection by automenders before the timer begins.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
We have lots of different ways for applying healing reagents, but the automender takes the cake for the most braindead default choice applicator. This leads to a lack of diversity in non-medbay reagent application.

This PR makes it so that the automender isn't the default best at everything, with healing on the move being handled better by pills or patches.

Prevously fox has argued for retaining this (https://github.com/ParadiseSS13/Paradise/pull/14704), i quote: 

> The instantaneous application is so inconsequential as to be not worth mentioning; it's not really going to save your life or make much of a difference in the times it matters. In the long drawn out circumstances that I'm sure some hypothesize regarding this, you had time to stop and apply a full amount anyway.

I do not believe this is correct, as we have seen countless instances of people running around slapping themselves repeatedly with automenders. Especially during spacewalks to keep themselves alive easily.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Applied medication
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Automender no longer injects before the timer begins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
