### PR TITLE
Fix AI alarm camera selection locate scope.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -685,7 +685,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		unset_machine()
 		src << browse(null, t1)
 	if(href_list["switchcamera"])
-		switchCamera(locate(href_list["switchcamera"])) in GLOB.cameranet.cameras
+		switchCamera(locate(href_list["switchcamera"]) in GLOB.cameranet.cameras)
 	if(href_list["showalerts"])
 		ai_alerts()
 	if(href_list["show_paper"])


### PR DESCRIPTION
## What Does This PR Do
Fixes what is almost certainly a logic error in Topic lookup for AI alarm alerts.

I am almost 100% certain this `in` clause is meant to select a reference from the list of available cameras. In its current position it has no effect since it is at the top-level expression of the statement, and its result is just thrown away. In point of fact it is a syntax error to attempt to assign this value:
```
var/x = switchCamera(locate(href_list["switchcamera"])) in GLOB.cameranet.cameras
// leads to
code\modules\mob\living\silicon\ai\ai.dm:688:error: GLOB.cameranet.cameras: unexpected 'in' expression
```

## Why It's Good For The Game
This is technically a minor performance improvement, as the locate call is now no longer using `world` as its search scope, which is the default if no `in` clause is specified, in the (relatively) rare cases an AI player uses these camera links.

## Testing
Spawned into Meta as AI, triggered APC Overload event, checked alarm HTML and clicked around to various cameras. Checked to ensure no runtimes.
