### PR TITLE
Removes smoke cluster grenades

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -7077,7 +7077,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/grenade/clusterbuster/smoke,
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel/dark,
 /area/admin)

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -209,7 +209,6 @@
 				/obj/item/stack/nanopaste = 50,
 				/obj/item/clothing/under/costume/psyjump = 50,
 				/obj/item/immortality_talisman = 50,
-				/obj/item/grenade/clusterbuster/smoke = 50
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/minerals
@@ -319,7 +318,6 @@
 
 				// Cluster grenades
 				/obj/item/grenade/clusterbuster = 50, // cluster flashbang
-				/obj/item/grenade/clusterbuster/teargas = 50
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/eng

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -84,10 +84,6 @@
 	name = "Electromagnetic Storm"
 	payload = /obj/item/grenade/empgrenade
 
-/obj/item/grenade/clusterbuster/smoke
-	name = "Ninja Vanish"
-	payload = /obj/item/grenade/smokebomb
-
 /obj/item/grenade/clusterbuster/metalfoam
 	name = "Instant Concrete"
 	payload = /obj/item/grenade/chem_grenade/metalfoam
@@ -96,17 +92,9 @@
 	name = "Inferno"
 	payload = /obj/item/grenade/chem_grenade/incendiary
 
-/obj/item/grenade/clusterbuster/antiweed
-	name = "RoundDown"
-	payload = /obj/item/grenade/chem_grenade/antiweed
-
 /obj/item/grenade/clusterbuster/cleaner
 	name = "Mr. Proper"
 	payload = /obj/item/grenade/chem_grenade/cleaner
-
-/obj/item/grenade/clusterbuster/teargas
-	name = "\improper Oignon Teargas Grenade"
-	payload = /obj/item/grenade/chem_grenade/teargas
 
 /obj/item/grenade/clusterbuster/facid
 	name = "Aciding Rain"
@@ -132,10 +120,6 @@
 	name = "\improper Mega Meat Grenade"
 	payload = /obj/item/grenade/chem_grenade/meat
 
-/obj/item/grenade/clusterbuster/nervegas
-	name = "\improper Nerve Gas Clusterbomb"
-	payload = /obj/item/grenade/chem_grenade/saringas
-
 /obj/item/grenade/clusterbuster/megadirt
 	name = "\improper Megamaid's Revenge Grenade"
 	payload = /obj/item/grenade/chem_grenade/dirt
@@ -150,20 +134,10 @@
 	desc = "An object in motion remains in motion."
 	payload = /obj/item/grenade/chem_grenade/lube
 
-/obj/item/grenade/clusterbuster/hippie
-	name = "\improper Hippie Grenade"
-	desc = "Almost as good as the summer of '69."
-	payload = /obj/item/grenade/chem_grenade/drugs
-
 /obj/item/grenade/clusterbuster/holy
 	name = "\improper Purification Grenade"
 	desc = "Blessed excessively."
 	payload = /obj/item/grenade/chem_grenade/holywater
-
-/obj/item/grenade/clusterbuster/hellwater
-	name = "Righteous Fury"
-	desc = "It's righteous, not badminnery."
-	payload = /obj/item/grenade/chem_grenade/hellwater
 
 /obj/item/grenade/clusterbuster/booze
 	name = "\improper Booze Grenade"

--- a/code/game/objects/items/weapons/grenades/custom_grenades.dm
+++ b/code/game/objects/items/weapons/grenades/custom_grenades.dm
@@ -49,23 +49,6 @@
 	B.reagents.add_reagent("holywater",100)
 	beakers += B
 
-/obj/item/grenade/chem_grenade/hellwater
-	payload_name = "hell water"
-	desc = "And he struck them down with an unholy fury that burn like one-thousands badmins."
-	stage = 2
-	det_time = 30
-
-/obj/item/grenade/chem_grenade/hellwater/Initialize(mapload)
-	. = ..()
-	var/obj/item/reagent_containers/glass/beaker/large/B1 = new(src)
-	var/obj/item/reagent_containers/glass/beaker/large/B2 = new(src)
-	B1.reagents.add_reagent("hell_water",80)
-	B1.reagents.add_reagent("sugar",20)
-	B2.reagents.add_reagent("hell_water", 60)
-	B2.reagents.add_reagent("potassium", 20)
-	B2.reagents.add_reagent("phosphorus", 20)
-
-
 /obj/item/grenade/chem_grenade/drugs
 	payload_name = "miracle"
 	desc = "How does it work?"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes any cluster grenade that contained smoke grenades of any kind, the only one of these that was actually obtainable was the regular smoke cluster grenade and the tear gas smoke cluster grenade that were available from traders. There were a few others in the code that existed but were impossible to obtain outside of an admin spawning them, they have been removed as well. Because the cluster smoke grenade was remove it had to be removed from the ninja room in the admin room area so there is a slight mapping change. I've also gone ahead and removed the hellwater cluster grenade since it didn't work anyways.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
These smoke grenades are incredibly performance intensive, in a recent round when a tear gas cluster grenade was set off time dilation reached 152% causing massive lag that made the server functionally unplayable for a minute until the gas clouds faded away. I've never seen these grenades used for anything other than "pranks" or just out of curiosity. Additionally removing the other admin spawned gas cluster grenades means that admins won't ever make the mistake of giving someone one of these grenades only to find out how much of an impact it can have on performance. Finally the hellwater cluster grenade was removed because it didn't work and the only way to of made it work would have been to make it a gas grenade.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
<!-- How did you test the PR, if at all? -->
Booted up test server
No errors in loading the map
Checked to see if the ninja vanish(Cluster smoke grenade) was in the admin room, it was not
Checked to see if I could spawn any of the grenades I removed, I could not
## Changelog
:cl:
del: All cluster smoke grenades
del: Hellwater grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
