### PR TITLE
Removes prisoner clothing from the temporary brig cells

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -19290,7 +19290,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -19315,14 +19315,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
 /area/security/permabrig)
 "bdd" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -20493,10 +20493,10 @@
 	name = "south bump";
 	pixel_y = -30
 	},
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1287,7 +1287,7 @@
 	},
 /area/security/main)
 "akN" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -69403,7 +69403,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard2)
 "mlj" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "red"
@@ -80614,7 +80614,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "rRp" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -81357,10 +81357,10 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "sml" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -86360,7 +86360,7 @@
 	},
 /area/assembly/robotics)
 "uSc" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -91595,10 +91595,10 @@
 	},
 /area/engine/equipmentstorage)
 "xCC" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/camera{
 	c_tag = "Prisoner Lockers"
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -92413,7 +92413,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "xWI" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -2616,7 +2616,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "apd" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -2626,6 +2625,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "ape" = (
@@ -4588,13 +4588,13 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "azk" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Prisoner Lockers"
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "azs" = (
@@ -56631,7 +56631,7 @@
 	},
 /area/security/nuke_storage)
 "jYh" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "jYp" = (
@@ -74791,10 +74791,10 @@
 	},
 /area/maintenance/maintcentral)
 "rgF" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "rgO" = (
@@ -88158,11 +88158,11 @@
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "wuE" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/item/radio/intercom{
 	pixel_y = -28;
 	name = "custom placement"
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "wuW" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -66435,7 +66435,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
 "egq" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -66445,6 +66444,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -70599,12 +70599,12 @@
 	},
 /area/maintenance/aft)
 "gZy" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -76007,7 +76007,7 @@
 /turf/space,
 /area/solar/auxstarboard)
 "lgS" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -81535,7 +81535,7 @@
 	},
 /area/quartermaster/storage)
 "psa" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -86796,12 +86796,12 @@
 	},
 /area/toxins/xenobiology)
 "tCY" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -89836,7 +89836,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "vDY" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "red"
@@ -92628,7 +92628,6 @@
 	},
 /area/security/execution)
 "xVM" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
@@ -92636,6 +92635,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/brig/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -4575,7 +4575,7 @@
 	},
 /area/mine/airlock)
 "op" = (
-/obj/structure/closet/secure_closet/brig/gulag,
+/obj/structure/closet/secure_closet/brig/prisoner/gulag,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "oA" = (
@@ -4676,8 +4676,8 @@
 /turf/simulated/wall,
 /area/mine/laborcamp)
 "rd" = (
-/obj/structure/closet/secure_closet/brig/gulag,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig/prisoner/gulag,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "rj" = (
@@ -4734,7 +4734,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/brig/gulag,
+/obj/structure/closet/secure_closet/brig/prisoner/gulag,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "sF" = (
@@ -5996,11 +5996,11 @@
 	},
 /area/mine/sleeper)
 "PK" = (
-/obj/structure/closet/secure_closet/brig/gulag,
 /obj/machinery/flasher{
 	id = "labor";
 	pixel_y = 32
 	},
+/obj/structure/closet/secure_closet/brig/prisoner/gulag,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "PQ" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -231,7 +231,7 @@
 	anchored = TRUE
 	var/id = null
 
-/obj/structure/closet/secure_closet/brig/populate_contents()
+/obj/structure/closet/secure_closet/brig/prisoner/populate_contents()
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/shoes/orange(src)
 	new /obj/item/card/id/prisoner/random(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -237,13 +237,13 @@
 	new /obj/item/card/id/prisoner/random(src)
 	new /obj/item/radio/headset(src)
 
-/obj/structure/closet/secure_closet/brig/gulag
+/obj/structure/closet/secure_closet/brig/prisoner/gulag
 	name = "labor camp locker"
 	desc = "A special locker designed to store prisoner belongings, allows access when prisoners meet their point quota."
 	locked = FALSE
 	var/registered_ID_UID
 
-/obj/structure/closet/secure_closet/brig/gulag/allowed(mob/M)
+/obj/structure/closet/secure_closet/brig/prisoner/gulag/allowed(mob/M)
 	. = ..()
 	if(.) //we were gonna let them do it anyway
 		return TRUE
@@ -265,7 +265,7 @@
 
 	return FALSE //if we didn't match above, no interaction for you
 
-/obj/structure/closet/secure_closet/brig/gulag/examine(mob/user)
+/obj/structure/closet/secure_closet/brig/prisoner/gulag/examine(mob/user)
 	. = ..()
 	if(registered_ID_UID)
 		var/obj/item/card/id/prisoner/prisoner_id = locateUID(registered_ID_UID)


### PR DESCRIPTION
## What Does This PR Do

Removes the prisoner clothing and ID from the temporary brig cell closets.

## Why It's Good For The Game

Legal SOP says to keep stuff on the prisoner when brigging non-permanently. Currently, the game suggests you should be re-dressing them. This fixes it.

## Images of changes

Cerestation - Perma

![image](https://user-images.githubusercontent.com/33333517/216933436-9df4a809-26c8-4183-a046-562d6e81335f.png)

Cerestation - Temp cells

![image](https://user-images.githubusercontent.com/33333517/216933512-15a2b113-4a9c-496b-a219-a3378665946b.png)

Cyberiad - Perma

![image](https://user-images.githubusercontent.com/33333517/216934222-ce37ceb9-5f86-4062-9804-e01e84ff1666.png)

Cyberiad - Temp cells

![image](https://user-images.githubusercontent.com/33333517/216937528-b3384389-6cef-4c31-9461-9699560e3fa7.png)

Cerebron - Perma

![image](https://user-images.githubusercontent.com/33333517/216935528-f1b04eaa-74f4-47d9-baa1-9d9d8ab12a82.png)

Cerebron - Temp cells

![image](https://user-images.githubusercontent.com/33333517/216935148-e0c3f2b3-60fb-4089-a2e1-01acfbcfda22.png)

Kerberos - Perma

![image](https://user-images.githubusercontent.com/33333517/216936564-37535c10-b4c9-42f1-b303-9a8a8498753d.png)

Kerberos - Temp cells

![image](https://user-images.githubusercontent.com/33333517/216936629-eab002f2-144f-490f-b9a8-840c1e566a9e.png)

Labor camp

![image](https://user-images.githubusercontent.com/33333517/216937768-661945cf-e336-4516-8568-ba1283b0de0f.png)

## Testing

Compiled all 4 maps, took screenshots.

## Changelog
:cl:
del: Temporary brig cell closets no longer have prisoner gear in them, to reduce confusion whether people should be re-dressed or not.
/:cl:
