### PR TITLE
alien spawncount is always 4

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -1,7 +1,6 @@
 /datum/event/alien_infestation
 	announceWhen	= 400
-	var/highpop_trigger = 80
-	var/spawncount = 2
+	var/spawncount = 4
 	var/list/playercount
 	var/successSpawn = FALSE	//So we don't make a command report if nothing gets spawned.
 
@@ -15,9 +14,6 @@
 		log_and_message_admins("Warning: Could not spawn any mobs for event Alien Infestation")
 
 /datum/event/alien_infestation/start()
-	playercount = length(GLOB.clients)//grab playercount when event starts not when game starts
-	if(playercount >= highpop_trigger) //spawn with 4 if highpop
-		spawncount = 4
 	INVOKE_ASYNC(src, PROC_REF(spawn_xenos))
 
 /datum/event/alien_infestation/proc/spawn_xenos()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Alien midround spawncount is always 4, rather than 2 if there are less than 80 clients connected (very unlikely to be the case)

## Why It's Good For The Game
Aliens already kind of have a problem with properly setting up. Often 1-2 things go wrong and the midround is just negated, or things go right and they never fucking stop. Making the setup consistent regardless of pop (we got a 2 roll once on 78 players, guess how that went) will let them be more easily balanced without changing that much. 

## Testing
Compiled
## Changelog
:cl:
tweak: Alieninfestation event will always spawn 4 aliens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
