### PR TITLE
Fiber Garrote now mutes all emotes when garroting target

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -124,6 +124,7 @@
 #define STATUS_EFFECT_DROWSINESS /datum/status_effect/transient/drowsiness
 #define STATUS_EFFECT_DRUNKENNESS /datum/status_effect/transient/drunkenness
 #define STATUS_EFFECT_SILENCED /datum/status_effect/transient/silence
+#define STATUS_EFFECT_ABSSILENCED /datum/status_effect/transient/silence/absolute
 #define STATUS_EFFECT_JITTER /datum/status_effect/transient/jittery
 #define STATUS_EFFECT_CULT_SLUR /datum/status_effect/transient/cult_slurring
 #define STATUS_EFFECT_STAMMER /datum/status_effect/transient/stammering

--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -593,6 +593,10 @@
 		return FALSE
 	if((emote_type & EMOTE_MOUTH) && !can_vocalize_emotes(user))
 		return FALSE
+	if(istype(user, /mob/living))
+		var/mob/living/live_user = user
+		if(live_user.has_status_effect(STATUS_EFFECT_SILENCED))
+			return FALSE
 	return TRUE
 
 /datum/emote/proc/remove_ending_punctuation(msg)

--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -593,7 +593,7 @@
 		return FALSE
 	if((emote_type & EMOTE_MOUTH) && !can_vocalize_emotes(user))
 		return FALSE
-	if(istype(user, /mob/living))
+	if(isliving(user))
 		var/mob/living/liveuser = user
 		if(liveuser.has_status_effect(STATUS_EFFECT_ABSSILENCED))
 			return FALSE

--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -593,6 +593,10 @@
 		return FALSE
 	if((emote_type & EMOTE_MOUTH) && !can_vocalize_emotes(user))
 		return FALSE
+	if(istype(user, /mob/living))
+		var/mob/living/liveuser = user
+		if(liveuser.has_status_effect(STATUS_EFFECT_ABSSILENCED))
+			return FALSE
 	return TRUE
 
 /datum/emote/proc/remove_ending_punctuation(msg)

--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -593,10 +593,6 @@
 		return FALSE
 	if((emote_type & EMOTE_MOUTH) && !can_vocalize_emotes(user))
 		return FALSE
-	if(istype(user, /mob/living))
-		var/mob/living/live_user = user
-		if(live_user.has_status_effect(STATUS_EFFECT_SILENCED))
-			return FALSE
 	return TRUE
 
 /datum/emote/proc/remove_ending_punctuation(msg)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -674,7 +674,7 @@
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_MUTE, id)
 
-/datum/status_effect/transient/silence/absolute
+/datum/status_effect/transient/silence/absolute // this one will mute all emote sounds including gasps
 	id = "abssilenced"
 
 /datum/status_effect/transient/jittery

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -674,6 +674,9 @@
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_MUTE, id)
 
+/datum/status_effect/transient/silence/absolute
+	id = "abssilenced"
+
 /datum/status_effect/transient/jittery
 	id = "jittering"
 

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -153,7 +153,7 @@
 		return
 
 
-	strangling.Silence(6 SECONDS) // Non-improvised effects
+	strangling.SetAbsoluteSilence(6 SECONDS) // Non-improvised effects
 	strangling.apply_damage(4, OXY, "head")
 
 

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -153,7 +153,7 @@
 		return
 
 
-	strangling.SetAbsoluteSilence(6 SECONDS) // Non-improvised effects
+	strangling.AbsoluteSilence(6 SECONDS) // Non-improvised effects
 	strangling.apply_damage(4, OXY, "head")
 
 

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -413,11 +413,17 @@ STATUS EFFECTS
 /mob/living/proc/Silence(amount)
 	SetSilence(max(amount, AmountSilenced()))
 
-/mob/living/proc/SetAbsoluteSilence(amount)
-	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_ABSSILENCED, amount)
-
 /mob/living/proc/SetSilence(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_SILENCED, amount)
+
+/mob/living/proc/AmountAbsoluteSilenced()
+	RETURN_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_ABSSILENCED)
+
+/mob/living/proc/AbsoluteSilence(amount)
+	SetAbsoluteSilence(max(amount, AmountAbsoluteSilenced()))
+
+/mob/living/proc/SetAbsoluteSilence(amount)
+	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_ABSSILENCED, amount)
 
 /mob/living/proc/AdjustSilence(amount, bound_lower = 0, bound_upper = INFINITY)
 	SetSilence(directional_bounded_sum(AmountSilenced(), amount, bound_lower, bound_upper))

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -413,6 +413,9 @@ STATUS EFFECTS
 /mob/living/proc/Silence(amount)
 	SetSilence(max(amount, AmountSilenced()))
 
+/mob/living/proc/SetAbsoluteSilence(amount)
+	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_ABSSILENCED, amount)
+
 /mob/living/proc/SetSilence(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_SILENCED, amount)
 


### PR DESCRIPTION
Fiber Garrote now applies new status effect, Absolute Silence
It means all emotes will be with disabled sound, no more gasping for a minute while you're trying to stealth

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR makes new effect status to silence all emotes. Currently this status effect applies only by fiber garrote, but can be used in future

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
We have fiber garrote in game, its 6 TC. It supposed to make target silenced and supposed to be able to kill someone without a sound
But instead the only thing it silence is talk. All gasps, all cry all other emotes will emit sound. 
Great silence item *clap

This PR changes that, if you are silenced by fiber garrote, all your emotes wont emit sound.

## Testing
<!-- How did you test the PR, if at all? -->
compiled, garroted, killed

## Changelog
:cl:
tweak: fiber garrote now mutes all emote sounds on use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
