### PR TITLE
WIP: Adds shoppers card, a new loyalty program

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -60,3 +60,9 @@
 #define SUPPLY_MATERIALS 	7
 #define SUPPLY_MISC 		8
 #define SUPPLY_VEND 		9
+
+/// A company associated with a product, used for Shoppers Cards
+#define COMPANY_NANOTRASEN	"NanoTrasen"
+#define COMPANY_SYNDICATE	"The Syndicate"
+#define COMPANY_MRCHANGS	"Mr. Chang's"
+#define COMPANY_DONKCO		"Donk Corporation"

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -715,6 +715,7 @@
 	prices = list(/obj/item/reagent_containers/food/drinks/cans/cola = 45, /obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 50,
 					/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 50, /obj/item/reagent_containers/food/drinks/cans/starkist = 50,
 					/obj/item/reagent_containers/food/drinks/cans/space_up = 50, /obj/item/reagent_containers/food/drinks/cans/grape_juice = 50, /obj/item/reagent_containers/glass/beaker/waterbottle = 20)
+	parent_companies = list(/obj/item/reagent_containers/food/drinks/cans/cola = COMPANY_SYNDICATE)	// DEBUG!!! cola is not evil I swear
 	refill_canister = /obj/item/vending_refill/cola
 
 /obj/machinery/economy/vending/cola/free

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -680,6 +680,9 @@
 					/obj/item/reagent_containers/food/snacks/sosjerky = 64, /obj/item/reagent_containers/food/snacks/no_raisin = 80, /obj/item/reagent_containers/food/snacks/pistachios = 80,
 					/obj/item/reagent_containers/food/snacks/spacetwinkie = 64, /obj/item/reagent_containers/food/snacks/cheesiehonkers = 64,/obj/item/reagent_containers/food/snacks/tastybread = 80,
 					/obj/item/reagent_containers/food/snacks/stroopwafel = 100, /obj/item/reagent_containers/food/snacks/syndicake = 175) //syndicakes are genuinely kind of powerful
+	parent_companies = list(
+					/obj/item/reagent_containers/food/snacks/candy/candybar = COMPANY_DONKCO,
+					/obj/item/reagent_containers/food/snacks/syndicake = COMPANY_SYNDICATE)
 	refill_canister = /obj/item/vending_refill/snack
 
 /obj/machinery/economy/vending/snack/free
@@ -715,7 +718,6 @@
 	prices = list(/obj/item/reagent_containers/food/drinks/cans/cola = 45, /obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 50,
 					/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 50, /obj/item/reagent_containers/food/drinks/cans/starkist = 50,
 					/obj/item/reagent_containers/food/drinks/cans/space_up = 50, /obj/item/reagent_containers/food/drinks/cans/grape_juice = 50, /obj/item/reagent_containers/glass/beaker/waterbottle = 20)
-	parent_companies = list(/obj/item/reagent_containers/food/drinks/cans/cola = COMPANY_SYNDICATE)	// DEBUG!!! cola is not evil I swear
 	refill_canister = /obj/item/vending_refill/cola
 
 /obj/machinery/economy/vending/cola/free

--- a/code/game/objects/items/shoppers_card.dm
+++ b/code/game/objects/items/shoppers_card.dm
@@ -22,3 +22,6 @@
 
 /obj/item/shoppers_card/donkco
 	parent_company = COMPANY_DONKCO
+
+// For character setup
+GLOBAL_LIST_INIT(shoppers_card_loadout_options, list(/obj/item/shoppers_card/nanotrasen, /obj/item/shoppers_card/mrchangs, /obj/item/shoppers_card/donkco))

--- a/code/game/objects/items/shoppers_card.dm
+++ b/code/game/objects/items/shoppers_card.dm
@@ -1,0 +1,24 @@
+// This item can be attached to /obj/item/card/id
+/// When an ID makes a purchase with the right shoppers_card in its contents, it gets a discount
+/obj/item/shoppers_card
+	name = "shoppers card"
+	desc = "A small, company loyalty chip, attachable to identification cards. You can get a discount on your purchases with this!"
+	icon = 'icons/obj/card.dmi'	// Need unique stuff
+	var/parent_company	// This is still a bad varname
+
+/obj/item/shoppers_card/Initialize(mapload)
+	. = ..()
+	if(parent_company)
+		name = "[initial(name)] ([parent_company])"
+
+/obj/item/shoppers_card/nanotrasen
+	parent_company = COMPANY_NANOTRASEN
+
+/obj/item/shoppers_card/syndicate
+	parent_company = COMPANY_SYNDICATE
+
+/obj/item/shoppers_card/mrchangs
+	parent_company = COMPANY_MRCHANGS
+
+/obj/item/shoppers_card/donkco
+	parent_company = COMPANY_DONKCO

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -1851,7 +1851,10 @@
 		character.body_accessory = GLOB.body_accessory_by_name[body_accessory]
 
 	character.backbag = backbag
-	// MIRA TODO ADD SHOPPERS CARD ATTACHMENT HERE
+
+	// TODO: Add this to their ID automatically?
+	if(shoppers_card != "None")
+		character.put_in_hands(new shoppers_card)
 
 	//Debugging report to track down a bug, which randomly assigned the plural gender to people.
 	if(character.dna.species.has_gender && (character.gender in list(PLURAL, NEUTER)))

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -101,6 +101,9 @@
 	/// Custom emote text ("name" = "emote text")
 	var/list/custom_emotes = list()
 
+	/// Attached to ID, used for discount purchases
+	var/shoppers_card = "None"
+
 // Fuckery to prevent null characters
 /datum/character_save/New()
 	real_name = random_name(gender, species)
@@ -185,7 +188,8 @@
 					hair_gradient_offset=:h_grad_offset,
 					hair_gradient_colour=:h_grad_colour,
 					hair_gradient_alpha=:h_grad_alpha,
-					custom_emotes=:custom_emotes
+					custom_emotes=:custom_emotes,
+					shoppers_card=.shoppers_card,
 					WHERE ckey=:ckey
 					AND slot=:slot"}, list(
 						// OH GOD SO MANY PARAMETERS
@@ -243,6 +247,7 @@
 						"h_grad_colour" = h_grad_colour,
 						"h_grad_alpha" = h_grad_alpha,
 						"custom_emotes" = json_encode(custom_emotes),
+						"shoppers_card" = shoppers_card,
 						"ckey" = C.ckey,
 						"slot" = slot_number
 					))
@@ -283,7 +288,7 @@
 			player_alt_titles,
 			disabilities, organ_data, rlimb_data, nanotrasen_relation, speciesprefs,
 			socks, body_accessory, gear, autohiss,
-			hair_gradient, hair_gradient_offset, hair_gradient_colour, hair_gradient_alpha, custom_emotes)
+			hair_gradient, hair_gradient_offset, hair_gradient_colour, hair_gradient_alpha, custom_emotes, shoppers_card)
 		VALUES
 			(:ckey, :slot, :metadata, :name, :be_random_name, :gender,
 			:age, :species, :language,
@@ -310,7 +315,7 @@
 			:playertitlelist,
 			:disabilities, :organlist, :rlimblist, :nanotrasen_relation, :speciesprefs,
 			:socks, :body_accessory, :gearlist, :autohiss_mode,
-			:h_grad_style, :h_grad_offset, :h_grad_colour, :h_grad_alpha, :custom_emotes)
+			:h_grad_style, :h_grad_offset, :h_grad_colour, :h_grad_alpha, :custom_emotes, :shoppers_card)
 	"}, list(
 		// This has too many params for anyone to look at this without going insae
 		"ckey" = C.ckey,
@@ -369,6 +374,7 @@
 		"h_grad_colour" = h_grad_colour,
 		"h_grad_alpha" = h_grad_alpha,
 		"custom_emotes" = json_encode(custom_emotes),
+		"shoppers_card" = shoppers_card
 	))
 
 	if(!query.warn_execute())
@@ -454,6 +460,7 @@
 	h_grad_colour = query.item[53]
 	h_grad_alpha = query.item[54]
 	var/custom_emotes_tmp = query.item[55]
+	shoppers_card = query.item[56]
 
 	//Sanitize
 	var/datum/species/SP = GLOB.all_species[species]
@@ -528,6 +535,7 @@
 	loadout_gear = sanitize_json(loadout_gear)
 	custom_emotes_tmp = sanitize_json(custom_emotes_tmp)
 	custom_emotes = init_custom_emotes(custom_emotes_tmp)
+	shoppers_card = sanitize_text(shoppers_card, initial(shoppers_card))
 
 	if(!player_alt_titles)
 		player_alt_titles = new()
@@ -1843,6 +1851,7 @@
 		character.body_accessory = GLOB.body_accessory_by_name[body_accessory]
 
 	character.backbag = backbag
+	// MIRA TODO ADD SHOPPERS CARD ATTACHMENT HERE
 
 	//Debugging report to track down a bug, which randomly assigned the plural gender to people.
 	if(character.dna.species.has_gender && (character.gender in list(PLURAL, NEUTER)))

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -694,6 +694,11 @@
 					if(new_backbag)
 						active_character.backbag = new_backbag
 
+				if("shoppers_card")
+					var/new_shoppers_card = input(user, "Choose your character's shopper's card:", "Character Preference") as null|anything in GLOB.shoppers_card_loadout_options
+					if(new_shoppers_card)
+						active_character.shoppers_card = new_shoppers_card
+
 				if("nt_relation")
 					var/new_relation = input(user, "Choose your relation to NT. Note that this represents what others can find out about your character by researching your background, not what your character actually thinks.", "Character Preference")  as null|anything in list("Loyal", "Supportive", "Neutral", "Skeptical", "Opposed")
 					if(new_relation)

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -376,6 +376,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			if(S.clothing_flags & HAS_SOCKS)
 				dat += "<b>Socks:</b> <a href ='?_src_=prefs;preference=socks;task=input'>[active_character.socks]</a><BR>"
 			dat += "<b>Backpack Type:</b> <a href ='?_src_=prefs;preference=bag;task=input'>[active_character.backbag]</a><br>"
+			dat += "<b>Shoppers Card:</b> <a href ='?_src_=prefs;preference=bag;task=input'>[active_character.shoppers_card]</a><br>"
 
 			dat += "</td></tr></table>"
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -376,7 +376,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			if(S.clothing_flags & HAS_SOCKS)
 				dat += "<b>Socks:</b> <a href ='?_src_=prefs;preference=socks;task=input'>[active_character.socks]</a><BR>"
 			dat += "<b>Backpack Type:</b> <a href ='?_src_=prefs;preference=bag;task=input'>[active_character.backbag]</a><br>"
-			dat += "<b>Shoppers Card:</b> <a href ='?_src_=prefs;preference=bag;task=input'>[active_character.shoppers_card]</a><br>"
+			dat += "<b>Shoppers Card:</b> <a href ='?_src_=prefs;preference=shoppers_card;task=input'>[active_character.shoppers_card]</a><br>"
 
 			dat += "</td></tr></table>"
 

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -219,7 +219,6 @@
 	icon_state = "dr_gibb"
 	list_reagents = list("dr_gibb" = 30)
 
-
 /obj/item/reagent_containers/food/drinks/cans/starkist
 	name = "Star-kist"
 	desc = "The taste of a star in liquid form. And, a bit of tuna...?"

--- a/paradise.dme
+++ b/paradise.dme
@@ -906,6 +906,7 @@
 #include "code\game\objects\items\mixing_bowl.dm"
 #include "code\game\objects\items\random_items.dm"
 #include "code\game\objects\items\shooting_range.dm"
+#include "code\game\objects\items\shoppers_card.dm"
 #include "code\game\objects\items\sport.dm"
 #include "code\game\objects\items\theft_items.dm"
 #include "code\game\objects\items\toys.dm"


### PR DESCRIPTION
## What Does This PR Do

**[I need feedback on this in this forum topic. Please keep this PR for code-related discussions.](https://www.paradisestation.org/forum/topic/23575-shoppers-card-the-new-loyalty-program/)**

Adds a new item, the "shoppers card" (loyalty card, clubcard, whatever you call it IRL). Each shoppers card is affiliated with exactly one company (NanoTrasen, Donk Co, Mr Changs, etc.). It can be attached to an ID. Players can select theirs in Setup Character.

IDs buying items from vending machines that are also associated with the same company get a 10% discount. For example, if you have a Mr. Changs shoppers card on your ID and you purchase a chow mein, you'll get a 10% discount on the price.

Each vending item can be associated with one company, it is not machine-bound. Check "Getmore Chocolate Corp", I included it as an example.

To avoid boring powergamers, YouTool items won't have an associated company with them.

It also tracks every successful discount purchase for a fun end-year report on which company the players supported the most.

You can add multiple shoppers cards to your ID.


- [x] Make shoppers cards attachable to and detachable from IDs
- [x] Make vending machines able to scan for shoppers cards and modify prices
- [x] Make vending items able to be associated with companies
- [x] Make vending machines openly announce whose product you bought (the original 20s speech cooldown still applies)
- [ ] Make selecting shoppers card in character setup display names, not paths
- [ ] Make shoppers card attach to IDs automatically upon spawning in
- [ ] Include every company in our lore in the code
- [ ] Custom sprites for shoppers cards
- [ ] Add overlays to modified IDs
- [ ] Add custom examine text to modified IDs
- [ ] [Seek and implement feedback from the community for more ideas](https://www.paradisestation.org/forum/topic/23575-shoppers-card-the-new-loyalty-program/)

## Why It's Good For The Game

1. Our economy system is fancy and this one expands on it
2. People picking the same organisation can have something to bond over
3. Lore representation in game
4. More unique(???) Paradise stuff

## Images of changes

![image](https://user-images.githubusercontent.com/33333517/216610420-a1b6367a-8f8b-452a-a36e-37cc68b3c47e.png)

## Testing

1. Spawn a `/obj/item/shoppers_card/syndicate`
2. Attach it to an ID with money on it
3. Spawn a `/obj/machinery/economy/vending/snack`
4. Buy syndicakes (450 creds -> 293 creds, 18 creds discount)

## Changelog
:cl:
add: Adds shoppers card, this will need an elaborate changelog.
/:cl:
