### PR TITLE
Orbit option on right click

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -92,6 +92,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	RegisterSignal(src, COMSIG_MOB_HUD_CREATED, PROC_REF(set_ghost_darkness_level)) //something something don't call this until we have a HUD
 	..()
 	plane = GAME_PLANE
+	add_observer_verbs()
 
 /mob/dead/observer/Destroy()
 	toggle_all_huds_off()
@@ -105,6 +106,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		QDEL_NULL(orbit_menu)
 	if(seerads)
 		STOP_PROCESSING(SSobj, src)
+	remove_observer_verbs()
 	return ..()
 
 /mob/dead/observer/examine(mob/user)
@@ -444,8 +446,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	orbit_menu.ui_interact(src)
 
+/mob/dead/observer/proc/add_observer_verbs()
+	verbs.Add(/mob/dead/observer/proc/ManualFollow)
+
+/mob/dead/observer/proc/remove_observer_verbs()
+	verbs.Remove(/mob/dead/observer/proc/ManualFollow)
+
 // This is the ghost's follow verb with an argument
 /mob/dead/observer/proc/ManualFollow(atom/movable/target)
+	set name = "\[Observer\] Orbit"
+	set desc = "Orbits the specified movable atom."
+	set category = null
+
 	if(!target || !isobserver(usr))
 		return
 
@@ -508,21 +520,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	to_chat(A, "This mob is not located in the game world.")
 
-/* Now a spell.  See spells.dm
-/mob/dead/observer/verb/boo()
-	set category = "Ghost"
-	set name = "Boo!"
-	set desc= "Scare your crew members because of boredom!"
-
-	if(bootime > world.time) return
-	bootime = world.time + 600
-	var/obj/machinery/light/L = locate(/obj/machinery/light) in view(1, src)
-	if(L)
-		L.flicker()
-	//Maybe in the future we can add more <i>spooky</i> code here!
-	return
-*/
-
 /mob/dead/observer/memory()
 	set hidden = 1
 	to_chat(src, "<span class='warning'>You are dead! You have no mind to store memory!</span>")
@@ -530,7 +527,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/add_memory()
 	set hidden = 1
 	to_chat(src, "<span class='warning'>You are dead! You have no mind to store memory!</span>")
-
 
 /mob/dead/observer/verb/toggle_health_scan()
 	set name = "Toggle Health Scan"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the ability to orbit a movable atom by using the right click
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Double clicking something that is moving, that has a ghost on top of it, or searching for it in the orbit menu is time consuming.
This is a small QoL to let you do this on the right click as a ghost.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
**User:**
![image](https://user-images.githubusercontent.com/12197162/214158545-5c855e40-d27a-4e77-aa2b-c80f7b711e76.png)

**Admin:**
![image](https://user-images.githubusercontent.com/12197162/214158551-1a0ba461-5fd1-4c9a-8033-16695a9256b6.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Orbited things, incarnated myself and could no longer orbit
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Added the ability to orbit a movable atom from the right click menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
