### PR TITLE
Janitorial holosign projector tweaks

### DIFF
--- a/code/game/objects/items/weapons/holosign_projector.dm
+++ b/code/game/objects/items/weapons/holosign_projector.dm
@@ -13,7 +13,7 @@
 	origin_tech = "magnets=1;programming=3"
 	flags = NOBLUDGEON
 	var/list/signs = list()
-	var/max_signs = 10
+	var/max_signs = 6
 	var/creation_time = 0 //time to create a holosign in deciseconds.
 	var/holosign_type = null
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
@@ -60,10 +60,11 @@
 		to_chat(user, "<span class='notice'>You clear all active holograms.</span>")
 
 /obj/item/holosign_creator/janitor
-	name = "Janitorial Holosign projector"
+	name = "janitorial holosign projector"
 	desc = "A handy-dandy holographic projector that displays a janitorial sign."
 	holosign_type = /obj/structure/holosign/wetsign
-	var/wet_enabled = FALSE
+	max_signs = 18
+	var/wet_enabled = TRUE
 
 /obj/item/holosign_creator/janitor/AltClick(mob/user)
 	wet_enabled = !wet_enabled
@@ -91,7 +92,6 @@
 	belt_icon = null
 	holosign_type = /obj/structure/holosign/barrier
 	creation_time = 30
-	max_signs = 6
 
 /obj/item/holosign_creator/engineering
 	name = "engineering holobarrier projector"
@@ -100,7 +100,6 @@
 	belt_icon = null
 	holosign_type = /obj/structure/holosign/barrier/engineering
 	creation_time = 30
-	max_signs = 6
 
 /obj/item/holosign_creator/atmos
 	name = "ATMOS holofan projector"
@@ -112,7 +111,7 @@
 	max_signs = 3
 
 /obj/item/holosign_creator/cyborg
-	name = "Energy Barrier Projector"
+	name = "energy barrier projector"
 	desc = "A holographic projector that creates fragile energy fields."
 	creation_time = 15
 	max_signs = 9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Janitorial holosign projector capacity has been increased (10 ->18).
Janitorial holosign projector now starts with the wet evaporation timer activated.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having the W.E.T system on as the standard mode is good for newer janitors that will very likely forget to delete their signs.
10 holosigns might feel like not enough for some janitors, 18 would be enough to cover 3 locations (considering someone that covers the wet floor with 3 signs on each side on a hallway)

## Testing
<!-- How did you test the PR, if at all? -->
- Changed modes and used the projector until max amount of holosigns
## Changelog
:cl:
tweak: Janitorial holosign projector capacity has been increased (10 ->18)
tweak: Janitorial holosign projector now starts with the wet evaporation timer activated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
