### PR TITLE
IDs with alternative titles now be able to select account associated with their department

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -253,7 +253,7 @@
 	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
 
 /obj/item/card/id/proc/get_departments()
-	return get_departments_from_job(assignment)
+	return get_departments_from_job(rank)
 
 /obj/item/card/id/attackby(obj/item/W as obj, mob/user as mob, params)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
IDs with alternative titles (Most notably acting heads) will now be able to select account associated with their department regardless of the title.
Fixes: #19779
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Acting heads should probably have access to their department's funds.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Create research director ID, rename the ID to Acting Research Director, attempt to order a crate on the science account.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: IDs with alternative titles are now able to select account associated with their department.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
