### PR TITLE
parry is now automatically binded to space

### DIFF
--- a/code/datums/keybindings/human_keybinds.dm
+++ b/code/datums/keybindings/human_keybinds.dm
@@ -45,6 +45,7 @@
 
 /datum/keybinding/human/parry
 	name = "Parry"
+	keys = list("F")
 
 /datum/keybinding/human/parry/down(client/C)
 	. = ..()

--- a/code/datums/keybindings/human_keybinds.dm
+++ b/code/datums/keybindings/human_keybinds.dm
@@ -45,7 +45,7 @@
 
 /datum/keybinding/human/parry
 	name = "Parry"
-	keys = list("F")
+	keys = list("Space")
 
 /datum/keybinding/human/parry/down(client/C)
 	. = ..()

--- a/code/datums/keybindings/mob.dm
+++ b/code/datums/keybindings/mob.dm
@@ -41,6 +41,7 @@
 // Intents
 /datum/keybinding/mob/prev_intent
 	name = "Previous Intent"
+	keys = list("F")
 
 /datum/keybinding/mob/prev_intent/down(client/C)
 	. = ..()

--- a/code/datums/keybindings/mob.dm
+++ b/code/datums/keybindings/mob.dm
@@ -41,7 +41,6 @@
 // Intents
 /datum/keybinding/mob/prev_intent
 	name = "Previous Intent"
-	keys = list("F")
 
 /datum/keybinding/mob/prev_intent/down(client/C)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title

## Why It's Good For The Game
Parrying is pretty important and it ought to be an automatically set keybind
Another big reason why this is very nice is because of how annoying parrying is without an automatic keybind while testing, you need to go into prefs `every time` and rebind it when you're testing something, just infuriating really.  

## Testing
Compiled, hit space

## Changelog
:cl:
tweak: Parry is now automatically binded to space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
