### PR TITLE
radial menu guardians

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -639,7 +639,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/guardian
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	cost = 12
-	refund_path = /obj/item/guardiancreator/tech/choose
+	refund_path = /obj/item/guardiancreator/tech
 	refundable = TRUE
 	cant_discount = TRUE
 

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -246,9 +246,7 @@
 	var/failure_message = "..And draw a card! It's...blank? Maybe you should try again later."
 	var/ling_failure = "The deck refuses to respond to a souless creature such as you."
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive", "Assassin", "Lightning", "Charger", "Protector")
-	var/random = FALSE
 	/// What type was picked the first activation
-	var/picked_random_type
 	var/color_list = list("Pink" = "#FFC0CB",
 		"Red" = "#FF0000",
 		"Orange" = "#FFA500",
@@ -263,28 +261,55 @@
 	if(user.mind && (ischangeling(user) || user.mind.has_antag_datum(/datum/antagonist/vampire)))
 		to_chat(user, "[ling_failure]")
 		return
-	if(used == TRUE)
+	if(used)
 		to_chat(user, "[used_message]")
 		return
 	used = TRUE // Set this BEFORE the popup to prevent people using the injector more than once, polling ghosts multiple times, and receiving multiple guardians.
-	var/choice = alert(user, "[confirmation_message]",, "Yes", "No")
-	if(choice == "No")
+
+	to_chat(user, "[use_message]")
+	var/guardian_type
+	switch(theme)
+		if("magic")
+			var/list/possible_guardians_magic = list("Chaos" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicOrange"),
+										"Standard" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicGreen"),
+										"Ranged" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicRed"),
+										"Support" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicBlue"),
+										"Explosive" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicRed"),
+										"Assassin" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicOrange"),
+										"Lightning" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicPink"),
+										"Charger" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicRed"),
+										"Protector" = image(icon = 'icons/mob/guardian.dmi', icon_state = "magicBlue"))
+
+			guardian_type = show_radial_menu(user, src, possible_guardians_magic, radius = 44)
+		if("tech")
+			var/list/possible_guardians_tech = list("Chaos" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techLilac"),
+										"Standard" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techZinnia"),
+										"Ranged" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techPeony"),
+										"Support" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techPetunia"),
+										"Explosive" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techViolet"),
+										"Assassin" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techRose"),
+										"Lightning" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techDaisy"),
+										"Charger" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techIvy"),
+										"Protector" = image(icon = 'icons/mob/guardian.dmi', icon_state = "techIris"))
+			guardian_type = show_radial_menu(user, src, possible_guardians_tech, radius = 44)
+		if("bio")
+			var/list/possible_guardians_bio = list("Chaos" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioIvy"),
+										"Standard" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioOrchid"),
+										"Ranged" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioRose"),
+										"Support" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioPetunia"),
+										"Explosive" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioLily"),
+										"Assassin" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioPeony"),
+										"Lightning" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioDaisy"),
+										"Charger" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioZinnia"),
+										"Protector" = image(icon = 'icons/mob/guardian.dmi', icon_state = "bioIris"))
+			guardian_type = show_radial_menu(user, src, possible_guardians_bio, radius = 44)
+	if(QDELETED(src) || !in_range(user, src) || user.stat)
+		used = FALSE
+		return
+	if(!guardian_type)
 		to_chat(user, "<span class='warning'>You decide against using the [name].</span>")
 		used = FALSE
 		return
-	to_chat(user, "[use_message]")
-
-	var/guardian_type
-	if(random)
-		if(!picked_random_type) // Only pick the type once. No type fishing
-			picked_random_type = pick(possible_guardians)
-		guardian_type = picked_random_type
-	else
-		guardian_type = input(user, "Pick the type of [mob_name]", "[mob_name] Creation") as null|anything in possible_guardians
-		if(!guardian_type)
-			to_chat(user, "<span class='warning'>You decide against using the [name].</span>")
-			used = FALSE
-			return
 
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the [mob_name] ([guardian_type]) of [user.real_name]?", ROLE_GUARDIAN, FALSE, 10 SECONDS, source = src, role_cleanname = "[mob_name] ([guardian_type])")
 	var/mob/dead/observer/theghost = null
@@ -367,9 +392,6 @@
 	G.icon_dead = "[theme][color]"
 	to_chat(user, "[G.magic_fluff_string].")
 
-/obj/item/guardiancreator/choose
-	random = FALSE
-
 /obj/item/guardiancreator/tech
 	name = "holoparasite injector"
 	desc = "It contains alien nanoswarm of unknown origin. Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, it requires an organic host as a home base and source of fuel."
@@ -407,9 +429,6 @@
 /obj/item/guardiancreator/tech/check_uplink_validity()
 	return !used
 
-/obj/item/guardiancreator/tech/choose
-	random = FALSE
-
 /obj/item/guardiancreator/biological
 	name = "scarab egg cluster"
 	desc = "A parasitic species that will nest in the closest living creature upon birth. While not great for your health, they'll defend their new 'hive' to the death."
@@ -444,10 +463,6 @@
 	G.attacktext = "swarms"
 	G.speak_emote = list("chitters")
 
-/obj/item/guardiancreator/biological/choose
-	random = FALSE
-
-
 /obj/item/paper/guardian
 	name = "Holoparasite Guide"
 	icon_state = "paper"
@@ -480,5 +495,5 @@
 	name = "holoparasite injector kit"
 
 /obj/item/storage/box/syndie_kit/guardian/populate_contents()
-	new /obj/item/guardiancreator/tech/choose(src)
+	new /obj/item/guardiancreator/tech(src)
 	new /obj/item/paper/guardian(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title
Removes unused random guardians 

## Why It's Good For The Game
Radial menus are better than basic input menus

## Images of changes
(Only 5 colors for the base ones, best I can do)
![Screenshot 2023-02-05 180634](https://user-images.githubusercontent.com/96800819/216854377-6fb505b9-3464-4f19-9606-2144cb422220.png)
![Screenshot 2023-02-05 180608](https://user-images.githubusercontent.com/96800819/216854393-857c95bf-8113-46cb-9693-f6498ef0661b.png)
![Screenshot 2023-02-05 180541](https://user-images.githubusercontent.com/96800819/216854397-7d17bbe9-71db-415f-affc-7668f3d9c41d.png)


## Testing
see screenshots

## Changelog
:cl:
tweak: Guardian creation items now use radial menus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
