### PR TITLE
carp scroll can no longer be refunded

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -884,7 +884,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/sleeping_carp_scroll
 	cost = 13
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
-	refundable = TRUE
 	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/cqc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Carp scroll can no longer be refunded

## Why It's Good For The Game
This was added because clingtot and vamptot were antagonists and couldn't use certain items, those antagonists no longer exist. Elimination of surplus based cheese brings a smile to my face, you got 40-120 tc worth of items, you can figure it out!
Holoparasite remains refundable due to it requiring a ghost. I thought about making it refundable only after attempting to use it once but I dunno seems overly complicated. 

## Testing
Compiled and ran
probably didn't need to this is a var change

## Changelog
:cl:
del: Scrolls of the carpfu can no longer be refunded. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
