### PR TITLE
science goggles now display projectile, obj force, and item armor

### DIFF
--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -60,6 +60,9 @@
 /datum/armor/proc/detachArmor(datum/armor/AA)
 	return getArmor(melee - AA.melee, bullet - AA.bullet, laser - AA.laser, energy - AA.energy, bomb - AA.bomb, bio - AA.bio, rad - AA.rad, fire - AA.fire, acid - AA.acid, magic - AA.magic)
 
+/datum/armor/proc/get_display_armor()
+	return list("Melee resistance = [melee]", "Bullet resistance = [bullet]", "Laser resistance = [laser]", "Energy resistance = [energy]", "Explosive resistance = [bomb]", "Biological resistance = [bio]", "Radiation resistance = [rad]", "Fire resistance = [fire]", "Acid resistance = [acid]")
+
 /datum/armor/vv_edit_var(var_name, var_value)
 	if (var_name == NAMEOF(src, tag))
 		return FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -237,6 +237,9 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 				msg += "[CallMaterialName(mat)]<BR>" //Capitize first word, remove the "$"
 		else
 			msg += "<span class='danger'>No extractable materials detected.</span><BR>"
+
+		if(force)
+			msg += "<span class='warning'>Force of [force], damage type of [damtype].</span><BR>"
 		msg += "*--------*"
 		. += msg
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -240,6 +240,10 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 
 		if(force)
 			msg += "<span class='warning'>Force of [force], damage type of [damtype].</span><BR>"
+		if(armor)
+			msg += "<span class='notice'>Following armor values detected: </span><BR>"
+			for(var/armor_value in armor.get_display_armor())
+				msg += "<span class='notice'>[armor_value]</span><BR>"
 		msg += "*--------*"
 		. += msg
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -137,7 +137,7 @@
 
 /obj/item/clothing/glasses/science/item_action_slot_check(slot)
 	if(slot == slot_glasses)
-		return 1
+		return TRUE
 
 /obj/item/clothing/glasses/science/night
 	name = "night vision science goggles"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -100,6 +100,8 @@
 			. += "<span class='info'>[bayonet] looks like it can be <b>unscrewed</b> from [src].</span>"
 	else if(can_bayonet)
 		. += "It has a <b>bayonet</b> lug on it."
+	if(user.research_scanner && chambered)
+		. += "<span class='warning'>The projectiles of this gun have a force of [chambered.BB.damage], deal [chambered.BB.stamina] stamina damage, damage type of [chambered.BB.damage_type].</span><BR>"
 
 /obj/item/gun/detailed_examine() // Truly detailed
 	return "This is a gun."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Science goggles now display projectile and obj force
if you examine an object, it will tell you its force, provided it has force
if you examine a gun, it will tell you the force of its chambered.projectile 
if you examine an item, it will tell you it's armor value
Example on a stechkin:
![Screenshot 2023-02-11 200226](https://user-images.githubusercontent.com/96800819/218288980-0c026df7-401e-4415-b52a-8da45ca567cc.png)

## Why It's Good For The Game
An IC way to figure out the force of weapons and guns is good
"Just codedive LMAO" aint a steller solution, and science is a very common new player role, the kind of people that will like this feature the most! 

## Testing
compiled, ran, checked out my glock collection 

## Changelog
:cl:
add: You can now see object and projectile force by examining an object with a research scanner enabled 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
