### PR TITLE
Alt-click on disposal bins to manually eject their contents

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -325,7 +325,7 @@
 	"<span class='notice'>You operate the manual ejection lever on [src].</span>")
 	if(do_after(user, 5 SECONDS, target = src))
 		user.visible_message(
-		"<span class='notice'>[user] ejects the contents of [src].'.</span>",
+		"<span class='notice'>[user] ejects the contents of [src].</span>",
 		"<span class='notice'>You eject the contents of [src].</span>")
 		eject()
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -321,12 +321,14 @@
 	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	user.visible_message(
-	"<span class='notice'>[user] tries to eject the contents of [src] manually.</span>",
-	"<span class='notice'>You operate the manual ejection lever on [src].</span>")
+		"<span class='notice'>[user] tries to eject the contents of [src] manually.</span>",
+		"<span class='notice'>You operate the manual ejection lever on [src].</span>"
+	)
 	if(do_after(user, 5 SECONDS, target = src))
 		user.visible_message(
-		"<span class='notice'>[user] ejects the contents of [src].</span>",
-		"<span class='notice'>You eject the contents of [src].</span>")
+			"<span class='notice'>[user] ejects the contents of [src].</span>",
+			"<span class='notice'>You eject the contents of [src].</span>"
+		)
 		eject()
 
 // update the icon & overlays to reflect mode & status

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -9,7 +9,7 @@
 
 /obj/machinery/disposal
 	name = "disposal unit"
-	desc = "A pneumatic waste disposal unit."
+	desc = "A pneumatic waste disposal unit. Alt-click to manually eject its contents."
 	icon = 'icons/obj/pipes/disposal.dmi'
 	icon_state = "disposal"
 	anchored = TRUE
@@ -316,6 +316,18 @@
 		AM.forceMove(loc)
 		AM.pipe_eject(0)
 	update()
+
+/obj/machinery/disposal/AltClick(mob/user)
+	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return
+	user.visible_message(
+	"<span class='notice'>[user] tries to eject the contents of [src] manually.</span>",
+	"<span class='notice'>You operate the manual ejection lever on [src].</span>")
+	if(do_after(user, 5 SECONDS, target = src))
+		user.visible_message(
+		"<span class='notice'>[user] ejects the contents of [src].'.</span>",
+		"<span class='notice'>You eject the contents of [src].</span>")
+		eject()
 
 // update the icon & overlays to reflect mode & status
 /obj/machinery/disposal/proc/update()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows humanoids (Borgs are unable to) to Alt-click on disposal bins to manually eject their contents after 5 seconds, even when depowered.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently when a disposals bin is depowered, the only way to get the contents out is by destroying the bin or powering it. This PR should offer a viable alternative to this.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Put something in a disposals bin, alt-click it, 5 seconds later the contents are ejected.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Alt-clicking on a disposal bin as a human now manually ejects its contents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
