### PR TITLE
Moves job-necessary things out of contraband in botany vendors

### DIFF
--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -75,9 +75,17 @@
 	icon_deny = "nutri_deny"
 	icon_lightmask = "nutri"
 	icon_panel = "thin_vendor"
-	products = list(/obj/item/reagent_containers/glass/bottle/nutrient/ez = 20, /obj/item/reagent_containers/glass/bottle/nutrient/l4z = 13, /obj/item/reagent_containers/glass/bottle/nutrient/rh = 6, /obj/item/reagent_containers/spray/pestspray = 20,
-					/obj/item/reagent_containers/syringe = 5, /obj/item/storage/bag/plants = 5, /obj/item/cultivator = 3, /obj/item/shovel/spade = 3, /obj/item/plant_analyzer = 4)
-	contraband = list(/obj/item/reagent_containers/glass/bottle/ammonia = 10, /obj/item/reagent_containers/glass/bottle/diethylamine = 5)
+	products = list(/obj/item/reagent_containers/glass/bottle/nutrient/ez = 20,
+					/obj/item/reagent_containers/glass/bottle/nutrient/l4z = 13,
+					/obj/item/reagent_containers/glass/bottle/nutrient/rh = 6,
+					/obj/item/reagent_containers/spray/pestspray = 20,
+					/obj/item/reagent_containers/syringe = 5,
+					/obj/item/storage/bag/plants = 5,
+					/obj/item/cultivator = 3,
+					/obj/item/shovel/spade = 3,
+					/obj/item/plant_analyzer = 4,
+					/obj/item/reagent_containers/glass/bottle/ammonia = 10,
+					/obj/item/reagent_containers/glass/bottle/diethylamine = 5)
 	refill_canister = /obj/item/vending_refill/hydronutrients
 
 /obj/machinery/economy/vending/hydroseeds
@@ -106,15 +114,18 @@
 					/obj/item/seeds/nymph =3,
 					/obj/item/seeds/eggplant = 3,
 					/obj/item/seeds/garlic = 3,
+					/obj/item/seeds/glowshroom = 3,
 					/obj/item/seeds/grape = 3,
 					/obj/item/seeds/grass = 3,
 					/obj/item/seeds/lemon = 3,
 					/obj/item/seeds/lime = 3,
 					/obj/item/seeds/mint = 3,
+					/obj/item/seeds/nettle = 3,
 					/obj/item/seeds/onion = 3,
 					/obj/item/seeds/orange = 3,
 					/obj/item/seeds/peanuts = 3,
 					/obj/item/seeds/pineapple = 3,
+					/obj/item/seeds/plump = 3,
 					/obj/item/seeds/poppy = 3,
 					/obj/item/seeds/potato = 3,
 					/obj/item/seeds/pumpkin = 3,
@@ -134,10 +145,7 @@
 	contraband = list(/obj/item/seeds/cannabis = 3,
 					/obj/item/seeds/amanita = 2,
 					/obj/item/seeds/fungus = 3,
-					/obj/item/seeds/glowshroom = 2,
 					/obj/item/seeds/liberty = 2,
-					/obj/item/seeds/nettle = 2,
-					/obj/item/seeds/plump = 2,
 					/obj/item/seeds/reishi = 2,
 					/obj/item/seeds/starthistle = 2,
 					/obj/item/seeds/random = 2)

--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -125,7 +125,6 @@
 					/obj/item/seeds/orange = 3,
 					/obj/item/seeds/peanuts = 3,
 					/obj/item/seeds/pineapple = 3,
-					/obj/item/seeds/plump = 3,
 					/obj/item/seeds/poppy = 3,
 					/obj/item/seeds/potato = 3,
 					/obj/item/seeds/pumpkin = 3,
@@ -146,6 +145,7 @@
 					/obj/item/seeds/amanita = 2,
 					/obj/item/seeds/fungus = 3,
 					/obj/item/seeds/liberty = 2,
+					/obj/item/seeds/plump = 2,
 					/obj/item/seeds/reishi = 2,
 					/obj/item/seeds/starthistle = 2,
 					/obj/item/seeds/random = 2)


### PR DESCRIPTION
## What Does This PR Do

PRing the only non-contentious parts of #19789 

The following is no longer contraband in botany's vendors:

**Nutrimax**
- ammonia bottle
- diethylamine bottle

**MegaSeed Servitor**
- glowshroom (bumped from 2 packs to 3 to be in line with the other seeds)
- nettle (same as above)

## Why It's Good For The Game

Ammonia and diethylamine are both used for two things, 1) you dumped copious amounts of mutagen on the plant and now it is dying, it needs health 2) you want to increase yield. If you dump all 300u ammonia and 150u diethylamine on a plant, you can increase its yield by 6.

Glowshroom and nettle are needed every single round for RND, it is tiresome to go ";hello can someone hack my vendor please or science will yell at me for not going to cargo to get the funny yellow gameboy" every round, or, worse, having to get a multitool as a botanist, as it is not part of their kit.

Botany still has to go beg RND for a chem dispenser or medchem for starter chems to actually start doing the fun part of their job, that's another issue we apparently did not find a good solution for. This PR would at least make the hacking part a non-issue for them.

## Images of changes

![image](https://user-images.githubusercontent.com/33333517/214254024-1de55cf4-4fe0-4226-8ba2-8fa0703c818a.png)

![image](https://user-images.githubusercontent.com/33333517/214254068-3d4cab97-80ed-472e-8abc-c43d098280de.png)


## Testing

Spawned in the vendors, checked their contents.

## Changelog
:cl:
tweak: The following items are no longer contraband in botany's vendors: ammonia bottle, diethylamine bottle, glowshroom seeds, nettle seeds. Instead, they are accessible from the get-go.
tweak: Added one more glowshroom and nettle seed packets to bring them in line with the other standard ones.
/:cl:
