### PR TITLE
more medborg love: surgery tool edition.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -229,7 +229,7 @@
 	name = "medical cyborg abductor upgrade"
 	desc = "An experimental upgrade that replaces a medical cyborgs tools with the abductor version."
 	icon_state = "abductor_mod"
-	origin_tech = "biotech=6;materials=6;abductor=3"
+	origin_tech = "biotech=6;materials=6;abductor=2"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/medical
 	items_to_replace = list(

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1064,7 +1064,7 @@
 	id = "borg_upgade_abductor_medi"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/abductor_medi
-	req_tech = list("biotech" = 7, "materials" = 7, "abductor" = 4)
+	req_tech = list("biotech" = 7, "materials" = 7, "abductor" = 3)
 	materials = list(MAT_METAL = 18000, MAT_GLASS = 1500, MAT_SILVER = 13000, MAT_GOLD = 1000, MAT_PLASMA = 4000, MAT_TITANIUM = 12000, MAT_DIAMOND = 1000) //Base abductor engineering tools *8 + IMS cost
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Lowers the alien level requirement for abductor surgery tool upgrade for the medborg from 4 to 3, and lowers the deconstruction reward from 3 to 2. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Always struck me as slightly strange that despite getting alien medical tools before, medborgs have to wait for the abductor event to roll to get faster tools.

## Testing
<!-- How did you test the PR, if at all? -->
I made sure i somehow didn't mess up changing two numbers by deconstructing a single abductor upgrade, verified it was not in the mechfab, did a second, verified it was now there.
## Additional notes
This was talked about a bit ago with qwerty, and they said they were up for this change, and did verify they are still willing for this to be made. 
## Changelog
:cl:
tweak: lowers the tech level requirement, and reward, for the abductor upgrade by one level. 
/:cl: