### PR TITLE
Bartender bandolier now starts with rubbershot instead of beanbag

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -495,7 +495,7 @@
 
 /obj/item/storage/belt/bandolier/full/populate_contents()
 	for(var/I in 1 to 8)
-		new /obj/item/ammo_casing/shotgun/beanbag(src)
+		new /obj/item/ammo_casing/shotgun/rubbershot(src)
 
 /obj/item/storage/belt/bandolier/update_icon_state()
 	icon_state = "[initial(icon_state)]_[min(length(contents), 8)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the beanbag shells to rubbershot for roundstart bartenders.

## Why It's Good For The Game
Rubbershot works better at handling people who jump the counter or tide inside the bar. Its a more close range ammo type and most of your time in the bar will be dealing with people getting in your face.

Beanbags also are a bit awkward and you need three while rubbershot needs two to stamcrit. Makes sense with a gun that can fire only two barrels.

## Testing
booted test server, spawned as bartender wow

## Changelog
:cl: Octus
tweak: Bartender bandoliers now start with rubbershot instead of beanbag shells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
