### PR TITLE
Wallets and ID card tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -57,7 +57,7 @@
 		if(wearing_human.wear_id == src)
 			wearing_human.sec_hud_set_ID()
 
-	update_icon(UPDATE_ICON_STATE)
+	update_appearance(UPDATE_NAME|UPDATE_ICON_STATE)
 
 /obj/item/storage/wallet/update_icon_state()
 	if(front_id)
@@ -76,6 +76,16 @@
 				return
 	icon_state = "wallet"
 
+
+/obj/item/storage/wallet/update_name(updates)
+	. = ..()
+	if(front_id)
+		name = "wallet displaying [front_id]"
+	else
+		name = get_empty_wallet_name()
+
+/obj/item/storage/wallet/proc/get_empty_wallet_name()
+	return initial(name)
 
 /obj/item/storage/wallet/GetID()
 	return front_id
@@ -118,12 +128,11 @@
 		new color_wallet(loc)
 		qdel(src)
 		return
-	UpdateDesc()
+	update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_ICON_STATE)
 
-/obj/item/storage/wallet/color/proc/UpdateDesc()
-	name = "cheap [item_color] wallet"
+/obj/item/storage/wallet/color/update_desc(updates)
+	. = ..()
 	desc = "A cheap, [item_color] wallet from the arcade."
-	icon_state = "[item_color]_wallet"
 
 /obj/item/storage/wallet/color/update_icon_state()
 	if(front_id)
@@ -159,3 +168,6 @@
 
 /obj/item/storage/waller/color/brown
 	item_color = "brown"
+
+/obj/item/storage/wallet/color/get_empty_wallet_name()
+	return "cheap [item_color] wallet"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -494,12 +494,13 @@
 //gets name from ID or PDA itself, ID inside PDA doesn't matter
 //Useful when player is being seen by other mobs
 /mob/living/carbon/human/proc/get_id_name(if_no_id = "Unknown")
-	var/obj/item/pda/pda = wear_id
-	var/obj/item/card/id/id = wear_id
-	if(istype(pda))		. = pda.owner
-	else if(istype(id))	. = id.registered_name
-	if(!.) 				. = if_no_id	//to prevent null-names making the mob unclickable
-	return
+	var/obj/item/card/id/id = wear_id?.GetID()
+	if(istype(id))
+		return id.registered_name
+	if(is_pda(wear_id))
+		var/obj/item/pda/pda
+		return pda.owner
+	return if_no_id	//to prevent null-names making the mob unclickable
 
 //gets ID card object from special clothes slot or, if applicable, hands as well
 /mob/living/carbon/human/proc/get_idcard(check_hands = FALSE)
@@ -1771,15 +1772,13 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 /mob/living/carbon/human/can_track(mob/living/user)
 	if(wear_id)
-		var/obj/item/card/id/id = wear_id
+		var/obj/item/card/id/id = wear_id.GetID()
 		if(istype(id) && id.is_untrackable())
 			return 0
 	if(wear_pda)
-		var/obj/item/pda/pda = wear_pda
-		if(istype(pda))
-			var/obj/item/card/id/id = pda.id
-			if(istype(id) && id.is_untrackable())
-				return 0
+		var/obj/item/card/id/id = wear_pda.GetID()
+		if(istype(id) && id.is_untrackable())
+			return 0
 	if(istype(head, /obj/item/clothing/head))
 		var/obj/item/clothing/head/hat = head
 		if(hat.blockTracking)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -498,7 +498,7 @@
 	if(istype(id))
 		return id.registered_name
 	if(is_pda(wear_id))
-		var/obj/item/pda/pda
+		var/obj/item/pda/pda = wear_id
 		return pda.owner
 	return if_no_id	//to prevent null-names making the mob unclickable
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Allows you to see the front ID on a wallet when examining someone. Also minorly refactors colored wallets. Idea comes from TG wallets. It also fixes people showing as Unknowns when having a wallet equipped but a mask on. It also refactors the can_track proc to use getID instead, which will make it consistent with wallets.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Makes it easier to understand what ID card someone is wearing without using a security HUD, and makes stuff more consistent.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Has an ID
![image](https://user-images.githubusercontent.com/91113370/213361299-5b725bf1-8129-4aa1-9de1-809e91815541.png)
No ID
![image](https://user-images.githubusercontent.com/91113370/213361316-d78e6a28-1d37-45a3-82a2-5deb541bcada.png)

## Testing
<!-- How did you test the PR, if at all? -->
See above. Using arcade wallets, they appear exactly as before but also have the new functionality.

## Changelog
:cl:
tweak: You can now see a Wallet's front ID when examining someone.
tweak: ID cards are now considered when showing someone (As Unknown)
tweak: Anti-tracking ID cards can be used inside wallets now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
