### PR TITLE
Security bots now consider wallets when arresting people

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -502,16 +502,10 @@
 	return
 
 //gets ID card object from special clothes slot or, if applicable, hands as well
-/mob/living/carbon/human/proc/get_idcard(check_hands = FALSE)
-	var/obj/item/card/id/id = wear_id
-	var/obj/item/pda/pda = wear_id
+/mob/living/carbon/human/proc/get_idcard(check_hands = FALSE) // here
+	var/obj/item/card/id/id = wear_id?.GetID()
 	if(!istype(id)) //We only check for PDAs if there isn't an ID in the ID slot. IDs take priority.
-		if(istype(pda) && pda.id)
-			id = pda.id
-		else
-			pda = wear_pda
-			if(istype(pda) && pda.id)
-				id = pda.id
+		id = wear_pda?.GetID()
 
 	if(check_hands)
 		if(istype(get_active_hand(), /obj/item/card/id))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -463,7 +463,7 @@
 	return if_no_id
 
 /mob/living/carbon/human/get_id_card(mob/living/carbon/human/H)
-	var/obj/item/card/id/id = wear_id.GetID()
+	var/obj/item/card/id/id = wear_id?.GetID()
 	if(istype(id)) // Make sure its actually an ID
 		return id
 	if(H.get_active_hand())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Currently, beepsky will think you dont have an ID if youre wearing a wallet with an ID in it. Beepsky now considers any IDs when considering weapon arrests/No ID arrests. It also fixes a runtime with people not wearing an ID causing a large runtime log.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Walking into the armory with a wallet on but a valid ID in it current gets you walloped by Armsky

## Testing
<!-- How did you test the PR, if at all? -->
Weapons mode on:
no ID, with a gun - arrested
HOS ID with a gun - not arrested
HOS ID in a wallet with a gun - not arrested
empty wallet with a gun - arrested

No ID arrest mode on:
No ID - arrested
HOS ID - not arrested
HOS ID in wallet - not arrested
empty wallet - arrested

## Changelog
:cl:
tweak: Security bots now consider wallets when performing arrests
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
