### PR TITLE
WIP: The start of making some grand theft items more valuable: The captains rapier.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -78,6 +78,8 @@
 #define NO_MALF_EFFECT_2		(1<<17)
 /// Use when this shouldn't be obscured by large icons.
 #define CRITICAL_ATOM_2			(1<<18)
+//Use this flag for items that can block randomly
+#define RANDOM_BLOCKER_2		(1<<19)
 
 //Reagent flags
 #define REAGENT_NOREACT			1

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -45,7 +45,7 @@
 
 /datum/theft_objective/captains_rapier
 	name = "the captain's rapier"
-	typepath = /obj/item/melee/rapier
+	typepath = /obj/item/twohanded/rapier
 	protected_jobs = list("Captain")
 	location_override = "the Captain's Office"
 

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -20,26 +20,7 @@
 	to_chat(viewers(user), "<span class='suicide'>[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	return OXYLOSS
 
-/obj/item/melee/rapier
-	name = "captain's rapier"
-	desc = "An elegant weapon, for a more civilized age."
-	icon_state = "rapier"
-	item_state = "rapier"
-	flags = CONDUCT
-	force = 15
-	throwforce = 10
-	w_class = WEIGHT_CLASS_BULKY
-	armour_penetration_percentage = 75
-	sharp = TRUE
-	origin_tech = "combat=5"
-	attack_verb = list("lunged at", "stabbed")
-	hitsound = 'sound/weapons/rapierhit.ogg'
-	materials = list(MAT_METAL = 1000)
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF // Theft targets should be hard to destroy
 
-/obj/item/melee/rapier/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.5, _parryable_attack_types = NON_PROJECTILE_ATTACKS)
 
 /obj/item/melee/icepick
 	name = "ice pick"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -608,10 +608,10 @@
 	storage_slots = 1
 	w_class = WEIGHT_CLASS_BULKY
 	max_w_class = WEIGHT_CLASS_BULKY
-	can_hold = list(/obj/item/melee/rapier)
+	can_hold = list(/obj/item/twohanded/rapier)
 
 /obj/item/storage/belt/rapier/populate_contents()
-	new /obj/item/melee/rapier(src)
+	new /obj/item/twohanded/rapier(src)
 	update_icon()
 
 /obj/item/storage/belt/rapier/attack_hand(mob/user)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -973,10 +973,9 @@
 	origin_tech = "combat=5"
 	attack_verb = list("lunged at", "stabbed")
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	wieldsound = 'sound/weapons/rapierhit.ogg'
-	unwieldsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF // Theft targets should be hard to destroy
+	flags_2 = RANDOM_BLOCKER_2
 
 /obj/item/twohanded/rapier/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!wielded || attack_type == PROJECTILE_ATTACK)
@@ -1030,9 +1029,11 @@
 				if(1)
 					owner.visible_message("<span class='danger'>[output] is grazed lightly by [src]!</span>")
 					output.apply_damage(force / 3 , BRUTE, output.run_armor_check(dam_zone, MELEE, null, null, armour_penetration_flat, armour_penetration_percentage))
+					playsound(get_turf(src), 'sound/weapons/rapierhit.ogg', 100, 1)
 				if(2)
 					owner.visible_message("<span class='danger'>[output] is grazed heavily by [src]!</span>")
 					output.apply_damage(force * 0.66, BRUTE, output.run_armor_check(dam_zone, MELEE, null, null, armour_penetration_flat, armour_penetration_percentage))
+					playsound(get_turf(src), 'sound/weapons/rapierhit.ogg', 100, 1)
 				if(3)
 					melee_attack_chain(owner, output)
 	if(.) //We do have them retaliate if block failed, or take stamina if block failed. Graze chance will be ignored if so.
@@ -1048,6 +1049,7 @@
 				owner.visible_message("<span class='danger'>[owner] is grazed heavily by [hitby]!</span>")
 				owner.apply_damage(damage * 0.66 , BRUTE, dam_zone)
 		owner.adjustStaminaLoss(5 + damage / 1.75)
+		playsound(owner, 'sound/weapons/parry.ogg', clamp(damage / 1.75, 40, 120))
 		return TRUE
 
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -244,6 +244,10 @@ emp_act
 	var/datum/component/parry/left_hand_parry = l_hand?.GetComponent(/datum/component/parry)
 	var/datum/component/parry/right_hand_parry = r_hand?.GetComponent(/datum/component/parry)
 	if(!right_hand_parry && !left_hand_parry)
+		if(l_hand?.flags_2 & RANDOM_BLOCKER_2)
+			return l_hand
+		if(r_hand?.flags_2 & RANDOM_BLOCKER_2)
+			return r_hand
 		return null // no parry component
 
 	if(right_hand_parry && left_hand_parry)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -582,10 +582,10 @@
 		else if(!user.IsStunned())
 			target.Stun(0.5 SECONDS)
 	else
-		if(target.IsSlowed() && target.get_active_hand())
+		if(target.IsSlowed() && target.get_active_hand() && !forced)
 			target.drop_item()
 			add_attack_logs(user, target, "Disarmed object out of hand", ATKLOG_ALL)
-		else
+		else if(!forced)
 			target.Slowed(2.5 SECONDS, 1)
 			var/obj/item/I = target.get_active_hand()
 			if(I)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -512,10 +512,10 @@
 			target.forcesay(GLOB.hit_appends)
 		SEND_SIGNAL(target, COMSIG_PARENT_ATTACKBY)
 
-/datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
+/datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style, forced = FALSE)
 	if(user == target)
 		return FALSE
-	if(target.check_block())
+	if(!forced && target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s disarm attempt!</span>")
 		return FALSE
 	if(target.absorb_stun(0))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Ignore the flag_2 stuff, temporary for testing while I wait.

The captains rapier is now a weapon that can be wielded, like a fire axe.
When wielded, the rapier becomes a powerful defencive weapon, reactive to intent.
By default, it can block, but when blocking it may shove the attacker back as the user lunges at them, or have the user get shoved back as they get lunged at.
The user may get grazed by attackers after blocking successfully, and when attacking back, may graze or even hit them.
User takes stamina damage per hit.
Intents will increase / decrease these values, help being defencive, disarm focusing on shoving back, harm being heavy offence, and grab being balanced.


## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Grand theft items should arguably be a useful unique item, or important to the station when stolen.
At the moment, the rapier while a nice armor peircing melee weapon, isn't that unique, nor will the captain really care when it is stolen.
Now, the item is valuable enough for the syndicate to want, and captain to care about. A nanomachine powered rapier, that teaches people how to fence well? Valuable, similar to the krav gloves.
Also is an interesting defencive option for a captain. Allows one to be quite defencive in melee, with many options, interact with the enviroment with the disarm system, while not allowing the user to use other weapons while active, and being quite vulnerable to range.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

Some clips, not all up to date, it will no longer slow people on disarm or causing people to drop items when not shoved into a wall.

https://cdn.discordapp.com/attachments/145700319819464704/1065798121428353135/Paradise_Station_13_2023-01-19_20-00-54.mp4

https://cdn.discordapp.com/attachments/145700319819464704/1065801783194177646/Paradise_Station_13_2023-01-19_20-15-18.mp4

## Testing
<!-- How did you test the PR, if at all? -->
Engaged in melee combat with various intents.

## Changelog
:cl:
tweak: The captains rapier can now be wielded, to teach the user some great fencing skills, for offense and defense.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
