### PR TITLE
regular space carp are no longer deleted when changing holodeck, only holocarp

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -286,7 +286,7 @@
 	for(var/obj/effect/decal/cleanable/blood/B in linkedholodeck)
 		qdel(B)
 
-	for(var/mob/living/simple_animal/hostile/carp/C in linkedholodeck)
+	for(var/mob/living/simple_animal/hostile/carp/holocarp/C in linkedholodeck)
 		qdel(C)
 
 	holographic_items = A.copy_contents_to(linkedholodeck , 1, perfect_copy = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title

## Why It's Good For The Game
Holocarp really should be the only kind being deleted, not *every* carp

## Testing
compiled, fibsh

## Changelog
:cl:
tweak: The holodeck no longer deletes any carp upon changing the chosen holodeck map, only holocarp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
