### PR TITLE
Whitespace fixes, final part (hopefully)

### DIFF
--- a/code/game/machinery/computer/brigcells.dm
+++ b/code/game/machinery/computer/brigcells.dm
@@ -1,13 +1,13 @@
 /obj/machinery/computer/brigcells
-    name = "cell management computer"
-    desc = "Used to manage prison cells."
-    icon_keyboard = "security_key"
-    icon_screen = "cell_monitor"
-    idle_power_consumption = 250
-    active_power_consumption = 500
-    circuit = /obj/item/circuitboard/brigcells
-    light_color = LIGHT_COLOR_DARKRED
-    req_access = list(ACCESS_BRIG)
+	name = "cell management computer"
+	desc = "Used to manage prison cells."
+	icon_keyboard = "security_key"
+	icon_screen = "cell_monitor"
+	idle_power_consumption = 250
+	active_power_consumption = 500
+	circuit = /obj/item/circuitboard/brigcells
+	light_color = LIGHT_COLOR_DARKRED
+	req_access = list(ACCESS_BRIG)
 
 /obj/machinery/computer/brigcells/attack_ai(mob/user)
 	attack_hand(user)

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -41,7 +41,7 @@
 	add_fingerprint(user)
 	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		user.visible_message("<span class='danger'>[user] accidentally clubs [user.p_themselves()] with [src]!</span>", \
-							 "<span class='userdanger'>You accidentally club yourself with [src]!</span>")
+							"<span class='userdanger'>You accidentally club yourself with [src]!</span>")
 		user.KnockDown(knockdown_duration)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user


### PR DESCRIPTION
## What Does This PR Do
This PR fixes two whitespace issues that snuck in between the last manual whitespace cleanup (#20226). With the submission of this PR all existing whitespace issues should be fixed and #19875 will be ready for review, making further whitespace checks part of CI.

There should be _no changes in this PR other than the following_:
1. The removal of leading spaces, or the replacement of leading spaces with tabs.
2. The addition of an asterix prefix for lines of comments which previously had leading whitespace.
3. Strings with leading spaces having their spaces moved to the previous line.