### PR TITLE
Re-enable logging for request consoles.

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -153,6 +153,7 @@ GLOBAL_DATUM_INIT(major_announcement, /datum/announcer, new(config_type = /datum
 
 /datum/announcement_configuration/requests_console
 	style = "minor"
+	add_log = TRUE
 
 /datum/announcement_configuration/comms_console
 	default_title = "Priority Announcement"


### PR DESCRIPTION
## What Does This PR Do
Sets the announcement config for request consoles to be logged.
## Why It's Good For The Game
This ensures that all proper logs are logged. Log.
## Testing
Launched server, spawned in, made bridge announcement, checked the output of `game.log`. Ensured ckey, character name, announcement type, and full text of the announcement were logged.
