### PR TITLE
Changelings no longer have to debrain changelings

### DIFF
--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -8,6 +8,7 @@
 #define TARGET_INVALID_EVENT		7
 #define TARGET_INVALID_IS_TARGET	8
 #define TARGET_INVALID_BLACKLISTED	9
+#define TARGET_INVALID_CHANGELING	10
 
 //gamemode istype helpers
 #define GAMEMODE_IS_BLOB		(SSticker && istype(SSticker.mode, /datum/game_mode/blob))

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -214,8 +214,9 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	martyr_compatible = 0
 
 /datum/objective/debrain/is_invalid_target(datum/mind/possible_target)
-	if(..())
-		return ..()
+	. = ..()
+	if(.)
+		return
 	// If the target is a changeling, then it's an invalid target. Since changelings can not be debrained.
 	if(ischangeling(possible_target.current))
 		return TARGET_INVALID_CHANGELING

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -213,6 +213,12 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	name = "Debrain"
 	martyr_compatible = 0
 
+/datum/objective/debrain/is_invalid_target(datum/mind/possible_target)
+	if(..() || !possible_target.current.client)
+		return TRUE
+	// If the target is a changeling, then it's an invalid target. Since changelings can not be debrained.
+	return ischangeling(possible_target.current)
+
 /datum/objective/debrain/find_target(list/target_blacklist)
 	..()
 	if(target && target.current)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -220,7 +220,6 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	// If the target is a changeling, then it's an invalid target. Since changelings can not be debrained.
 	if(ischangeling(possible_target.current))
 		return TARGET_INVALID_CHANGELING
-	return
 
 /datum/objective/debrain/find_target(list/target_blacklist)
 	..()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -214,10 +214,12 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	martyr_compatible = 0
 
 /datum/objective/debrain/is_invalid_target(datum/mind/possible_target)
-	if(..() || !possible_target.current.client)
-		return TRUE
+	if(..())
+		return ..()
 	// If the target is a changeling, then it's an invalid target. Since changelings can not be debrained.
-	return ischangeling(possible_target.current)
+	if(ischangeling(possible_target.current))
+		return TARGET_INVALID_CHANGELING
+	return
 
 /datum/objective/debrain/find_target(list/target_blacklist)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Changelings no longer have to debrain changelings, since well, debraining them isn't their real mind, nor does it kill them.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Impossible to complete objectives make no sense. It is good to have changelings be targeted by traitors / changelings, but it's also good to not give people impossible objectives.

In an ideal world, this would stay a debrain objective, then update to assassinate once the changeling revives / uses some offensive cling power on a person. Hard to code well, so this is the better solution for now

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed that the game would not roll the changeling as a target.

## Changelog
:cl:
fix: Changelings no longer have to debrain changelings, as the objective is impossible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
