### PR TITLE
Fix pointing into containers and cooldown

### DIFF
--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -104,15 +104,13 @@
 	if(istype(A, /obj/effect/temp_visual/point) || istype(A, /atom/movable/emissive_blocker))
 		return FALSE
 
+	changeNext_move(CLICK_CD_POINT)
+
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(run_pointed), A))
 
 /// possibly delayed verb that finishes the pointing process starting in [/mob/verb/pointed()].
 /// either called immediately or in the tick after pointed() was called, as per the [DEFAULT_QUEUE_OR_CALL_VERB()] macro
 /mob/proc/run_pointed(atom/A)
-	if(client && !(A in view(client.view, src)))
-		return FALSE
-
-	changeNext_move(CLICK_CD_POINT)
 	if(A.loc in src) // Object is inside a container on the mob. It's not part of the verb's list since it's not in view and requires middle clicking.
 		point_at(A)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes duplicate code that broke pointing inside carried containers, and moved the cooldown to the initial verb, so that people can't just queue spam.

## Why It's Good For The Game
Fixes pointing into things. The cooldown was something I noticed and decided to fix there instead of risking it.

## Images of changes
![InsideOut](https://user-images.githubusercontent.com/80771500/215615555-5c4993c5-1c0b-4bc0-acb7-666a27155c36.PNG)

## Testing
Spawned and pointed at something inside a container on self.

## Changelog
:cl:
fix: You can point in carried containers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
