### PR TITLE
Cleans up and fixes an issue with demon fluff objectives

### DIFF
--- a/code/game/gamemodes/miniantags/demons/slaughter demon/slaughter.dm
+++ b/code/game/gamemodes/miniantags/demons/slaughter demon/slaughter.dm
@@ -51,7 +51,7 @@
 		SEND_SOUND(src, sound('sound/misc/demon_dies.ogg'))
 		if(!(vialspawned))
 			var/datum/objective/slaughter/objective = new
-			var/datum/objective/demonFluff/fluffObjective = new
+			var/datum/objective/demon_fluff/fluffObjective = new
 			SSticker.mode.traitors |= mind
 			objective.owner = mind
 			fluffObjective.owner = mind
@@ -309,6 +309,7 @@
 
 //Objective info, Based on Reverent mini Atang
 /datum/objective/slaughter
+	needs_target = FALSE
 	var/targetKill = 10
 
 /datum/objective/slaughter/New()
@@ -327,27 +328,30 @@
 		return TRUE
 	return FALSE
 
-/datum/objective/demonFluff
+/datum/objective/demon_fluff
+	needs_target = FALSE
 
-
-/datum/objective/demonFluff/New()
+/datum/objective/demon_fluff/New()
 	find_target()
 	var/targetname = "someone"
 	if(target && target.current)
 		targetname = target.current.real_name
-	var/list/explanationTexts = list("Spread blood all over the bridge.", \
-									"Spread blood all over the brig.", \
-									"Spread blood all over the chapel.", \
-									"Kill or Destroy all Janitors or Sanitation bots.", \
-									"Spare a few after striking them... make them bleed before the harvest.", \
-									"Hunt those that try to hunt you first.", \
-									"Hunt those that run away from you in fear", \
-									"Show [targetname] the power of blood.", \
-									"Drive [targetname] insane with demonic whispering."
-									)
-
-	explanation_text = pick(explanationTexts)
+	var/list/explanation_texts = list(
+		"Spread blood all over the bridge.",
+		"Spread blood all over the brig.",
+		"Spread blood all over the chapel.",
+		"Kill or Destroy all Janitors or Sanitation bots.",
+		"Spare a few after striking them... make them bleed before the harvest.",
+		"Hunt those that try to hunt you first.",
+		"Hunt those that run away from you in fear",
+		"Show [targetname] the power of blood.",
+		"Drive [targetname] insane with demonic whispering."
+	)
+	// As this is a fluff objective, we don't need a target, so we want to null it out.
+	// We don't want the demon getting a "Time for Plan B" message if the target cryos.
+	target = null
+	explanation_text = pick(explanation_texts)
 	..()
 
-/datum/objective/demonFluff/check_completion()
-	return 1
+/datum/objective/demon_fluff/check_completion()
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The demon fluff objective was finding a crew target and then when that target cryo'd, it would give the demon the "Time for plan B" message. This shouldn't be happening.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Testing
Spawned in as a slaughter demon, VV'd through my demon objectives. Everything worked.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Demon fluff objectives will no longer be assigned targets or attempt to re-roll targets who have cryo'd.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
