### PR TITLE
combat defib tweaks, moved out of the medikit

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -552,6 +552,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/twohanded/chainsaw
 	cost = 13
 
+/datum/uplink_item/dangerous/combat_defib
+	name = "Combat defibrillator"
+	desc = "A lifesaving device turned dangerous weapon. Click on someone with the paddles on harm intent to instantly stop their heart. Can be used as a regular defib as well."
+	reference = "CD"
+	item = /obj/item/defibrillator/compact/combat/loaded
+	cost = 12
+
 // SUPPORT AND MECHAS
 
 /datum/uplink_item/support
@@ -1414,7 +1421,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	and other medical supplies helpful for a medical field operative."
 	reference = "SCMK"
 	item = /obj/item/storage/firstaid/tactical
-	cost = 7
+	cost = 4
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/device_tools/vtec
@@ -1786,7 +1793,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			a medical beam gun and a pair of syndicate magboots."
 	reference = "MEDB"
 	item = /obj/item/storage/backpack/duffel/syndie/med/medicalbundle
-	cost = 20 // normally 24
+	cost = 16 // normally 21
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/bundles_TC/sniper

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -185,9 +185,9 @@
 /obj/item/storage/firstaid/tactical/populate_contents()
 	new /obj/item/reagent_containers/hypospray/combat(src)
 	new /obj/item/reagent_containers/applicator/dual/syndi(src) // Because you ain't got no time to look at what damage dey taking yo
-	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
-	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
-	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/emergency_nuclear(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/emergency_nuclear(src)
+	new /obj/item/storage/pill_bottle/painkillers(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 
 /obj/item/storage/firstaid/tactical/empty/populate_contents()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -185,7 +185,9 @@
 /obj/item/storage/firstaid/tactical/populate_contents()
 	new /obj/item/reagent_containers/hypospray/combat(src)
 	new /obj/item/reagent_containers/applicator/dual/syndi(src) // Because you ain't got no time to look at what damage dey taking yo
-	new /obj/item/defibrillator/compact/combat/loaded(src)
+	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 
 /obj/item/storage/firstaid/tactical/empty/populate_contents()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -164,7 +164,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/emergency_nuclear
 	name = "emergency stabilization medipen"
-	desc = "A fast acting livesaving emergency autoinjector. Effective in combat situations, make by the syndicate for the syndicate.</span>"
+	desc = "A fast acting live-saving emergency autoinjector. Effective in combat situations, made by the syndicate for the syndicate."
 	icon_state = "stimpen"
 	volume = 15
 	amount_per_transfer_from_this = 15

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -164,7 +164,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/emergency_nuclear
 	name = "emergency stabilization medipen"
-	desc = "A fast acting live-saving emergency autoinjector. Effective in combat situations, made by the syndicate for the syndicate."
+	desc = "A fast acting life-saving emergency autoinjector. Effective in combat situations, made by the syndicate for the syndicate."
 	icon_state = "stimpen"
 	volume = 15
 	amount_per_transfer_from_this = 15

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -162,6 +162,14 @@
 	amount_per_transfer_from_this = 42
 	list_reagents = list("salbutamol" = 10, "teporone" = 15, "epinephrine" = 10, "lavaland_extract" = 2, "weak_omnizine" = 5) //Short burst of healing, followed by minor healing from the saline
 
+/obj/item/reagent_containers/hypospray/autoinjector/emergency_nuclear
+	name = "emergency stabilization medipen"
+	desc = "A fast acting livesaving emergency autoinjector. Effective in combat situations, make by the syndicate for the syndicate.</span>"
+	icon_state = "stimpen"
+	volume = 15
+	amount_per_transfer_from_this = 15
+	list_reagents = list("perfluorodecalin" = 3, "teporone" = 3, "atropine" = 3, "stimulants" = 3, "mannitol" = 3)
+
 /obj/item/reagent_containers/hypospray/autoinjector/nanocalcium
 	name = "protoype nanite autoinjector"
 	desc = "After a short period of time the nanites will slow the body's systems and assist with body repair. Nanomachines son."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -166,9 +166,9 @@
 	name = "emergency stabilization medipen"
 	desc = "A fast acting life-saving emergency autoinjector. Effective in combat situations, made by the syndicate for the syndicate."
 	icon_state = "stimpen"
-	volume = 15
-	amount_per_transfer_from_this = 15
-	list_reagents = list("perfluorodecalin" = 3, "teporone" = 3, "atropine" = 3, "stimulants" = 3, "mannitol" = 3)
+	volume = 12
+	amount_per_transfer_from_this = 12
+	list_reagents = list("perfluorodecalin" = 3, "teporone" = 3, "atropine" = 3, "mannitol" = 3)
 
 /obj/item/reagent_containers/hypospray/autoinjector/nanocalcium
 	name = "protoype nanite autoinjector"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Syndicate medikit now costs 4 TC, no longer has combat defib in it, contains 2 emergency epipens and a sacid pill bottle as well now (10 units each)
Syndicate medikit bundle now costs 16 TC from 20
Combat defib is it's own item in the uplink now, costs 12 TC 

## Why It's Good For The Game
The combat defib stands out as one of the strongest nuclear available weapons, the ability to instantly 1-tap anyone resulting in them being stunned and soon dead is frankly amazing, and right now it is far too cheap for it's power level.
The Syndicate medikit, a healing tool, is pretty much only bought explicitly for the combat defib to it's sheer power level. At 7 TC nothing can really remotely compete with it, and it makes the "healing kit" not really used for healing.
at 12 TC the combat defib can still certainly hold it's own but it'll be less of a "oh extra tc lemme get the onetapper" and something to actually consider in a build.
medikit now gets a lower TC cost, 2 new emergency epipens (heals oxygen damage extremely quickly and helps with everything a bit while in crit, will fuck you up if used out of crit), and 8 sacid pills to make it better at the role of an actual combat medic, rather than a combat
Syndibundle medkit has also been decreased in cost to reflect the changes to the medkit, and 16 is a better number than 17
New emergency epipens have 15 total units of medication, the following chemicals are in the emergency epipen:
list_reagents = list("perfluorodecalin" = 3, "teporone" = 3, "atropine" = 3, "mannitol" = 3)

## Testing
I looked at in game

## Changelog
:cl:
tweak: combat defib has been removed from the medkit, now it's own uplink item at 12 tc
tweak: syndi medkit is now 4 TC, no longer contains the combat defib, now two emergency epipens and a bottle of sacid
tweak: syndibundle medikit now is 16 TC
add: adds the emergency epipen to the syndi medkit, perfect for getting someone out of deepcrit, bad at literally everything else
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
