### PR TITLE
Fixes Negative Power Consumption Caused by Thermo Machines

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -149,6 +149,16 @@
 
 	power_state = use_type
 
+/obj/machinery/proc/update_idle_power_consumption(channel = power_channel, amount)
+	if(power_state == ACTIVE_POWER_USE)
+		machine_powernet.adjust_static_power(power_channel, amount - idle_power_consumption)
+	idle_power_consumption = amount
+
+/obj/machinery/proc/update_active_power_consumption(channel = power_channel, amount)
+	if(power_state == ACTIVE_POWER_USE)
+		machine_powernet.adjust_static_power(power_channel, amount - active_power_consumption)
+	active_power_consumption = amount
+
 /obj/machinery/default_welder_repair(mob/user, obj/item/I)
 	. = ..()
 	if(.)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -107,10 +107,10 @@
 
 	var/temperature_delta= abs(old_temperature - air_contents.temperature)
 	if(temperature_delta > 1)
-		active_power_consumption = (heat_capacity * temperature_delta) / 10 + idle_power_consumption
+		update_active_power_consumption(power_channel, (heat_capacity * temperature_delta) / 10 + idle_power_consumption)
 		parent.update = 1
 	else
-		active_power_consumption = idle_power_consumption
+		update_active_power_consumption(power_channel, idle_power_consumption)
 	return 1
 
 /obj/machinery/atmospherics/unary/thermomachine/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## What Does This PR Do
Fixes issues with APCs having negative power consumption on certain channels

## Why It's Good For The Game
power needs to come from somewhere, not just exist infinitely


## Testing
Ran on test server in, checked to make sure heaters adjusted their power consumption properly.

## Changelog
:cl:
fix: Fixes Negative Power Consumption on Toxin APCs
/:cl:


