### PR TITLE
Allows Prisoners to Use the Perma Library Computer

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -705,6 +705,7 @@
 	item_state = "orange-id"
 	assignment = "Prisoner"
 	registered_name = "Scum"
+	access = list(ACCESS_LIBRARY)
 	var/goal = 0 //How far from freedom?
 
 /obj/item/card/id/prisoner/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the Prisoner IDs `LIBRARY_ACCESS` so that they can use the book computer in Perma (mapping is scary and I didnt want to make a new Library Computer variant to clog map queue).

## Why It's Good For The Game
Allowing the Prisoners to read is good for morale. Library access is also not something that would be "useful" for a prisoner so far from the Library to begin with. In terms of an ID getting stolen and used by a Temp Prisoner from the cells, theyre simply asking for a free Theft + Trespass charge.

## Testing
I went and READ a BOOK!

## Changelog
:cl:
add: Added Library access to the Perma Prisoner ID so they can print books.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
