### PR TITLE
buffs the changeling's shield

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -368,7 +368,7 @@
 	var/obj/item/shield/changeling/S = ..(user)
 	if(!S)
 		return FALSE
-	S.remaining_uses = round(cling.absorbed_count * 3)
+	S.remaining_uses = round(cling.absorbed_count * 5)
 	return TRUE
 
 /obj/item/shield/changeling
@@ -381,7 +381,7 @@
 
 /obj/item/shield/changeling/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.5, _parryable_attack_types = ALL_ATTACK_TYPES)
+	AddComponent(/datum/component/parry, _stamina_constant = 0, _stamina_coefficient = 0, _parryable_attack_types = ALL_ATTACK_TYPES)
 	if(ismob(loc))
 		loc.visible_message("<span class='warning'>The end of [loc.name]\'s hand inflates rapidly, forming a huge shield-like mass!</span>", "<span class='warning'>We inflate our hand into a strong shield.</span>", "<span class='warning'>You hear organic matter ripping and tearing!</span>")
 
@@ -392,10 +392,9 @@
 			H.visible_message("<span class='warning'>With a sickening crunch, [H] reforms [H.p_their()] shield into an arm!</span>", "<span class='notice'>We assimilate our shield into our body</span>", "<span class='italics>You hear organic matter ripping and tearing!</span>")
 			H.unEquip(src, 1)
 		qdel(src)
-		return 0
-	else
-		remaining_uses--
-		return ..()
+		return FALSE
+	remaining_uses--
+	return ..()
 
 
 /***************************************\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changeling shield no longer deals stamina damage to the user on parry 
Changeling shield now gains 5 uses per DNA, rather than 3

## Why It's Good For The Game
Right now this ability is pretty bad and from the survey I've been running, this was the most suggested ability to be buffed. Resetting stamina damage upon use is bad against nonlethals and the fact this ability requires more active use than fleshmend while being pretty much always worse against lethals is also bad.
Might end up adding a little extra on this later but letting this do well against nonlethal options is a good start
5 uses per DNA gained because 3 is just sad 

## Testing
played dodgeball with some turrets

## Changelog
:cl:
tweak: organic shield no longer deals stamina damage to the user on a successful parry 
tweak: organic shield now gains 5 uses from each DNA strand, rather than 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
