### PR TITLE
the mime's force wall is now destructible

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -3,7 +3,7 @@
 	desc = "The mime's performance transmutates into physical reality."
 	school = "mime"
 	panel = "Mime"
-	summon_type = list(/obj/effect/forcefield/mime)
+	summon_type = list(/obj/structure/forcefield/mime)
 	invocation_type = "emote"
 	invocation_emote_self = "<span class='notice'>You form a wall in front of yourself.</span>"
 	summon_lifespan = 20 SECONDS

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -53,8 +53,10 @@
 	return !blocks_atmos
 
 /obj/structure/forcefield/mime
-	icon_state = "empty"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "5"
 	name = "invisible wall"
+	alpha = 1
 	desc = "You have a bad feeling about this."
 	max_integrity = 80
 

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -29,12 +29,37 @@
 
 ///////////Mimewalls///////////
 
-/obj/effect/forcefield/mime
+/obj/structure/forcefield
+	name = "ain't supposed to see this"
+	desc = "file a github report if you do!"
+	icon = 'icons/effects/effects.dmi'
+	density = TRUE
+	anchored = TRUE
+	var/blocks_atmos = TRUE
+
+/obj/structure/forcefield/Initialize(mapload)
+	. = ..()
+	if(blocks_atmos)
+		air_update_turf(TRUE)
+
+/obj/structure/forcefield/Destroy()
+	var/turf/turf_to_update = get_turf(src)
+	. = ..()
+	if(blocks_atmos)
+		blocks_atmos = FALSE
+		turf_to_update.air_update_turf(TRUE)
+
+/obj/structure/forcefield/CanAtmosPass(turf/T)
+	return !blocks_atmos
+
+/obj/structure/forcefield/mime
 	icon_state = "empty"
 	name = "invisible wall"
 	desc = "You have a bad feeling about this."
+	max_integrity = 80
 
 /obj/effect/forcefield/mime/advanced
+	icon_state = "empty"
 	name = "invisible blockade"
 	desc = "You might be here a while."
 	lifetime = 60 SECONDS

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -43,10 +43,9 @@
 		air_update_turf(TRUE)
 
 /obj/structure/forcefield/Destroy()
-	var/turf/turf_to_update = get_turf(src)
 	if(blocks_atmos)
 		blocks_atmos = FALSE
-		turf_to_update.air_update_turf(TRUE)
+		air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/forcefield/CanAtmosPass(turf/T)

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -44,10 +44,10 @@
 
 /obj/structure/forcefield/Destroy()
 	var/turf/turf_to_update = get_turf(src)
-	. = ..()
 	if(blocks_atmos)
 		blocks_atmos = FALSE
 		turf_to_update.air_update_turf(TRUE)
+	return ..()
 
 /obj/structure/forcefield/CanAtmosPass(turf/T)
 	return !blocks_atmos


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
the mime's (normal, traitor version is not affected) invisible wall can now be destroyed and has integrity. 
currently has 80 integrity (can probably be pushed up into the 100 range)

## Why It's Good For The Game
Mime's forcewall is pretty often used as a griefing tool as a nonantag more than anything else. Mimes slapping this down wherever whenever for really no reason is a pretty common sight, and a 20 second forcewall gets pretty annoying rather quickly. This gives it some integrity so that if this is used for complete shittery it can be broken down and delt with. 
Mime tot variant is kept as is because it's a tot item. 

## Testing
compiled and ran, tried to pass atmos conditions but couldn't 

## Changelog
:cl:
tweak: The mime's basic invisible wall now has 80 integrity and can be broken
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
