### PR TITLE
nuke no longer needs power to be armed

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -21,6 +21,7 @@ GLOBAL_VAR(bomb_set)
 	flags_2 = NO_MALF_EFFECT_2 | CRITICAL_ATOM_2
 	anchored = TRUE
 	power_state = NO_POWER_USE
+	requires_power = FALSE
 
 	var/extended = TRUE
 	var/lighthack = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The nuclear fission explosive no longer needs power to be armed

## Why It's Good For The Game
bugfix

## Testing
set the var to false and killed some APCs
## Changelog
:cl:
fix: nuclear bomb no longer needs to be powered to be used
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
