### PR TITLE
Reworks the poison pen

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -431,12 +431,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/poison_pen
 	name = "Poison Pen"
-	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with delayed contact poison."
+	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink is regular ink, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze."
 	reference = "PP"
-	item = /obj/item/pen/poison
+	item = /obj/item/pen/multi/poison
 	cost = 1
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
-	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian")
+	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian", "Coroner", "Psychiatrist")
 
 
 // DANGEROUS WEAPONS

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -431,9 +431,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/poison_pen
 	name = "Poison Pen"
-	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink dispenses medicine, in case of self-poisoning, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze."
+	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink is normal ink, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze. The included gloves will protect you from your own poisons."
 	reference = "PP"
-	item = /obj/item/pen/multi/poison
+	item = /obj/item/storage/box/syndie_kit/poisoner
 	cost = 2
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian", "Coroner", "Psychiatrist", "Virologist")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -431,12 +431,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/poison_pen
 	name = "Poison Pen"
-	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink is regular ink, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze."
+	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink dispenses a medcine, in case of self-poisoning, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze."
 	reference = "PP"
 	item = /obj/item/pen/multi/poison
 	cost = 2
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
-	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian", "Coroner", "Psychiatrist")
+	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian", "Coroner", "Psychiatrist", "Virologist")
 
 
 // DANGEROUS WEAPONS

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -431,7 +431,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/poison_pen
 	name = "Poison Pen"
-	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink dispenses a medcine, in case of self-poisoning, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze."
+	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink dispenses medicine, in case of self-poisoning, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze."
 	reference = "PP"
 	item = /obj/item/pen/multi/poison
 	cost = 2

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -434,7 +434,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink is regular ink, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze."
 	reference = "PP"
 	item = /obj/item/pen/multi/poison
-	cost = 1
+	cost = 2
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian", "Coroner", "Psychiatrist")
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -182,6 +182,13 @@
 	new /obj/item/grenade/empgrenade(src)
 	new /obj/item/implanter/emp/(src)
 
+/obj/item/storage/box/syndie_kit/poisoner
+	name = "poisoner's kit"
+
+/obj/item/storage/box/syndie_kit/poisoner/populate_contents()
+	new /obj/item/pen/multi/poison(src)
+	new /obj/item/clothing/gloves/color/black/poisoner(src)
+
 /obj/item/storage/box/syndie_kit/c4
 	name = "pack of C-4 explosives"
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -267,6 +267,7 @@
 	var/transfer_prints = FALSE
 	var/pickpocket = 0 //Master pickpocket?
 	var/clipped = 0
+	var/safe_from_poison = FALSE //Do they protect the wearer from poison ink?
 	strip_delay = 20
 	put_on_delay = 40
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -257,7 +257,8 @@
 //Gloves
 /obj/item/clothing/gloves
 	name = "gloves"
-	gender = PLURAL //Carn: for grammarically correct text-parsing
+	///Carn: for grammarically correct text-parsing
+	gender = PLURAL
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/clothing/gloves.dmi'
 	siemens_coefficient = 0.50
@@ -265,9 +266,11 @@
 	slot_flags = SLOT_GLOVES
 	attack_verb = list("challenged")
 	var/transfer_prints = FALSE
-	var/pickpocket = 0 //Master pickpocket?
+	///Master pickpocket?
+	var/pickpocket = 0
 	var/clipped = 0
-	var/safe_from_poison = FALSE //Do they protect the wearer from poison ink?
+	///Do they protect the wearer from poison ink?
+	var/safe_from_poison = FALSE
 	strip_delay = 20
 	put_on_delay = 40
 

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -124,6 +124,10 @@
 				return
 	..()
 
+/obj/item/clothing/gloves/color/black/poisoner
+	desc = "These gloves are fire-resistant. They seem thicker than usual."
+	safe_from_poison = TRUE
+
 /obj/item/clothing/gloves/color/orange
 	name = "orange gloves"
 	desc = "A pair of gloves, they don't look special in any way."

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -784,11 +784,9 @@
 /obj/item/paper/pickup(user)
 	if(contact_poison && ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/obj/item/clothing/gloves/G = H.gloves
-		if(!istype(G) || G.transfer_prints)
-			H.reagents.add_reagent(contact_poison, contact_poison_volume)
-			contact_poison = null
-			add_attack_logs(src, user, "Picked up [src], the paper poisoned by [contact_poison_poisoner]")
+		H.reagents.add_reagent(contact_poison, contact_poison_volume)
+		add_attack_logs(src, user, "Picked up [src], coated with [contact_poison] by [contact_poison_poisoner]")
+		contact_poison = null
 	. = ..()
 
 /obj/item/paper/researchnotes

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -784,9 +784,11 @@
 /obj/item/paper/pickup(user)
 	if(contact_poison && ishuman(user))
 		var/mob/living/carbon/human/H = user
-		H.reagents.add_reagent(contact_poison, contact_poison_volume)
-		add_attack_logs(src, user, "Picked up [src], coated with [contact_poison] by [contact_poison_poisoner]")
-		contact_poison = null
+		var/obj/item/clothing/gloves/G = H.gloves
+		if(!istype(G) || !G.safe_from_poison)
+			H.reagents.add_reagent(contact_poison, contact_poison_volume)
+			add_attack_logs(src, user, "Picked up [src], coated with [contact_poison] by [contact_poison_poisoner]")
+			contact_poison = null
 	. = ..()
 
 /obj/item/paper/researchnotes

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -212,13 +212,13 @@
 	return
 
 /obj/item/pen/multi/poison
-	var/current_poison = "charcoal"
+	var/current_poison = null
 
 /obj/item/pen/multi/poison/attack_self(mob/living/user)
 	. = ..()
 	switch(colour)
 		if("black")
-			current_poison = "charcoal"
+			current_poison = null
 		if("red")
 			current_poison = "amanitin"
 		if("green")

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -211,18 +211,30 @@
 /obj/item/proc/on_write(obj/item/paper/P, mob/user)
 	return
 
-/obj/item/pen/poison
-	var/uses_left = 3
+/obj/item/pen/multi/poison
+	var/current_poison
 
-/obj/item/pen/poison/on_write(obj/item/paper/P, mob/user)
-	if(P.contact_poison_volume)
-		to_chat(user, "<span class='warning'>[P] is already coated.</span>")
-	else if(uses_left)
-		uses_left--
-		P.contact_poison = "amanitin"
-		P.contact_poison_volume = 15
-		P.contact_poison_poisoner = user.name
-		add_attack_logs(user, P, "Poison pen'ed")
-		to_chat(user, "<span class='warning'>You apply the poison to [P].</span>")
-	else
-		to_chat(user, "<span class='warning'>[src] clicks. It seems to be depleted.</span>")
+/obj/item/pen/multi/poison/attack_self(mob/living/user)
+	. = ..()
+	switch(colour)
+		if("black")
+			current_poison = null
+		if("red")
+			current_poison = "amanitin"
+		if("green")
+			current_poison = "polonium"
+		if("blue")
+			current_poison = "teslium"
+		if("yellow")
+			current_poison = "pancuronium"
+
+/obj/item/pen/multi/poison/on_write(obj/item/paper/P, mob/user)
+	if(current_poison)
+		if(P.contact_poison)
+			to_chat(user, "<span class='warning'>[P] is already coated.</span>")
+		else
+			P.contact_poison = current_poison
+			P.contact_poison_volume = 20
+			P.contact_poison_poisoner = user.name
+			add_attack_logs(user, P, "Poison pen'ed")
+			to_chat(user, "<span class='warning'>You apply the poison to [P].</span>")

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -212,13 +212,13 @@
 	return
 
 /obj/item/pen/multi/poison
-	var/current_poison
+	var/current_poison = "charcoal"
 
 /obj/item/pen/multi/poison/attack_self(mob/living/user)
 	. = ..()
 	switch(colour)
 		if("black")
-			current_poison = null
+			current_poison = "charcoal"
 		if("red")
 			current_poison = "amanitin"
 		if("green")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Reworks the poison pen to have unlimited uses, different poisons based on the selected color ink, and it goes through normal gloves now. Increases the TC cost as a drawback, while allowing coroners and psychiatrists to purchase them from uplinks. Also comes with a special pair of gloves that prevent you from poisoning yourself.

**Able to apply 20 units of these poisons, by selecting these colors**
- Black Ink: Nothing
- Red Ink: Amanitin
- Green Ink: Polonium
- Blue Ink: Teslium
- Yellow Ink: Pancuronium

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Poison pen is an interesting concept, with a lackluster execution. It is a 3 use item with a very niche activation mechanic, that is not even guaranteed to put the target into crit. Even if it always did max damage, so many people on the station wear gloves, which completely blocks it from having any effect.

**Reasoning for specific changes, Feel free to discuss in the comments, or ping me on discord if you feel strongly about any of these.**
- Going through gloves: It is already hard enough to get a victim to hold a paper at all, needing them to also not be wearing gloves on top of that is nearly impossible. This was the biggest thing holding poison pen back, and if only one thing could change, it should be this.
- 20 units instead of 15: Increases the lethality of every option. I am thinking of having a different amount injected for each poison, but I am unsure if that's needed.
- Unlimited uses: The condition for someone to get poisoned is already difficult enough, and someone probably won't fall for it more than once. This allows for more freedom in who you use it on, especially now that it has more applications.
- Polonium: Kills more slowly than amanitin, but is more difficult to deal with. Does about 1500 rads over the course of the 20 units. My main worry about this is if medbay is bald, this will send you into malpractice hell for a while.
- Teslium: Kills a lot quicker than the other poisons, but is much more obvious than the others. It also affects IPCs as well. This is the loudest option of the poisons, while still taking a bit of time to kick in.
- Pancuronium: Paralyzes after a delay, while still allowing the victim to yell for help. Good as a non-lethal alternative to the other poisons, while still giving the victim a chance to get saved. This is the main reason I was thinking of having each poison inject a different amount, because 20u of panc will paralyze for a frustratingly long time.
- Pysch and Coroner: Both roles can choose to do paperwork if they want, and this gives them more options for RP murder, which is always fun.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Checked to make sure different colors do different things, tested a bunch of different poisons to see how quickly, and how effectively they kill.
## Changelog
:cl:
tweak: Reworks the poison pen to have multiple poison options
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
