### PR TITLE
Fixes BDM trophy causing you to take absurd damage

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -129,12 +129,12 @@
 /datum/status_effect/blooddrunk/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod *= 10
-		H.physiology.burn_mod *= 10
-		H.physiology.tox_mod *= 10
-		H.physiology.oxy_mod *= 10
-		H.physiology.clone_mod *= 10
-		H.physiology.stamina_mod *= 10
+		H.physiology.brute_mod *= 4
+		H.physiology.burn_mod *= 4
+		H.physiology.tox_mod *= 4
+		H.physiology.oxy_mod *= 4
+		H.physiology.clone_mod *= 4
+		H.physiology.stamina_mod *= 4
 	add_attack_logs(owner, owner, "lost blood-drunk stun immunity", ATKLOG_ALL)
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 	if(islist(owner.stun_absorption) && owner.stun_absorption["blooddrunk"])

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -104,11 +104,7 @@
 	duration = 10
 	tick_interval = 0
 	alert_type = /obj/screen/alert/status_effect/blooddrunk
-	var/blooddrunk_damage_mod_remove = 4
-
-GLOBAL_VAR_INIT(blooddrunk_damage_mod_remove, 4) // Damage is multiplied by this at the end of the status effect. Modify this one, it changes the _add. Blame Gatchapod for this being global.
-GLOBAL_VAR_INIT(blooddrunk_damage_mod_add, 1 / blooddrunk_damage_mod_remove) // Damage is multiplied by this at the start of the status effect. Don't modify this one directly.
-
+	var/blooddrunk_damage_mod_remove = 4 // Damage is multiplied by this at the end of the status effect. Modify this one, it changes the _add
 
 /obj/screen/alert/status_effect/blooddrunk
 	name = "Blood-Drunk"
@@ -121,12 +117,13 @@ GLOBAL_VAR_INIT(blooddrunk_damage_mod_add, 1 / blooddrunk_damage_mod_remove) // 
 		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			H.physiology.brute_mod *= GLOB.blooddrunk_damage_mod_add
-			H.physiology.burn_mod *= GLOB.blooddrunk_damage_mod_add
-			H.physiology.tox_mod *= GLOB.blooddrunk_damage_mod_add
-			H.physiology.oxy_mod *= GLOB.blooddrunk_damage_mod_add
-			H.physiology.clone_mod *= GLOB.blooddrunk_damage_mod_add
-			H.physiology.stamina_mod *= GLOB.blooddrunk_damage_mod_add
+			var/blooddrunk_damage_mod_add = 1 / blooddrunk_damage_mod_remove // Damage is multiplied by this at the start of the status effect. Don't modify this one directly.
+			H.physiology.brute_mod *= blooddrunk_damage_mod_add
+			H.physiology.burn_mod *= blooddrunk_damage_mod_add
+			H.physiology.tox_mod *= blooddrunk_damage_mod_add
+			H.physiology.oxy_mod *= blooddrunk_damage_mod_add
+			H.physiology.clone_mod *= blooddrunk_damage_mod_add
+			H.physiology.stamina_mod *= blooddrunk_damage_mod_add
 		add_attack_logs(owner, owner, "gained blood-drunk stun immunity", ATKLOG_ALL)
 		owner.add_stun_absorption("blooddrunk", INFINITY, 4)
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, TRUE, use_reverb = FALSE)
@@ -134,12 +131,12 @@ GLOBAL_VAR_INIT(blooddrunk_damage_mod_add, 1 / blooddrunk_damage_mod_remove) // 
 /datum/status_effect/blooddrunk/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod *= GLOB.blooddrunk_damage_mod_remove
-		H.physiology.burn_mod *= GLOB.blooddrunk_damage_mod_remove
-		H.physiology.tox_mod *= GLOB.blooddrunk_damage_mod_remove
-		H.physiology.oxy_mod *= GLOB.blooddrunk_damage_mod_remove
-		H.physiology.clone_mod *= GLOB.blooddrunk_damage_mod_remove
-		H.physiology.stamina_mod *= GLOB.blooddrunk_damage_mod_remove
+		H.physiology.brute_mod *= blooddrunk_damage_mod_remove
+		H.physiology.burn_mod *= blooddrunk_damage_mod_remove
+		H.physiology.tox_mod *= blooddrunk_damage_mod_remove
+		H.physiology.oxy_mod *= blooddrunk_damage_mod_remove
+		H.physiology.clone_mod *= blooddrunk_damage_mod_remove
+		H.physiology.stamina_mod *= blooddrunk_damage_mod_remove
 	add_attack_logs(owner, owner, "lost blood-drunk stun immunity", ATKLOG_ALL)
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 	if(islist(owner.stun_absorption) && owner.stun_absorption["blooddrunk"])

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -104,6 +104,7 @@
 	duration = 10
 	tick_interval = 0
 	alert_type = /obj/screen/alert/status_effect/blooddrunk
+	var/blooddrunk_damage_mod = 4 // Damage is divided by this at the start of the status effect and multiplied at the end.
 
 /obj/screen/alert/status_effect/blooddrunk
 	name = "Blood-Drunk"
@@ -116,12 +117,12 @@
 		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			H.physiology.brute_mod *= 0.25
-			H.physiology.burn_mod *= 0.25
-			H.physiology.tox_mod *= 0.25
-			H.physiology.oxy_mod *= 0.25
-			H.physiology.clone_mod *= 0.25
-			H.physiology.stamina_mod *= 0.25
+			H.physiology.brute_mod /= blooddrunk_damage_mod
+			H.physiology.burn_mod /= blooddrunk_damage_mod
+			H.physiology.tox_mod /= blooddrunk_damage_mod
+			H.physiology.oxy_mod /= blooddrunk_damage_mod
+			H.physiology.clone_mod /= blooddrunk_damage_mod
+			H.physiology.stamina_mod /= blooddrunk_damage_mod
 		add_attack_logs(owner, owner, "gained blood-drunk stun immunity", ATKLOG_ALL)
 		owner.add_stun_absorption("blooddrunk", INFINITY, 4)
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, TRUE, use_reverb = FALSE)
@@ -129,12 +130,12 @@
 /datum/status_effect/blooddrunk/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod *= 4
-		H.physiology.burn_mod *= 4
-		H.physiology.tox_mod *= 4
-		H.physiology.oxy_mod *= 4
-		H.physiology.clone_mod *= 4
-		H.physiology.stamina_mod *= 4
+		H.physiology.brute_mod *= blooddrunk_damage_mod
+		H.physiology.burn_mod *= blooddrunk_damage_mod
+		H.physiology.tox_mod *= blooddrunk_damage_mod
+		H.physiology.oxy_mod *= blooddrunk_damage_mod
+		H.physiology.clone_mod *= blooddrunk_damage_mod
+		H.physiology.stamina_mod *= blooddrunk_damage_mod
 	add_attack_logs(owner, owner, "lost blood-drunk stun immunity", ATKLOG_ALL)
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 	if(islist(owner.stun_absorption) && owner.stun_absorption["blooddrunk"])

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -104,7 +104,7 @@
 	duration = 10
 	tick_interval = 0
 	alert_type = /obj/screen/alert/status_effect/blooddrunk
-	var/blooddrunk_damage_mod = 4 // Damage is divided by this at the start of the status effect and multiplied at the end.
+	var/blooddrunk_damage_mod_remove = 4 // Damage is multiplied by this at the end of the status effect. Modify this one, it changes the _add
 
 /obj/screen/alert/status_effect/blooddrunk
 	name = "Blood-Drunk"
@@ -117,12 +117,13 @@
 		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			H.physiology.brute_mod /= blooddrunk_damage_mod
-			H.physiology.burn_mod /= blooddrunk_damage_mod
-			H.physiology.tox_mod /= blooddrunk_damage_mod
-			H.physiology.oxy_mod /= blooddrunk_damage_mod
-			H.physiology.clone_mod /= blooddrunk_damage_mod
-			H.physiology.stamina_mod /= blooddrunk_damage_mod
+			var/blooddrunk_damage_mod_add = 1 / blooddrunk_damage_mod_remove // Damage is multiplied by this at the start of the status effect. Don't modify this one directly.
+			H.physiology.brute_mod *= blooddrunk_damage_mod_add
+			H.physiology.burn_mod *= blooddrunk_damage_mod_add
+			H.physiology.tox_mod *= blooddrunk_damage_mod_add
+			H.physiology.oxy_mod *= blooddrunk_damage_mod_add
+			H.physiology.clone_mod *= blooddrunk_damage_mod_add
+			H.physiology.stamina_mod *= blooddrunk_damage_mod_add
 		add_attack_logs(owner, owner, "gained blood-drunk stun immunity", ATKLOG_ALL)
 		owner.add_stun_absorption("blooddrunk", INFINITY, 4)
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, TRUE, use_reverb = FALSE)
@@ -130,12 +131,12 @@
 /datum/status_effect/blooddrunk/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod *= blooddrunk_damage_mod
-		H.physiology.burn_mod *= blooddrunk_damage_mod
-		H.physiology.tox_mod *= blooddrunk_damage_mod
-		H.physiology.oxy_mod *= blooddrunk_damage_mod
-		H.physiology.clone_mod *= blooddrunk_damage_mod
-		H.physiology.stamina_mod *= blooddrunk_damage_mod
+		H.physiology.brute_mod *= blooddrunk_damage_mod_remove
+		H.physiology.burn_mod *= blooddrunk_damage_mod_remove
+		H.physiology.tox_mod *= blooddrunk_damage_mod_remove
+		H.physiology.oxy_mod *= blooddrunk_damage_mod_remove
+		H.physiology.clone_mod *= blooddrunk_damage_mod_remove
+		H.physiology.stamina_mod *= blooddrunk_damage_mod_remove
 	add_attack_logs(owner, owner, "lost blood-drunk stun immunity", ATKLOG_ALL)
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 	if(islist(owner.stun_absorption) && owner.stun_absorption["blooddrunk"])

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -104,7 +104,11 @@
 	duration = 10
 	tick_interval = 0
 	alert_type = /obj/screen/alert/status_effect/blooddrunk
-	var/blooddrunk_damage_mod_remove = 4 // Damage is multiplied by this at the end of the status effect. Modify this one, it changes the _add
+	var/blooddrunk_damage_mod_remove = 4
+
+GLOBAL_VAR_INIT(blooddrunk_damage_mod_remove, 4) // Damage is multiplied by this at the end of the status effect. Modify this one, it changes the _add. Blame Gatchapod for this being global.
+GLOBAL_VAR_INIT(blooddrunk_damage_mod_add, 1 / blooddrunk_damage_mod_remove) // Damage is multiplied by this at the start of the status effect. Don't modify this one directly.
+
 
 /obj/screen/alert/status_effect/blooddrunk
 	name = "Blood-Drunk"
@@ -117,13 +121,12 @@
 		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			var/blooddrunk_damage_mod_add = 1 / blooddrunk_damage_mod_remove // Damage is multiplied by this at the start of the status effect. Don't modify this one directly.
-			H.physiology.brute_mod *= blooddrunk_damage_mod_add
-			H.physiology.burn_mod *= blooddrunk_damage_mod_add
-			H.physiology.tox_mod *= blooddrunk_damage_mod_add
-			H.physiology.oxy_mod *= blooddrunk_damage_mod_add
-			H.physiology.clone_mod *= blooddrunk_damage_mod_add
-			H.physiology.stamina_mod *= blooddrunk_damage_mod_add
+			H.physiology.brute_mod *= GLOB.blooddrunk_damage_mod_add
+			H.physiology.burn_mod *= GLOB.blooddrunk_damage_mod_add
+			H.physiology.tox_mod *= GLOB.blooddrunk_damage_mod_add
+			H.physiology.oxy_mod *= GLOB.blooddrunk_damage_mod_add
+			H.physiology.clone_mod *= GLOB.blooddrunk_damage_mod_add
+			H.physiology.stamina_mod *= GLOB.blooddrunk_damage_mod_add
 		add_attack_logs(owner, owner, "gained blood-drunk stun immunity", ATKLOG_ALL)
 		owner.add_stun_absorption("blooddrunk", INFINITY, 4)
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, TRUE, use_reverb = FALSE)
@@ -131,12 +134,12 @@
 /datum/status_effect/blooddrunk/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod *= blooddrunk_damage_mod_remove
-		H.physiology.burn_mod *= blooddrunk_damage_mod_remove
-		H.physiology.tox_mod *= blooddrunk_damage_mod_remove
-		H.physiology.oxy_mod *= blooddrunk_damage_mod_remove
-		H.physiology.clone_mod *= blooddrunk_damage_mod_remove
-		H.physiology.stamina_mod *= blooddrunk_damage_mod_remove
+		H.physiology.brute_mod *= GLOB.blooddrunk_damage_mod_remove
+		H.physiology.burn_mod *= GLOB.blooddrunk_damage_mod_remove
+		H.physiology.tox_mod *= GLOB.blooddrunk_damage_mod_remove
+		H.physiology.oxy_mod *= GLOB.blooddrunk_damage_mod_remove
+		H.physiology.clone_mod *= GLOB.blooddrunk_damage_mod_remove
+		H.physiology.stamina_mod *= GLOB.blooddrunk_damage_mod_remove
 	add_attack_logs(owner, owner, "lost blood-drunk stun immunity", ATKLOG_ALL)
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
 	if(islist(owner.stun_absorption) && owner.stun_absorption["blooddrunk"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes BDM trophy resetting your damage to the initial value it would have instead of the updated value (as it now reduces damage to 1/4th instead of 1/10th).
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I dunno, miners exploding upon being hit with a light breeze is very entertaining but this is a bug, so...
Fixes https://github.com/ParadiseSS13/Paradise/issues/20335.
## Testing
<!-- How did you test the PR, if at all? -->
Beat up some goliaths with it on, seemed to be taking correct damage before and after, and during the resistance activation.
## Changelog
:cl:
fix: Fixed BDM trophy causing you to take absurd damage after it deactivates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
