### PR TITLE
Attacks on turrets no longer do 2x-> 1.5x damage, and now respect armor

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -383,7 +383,6 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	else
 		//if the turret was attacked with the intention of harming it:
 		user.changeNext_move(CLICK_CD_MELEE)
-		take_damage(I.force * 0.5)
 		playsound(src.loc, 'sound/weapons/smash.ogg', 60, 1)
 		if(I.force * 0.5 > 1) //if the force of impact dealt at least 1 damage, the turret gets pissed off
 			if(!attacked && !emagged)
@@ -430,14 +429,16 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		sleep(60) //6 seconds for the traitor to gtfo of the area before the turret decides to ruin his shit
 		enabled = TRUE //turns it back on. The cover pop_up() pop_down() are automatically called in process(), no need to define it here
 
-/obj/machinery/porta_turret/take_damage(force)
+
+/obj/machinery/porta_turret/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration_flat = 0, armour_penetration_percentage = 0)
+	damage_amount = run_obj_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration_flat, armour_penetration_percentage)
 	if(!raised && !raising)
-		force = force / 8
-		if(force < 5)
+		damage_amount = damage_amount / 8
+		if(damage_amount < 5)
 			return
 
-	health -= force
-	if(force > 5 && prob(45) && spark_system)
+	health -= damage_amount
+	if(damage_amount > 5 && prob(45) && spark_system)
 		spark_system.start()
 	if(health <= 0)
 		die()	//the death process :(
@@ -452,10 +453,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			spawn(60)
 				attacked = FALSE
 
-	..()
-
-	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
-		take_damage(Proj.damage)
+	return ..()
 
 /obj/machinery/porta_turret/emp_act(severity)
 	if(enabled && emp_vulnerable)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -399,7 +399,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		return
 	if(!(stat & BROKEN))
 		visible_message("<span class='danger'>[M] [M.attacktext] [src]!</span>")
-		take_damage(M.melee_damage_upper)
+		..()
 	else
 		to_chat(M, "<span class='danger'>That object is useless to you.</span>")
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Turrets no longer take damage from a projectile, then call the parent, to take damage from a projectile again.
Turrets no longer take half damage from a melee attack, then call the parent, to take damage again.
Turrets now use their armor when hit by an attack.
Mob attacks on turrets now respect armor / act like any other structure being hit.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

When object damage was brought over, some remenants of  turrets taking damage from attacks were not fully removed, causing them to take damage twice from some sources.

Turrets are supposed to have 80 hp, 50 melee armor, and 30 bullet / energy. They are supposed to die in 6 laser shots. Currently they die in 2. This is bad.

(Admittedly turrets still should be harder to fight and less cheeseable, but that is not a fix.)

## Testing
<!-- How did you test the PR, if at all? -->
shot / toolboxed / blobernaughted a bunch of turrets

## Changelog
:cl:
fix: Attacks on turrets now respect armor.
fix: Turrets no longer take 2x damage from projectiles.
fix: Turrets no longer take 1.5x damage from melee.
fix: Turrets get damaged by hostile mobs in a more similar method to every other structure
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
