### PR TITLE
Assemblies containing an igniter do not prime grenade when used in hand

### DIFF
--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -56,5 +56,12 @@
 
 
 /obj/item/assembly/igniter/attack_self(mob/user)
-	activate()
+	if(cooldown > 0)
+		return FALSE
+	cooldown = 2
+	addtimer(CALLBACK(src, PROC_REF(process_cooldown)), 10)
+	var/turf/location = get_turf(loc)
+	if(location)
+		location.hotspot_expose(1000, 1000)
+	sparks.start()
 	add_fingerprint(user)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -56,12 +56,6 @@
 
 
 /obj/item/assembly/igniter/attack_self(mob/user)
-	if(cooldown > 0)
-		return FALSE
-	cooldown = 2
-	addtimer(CALLBACK(src, PROC_REF(process_cooldown)), 10)
-	var/turf/location = get_turf(loc)
-	if(location)
-		location.hotspot_expose(1000, 1000)
-	sparks.start()
+	if(!istype(loc, /obj/item/assembly_holder))
+		activate()
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Assemblies containing an igniter do not prime grenade when used in hand
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This was unintended behaviour introduced in a previous PR. Bombs should not explode in your hand while you're trying to set a timer for it or change the frequency on a signaller.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Build a timer-igniter assembly, use it in hand, bomb does not explode, set timer, bomb explodes upon timer elapsing.
Build a signaller-igniter assembly, use it in hand, bomb does not explode, signal bomb frequency and bomb explodes.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Assemblies containing an igniter do not prime grenade when used in hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
