### PR TITLE
Add SSair Recover

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -47,21 +47,6 @@ SUBSYSTEM_DEF(air)
 	var/list/currentrun = list()
 	var/currentpart = SSAIR_DEFERREDPIPENETS
 
-/datum/controller/subsystem/air/Recover()
-	excited_groups |= SSair.excited_groups
-	active_turfs |= SSair.active_turfs
-	hotspots |= SSair.hotspots
-	deferred_pipenet_rebuilds |= SSair.deferred_pipenet_rebuilds
-	networks |= SSair.networks
-	atmos_machinery |= SSair.atmos_machinery
-	pipe_init_dirs_cache |= SSair.pipe_init_dirs_cache
-	machinery_to_construct |= SSair.machinery_to_construct
-	active_super_conductivity |= SSair.active_super_conductivity
-	high_pressure_delta |= SSair.high_pressure_delta
-	icon_manager = SSair.icon_manager
-	currentrun |= SSair.currentrun
-	currentpart = SSair.currentpart
-
 /datum/controller/subsystem/air/get_stat_details()
 	var/list/msg = list()
 	msg += "C:{"
@@ -100,6 +85,21 @@ SUBSYSTEM_DEF(air)
 	setup_pipenets(GLOB.machines)
 	for(var/obj/machinery/atmospherics/A in machinery_to_construct)
 		A.initialize_atmos_network()
+
+/datum/controller/subsystem/air/Recover()
+	excited_groups = SSair.excited_groups
+	active_turfs = SSair.active_turfs
+	hotspots = SSair.hotspots
+	deferred_pipenet_rebuilds = SSair.deferred_pipenet_rebuilds
+	networks = SSair.networks
+	atmos_machinery = SSair.atmos_machinery
+	pipe_init_dirs_cache = SSair.pipe_init_dirs_cache
+	machinery_to_construct = SSair.machinery_to_construct
+	active_super_conductivity = SSair.active_super_conductivity
+	high_pressure_delta = SSair.high_pressure_delta
+	icon_manager = SSair.icon_manager
+	currentrun = SSair.currentrun
+	currentpart = SSair.currentpart
 
 /datum/controller/subsystem/air/fire(resumed = 0)
 	var/timer = TICK_USAGE_REAL

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -58,7 +58,7 @@ SUBSYSTEM_DEF(air)
 	machinery_to_construct |= SSair.machinery_to_construct
 	active_super_conductivity |= SSair.active_super_conductivity
 	high_pressure_delta |= SSair.high_pressure_delta
-	icon_manager = icon_manager
+	icon_manager = SSair.icon_manager
 	currentrun |= SSair.currentrun
 	currentpart = SSair.currentpart
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -47,6 +47,21 @@ SUBSYSTEM_DEF(air)
 	var/list/currentrun = list()
 	var/currentpart = SSAIR_DEFERREDPIPENETS
 
+/datum/controller/subsystem/air/Recover()
+	excited_groups |= SSair.excited_groups
+	active_turfs |= SSair.active_turfs
+	hotspots |= SSair.hotspots
+	deferred_pipenet_rebuilds |= SSair.deferred_pipenet_rebuilds
+	networks |= SSair.networks
+	atmos_machinery |= SSair.atmos_machinery
+	pipe_init_dirs_cache |= SSair.pipe_init_dirs_cache
+	machinery_to_construct |= SSair.machinery_to_construct
+	active_super_conductivity |= SSair.active_super_conductivity
+	high_pressure_delta |= SSair.high_pressure_delta
+	icon_manager = icon_manager
+	currentrun |= SSair.currentrun
+	currentpart = SSair.currentpart
+
 /datum/controller/subsystem/air/get_stat_details()
 	var/list/msg = list()
 	msg += "C:{"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the SSair Recover override.

## Why It's Good For The Game
Seems like peeps found a way to make Atmos go tits up, and since it can't recover, that's bad.

## Testing
Let the ai sat die, checked the offline SSair and it still had the original's pipenets and turfs.

![Atmos](https://user-images.githubusercontent.com/80771500/214887777-49bf8070-50e3-4879-83f4-152fda62c829.png)

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
