### PR TITLE
fixes a floor tile runtime

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -166,6 +166,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 
 	if(intact && istype(C, /obj/item/stack/tile))
 		try_replace_tile(C, user, params)
+		return TRUE
 
 	if(istype(C, /obj/item/pipe))
 		var/obj/item/pipe/P = C


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds a missing RETURN TRUE to the try_replace_floortile proc

## Why It's Good For The Game
Runtimes bad, incorrect proc calls are bad

## Testing
Compiled and ran

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
