### PR TITLE
Re-adds the LWAP, reworked

### DIFF
--- a/code/modules/crafting/guncrafting.dm
+++ b/code/modules/crafting/guncrafting.dm
@@ -70,6 +70,11 @@
 	desc = "A suitcase containing the necessary gun parts to transform a standard laser gun into an accelerator laser cannon."
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 
+/obj/item/weaponcrafting/gunkit/lwap
+	name = "\improper lwap laser sniper parts kit"
+	desc = "A suitcase containing the necessary gun parts to transform an accelerator laser cannon into an even meaner laser sniper. Somehow turns the laser purple!"
+	origin_tech = "combat=6;magnets=6;powerstorage=4"
+
 /obj/item/weaponcrafting/gunkit/plasma
 	name = "\improper plasma pistol parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform a standard laser gun into a plasma pistol. Wort, wort, wort!"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -218,6 +218,17 @@
 	..()
 	blacklist += subtypesof(/obj/item/gun/energy/laser)
 
+/datum/crafting_recipe/lwap
+	name = "LWAP Laser Sniper"
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = list(/obj/item/gun/energy/lwap)
+	reqs = list(/obj/item/gun/energy/lasercannon = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/lwap = 1)
+	time = 20 SECONDS
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/silencer
 	name = "u-ION Silencer"
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -106,6 +106,45 @@
 /obj/item/gun/energy/lasercannon/cyborg/emp_act()
 	return
 
+/obj/item/gun/energy/lwap
+	name = "LWAP laser sniper"
+	desc = "A highly advanced laser sniper that does more damage the farther away the target is, but fires slowly."
+	icon_state = "esniper"
+	item_state = null
+	w_class = WEIGHT_CLASS_BULKY
+	force = 12
+	flags =  CONDUCT
+	slot_flags = SLOT_BACK
+	can_holster = FALSE
+	origin_tech = "combat=6;magnets=6;powerstorage=4"
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/sniper)
+	zoomable = TRUE
+	zoom_amt = 7
+	shaded_charge = TRUE
+
+/obj/item/ammo_casing/energy/laser/sniper
+	projectile_type = /obj/item/projectile/beam/laser/sniper
+	muzzle_flash_color = LIGHT_COLOR_PINK
+	select_name = "sniper"
+	fire_sound = 'sound/weapons/marauder.ogg'
+	delay = 50
+
+/obj/item/projectile/beam/laser/sniper
+	name = "sniper laser"
+	icon_state = "sniperlaser"
+	range = 255
+	damage = 10
+
+/obj/item/projectile/beam/laser/sniper/Range()
+	..()
+	damage = min(damage+5, 100)
+
+/obj/item/projectile/beam/laser/sniper/on_hit(atom/target, blocked = 0, hit_zone)
+	..()
+	var/mob/living/carbon/human/M = target
+	if(ishuman(target) && damage >= 40)
+		M.KnockDown(2 SECONDS * (damage/10))
+
 /obj/item/gun/energy/xray
 	name = "xray laser gun"
 	desc = "A high-power laser gun capable of expelling concentrated xray blasts. These blasts will penetrate solid objects, but will decrease in power the longer they have to travel."

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -128,7 +128,7 @@
 	muzzle_flash_color = LIGHT_COLOR_PINK
 	select_name = "sniper"
 	fire_sound = 'sound/weapons/marauder.ogg'
-	delay = 50
+	delay = 5 SECONDS
 
 /obj/item/projectile/beam/laser/sniper
 	name = "sniper laser"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -116,6 +116,7 @@
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
 	can_holster = FALSE
+	weapon_weight = WEAPON_HEAVY
 	origin_tech = "combat=6;magnets=6;powerstorage=4"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/sniper)
 	zoomable = TRUE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -138,13 +138,13 @@
 
 /obj/item/projectile/beam/laser/sniper/Range()
 	..()
-	damage = min(damage+5, 100)
+	damage = min(damage + 5, 100)
 
 /obj/item/projectile/beam/laser/sniper/on_hit(atom/target, blocked = 0, hit_zone)
 	..()
 	var/mob/living/carbon/human/M = target
-	if(ishuman(target) && damage >= 40)
-		M.KnockDown(2 SECONDS * (damage/10))
+	if(istype(M) && damage >= 40)
+		M.KnockDown(2 SECONDS * (damage / 10))
 
 /obj/item/gun/energy/xray
 	name = "xray laser gun"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -125,6 +125,16 @@
 	build_path = /obj/item/weaponcrafting/gunkit/accelerator
 	category = list("Weapons")
 
+/datum/design/lwap
+	name = "LWAP Laser Sniper Parts Kit"
+	desc = "Parts for a scoped laser sniper. It does more damage the farther away the target is, and can knock them down if it goes far enough."
+	id = "lwap"
+	req_tech = list("combat" = 7, "magnets" = 7, "powerstorage" = 5)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 5000, MAT_GOLD = 5000, MAT_DIAMOND = 5000)
+	build_path = /obj/item/weaponcrafting/gunkit/lwap
+	category = list("Weapons")
+
 /datum/design/plasmapistol
 	name = "Plasma Pistol Parts Kit"
 	desc = "A kit for a specialized firearm designed to fire heated bolts of plasma. Can be charged up for a shield breaking shot."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Re-adds the LWAP sniper rifle to the game, with a rework to its functionality to better suit the current state of the game.
The LWAP sniper rifle functions similarly to the accelerator sniper rifle, starting with higher damage but increasing more slowly. Its benefits lie in its scope and ability to knock people down if the damage is above a certain threshold (40), with the knockdown scaling with the damage dealt.  It is limited by a severely bad firerate and gives you poor situational awareness while scoped. 
The LWAP used to appear in the Gamma Armory, but things that got the Gamma Armory caused were rarely something that would require the LWAP - so it is instead integrated into the RnD weapons kit system, requiring a LWAP kit and an Accelerator Laser (because it functions as a up/sidegrade to the Accel Laser). The LWAP kit requires Combat tech seven, Magnets tech seven, Powerstorage tech five, making it something that Science will actually have to work to produce.

For damage specifics, the LWAP starts at 10 damage and increments 5 damage per tile. Comparatively, the Accelerator Laser starts at 6 damage and increments 7 per tile, so it gets stronger considerably more quickly. The LWAP's strength is therefore in its ability to fire from further away with greater accuracy due to the scope.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The LWAP was removed in https://github.com/ParadiseSS13/Paradise/pull/17075, for good reason (as it was either terrible or overpowered depending on whether you were fighting a human mob or not). However, we could use more energy guns and the LWAP does have its own niche that it can fill. Converting it to knockdown and giving it range-based damage to complement its sights should hopefully help it find a good place in the current combat system.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
LWAP kit, unupgraded Protolathe
![image](https://user-images.githubusercontent.com/71326864/218252351-f6e1e6c5-c314-4832-8678-8c1276cb31d9.png)
Ditto, upgraded Proto
![image](https://user-images.githubusercontent.com/71326864/218252362-1257501f-0db3-4169-b92c-842cc9e3d174.png)
Assembly
![image](https://user-images.githubusercontent.com/71326864/218252379-2838bf0c-a772-4b53-bb67-9063ad815288.png)
LWAP
![image](https://user-images.githubusercontent.com/71326864/218252395-3f2d3220-d73d-4925-8898-4350e8ef60d6.png)
LWAP kit
![image](https://user-images.githubusercontent.com/71326864/218252407-b1089a9e-ce27-4bad-b314-404bc1533d48.png)
## Testing
<!-- How did you test the PR, if at all? -->
Above images plus shot it a bunch, scratched head as to why knockdown wasn't working, realized dummies can't get knocked down, shot Vox (as god intended), knocked down when far enough away, life is good.
## Changelog
:cl:
add: Re-added the LWAP sniper rifle, with a rework
/:cl:

What the fuck does LWAP even stand for anyways?
