### PR TITLE
janicart (pimpin' ride) tweaks

### DIFF
--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -62,21 +62,33 @@
 
 
 /obj/vehicle/janicart/attackby(obj/item/I, mob/user, params)
+	var/fail_msg = "<span class='notice'>There is already one of those in [src].</span>"
+
 	if(istype(I, /obj/item/storage/bag/trash))
-		if(!user.drop_item())
+		if(!mybag)
+			if(!user.drop_item())
+				return
+			to_chat(user, "<span class='notice'>You hook [I] onto [src].</span>")
+			I.forceMove(src)
+			mybag = I
+			update_icon(UPDATE_OVERLAYS)
 			return
-		to_chat(user, "<span class='notice'>You hook [I] onto [src].</span>")
-		I.forceMove(src)
-		mybag = I
-		update_icon(UPDATE_OVERLAYS)
-		return
+		else
+			to_chat(user, fail_msg)
 	if(istype(I, /obj/item/janiupgrade))
-		floorbuffer = TRUE
-		qdel(I)
-		to_chat(user,"<span class='notice'>You upgrade [src] with [I].</span>")
-		update_icon(UPDATE_OVERLAYS)
-		return
-	return ..()
+		if(!floorbuffer)
+			floorbuffer = TRUE
+			qdel(I)
+			to_chat(user,"<span class='notice'>You upgrade [src] with [I].</span>")
+			update_icon(UPDATE_OVERLAYS)
+			return
+		else
+			to_chat(user, fail_msg)
+	if(istype(I, /obj/item/key/janitor))
+		..()
+	if(mybag && user.a_intent == INTENT_HELP)
+		mybag.attackby(I, user)
+	return
 
 /obj/vehicle/janicart/update_overlays()
 	. = ..()

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -65,25 +65,25 @@
 	var/fail_msg = "<span class='notice'>There is already one of those in [src].</span>"
 
 	if(istype(I, /obj/item/storage/bag/trash))
-		if(!mybag)
-			if(!user.drop_item())
-				return
-			to_chat(user, "<span class='notice'>You hook [I] onto [src].</span>")
-			I.forceMove(src)
-			mybag = I
-			update_icon(UPDATE_OVERLAYS)
-			return
-		else
+		if(mybag)
 			to_chat(user, fail_msg)
+			return
+		if(!user.drop_item())
+			return
+		to_chat(user, "<span class='notice'>You hook [I] onto [src].</span>")
+		I.forceMove(src)
+		mybag = I
+		update_icon(UPDATE_OVERLAYS)
+		return
 	if(istype(I, /obj/item/janiupgrade))
-		if(!floorbuffer)
-			floorbuffer = TRUE
-			qdel(I)
-			to_chat(user,"<span class='notice'>You upgrade [src] with [I].</span>")
-			update_icon(UPDATE_OVERLAYS)
-			return
-		else
+		if(floorbuffer)
 			to_chat(user, fail_msg)
+			return
+		floorbuffer = TRUE
+		qdel(I)
+		to_chat(user,"<span class='notice'>You upgrade [src] with [I].</span>")
+		update_icon(UPDATE_OVERLAYS)
+		return
 	if(mybag && user.a_intent == INTENT_HELP && !is_key(I))
 		mybag.attackby(I, user)
 	else

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -88,7 +88,7 @@
 		..()
 	if(mybag && user.a_intent == INTENT_HELP)
 		mybag.attackby(I, user)
-	return
+	return ..()
 
 /obj/vehicle/janicart/update_overlays()
 	. = ..()

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -84,11 +84,10 @@
 			return
 		else
 			to_chat(user, fail_msg)
-	if(istype(I, /obj/item/key/janitor))
-		..()
-	if(mybag && user.a_intent == INTENT_HELP)
+	if(mybag && user.a_intent == INTENT_HELP && !is_key(I))
 		mybag.attackby(I, user)
-	return ..()
+	else
+		return ..()
 
 /obj/vehicle/janicart/update_overlays()
 	. = ..()

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -62,10 +62,12 @@
 
 
 /obj/vehicle/janicart/attackby(obj/item/I, mob/user, params)
-	if(mybag || floorbuffer)
-		to_chat(user, "<span class='notice'>There is already one of those in [src].</span>")
-		return
+	var/fail_msg = "<span class='notice'>There is already one of those in [src].</span>"
+
 	if(istype(I, /obj/item/storage/bag/trash))
+		if(mybag)
+			to_chat(user, fail_msg)
+			return
 		if(!user.drop_item())
 			return
 		to_chat(user, "<span class='notice'>You hook [I] onto [src].</span>")
@@ -74,6 +76,9 @@
 		update_icon(UPDATE_OVERLAYS)
 		return
 	if(istype(I, /obj/item/janiupgrade))
+		if(floorbuffer)
+			to_chat(user, fail_msg)
+			return
 		floorbuffer = TRUE
 		qdel(I)
 		to_chat(user,"<span class='notice'>You upgrade [src] with [I].</span>")

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -62,12 +62,10 @@
 
 
 /obj/vehicle/janicart/attackby(obj/item/I, mob/user, params)
-	var/fail_msg = "<span class='notice'>There is already one of those in [src].</span>"
-
+	if(mybag || floorbuffer)
+		to_chat(user, "<span class='notice'>There is already one of those in [src].</span>")
+		return
 	if(istype(I, /obj/item/storage/bag/trash))
-		if(mybag)
-			to_chat(user, fail_msg)
-			return
 		if(!user.drop_item())
 			return
 		to_chat(user, "<span class='notice'>You hook [I] onto [src].</span>")
@@ -76,9 +74,6 @@
 		update_icon(UPDATE_OVERLAYS)
 		return
 	if(istype(I, /obj/item/janiupgrade))
-		if(floorbuffer)
-			to_chat(user, fail_msg)
-			return
 		floorbuffer = TRUE
 		qdel(I)
 		to_chat(user,"<span class='notice'>You upgrade [src] with [I].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
You can now add trash directly to a trashbag attached to the pimpin' ride.
You can no longer waste multiple bags and upgrades by inserting lots of them.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having to remove the trashbag from the vehicle to use it is too clunky, it should work like the janicart.

## Testing
<!-- How did you test the PR, if at all? -->
- Tried to insert more than one trashbag, received failure message
- Deposited lots of trash while riding the pimpin' ride
## Changelog
:cl:
tweak: You can now add trash directly to a trashbag attached to the pimpin' ride
fix: Pimpin' ride: You can no longer waste multiple bags and upgrades by inserting lots of them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
