### PR TITLE
Minor is_blocked_turf optimization

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -602,11 +602,14 @@ Returns 1 if the chain up to the area contains the given typepath
 /proc/is_blocked_turf(turf/T, exclude_mobs)
 	if(T.density)
 		return TRUE
-	for(var/i in T)
-		var/atom/A = i
-		if(isAI(A)) //Prevents jaunting onto the AI core cheese, AI should always block a turf due to being a dense mob even when unanchored
-			return TRUE
-		if(A.density && (!exclude_mobs || !ismob(A)))
+	if(locate(/mob/living/silicon/ai) in T) //Prevents jaunting onto the AI core cheese, AI should always block a turf due to being a dense mob even when unanchored
+		return TRUE
+	if(!exclude_mobs)
+		for(var/mob/living/L in T)
+			if(L.density)
+				return TRUE
+	for(var/obj/O in T)
+		if(O.density)
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the `is_blocked_turf` proc a little bit so it doesn't iterate over the entire contents of a turf unless it has to. So in this case, returning immediately if it finds an AI instead of happening to come across one at some point in the loop. The double negative with `||` was also hurting my head, and it made sense to simply check for living mobs first if `exclude_mobs` isn't true. The likelyhood of living mobs dogpiling in a turf are low, so it'd be in the single digits to check before actually iterating over objects.

## Why It's Good For The Game
To be honest, I was doing other optimizations until I came across this proc and got confused. So I decided to fix it first.

## Testing
I tried jaunting or placing holosigns among other things.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
