### PR TITLE
Fixed varedited areas on Cere.

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -26,9 +26,7 @@
 /area/maintenance/disposal/external/north)
 "aaf" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "AI Asteroid"
-	})
+/area/mine/unexplored/cere/ai)
 "aaj" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -203,9 +201,7 @@
 /area/maintenance/disposal/external/north)
 "abE" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "abG" = (
 /obj/structure/cable/orange{
 	d2 = 4;
@@ -312,9 +308,7 @@
 /area/maintenance/disposal/external/north)
 "abW" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "abY" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -553,9 +547,7 @@
 "adh" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "adm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -767,9 +759,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "aeM" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -1068,9 +1058,7 @@
 /area/turret_protected/ai)
 "ahF" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "AI Asteroid"
-	})
+/area/mine/unexplored/cere/ai)
 "ahH" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -1380,17 +1368,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "ajI" = (
 /obj/structure/rack,
 /obj/item/shovel,
 /obj/item/shovel,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "ajJ" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "cell1";
@@ -1498,9 +1482,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "akc" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -1707,17 +1689,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "akE" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "akF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/flasher{
@@ -1772,9 +1750,7 @@
 /area/turret_protected/ai)
 "alc" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "ale" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -1821,17 +1797,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "alj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "alk" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -1845,9 +1817,7 @@
 "all" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "aln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2178,9 +2148,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "amN" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -2196,9 +2164,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "amO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -2207,9 +2173,7 @@
 /area/security/permabrig)
 "amP" = (
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "amQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2262,9 +2226,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "amX" = (
 /obj/structure/disposalpipe/junction,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -2771,9 +2733,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "apI" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -4426,9 +4386,7 @@
 /area/maintenance/fore2)
 "ayb" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "ayc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5568,9 +5526,7 @@
 "aGx" = (
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "aGy" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight/lantern,
@@ -8778,9 +8734,7 @@
 /area/maintenance/gambling_den)
 "aXn" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Civilian Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "aXr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -8815,9 +8769,7 @@
 /area/quartermaster/office)
 "aXD" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Engineering Asteroid"
-	})
+/area/mine/unexplored/cere/engineering)
 "aXG" = (
 /obj/machinery/camera{
 	c_tag = "Mini Satellite Teleporter";
@@ -8832,45 +8784,28 @@
 "aXN" = (
 /obj/machinery/economy/vending/hydronutrients,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aXO" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aXP" = (
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aXQ" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aXR" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Engineering Asteroid"
-	})
+/area/mine/unexplored/cere/engineering)
 "aYa" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYb" = (
 /obj/structure/table/wood,
 /obj/item/seeds/apple,
@@ -8884,10 +8819,7 @@
 /obj/item/reagent_containers/spray/pestspray,
 /obj/item/reagent_containers/spray/plantbgone,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYc" = (
 /obj/structure/table/wood,
 /obj/item/cultivator,
@@ -8896,17 +8828,11 @@
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYd" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYe" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/alarm{
@@ -8919,15 +8845,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYg" = (
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Engineering Asteroid"
-	})
+/area/mine/unexplored/cere/engineering)
 "aYk" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -8944,27 +8865,18 @@
 	c_tag = "Rehabilitation Dome North"
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYn" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYq" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/firealarm{
@@ -8974,10 +8886,7 @@
 	},
 /mob/living/simple_animal/butterfly,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYt" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9015,34 +8924,22 @@
 "aYD" = (
 /mob/living/simple_animal/butterfly,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYH" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYI" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aYJ" = (
 /turf/simulated/wall,
 /area/hallway/primary/central)
@@ -9174,39 +9071,24 @@
 	dir = 8
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZg" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZh" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZi" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZj" = (
 /obj/structure/flora/ausbushes/reedbush,
 /mob/living/simple_animal/butterfly,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9260,9 +9142,7 @@
 /area/quartermaster/office)
 "aZu" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "aZD" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -9286,26 +9166,17 @@
 "aZH" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZI" = (
 /obj/structure/sink/puddle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZJ" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "aZK" = (
 /turf/simulated/mineral/ancient,
 /area/hallway/primary/central)
@@ -9335,14 +9206,10 @@
 /area/turret_protected/aisat_interior/secondary)
 "aZM" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "aZN" = (
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "aZQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9410,10 +9277,7 @@
 "bag" = (
 /obj/machinery/light,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bah" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/hallway/primary/central)
@@ -9587,10 +9451,7 @@
 "baI" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "baJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
@@ -9599,10 +9460,7 @@
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "baK" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -9614,10 +9472,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "baL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9752,10 +9607,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bbo" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -9847,10 +9699,7 @@
 	name = "Rehabilitation Dome"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bbO" = (
 /obj/machinery/camera{
 	c_tag = "Rehabilitation Dome Lobby East";
@@ -10055,10 +9904,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bcy" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -10237,30 +10083,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bdl" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bdm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bdn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10271,10 +10108,7 @@
 	},
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bdr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -10454,10 +10288,7 @@
 "beb" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bec" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10668,10 +10499,7 @@
 "beR" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "beS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10949,10 +10777,7 @@
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bfR" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -10961,27 +10786,18 @@
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bfS" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bfT" = (
 /obj/machinery/light,
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bfU" = (
 /obj/structure/sign/poster/random{
 	name = "random official poster";
@@ -10990,10 +10806,7 @@
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "bfV" = (
 /obj/machinery/camera{
 	c_tag = "Rehabilitation Dome Lobby South";
@@ -11661,9 +11474,7 @@
 /area/crew_quarters/kitchen)
 "bhO" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Civilian Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "bhP" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -13063,9 +12874,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "bnv" = (
 /obj/structure/closet,
 /obj/structure/window/reinforced{
@@ -14347,9 +14156,7 @@
 "brX" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "brY" = (
 /obj/structure/bed/dogbed,
 /obj/item/radio/intercom{
@@ -24867,11 +24674,6 @@
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
-"cbV" = (
-/turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
 "cbW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4;
@@ -24885,10 +24687,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cca" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -25106,9 +24905,7 @@
 /area/maintenance/fore2)
 "ccW" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Research Asteroid"
-	})
+/area/mine/unexplored/cere/research)
 "ccZ" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -25141,9 +24938,7 @@
 /area/crew_quarters/locker)
 "cdb" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Research Asteroid"
-	})
+/area/mine/unexplored/cere/research)
 "cdc" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/mineral/ancient/outer,
@@ -28333,10 +28128,7 @@
 "ctw" = (
 /obj/structure/flora/tree/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "ctA" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -30413,10 +30205,7 @@
 	random_basetype = /obj/structure/sign/poster/official
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cFc" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/newscaster{
@@ -30425,10 +30214,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cFe" = (
 /obj/machinery/door/window/westright{
 	dir = 2;
@@ -30472,10 +30258,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cFi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30851,10 +30634,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cGr" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -31188,10 +30968,7 @@
 	},
 /mob/living/simple_animal/butterfly,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cHY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31218,10 +30995,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cIe" = (
 /turf/simulated/floor/plasteel{
 	dir = 5
@@ -31248,19 +31022,13 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cIh" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cIm" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine{
@@ -31360,10 +31128,7 @@
 	},
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cIF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -31407,10 +31172,7 @@
 	},
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "cIS" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -31943,9 +31705,7 @@
 "cKA" = (
 /obj/item/clothing/head/sombrero/shamebrero,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "cKG" = (
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -33683,9 +33443,7 @@
 /area/bridge)
 "cRv" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "cRz" = (
 /turf/simulated/floor/plating,
 /area/clownoffice/secret)
@@ -35588,9 +35346,7 @@
 /obj/item/pickaxe,
 /obj/structure/rack,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "cYu" = (
 /obj/structure/statue/bananium/clown,
 /obj/machinery/camera{
@@ -37468,9 +37224,7 @@
 "dlb" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "dlc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/window/reinforced,
@@ -37883,9 +37637,7 @@
 	total_amount = 20
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "dnC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -37981,9 +37733,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "doH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -38016,9 +37766,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "doO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security SMES Access";
@@ -38038,9 +37786,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "doZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -38101,9 +37847,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "dpl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -38338,9 +38082,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "dqz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -38554,9 +38296,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "drA" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -40875,9 +40615,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "dCv" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 8
@@ -41399,9 +41137,7 @@
 "dLo" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "dLQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -41483,9 +41219,7 @@
 "dMG" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "dMN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -42432,9 +42166,7 @@
 /area/maintenance/fsmaint)
 "egm" = (
 /turf/simulated/wall/r_wall,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "egq" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -42651,12 +42383,6 @@
 	icon_state = "white"
 	},
 /area/medical/virology)
-"ekY" = (
-/obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
 "ell" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -43264,9 +42990,7 @@
 "eyx" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Civilian Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "eyA" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -43994,9 +43718,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "eNW" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/structure/cable/orange{
@@ -44463,9 +44185,7 @@
 	layer = 4
 	},
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "eWS" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plasteel{
@@ -44494,9 +44214,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Civilian Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "eYr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -45173,10 +44891,7 @@
 "fph" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "fpm" = (
 /obj/machinery/light{
 	dir = 1
@@ -45819,9 +45534,7 @@
 "fDu" = (
 /obj/structure/lattice,
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "fDw" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -46283,9 +45996,7 @@
 /area/crew_quarters/locker)
 "fMl" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "fMG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48673,10 +48384,7 @@
 "gID" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "gIG" = (
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -50329,10 +50037,7 @@
 "hqg" = (
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "hqL" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fsmaint)
@@ -50565,9 +50270,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "huF" = (
 /obj/structure/table,
 /turf/simulated/floor/plating,
@@ -51907,9 +51610,7 @@
 /area/maintenance/disposal/east)
 "hUU" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Civilian Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "hVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51958,10 +51659,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "hVP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52058,9 +51756,7 @@
 	layer = 4
 	},
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "hYW" = (
 /turf/simulated/mineral/ancient,
 /area/medical/paramedic)
@@ -52579,15 +52275,11 @@
 "imt" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "imE" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "imG" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/asmaint)
@@ -52774,10 +52466,7 @@
 	name = "south bump"
 	},
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "iqZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53027,9 +52716,7 @@
 /area/toxins/misc_lab)
 "ivS" = (
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "iwn" = (
 /obj/machinery/newscaster{
 	name = "north bump";
@@ -53101,9 +52788,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "ixh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53133,10 +52818,7 @@
 "ixW" = (
 /obj/machinery/biogenerator,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "iys" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -53446,9 +53128,7 @@
 /area/crew_quarters/fitness)
 "iFs" = (
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Research Asteroid"
-	})
+/area/mine/unexplored/cere/research)
 "iFv" = (
 /obj/machinery/door/window/westleft{
 	name = "Monkey Pen";
@@ -54043,9 +53723,7 @@
 "iSn" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "iSo" = (
 /obj/machinery/door_control{
 	id = "mixvent";
@@ -54348,9 +54026,7 @@
 /area/medical/genetics)
 "iXD" = (
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "iXO" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -54368,9 +54044,7 @@
 /area/hallway/primary/central)
 "iYg" = (
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "iYr" = (
 /obj/effect/spawner/airlock/s_to_n,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -54390,9 +54064,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "iZd" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -54483,9 +54155,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "jaR" = (
 /obj/structure/sign/evac,
 /turf/simulated/wall,
@@ -54672,9 +54342,7 @@
 /area/maintenance/asmaint)
 "jft" = (
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "jfM" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -56302,9 +55970,7 @@
 "jKO" = (
 /obj/structure/mineral_door/iron,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "jLv" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -56405,9 +56071,7 @@
 /area/hallway/primary/fore/east)
 "jNX" = (
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "jNZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo SMES Access";
@@ -56569,9 +56233,7 @@
 /obj/machinery/door/airlock/glass,
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "jQH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -57763,17 +57425,13 @@
 "koT" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "kpb" = (
 /obj/structure/sign/poster/contraband/rip_badger{
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "kpd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -58700,9 +58358,7 @@
 	total_amount = 20
 	},
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "kFK" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -58717,9 +58373,7 @@
 "kGr" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "kGE" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -58953,10 +58607,7 @@
 "kMs" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "kMZ" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -59568,9 +59219,7 @@
 "kYe" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "kYz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -59624,10 +59273,7 @@
 "kZW" = (
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "lai" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
@@ -59709,16 +59355,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "lcv" = (
 /obj/structure/table,
 /obj/item/pen,
 /turf/simulated/floor/plating,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "lcR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -60603,9 +60245,7 @@
 "lrS" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Engineering Asteroid"
-	})
+/area/mine/unexplored/cere/engineering)
 "lsg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
@@ -60780,10 +60420,7 @@
 "lwc" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "lwr" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -61100,9 +60737,7 @@
 /area/maintenance/starboard)
 "lCC" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "lCJ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/trinary/filter{
@@ -61302,9 +60937,7 @@
 /area/security/vacantoffice)
 "lGk" = (
 /turf/space,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "lHa" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -61730,9 +61363,7 @@
 /area/maintenance/fore2)
 "lRR" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Near Station Asteroids"
-	})
+/area/mine/unexplored/cere/orbiting)
 "lRU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -61954,10 +61585,7 @@
 /area/crew_quarters/sleep)
 "lWT" = (
 /turf/simulated/wall,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "lXe" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62520,9 +62148,7 @@
 /area/hallway/spacebridge/sercom)
 "mic" = (
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Civilian Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "mix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63260,9 +62886,7 @@
 /area/maintenance/disposal/westalt)
 "mCL" = (
 /turf/simulated/wall/r_wall,
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "mCM" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63518,9 +63142,7 @@
 /area/hallway/primary/aft/west)
 "mKK" = (
 /turf/simulated/wall/r_wall,
-/area/mine/unexplored{
-	name = "Research Asteroid"
-	})
+/area/mine/unexplored/cere/research)
 "mKO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -63807,9 +63429,7 @@
 /area/storage/primary)
 "mPI" = (
 /turf/simulated/wall/r_wall,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "mPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -64618,10 +64238,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 5
 	},
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "ngA" = (
 /obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
@@ -67169,9 +66786,7 @@
 "ocw" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "ocA" = (
 /obj/machinery/light{
 	dir = 8
@@ -67731,10 +67346,7 @@
 "ooA" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "ooF" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -70708,10 +70320,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "pwt" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -71108,9 +70717,7 @@
 "pFc" = (
 /obj/structure/railing,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "AI Asteroid"
-	})
+/area/mine/unexplored/cere/ai)
 "pFm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -73774,11 +73381,6 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/fore)
-"qBg" = (
-/turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
 "qBl" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers,
@@ -74355,9 +73957,7 @@
 "qKh" = (
 /obj/structure/railing,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Civilian Asteroid"
-	})
+/area/mine/unexplored/cere/civilian)
 "qKE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76066,9 +75666,7 @@
 /area/maintenance/apmaint)
 "rzh" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Cargo Asteroid"
-	})
+/area/mine/unexplored/cere/cargo)
 "rzr" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -76259,9 +75857,7 @@
 /area/maintenance/disposal/southwest)
 "rBH" = (
 /turf/simulated/wall/r_wall,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "rBO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -76866,11 +76462,6 @@
 	icon_state = "dark"
 	},
 /area/medical/cmo)
-"rOU" = (
-/turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
 "rOX" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/alarm{
@@ -77278,9 +76869,7 @@
 /area/hallway/primary/aft/east)
 "rWw" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Research Asteroid"
-	})
+/area/mine/unexplored/cere/research)
 "rWC" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -78240,9 +77829,7 @@
 "smT" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/mineral/ancient,
-/area/mine/unexplored{
-	name = "Medical Asteroid"
-	})
+/area/mine/unexplored/cere/medical)
 "smX" = (
 /obj/machinery/door/window/northleft{
 	name = "Bar"
@@ -78651,9 +78238,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/mine/unexplored{
-	name = "Engineering Asteroid"
-	})
+/area/mine/unexplored/cere/engineering)
 "svr" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -78728,9 +78313,7 @@
 "sxa" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -81060,9 +80643,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution{
-	name = "Prisoner Transfer Lounge"
-	})
+/area/security/execution)
 "ttU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81312,10 +80893,7 @@
 	layer = 4
 	},
 /turf/simulated/mineral/ancient,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "tyF" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -81679,9 +81257,7 @@
 "tFY" = (
 /obj/structure/railing,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Engineering Asteroid"
-	})
+/area/mine/unexplored/cere/engineering)
 "tFZ" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment/corner{
@@ -84295,10 +83871,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "uMQ" = (
 /obj/structure/table,
 /obj/structure/cable/orange{
@@ -85941,9 +85514,7 @@
 /area/hallway/primary/fore)
 "vva" = (
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "vvf" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -88047,11 +87618,6 @@
 	icon_state = "barber"
 	},
 /area/civilian/barber)
-"wlG" = (
-/turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/mine/unexplored{
-	name = "Docking Asteroid"
-	})
 "wlV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -88185,9 +87751,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "woU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/bluespace_beacon,
@@ -88294,9 +87858,7 @@
 "wqx" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/mine/unexplored{
-	name = "Research Asteroid"
-	})
+/area/mine/unexplored/cere/research)
 "wqE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -89316,9 +88878,7 @@
 /area/hallway/primary/starboard/south)
 "wIp" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "AI Asteroid"
-	})
+/area/mine/unexplored/cere/ai)
 "wIq" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/apmaint)
@@ -90021,10 +89581,7 @@
 /area/maintenance/disposal/southwest)
 "wWC" = (
 /turf/simulated/mineral/ancient,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "wWP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -90340,9 +89897,7 @@
 /area/shuttle/arrival/station)
 "xbO" = (
 /turf/simulated/mineral/ancient/outer,
-/area/mine/unexplored{
-	name = "Engineering Asteroid"
-	})
+/area/mine/unexplored/cere/engineering)
 "xbX" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/weightmachine/weightlifter,
@@ -91040,10 +90595,7 @@
 /area/clownoffice/secret)
 "xut" = (
 /turf/simulated/floor/carpet/blue,
-/area/hallway/secondary/construction{
-	name = "\improper Garden";
-	sound_environment = 15
-	})
+/area/hallway/secondary/garden)
 "xuC" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
@@ -92009,9 +91561,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored{
-	name = "Command Asteroid"
-	})
+/area/mine/unexplored/cere/command)
 "xNq" = (
 /obj/machinery/camera{
 	c_tag = "Bar";
@@ -131001,14 +130551,14 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 rNK
 rNK
 rNK
-wlG
-wlG
+bhO
+bhO
 nFW
 jqW
 koo
@@ -131254,18 +130804,18 @@ rNK
 nhh
 vUb
 kJS
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
-qBg
-qBg
-wlG
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
+hUU
+hUU
+bhO
+bhO
+bhO
+bhO
 nFW
 abZ
 tuh
@@ -131511,13 +131061,13 @@ rNK
 nhh
 vUb
 nhh
-wlG
-wlG
-wlG
-qBg
-qBg
-qBg
-qBg
+bhO
+bhO
+bhO
+hUU
+hUU
+hUU
+hUU
 nFW
 pLr
 pLr
@@ -131763,18 +131313,18 @@ rNK
 rNK
 rNK
 rNK
-wlG
+bhO
 nhh
 nhh
 vUb
 nhh
 nhh
-wlG
-qBg
-qBg
-cbV
-cbV
-cbV
+bhO
+hUU
+hUU
+aXn
+aXn
+aXn
 nFW
 cfh
 pxm
@@ -132019,8 +131569,8 @@ rNK
 rNK
 rNK
 rNK
-cbV
-wlG
+aXn
+bhO
 dGU
 eVY
 dLb
@@ -132028,10 +131578,10 @@ nKY
 plQ
 wLr
 vpJ
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
 nFW
 pQS
 cfG
@@ -132275,9 +131825,9 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 plQ
 ccB
 pyl
@@ -132529,12 +132079,12 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
 dGU
 pnb
 eLX
@@ -132786,12 +132336,12 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
 dGU
 dGU
 plQ
@@ -133043,14 +132593,14 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
-qBg
-cbV
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
+hUU
+aXn
 kDn
 mBq
 rIn
@@ -133298,23 +132848,23 @@ rNK
 rNK
 rNK
 rNK
-cbV
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
-qBg
-qBg
-cbV
+aXn
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
+hUU
+hUU
+aXn
 daS
 imG
 cdG
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
 vpJ
 wLr
 wLr
@@ -133555,26 +133105,26 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
-qBg
-cbV
-cbV
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
+hUU
+aXn
+aXn
 gLj
 imG
 htH
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 yep
 imG
 gge
@@ -133811,27 +133361,27 @@ rNK
 rNK
 rNK
 rNK
-cbV
-wlG
-wlG
-wlG
+aXn
+bhO
+bhO
+bhO
 nHI
 nHI
 nHI
 nHI
-qBg
-cbV
-cbV
+hUU
+aXn
+aXn
 fdD
 vRX
 cdG
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 yep
 jfo
 wLr
@@ -134068,10 +133618,10 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
+bhO
 nHI
 gMv
 uCy
@@ -134082,7 +133632,7 @@ imG
 imG
 rIn
 xTS
-cbV
+aXn
 mpB
 wLr
 wLr
@@ -134323,12 +133873,12 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
 nHI
 sif
 xrN
@@ -134339,7 +133889,7 @@ tqb
 mJk
 wgq
 lnF
-cbV
+aXn
 mpB
 pVm
 cdF
@@ -134580,13 +134130,13 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
-qBg
-qBg
-qBg
-qBg
+bhO
+bhO
+bhO
+hUU
+hUU
+hUU
+hUU
 qqd
 lkA
 neh
@@ -134596,7 +134146,7 @@ goH
 piO
 imG
 imG
-cbV
+aXn
 wLr
 dQc
 tSs
@@ -134837,13 +134387,13 @@ rNK
 rNK
 rNK
 rNK
-wlG
-qBg
-qBg
-qBg
-cbV
-cbV
-cbV
+bhO
+hUU
+hUU
+hUU
+aXn
+aXn
+aXn
 fuH
 mGK
 mGK
@@ -134853,7 +134403,7 @@ fbs
 imG
 lJL
 hAJ
-cbV
+aXn
 wLr
 vSy
 lhA
@@ -135094,13 +134644,13 @@ rNK
 rNK
 rNK
 rNK
-wlG
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
 sPp
 hhs
 qkF
@@ -135110,7 +134660,7 @@ lJL
 nca
 per
 jty
-cbV
+aXn
 wLr
 mpB
 ftG
@@ -135351,13 +134901,13 @@ rNK
 rNK
 jft
 jft
-wlG
-qBg
-qBg
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+hUU
+aXn
+aXn
+aXn
+aXn
 gpZ
 kzq
 kzq
@@ -135367,8 +134917,8 @@ kzq
 smX
 fbs
 fwd
-cbV
-cbV
+aXn
+aXn
 mpB
 mpB
 mpB
@@ -135609,12 +135159,12 @@ rNK
 rNK
 rNK
 rNK
-wlG
-qBg
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+aXn
+aXn
+aXn
+aXn
 pAD
 vjB
 tWA
@@ -135624,11 +135174,11 @@ yhf
 rNo
 bDF
 opD
-cbV
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
+aXn
 wLr
 imG
 wZA
@@ -135866,26 +135416,26 @@ lzH
 lzH
 lzH
 lzH
-rOU
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+mic
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 wLr
 uir
 wZA
@@ -136123,27 +135673,27 @@ rNK
 rNK
 rNK
 rNK
-qBg
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 uir
 eST
 sSj
@@ -136381,26 +135931,26 @@ rNK
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 vpJ
 eST
 yep
@@ -136638,15 +136188,15 @@ rNK
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 tZz
 tZz
 tZz
@@ -136655,10 +136205,10 @@ gzv
 gzv
 tZz
 tZz
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
 eST
 yep
 xSo
@@ -136895,15 +136445,15 @@ lzH
 lzH
 lzH
 lzH
-rOU
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+mic
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 gzv
 mNG
 bJX
@@ -136912,9 +136462,9 @@ tCc
 oKS
 oIS
 tZz
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
 wLr
 eST
 ihT
@@ -137153,14 +136703,14 @@ rNK
 rNK
 rNK
 rNK
-qBg
+hUU
 wPr
 xbr
 oRW
 cbU
 nqO
 hPZ
-cbV
+aXn
 gzv
 tHv
 tHv
@@ -137169,9 +136719,9 @@ vPZ
 kBo
 vPy
 gzv
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
 wLr
 fka
 pXf
@@ -137417,7 +136967,7 @@ mAZ
 olv
 lvk
 diY
-cbV
+aXn
 gzv
 tHv
 tHv
@@ -137428,7 +136978,7 @@ sJs
 gzv
 dhm
 diY
-cbV
+aXn
 vpJ
 wLr
 wIS
@@ -137685,8 +137235,8 @@ nQr
 gzv
 diY
 iNr
-cbV
-cbV
+aXn
+aXn
 rpW
 eST
 yep
@@ -137942,8 +137492,8 @@ gzv
 gzv
 qet
 wPr
-cbV
-cbV
+aXn
+aXn
 vpJ
 uOe
 sju
@@ -138962,10 +138512,10 @@ wPr
 wPr
 lmF
 wPr
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
 vpJ
 vpJ
 vpJ
@@ -139218,13 +138768,13 @@ squ
 afX
 afX
 eDQ
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 vpJ
 vpJ
 xdy
@@ -139473,15 +139023,15 @@ aoO
 diY
 diY
 diY
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 wLr
 xXq
 cAU
@@ -139722,23 +139272,23 @@ rNK
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
 qPU
 fWs
 vPD
 dJA
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 vpJ
 xXq
 yep
@@ -139979,23 +139529,23 @@ xcc
 xcc
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 wLr
 xdy
 cdG
@@ -140235,24 +139785,24 @@ rNK
 rNK
 rNK
 rNK
-qBg
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 wLr
 cdx
 cdG
@@ -140492,24 +140042,24 @@ lzH
 lzH
 lzH
 lzH
-rOU
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+mic
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 vWF
 vRX
 nff
@@ -140749,24 +140299,24 @@ rNK
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 vWF
 vRX
 cdG
@@ -141006,24 +140556,24 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 yev
 qZT
 qfX
@@ -141263,22 +140813,22 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
 wLr
 wLr
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 vpJ
 vpJ
 pXP
@@ -141520,22 +141070,22 @@ aZu
 aZu
 rNK
 rNK
-qBg
-qBg
-cbV
-cbV
-cbV
-cbV
+hUU
+hUU
+aXn
+aXn
+aXn
+aXn
 wLr
 xvx
 nKr
 wLr
-cbV
+aXn
 vpJ
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
 tVf
 djo
 djo
@@ -141554,7 +141104,7 @@ xro
 djw
 wby
 csG
-wlG
+bhO
 rNK
 rNK
 rNK
@@ -141777,20 +141327,20 @@ aZu
 rNK
 rNK
 rNK
-aZu
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
 xyo
 iJa
 imG
 imG
 imG
 imG
-cbV
+aXn
 imG
 vRX
 tVf
@@ -141811,7 +141361,7 @@ cjF
 djw
 wby
 csG
-wlG
+bhO
 rNK
 rNK
 rNK
@@ -142034,14 +141584,14 @@ fMl
 aZu
 rNK
 rNK
-aZu
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 qlb
 vRX
 imG
@@ -142050,9 +141600,9 @@ vRX
 imG
 imG
 frV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
 nyL
 yep
 vpJ
@@ -142068,7 +141618,7 @@ daX
 djw
 wby
 csG
-wlG
+bhO
 rNK
 rNK
 rNK
@@ -142291,24 +141841,24 @@ fMl
 aZu
 rNK
 rNK
-aZu
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 wLr
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
 hIi
 jeA
 yep
@@ -142325,7 +141875,7 @@ vMR
 djw
 wby
 csG
-wlG
+bhO
 rNK
 rNK
 rNK
@@ -142549,22 +142099,22 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 xdy
 nyL
 xdy
@@ -142582,7 +142132,7 @@ ckv
 kzz
 wby
 csG
-wlG
+bhO
 rNK
 rNK
 rNK
@@ -142806,22 +142356,22 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 xdy
 nyL
 xdy
@@ -142839,8 +142389,8 @@ daX
 djw
 roj
 xMQ
-wlG
-wlG
+bhO
+bhO
 rNK
 rNK
 rNK
@@ -143063,20 +142613,20 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 cdT
-cbV
+aXn
 jpk
 cdT
 pez
@@ -143096,9 +142646,9 @@ qct
 lkg
 fYb
 xMQ
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 rNK
 rNK
 rNK
@@ -143320,13 +142870,13 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 eWL
 ehC
 gdn
@@ -143353,9 +142903,9 @@ xjc
 rns
 pJX
 dMG
-qBg
-qBg
-qBg
+hUU
+hUU
+hUU
 rNK
 rNK
 rNK
@@ -143577,14 +143127,14 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 dif
 hiI
 jah
@@ -143609,12 +143159,12 @@ jvl
 qoU
 jvl
 gJV
-cbV
-cbV
-cbV
-qBg
-qBg
-qBg
+aXn
+aXn
+aXn
+hUU
+hUU
+hUU
 rNK
 rNK
 rNK
@@ -143834,14 +143384,14 @@ aZu
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 jby
 ceQ
 qot
@@ -143869,10 +143419,10 @@ tDr
 lmS
 uut
 wCU
-cbV
-cbV
-qBg
-wlG
+aXn
+aXn
+hUU
+bhO
 rNK
 rNK
 rNK
@@ -144090,15 +143640,15 @@ fMl
 aZu
 rNK
 rNK
-aZu
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 hud
 ceQ
 qot
@@ -144123,17 +143673,17 @@ awH
 cpX
 ceQ
 cZu
-cbV
-cbV
+aXn
+aXn
 ske
 wCU
-cbV
-qBg
-wlG
-wlG
-wlG
+aXn
+hUU
+bhO
+bhO
+bhO
 rNK
-cbV
+aXn
 rNK
 rNK
 rNK
@@ -144347,15 +143897,15 @@ fMl
 aZu
 rNK
 rNK
-wlG
-qBg
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+bhO
+hUU
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 iXO
 rTV
 njn
@@ -144380,17 +143930,17 @@ qwt
 cRQ
 ceQ
 iCf
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
 qqL
-cbV
-qBg
-qBg
-qBg
-wlG
-wlG
-cbV
+aXn
+hUU
+hUU
+hUU
+bhO
+bhO
+aXn
 rNK
 rNK
 rNK
@@ -144606,13 +144156,13 @@ rNK
 rNK
 rNK
 rNK
-qBg
-cbV
-cbV
-cbV
-cbV
-cbV
-cbV
+hUU
+aXn
+aXn
+aXn
+aXn
+aXn
+aXn
 lts
 ceQ
 lvj
@@ -144637,17 +144187,17 @@ aRZ
 cHj
 ceQ
 vuF
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
 hDL
-cbV
-cbV
-cbV
-qBg
-wlG
-cbV
-cbV
+aXn
+aXn
+aXn
+hUU
+bhO
+aXn
+aXn
 rNK
 rNK
 rNK
@@ -144863,12 +144413,12 @@ rNK
 rNK
 rNK
 rNK
-qBg
-cbV
-qBg
-qBg
-qBg
-qBg
+hUU
+aXn
+hUU
+hUU
+hUU
+hUU
 cdT
 hsj
 eAj
@@ -144894,12 +144444,12 @@ ciX
 iaA
 eAj
 pDE
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
 ske
 wCU
-cbV
+aXn
 sqc
 cdT
 cdT
@@ -145120,12 +144670,12 @@ rNK
 rNK
 rNK
 rNK
-qBg
-cbV
-qBg
-wlG
-wlG
-qBg
+hUU
+aXn
+hUU
+bhO
+bhO
+hUU
 cdT
 iXO
 ceQ
@@ -145151,10 +144701,10 @@ cpm
 chg
 ceQ
 ckw
-cbV
-cbV
-cbV
-ekY
+aXn
+aXn
+aXn
+eyx
 pWu
 uut
 fJJ
@@ -145377,12 +144927,12 @@ rNK
 rNK
 rNK
 rNK
-qBg
-qBg
-qBg
-wlG
-wlG
-wlG
+hUU
+hUU
+hUU
+bhO
+bhO
+bhO
 cdT
 hud
 ceQ
@@ -145408,13 +144958,13 @@ ceQ
 ceQ
 ceQ
 uYU
-cbV
-cbV
-cbV
-cbV
+aXn
+aXn
+aXn
+aXn
 jNX
 ocw
-cbV
+aXn
 cdT
 cdT
 cdT
@@ -145639,7 +145189,7 @@ rNK
 rNK
 rNK
 rNK
-wlG
+bhO
 cdT
 gOC
 ceQ
@@ -145665,13 +145215,13 @@ cpF
 hcB
 hiI
 iTR
-cbV
-cbV
-cbV
-cbV
-cbV
-qBg
-qBg
+aXn
+aXn
+aXn
+aXn
+aXn
+hUU
+hUU
 rNK
 rNK
 lzH
@@ -145896,7 +145446,7 @@ lzH
 lzH
 lzH
 lzH
-rOU
+mic
 cdT
 qxj
 nLR
@@ -145921,13 +145471,13 @@ cdT
 cdT
 cdT
 cdT
-cbV
-cbV
-cbV
-cbV
-cbV
-rOU
-qBg
+aXn
+aXn
+aXn
+aXn
+aXn
+mic
+hUU
 rNK
 rNK
 rNK
@@ -146175,15 +145725,15 @@ vgt
 vgt
 cdT
 cdT
-wlG
-wlG
-wlG
-qBg
-cbV
-cbV
-cbV
-cbV
-qBg
+bhO
+bhO
+bhO
+hUU
+aXn
+aXn
+aXn
+aXn
+hUU
 rNK
 rNK
 rNK
@@ -146419,9 +145969,9 @@ wTg
 vgt
 chk
 vgt
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 vgt
 chk
 vgt
@@ -146431,16 +145981,16 @@ veA
 veA
 veA
 veA
-wlG
-wlG
-wlG
-wlG
-qBg
-qBg
-qBg
-qBg
-qBg
-qBg
+bhO
+bhO
+bhO
+bhO
+hUU
+hUU
+hUU
+hUU
+hUU
+hUU
 rNK
 rNK
 rNK
@@ -146668,17 +146218,17 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 vgt
 chk
 vgt
 nhx
 vgt
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 vgt
 nhx
 vgt
@@ -146688,9 +146238,9 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 rNK
 rNK
 rNK
@@ -146925,17 +146475,17 @@ rNK
 rNK
 rNK
 rNK
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 vgt
 nhx
 vgt
 eFI
 vgt
-wlG
-wlG
-wlG
+bhO
+bhO
+bhO
 vgt
 eFI
 vgt
@@ -146945,7 +146495,7 @@ rNK
 rNK
 rNK
 rNK
-wlG
+bhO
 rNK
 rNK
 rNK
@@ -147182,7 +146732,7 @@ rNK
 rNK
 rNK
 rNK
-wlG
+bhO
 rNK
 rNK
 vgt
@@ -147190,7 +146740,7 @@ eFI
 vgt
 nhx
 vgt
-wlG
+bhO
 rNK
 rNK
 vgt


### PR DESCRIPTION
## What Does This PR Do
Removes varedited areas on Cerestation.

Part of #20018, fixes for which I'm splitting into separate PRs because I'm not going to attempt to manage one PR that touches ~~five~~ six different maps if I don't absolutely have to.

- Switched some overridden unknown mining areas to the appropriate Cere per-department mining areas. There was a tiny bit of unexplored mining with an override name of "Medical Asteroid" that were surrounded by "Civilian Asteroid" and not located directly on the med asteroid, so I moved those over to Civilian Asteroid.
- For some reason /area/security/execution had a custom label of "Prisoner Transfer Lounge", which I guess is technically true but probably not the intended name, so it was removed
- Garden was marked as construction area.

## Why It's Good For The Game
Varedited areas bad.

## Testing
Started server, joined, observed. Checked no runtimes were logged.

No visual changes.