### PR TITLE
Stops the mother of terror from shitting out too much jelly

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -82,8 +82,11 @@
 		to_chat(src, "<span class='danger'>Cannot secrete jelly in space.</span>")
 		return
 	visible_message("<span class='notice'>[src] begins to secrete royal jelly.</span>")
-	if(do_after(src, 100, target = loc))
+	if(do_after_once(src, 100, target = loc, attempt_cancel_message = "You stop producing jelly."))
 		if(loc != mylocation)
+			return
+		if(regen_points < jelly_cost)
+			to_chat(src, "<span class='danger'>You only have [regen_points] of the [jelly_cost] regeneration points you need to do this.</span>")
 			return
 		new /obj/structure/spider/royaljelly(loc)
 		regen_points -= jelly_cost


### PR DESCRIPTION
## What Does This PR Do
Puts a check after the do_after. As well as converts the `do_after` to a `do_after_once`.

## Why It's Good For The Game
Shouldn't be able to get more jelly than you can buy

## Testing
Spawned myself a MOT. Set the regen variable to 100. Started the process, stopped it by doing it again. Started it again and set my regen stat to 10 so it would fail once the do_after was done.

## Changelog
:cl:
fix: Mother of terrors can't produce jelly they can't afford
/:cl: