### PR TITLE
Standardizes all tech storages contents

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -27561,10 +27561,6 @@
 	pixel_y = 3
 	},
 /obj/item/circuitboard/card,
-/obj/item/circuitboard/crew{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -31277,15 +31273,24 @@
 	},
 /area/hallway/primary/central)
 "bDH" = (
-/obj/structure/rack,
-/obj/item/circuitboard/scan_consolenew{
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/cyborgrecharger{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/circuitboard/med_data,
-/obj/item/circuitboard/pandemic{
+/obj/item/circuitboard/mech_bay_power_console{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/mech_recharger{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/circuitboard/mechfab{
+	pixel_y = -6;
+	pixel_x = 6
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -31300,15 +31305,26 @@
 /turf/simulated/floor/plasteel/dark,
 /area/storage/tech)
 "bDJ" = (
-/obj/structure/rack,
-/obj/item/circuitboard/aifixer{
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/rdconsole{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/rdserver{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/circuitboard/rdconsole,
-/obj/item/circuitboard/rdserver{
+/obj/item/circuitboard/destructive_analyzer,
+/obj/item/circuitboard/protolathe{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/circuitboard/circuit_imprinter{
+	pixel_y = -6;
+	pixel_x = 6
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -32012,15 +32028,37 @@
 /turf/simulated/floor/plasteel/dark,
 /area/storage/tech)
 "bFj" = (
-/obj/structure/rack,
-/obj/item/circuitboard/cloning{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/circuitboard/clonescanner,
+/obj/item/circuitboard/cloning{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/circuitboard/clonescanner{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /obj/item/circuitboard/clonepod{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/circuitboard/cryo_tube{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/circuitboard/pandemic{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/circuitboard/bodyscanner{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/circuitboard/sleeper{
+	pixel_x = 9;
+	pixel_y = -9
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -32028,13 +32066,15 @@
 	},
 /area/storage/tech)
 "bFk" = (
-/obj/structure/rack,
-/obj/item/circuitboard/destructive_analyzer{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/circuitboard/protolathe,
-/obj/item/circuitboard/circuit_imprinter{
+/obj/item/circuitboard/autolathe{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/circuitboard/ore_redemption{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -32938,7 +32978,6 @@
 	pixel_x = -24
 	},
 /obj/item/folder/yellow,
-/obj/item/airlock_electronics,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -32973,12 +33012,6 @@
 	},
 /area/storage/tech)
 "bGW" = (
-/obj/structure/rack,
-/obj/item/circuitboard/mechfab,
-/obj/item/circuitboard/autolathe{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -33763,15 +33796,21 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "bIJ" = (
-/obj/structure/rack,
-/obj/item/circuitboard/camera{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/circuitboard/prisoner,
 /obj/item/circuitboard/secure_data{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/circuitboard/camera{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/circuitboard/prisoner{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -33789,20 +33828,32 @@
 	c_tag = "Technical Storage";
 	dir = 4
 	},
-/obj/item/airalarm_electronics,
-/obj/item/apc_electronics,
+/obj/item/paicard,
 /turf/simulated/floor/plasteel/dark,
 /area/storage/tech)
 "bIO" = (
-/obj/structure/rack,
-/obj/item/circuitboard/atmos_alert{
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/message_monitor{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/circuitboard/aifixer{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/stationalert{
+/obj/item/circuitboard/teleporter{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/teleporter_hub{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/circuitboard/teleporter_station{
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -34532,15 +34583,24 @@
 	},
 /area/engine/break_room)
 "bKu" = (
-/obj/structure/rack,
-/obj/item/circuitboard/teleporter_hub{
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/powermonitor{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/circuitboard/teleporter_station,
-/obj/item/circuitboard/teleporter{
+/obj/item/circuitboard/stationalert{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/atmos_alert{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/circuitboard/smes{
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -35424,10 +35484,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/firelock_electronics,
-/obj/item/firelock_electronics,
-/obj/item/firealarm_electronics,
-/obj/item/firealarm_electronics,
 /obj/item/circuitboard/sleeper,
 /turf/simulated/floor/plasteel/dark,
 /area/storage/tech)
@@ -36220,7 +36276,6 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/item/paicard,
 /obj/machinery/newscaster{
 	dir = 1;
 	name = "south bump";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15416,14 +15416,21 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/item/circuitboard/cyborgrecharger{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/t_scanner,
-/obj/item/multitool,
-/obj/item/clothing/glasses/meson,
+/obj/item/circuitboard/mech_bay_power_console{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/mech_recharger{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/mechfab{
+	pixel_y = -6;
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15433,17 +15440,33 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/powermonitor{
+/obj/item/circuitboard/cloning{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/circuitboard/clonescanner{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/circuitboard/clonepod{
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/circuitboard/stationalert{
+/obj/item/circuitboard/cryo_tube{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/circuitboard/atmos_alert{
+/obj/item/circuitboard/pandemic{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/circuitboard/bodyscanner{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/circuitboard/sleeper{
+	pixel_x = 9;
+	pixel_y = -9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -15467,14 +15490,21 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/med_data{
+/obj/item/circuitboard/powermonitor{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/stationalert{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/atmos_alert{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/circuitboard/clonescanner,
-/obj/item/circuitboard/clonepod,
-/obj/item/circuitboard/scan_consolenew,
+/obj/item/circuitboard/smes{
+	pixel_x = 6;
+	pixel_y = -6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16625,6 +16655,10 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
+/obj/item/circuitboard/aicore{
+	pixel_x = 5;
+	pixel_y = -5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16658,15 +16692,22 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/message_monitor{
-	pixel_y = -5
+/obj/item/circuitboard/rdconsole{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/item/circuitboard/arcade/battle{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/item/circuitboard/rdserver{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/circuitboard/arcade/orion_trail{
-	pixel_x = 4
+/obj/item/circuitboard/destructive_analyzer,
+/obj/item/circuitboard/protolathe{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/circuit_imprinter{
+	pixel_y = -6;
+	pixel_x = 6
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16683,6 +16724,10 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/autolathe{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/circuitboard/ore_redemption{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -16695,13 +16740,25 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/rdconsole,
-/obj/item/circuitboard/rdserver{
+/obj/item/circuitboard/message_monitor{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/circuitboard/aifixer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/teleporter{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/teleporter_hub{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/circuitboard/destructive_analyzer,
-/obj/item/circuitboard/protolathe,
+/obj/item/circuitboard/teleporter_station{
+	pixel_x = 6;
+	pixel_y = -6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16719,8 +16776,7 @@
 /area/storage/tech)
 "bgt" = (
 /obj/structure/table,
-/obj/item/apc_electronics,
-/obj/item/airlock_electronics,
+/obj/item/analyzer,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16883,12 +16939,16 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/secure_data{
-	pixel_x = -2;
-	pixel_y = 2
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /obj/item/circuitboard/camera{
-	pixel_x = 1;
-	pixel_y = -1
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/circuitboard/prisoner{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /obj/machinery/ai_status_display{
 	pixel_y = 31
@@ -17223,10 +17283,6 @@
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
-	},
-/obj/item/circuitboard/crew{
-	pixel_x = -1;
-	pixel_y = 1
 	},
 /obj/item/circuitboard/card{
 	pixel_x = 2;
@@ -18019,21 +18075,38 @@
 /area/storage/tech)
 "bjy" = (
 /obj/structure/table,
-/obj/item/plant_analyzer,
+/obj/item/plant_analyzer{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	name = "south bump";
 	pixel_y = -24
+	},
+/obj/item/healthanalyzer{
+	pixel_y = 0;
+	pixel_x = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/storage/tech)
 "bjz" = (
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/item/healthanalyzer,
-/obj/machinery/camera/autoname{
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/t_scanner,
+/obj/item/multitool,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -26933,8 +26933,7 @@
 /area/storage/tech)
 "cmX" = (
 /obj/structure/table,
-/obj/item/airlock_electronics,
-/obj/item/apc_electronics,
+/obj/item/multitool,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cmZ" = (
@@ -29757,18 +29756,24 @@
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "cCe" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
 /obj/item/circuitboard/cyborgrecharger{
-	pixel_x = -4;
-	pixel_y = -2
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/circuitboard/mech_bay_power_console{
-	pixel_x = 2;
-	pixel_y = 2
+	pixel_y = 0
 	},
-/obj/item/circuitboard/mech_recharger,
+/obj/item/circuitboard/mech_recharger{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/item/circuitboard/mechfab{
-	pixel_y = 3
+	pixel_y = -6;
+	pixel_x = 6
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -29799,7 +29804,6 @@
 /obj/machinery/cell_charger{
 	pixel_y = 5
 	},
-/obj/item/multitool,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cCp" = (
@@ -64933,10 +64937,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/rack,
-/obj/item/circuitboard/crew{
-	pixel_x = -1;
-	pixel_y = 1
-	},
 /obj/item/circuitboard/card{
 	pixel_x = 2;
 	pixel_y = -2
@@ -65517,6 +65517,10 @@
 /obj/item/circuitboard/aiupload{
 	pixel_x = 2;
 	pixel_y = -2
+	},
+/obj/item/circuitboard/aicore{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -70821,6 +70825,30 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"pGT" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/rdconsole{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/rdserver{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/destructive_analyzer,
+/obj/item/circuitboard/protolathe{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/circuit_imprinter{
+	pixel_y = -6;
+	pixel_x = 6
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
 "pGZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -72438,17 +72466,24 @@
 	},
 /area/maintenance/storage)
 "qkQ" = (
-/obj/structure/rack,
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/med_data{
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/powermonitor{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/stationalert{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/atmos_alert{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/circuitboard/clonescanner,
-/obj/item/circuitboard/clonepod,
-/obj/item/circuitboard/scan_consolenew,
-/obj/item/circuitboard/cryo_tube{
-	pixel_x = 3
+/obj/item/circuitboard/smes{
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -86495,21 +86530,16 @@
 	},
 /area/security/brig)
 "vQx" = (
-/obj/structure/rack,
-/obj/item/circuitboard/rdconsole{
-	pixel_x = -4
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/circuitboard/rdserver{
-	pixel_x = 4;
-	pixel_y = -2
+/obj/item/circuitboard/autolathe{
+	pixel_x = -1;
+	pixel_y = 1
 	},
-/obj/item/circuitboard/destructive_analyzer,
-/obj/item/circuitboard/protolathe{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/circuit_imprinter{
-	pixel_x = -4;
+/obj/item/circuitboard/ore_redemption{
+	pixel_x = 3;
 	pixel_y = -3
 	},
 /obj/machinery/light/small{
@@ -86517,8 +86547,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -86782,14 +86812,37 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "vUt" = (
-/obj/structure/rack,
-/obj/item/circuitboard/secure_data{
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/cloning{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/circuitboard/clonescanner{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/circuitboard/clonepod{
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/circuitboard/camera{
+/obj/item/circuitboard/cryo_tube{
 	pixel_x = 1;
 	pixel_y = -1
+	},
+/obj/item/circuitboard/pandemic{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/bodyscanner{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/circuitboard/sleeper{
+	pixel_x = 9;
+	pixel_y = -9
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -90128,14 +90181,28 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/southwest)
 "xfN" = (
-/obj/structure/rack,
-/obj/item/circuitboard/message_monitor{
-	pixel_y = -5
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/circuitboard/arcade/battle,
-/obj/item/circuitboard/arcade/orion_trail{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/item/circuitboard/message_monitor{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/circuitboard/aifixer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/teleporter{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/teleporter_hub{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/teleporter_station{
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -91445,14 +91512,21 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/south)
 "xKM" = (
-/obj/structure/rack,
-/obj/item/circuitboard/autolathe{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/circuitboard/bodyscanner,
-/obj/item/circuitboard/sleeper{
-	pixel_x = 3
+/obj/item/circuitboard/secure_data{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/circuitboard/camera{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/circuitboard/prisoner{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -129706,7 +129780,7 @@ cSf
 dqI
 dyM
 baR
-xfN
+pGT
 vQx
 xfN
 vRp

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -49089,16 +49089,19 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/cyborgrecharger{
-	pixel_x = -4;
-	pixel_y = -2
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/circuitboard/mech_bay_power_console{
-	pixel_x = 2;
-	pixel_y = 2
+	pixel_y = 0
 	},
-/obj/item/circuitboard/mech_recharger,
+/obj/item/circuitboard/mech_recharger{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/item/circuitboard/mechfab{
-	pixel_y = 3
+	pixel_y = -6;
+	pixel_x = 6
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -49120,7 +49123,6 @@
 "cvA" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
-/obj/item/stock_parts/cell/high/plus,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cvB" = (
@@ -49469,8 +49471,11 @@
 /area/engine/controlroom)
 "cwN" = (
 /obj/structure/table,
-/obj/item/apc_electronics,
-/obj/item/airlock_electronics,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cwO" = (
@@ -50130,6 +50135,10 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
+/obj/item/circuitboard/aicore{
+	pixel_x = 5;
+	pixel_y = -5
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "cyv" = (
@@ -50142,16 +50151,17 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/rdconsole{
-	pixel_x = -4
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /obj/item/circuitboard/rdserver{
-	pixel_x = 4;
-	pixel_y = -2
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/circuitboard/destructive_analyzer,
 /obj/item/circuitboard/protolathe{
-	pixel_x = -2;
-	pixel_y = 3
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50159,8 +50169,8 @@
 	icon_state = "1-2"
 	},
 /obj/item/circuitboard/circuit_imprinter{
-	pixel_x = -4;
-	pixel_y = -3
+	pixel_y = -6;
+	pixel_x = 6
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -50175,12 +50185,23 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/message_monitor{
-	pixel_y = -5
+	pixel_y = 6;
+	pixel_x = -6
 	},
-/obj/item/circuitboard/arcade/battle,
-/obj/item/circuitboard/arcade/orion_trail{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/item/circuitboard/aifixer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/teleporter{
+	pixel_y = 0
+	},
+/obj/item/circuitboard/teleporter_hub{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/teleporter_station{
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -50201,12 +50222,12 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/autolathe{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/circuitboard/ore_redemption{
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/item/circuitboard/bodyscanner,
-/obj/item/circuitboard/sleeper{
-	pixel_x = 3
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -50700,17 +50721,13 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/crew{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/item/circuitboard/communications{
+	pixel_y = 1;
+	pixel_x = -1
 	},
 /obj/item/circuitboard/card{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/circuitboard/communications{
-	pixel_x = 5;
-	pixel_y = -5
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -51177,7 +51194,7 @@
 "cBl" = (
 /obj/structure/table,
 /obj/item/screwdriver{
-	pixel_y = 16
+	pixel_y = 8
 	},
 /obj/item/wirecutters,
 /turf/simulated/floor/plating,
@@ -51226,12 +51243,12 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/robotics{
-	pixel_x = -2;
-	pixel_y = 2
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /obj/item/circuitboard/mecha_control{
-	pixel_x = 1;
-	pixel_y = -1
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -51240,16 +51257,33 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/med_data{
+/obj/item/circuitboard/cloning{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/circuitboard/clonescanner{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/circuitboard/clonepod{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/circuitboard/cryo_tube{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/circuitboard/pandemic{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/circuitboard/clonescanner,
-/obj/item/circuitboard/clonepod,
-/obj/item/circuitboard/scan_consolenew,
-/obj/item/circuitboard/cryo_tube{
-	pixel_x = 3
+/obj/item/circuitboard/bodyscanner{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/circuitboard/sleeper{
+	pixel_x = 9;
+	pixel_y = -9
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -51259,20 +51293,19 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/powermonitor{
-	pixel_x = -2;
-	pixel_y = 2
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/circuitboard/stationalert{
-	pixel_x = 1;
-	pixel_y = -1
+	pixel_y = 0
 	},
 /obj/item/circuitboard/atmos_alert{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/circuitboard/thermomachine,
 /obj/item/circuitboard/smes{
-	pixel_x = 4
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -51282,12 +51315,16 @@
 	layer = 2.9
 	},
 /obj/item/circuitboard/secure_data{
-	pixel_x = -2;
-	pixel_y = 2
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /obj/item/circuitboard/camera{
-	pixel_x = 1;
-	pixel_y = -1
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/circuitboard/prisoner{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -51673,7 +51710,6 @@
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil,
-/obj/item/stock_parts/cell/high/plus,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cCQ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Piled the circuit boards to make them look better.
Standardized all tech storages contents, some stations had more, others had less.

**ADDED:** ORM circuit board
**REMOVED:** Crew monitoring/All electronics/Medical records/DNA machine/thermomachine/orion trail/arcade battle

**TECH STORAGE (each line is a rack)**
Cyborg recharger/exosuit fabricator/mech bay recharger/mech bay power control
protolathe/RD console/Destructive analyzer/circuit imprinter/R&D server
autolathe/ORM
message monitor/AI integrity rest/teleporter hub/teleporter station/teleporter console
camera monitor/prisoner management/security records
atmos alert/station alert/power monitor/SMES
clone pod/cloning scanner/cloning machine console/pandemic/cryotube/sleeper/body scanner

**SECURE TECH STORAGE**
Exosuit control console/Robotics Control
AI upload/Cyborg upload/AI core
ID computer/Communications console
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Tech storage should contain critical boards for the station to function, the removed ones are not important enough to be present there. 
All electronics (APC, airlock...) have been removed because engineering already has a free vendor with 10 units of each one, having one more unit inside the tech storage seens unnecessary.

Having organized racks is good for my eyes and my mouse that can now be used to pick one of the boards.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![cyberiad_tech_storage](https://user-images.githubusercontent.com/77684085/218142723-063baf00-06b8-492f-a08f-9b0803d33970.png)
Other ones do have the same desk organization.
## Testing
<!-- How did you test the PR, if at all? -->
- Compiled and looked at some tech storages
## Changelog
:cl:
tweak: Standardized all tech storages contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
