### PR TITLE
Gives chitinous armor durability

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -499,7 +499,7 @@
 		else
 			armordurability -= damage
 	if(armordurability <= 0)
-		visible_message("<span class='warning'>[owner]'s chitinous armor collapses in clumps onto the ground.</span>",)
+		visible_message("<span class='warning'>[owner]'s chitinous armor collapses in clumps onto the ground.</span>")
 		new /obj/effect/decal/cleanable/shreds(owner.loc)
 		// just unequip them since they qdel on drop
 		owner.unEquip(src, TRUE, TRUE)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -469,7 +469,7 @@
 	flags = NODROP | DROPDEL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 20, BOMB = 10, BIO = 4, RAD = 0, FIRE = 90, ACID = 90)
-	var/armordurability = 600
+	var/armor_durability = 600
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = 0
 	heat_protection = 0
@@ -483,22 +483,22 @@
 /obj/item/clothing/suit/armor/changeling/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage)
 	. = ..()
 	if(istype(hitby, /obj/item/projectile/energy/charged_plasma))
-		armordurability -= 200 // the plasma pistol is designed to be a niche tool for blasting through shields, may as well let it cut away armor
+		armor_durability -= 200 // the plasma pistol is designed to be a niche tool for blasting through shields, may as well let it cut away armor
 	else if(istype(hitby, /obj/item/projectile))
 		var/obj/item/projectile/P = hitby
 		if(P.damage_type == BURN)
-			armordurability -= damage * 2
+			armor_durability -= damage * 2
 		else
-			armordurability -= damage
+			armor_durability -= damage
 	else
 		var/obj/item/I = hitby
 		if(istype(I, /obj/item/circular_saw))
-			armordurability -= 25 // saws used to cut away armor through an interaction, so let's keep them somewhat more effective
+			armor_durability -= 25 // saws used to cut away armor through an interaction, so let's keep them somewhat more effective
 		else if(I.damtype == BURN)
-			armordurability -= damage * 2
+			armor_durability -= damage * 2
 		else
-			armordurability -= damage
-	if(armordurability <= 0)
+			armor_durability -= damage
+	if(armor_durability <= 0)
 		visible_message("<span class='warning'>[owner]'s chitinous armor collapses in clumps onto the ground.</span>")
 		new /obj/effect/decal/cleanable/shreds(owner.loc)
 		// just unequip them since they qdel on drop

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -507,7 +507,6 @@
 		owner.unEquip(src, TRUE, TRUE)
 		if(istype(owner.head, /obj/item/clothing/head/helmet/changeling))
 			owner.unEquip(owner.head, TRUE, TRUE)
-	return
 
 /obj/item/clothing/head/helmet/changeling
 	name = "chitinous mass"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -469,6 +469,7 @@
 	flags = NODROP | DROPDEL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 20, BOMB = 10, BIO = 4, RAD = 0, FIRE = 90, ACID = 90)
+	var/armordurability = 600
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = 0
 	heat_protection = 0
@@ -479,61 +480,32 @@
 	if(ismob(loc))
 		loc.visible_message("<span class='warning'>[loc.name]\'s flesh turns black, quickly transforming into a hard, chitinous mass!</span>", "<span class='warning'>We harden our flesh, creating a suit of armor!</span>", "<span class='warning'>You hear organic matter ripping and tearing!</span>")
 
-
-/obj/item/clothing/suit/armor/changeling/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type)
+/obj/item/clothing/suit/armor/changeling/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage)
 	. = ..()
-
-	if(!IS_HORIZONTAL(owner))
-		return
-
-	var/obj/item/I = hitby
-
-	if(!isliving(I.loc))
-		// Maybe it's on the ground? Maybe it's being used telekinetically? IDK
-		return
-
-	// The user who's wielding the tool
-	var/mob/living/user = I.loc
-
-	// snowflake checks my beloved
-	// this will become tooltype checks I swear
-	if(!istype(I, /obj/item/circular_saw) && !istype(I, /obj/item/twohanded/required/chainsaw) && !istype(I, /obj/item/twohanded/chainsaw))
-		return
-
-	user.visible_message(
-		"<span class='notice'>[user] starts to saw through [owner]'s [name].</span>",
-		"<span class='notice'>You start to saw through [owner]'s [name].</span>",
-		"<span class='notice'>You hear a loud grinding noise.</span>"
-	)
-
-	if(!do_after(user, 15 SECONDS, target = owner))
-		user.visible_message(
-			"<span class='warning'>[user] fails to cut through [owner]'s [name].</span>",
-			"<span class='warning'>You fail to cut through [owner]'s [name].</span>",
-			"<span class='notice'>You hear the grinding stop.</span>"
-		)
-		return FALSE
-
-	// check again after the do_after to make sure they haven't gotten up
-	if(!IS_HORIZONTAL(owner))
-		return FALSE
-
-	user.visible_message(
-		"<span class='warning'>\The [name] turns to shreds as [user] cleaves through it!</span>",
-		"<span class='warning'>\The [name] turns to shreds as you cleave through it!</span>",
-		"<span class='notice'>You hear something fall as the grinding ends.</span>"
-	)
-
-	playsound(I, I.hitsound, 50)
-	// you've torn it up, get rid of it.
-	new /obj/effect/decal/cleanable/shreds(owner.loc)
-	// just unequip them since they qdel on drop
-	owner.unEquip(src, TRUE, TRUE)
-	if(istype(owner.head, /obj/item/clothing/head/helmet/changeling))
-		owner.unEquip(owner.head, TRUE, TRUE)
-
-	return TRUE
-
+	if(istype(hitby, /obj/item/projectile/energy/charged_plasma))
+		armordurability -= 200 // the plasma pistol is designed to be a niche tool for blasting through shields, may as well let it cut away armor
+	else if(istype(hitby, /obj/item/projectile))
+		var/obj/item/projectile/P = hitby
+		if(P.damage_type == BURN)
+			armordurability -= damage * 2
+		else
+			armordurability -= damage
+	else
+		var/obj/item/I = hitby
+		if(istype(I, /obj/item/circular_saw))
+			armordurability -= 25 // saws used to cut away armor through an interaction, so let's keep them somewhat more effective
+		else if(I.damtype == BURN)
+			armordurability -= damage * 2
+		else
+			armordurability -= damage
+	if(armordurability <= 0)
+		visible_message("<span class='warning'>[owner]'s chitinous armor collapses in clumps onto the ground.</span>",)
+		new /obj/effect/decal/cleanable/shreds(owner.loc)
+		// just unequip them since they qdel on drop
+		owner.unEquip(src, TRUE, TRUE)
+		if(istype(owner.head, /obj/item/clothing/head/helmet/changeling))
+			owner.unEquip(owner.head, TRUE, TRUE)
+	return
 
 /obj/item/clothing/head/helmet/changeling
 	name = "chitinous mass"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -484,6 +484,8 @@
 	. = ..()
 	if(istype(hitby, /obj/item/projectile/energy/charged_plasma))
 		armor_durability -= 200 // the plasma pistol is designed to be a niche tool for blasting through shields, may as well let it cut away armor
+	else if(istype(hitby, /obj/item/projectile/plasma))
+		armor_durability -= damage * 4
 	else if(istype(hitby, /obj/item/projectile))
 		var/obj/item/projectile/P = hitby
 		if(P.damage_type == BURN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Replaces the old removal method of chitinous armor (using a saw on a prone target over 15 seconds) with an armor durability system. It functions as follows:
Every time the armor is deployed, it sets its durability to 600. Damage done to the Changeling is also done to the armor, with modifications dependent on damage type and certain weapons.
Charged Plasma Pistol shots do 200 flat damage to the armor. The Plasma Pistol is designed to be a niche weapon that destroys shields and armor, so giving it some targeted functionality here seems like a good idea. 
Plasma Cutters do 4x damage to armor, so regular does 20, advanced does 28, and the mech one does 40.
Circular saws do 25 flat damage to the armor. This is because previously, circular saws were the only tools that could remove the armor apart from the cling doing so - so having them be slightly more effective makes sense.
Ranged/melee burn attacks (welders, lasers, etc) will do double damage to armor durability.
All other ranged/melee attacks (mostly brute though this could technically include wt toxin bullets and the like) will have an unmodified damage value being applied to the armor.
Once the armor's durability falls below zero, it falls off the changeling in shreds. 
The armor durability value is not final and can be increased if requested by the balance team, these numbers are just what I floated by Hal earlier.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
There's quite a few reasons for this change, so I'll go through them in order:

There's already a currently existing interaction for removing the suit with a saw but it's not very practical (requires the changeling to sit still for 15 seconds, so it'd have to be dead and it already revives in 40 seconds so good luck getting the armor off and doing anything else meaningful before it stands up and re-equips it), and the interaction is not very known. 

The armor itself is quite powerful, being an ability that costs chemicals once to deploy and barely slowing down chemical regen while it's active, with good armor values to boot. Having it degrade over combat is one way to actually have it have implications to the Changeling's chemical economy, as you'll have to choose whether to re-apply it when it falls off or use another ability, instead of just having it up forever once you've clicked it once.

Lastly, this armor actually makes it quite hard to properly destroy the Changeling once it's been activated. Now that decapitation isn't an option versus Clings, all a Changeling has to do is break the cremator and pop this armor and you suddenly have very few options of actually dealing with them, as this armor pretty much prevents you from putting them in a gibber as the armor obstructs most of your items and you can't gibber people wearing said items. Your only options at that point are repairing the cremator which takes a bit and will probably get broken again, shuttle-gibbing them which (while it's very cool) is generally not practical most of the time, or carrying around SR pills in your pockets to kill Changelings who have made it very hard to otherwise kill them. I don't think the latter practice is at all healthy as it basically removes the whole point of making Changelings harder to kill elsewise, so I think making it more practical to kill them through means like the gibber (which still leaves the Cling a chance to get up and escape before they get shoved in) is better.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
https://user-images.githubusercontent.com/71326864/217941509-16e26c18-8ea9-48f4-949e-be02d90fd920.mp4
## Testing
<!-- How did you test the PR, if at all? -->
Tested the cling armor with plasma pistol, circular saw, batong, WT autorifle, laser gun, welder, all applied damage as it should, armor broke when armordurability hit zero. Visible in the above video.
## Changelog
tweak: Changeling chitinous armor now has durability, and can break once damaged enough.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
