### PR TITLE
fixes improper scoping on revenant hallucination

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -415,7 +415,7 @@
 /obj/effect/proc_holder/spell/aoe/revenant/hallucinations/create_new_targeting()
 	var/datum/spell_targeting/aoe/targeting = new()
 	targeting.range = aoe_range
-	targeting.allowed_type = /mob/living
+	targeting.allowed_type = /mob/living/carbon
 	return targeting
 
 /obj/effect/proc_holder/spell/aoe/revenant/hallucinations/cast(list/targets, mob/living/simple_animal/revenant/user = usr)

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -422,7 +422,7 @@
 	if(!attempt_cast(user))
 		return
 
-	for(var/mob/living/carbon/M in targets)
+	for(var/mob/living/carbon/M as anything in targets)
 		M.AdjustHallucinate(120 SECONDS, bound_upper = 300 SECONDS) //Lets not let them get more than 5 minutes of hallucinations
 		new /obj/effect/temp_visual/revenant(get_turf(M))
 

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -422,7 +422,7 @@
 	if(!attempt_cast(user))
 		return
 
-	for(var/mob/living/M as anything in targets)
+	for(var/mob/living/carbon/M as anything in targets)
 		M.AdjustHallucinate(120 SECONDS, bound_upper = 300 SECONDS) //Lets not let them get more than 5 minutes of hallucinations
 		new /obj/effect/temp_visual/revenant(get_turf(M))
 

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -422,7 +422,7 @@
 	if(!attempt_cast(user))
 		return
 
-	for(var/mob/living/carbon/M as anything in targets)
+	for(var/mob/living/carbon/M in targets)
 		M.AdjustHallucinate(120 SECONDS, bound_upper = 300 SECONDS) //Lets not let them get more than 5 minutes of hallucinations
 		new /obj/effect/temp_visual/revenant(get_turf(M))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
only carbons can hallucinate!

## Why It's Good For The Game
![what even](https://user-images.githubusercontent.com/96800819/216480912-ec375ccd-a64f-424a-bec5-43f22f7c969b.jpg)

## Testing
compiled and ran

## Changelog
:cl:
fix: Revenant's hallucination no longer shows non carbon mobs being targeted, this is only visual, they weren't actually affected by the hallucination spell
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
