### PR TITLE
Fixes a security issue on runtime logging

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -234,6 +234,7 @@ GLOBAL_LIST_INIT(admin_verbs_maintainer, list(
 	/client/proc/debugNatureMapGenerator, // This lags like hell, and is very easy to nuke half the server with
 	/client/proc/vv_by_ref, // This allows you to lookup **ANYTHING** in the server memory by spamming refs. Locked for security.
 	/client/proc/cinematic, // This will break everyone's screens in the round. Dont use this for adminbus.
+	/client/proc/throw_runtime, // Do I even need to explain why this is locked?
 ))
 
 /client/proc/on_holder_add()

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -14,6 +14,38 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		return ..()
 	GLOB.total_runtimes++
 
+	// STEP 1 - WE SANITIZE
+	// Proc args are included in runtimes. This has a habit of leaking secrets. We dont want this.
+	var/list/sanitize_splitlines = splittext(e.desc, "\n")
+	var/callstack_hit = FALSE
+	for(var/i in 1 to length(sanitize_splitlines))
+		var/original_line = sanitize_splitlines[i]
+		// Blank line, skip it
+		if(length(original_line) < 3)
+			continue
+
+		// We only care about lines after callstack
+		if(original_line == "  call stack:")
+			callstack_hit = TRUE
+			continue
+
+		// If we aint hit it, next
+		if(!callstack_hit)
+			continue
+
+		// First split on the colon
+		var/list/inner_split = splittext(original_line, ": ")
+		var/source_half = "[inner_split[1]]: "
+		var/proc_half = inner_split[2]
+		var/proc_name = splittext(proc_half, "(")[1] // Put a ) here to stop the bracket colouriser whining
+
+		proc_name = replacetext(proc_name, " ", "_") // Put the underscores back because BYOND removes them for some reason
+
+		sanitize_splitlines[i] = "[source_half][proc_name]"
+
+	e.desc = sanitize_splitlines.Join("\n")
+
+	// Ok now we can do everything else
 	var/erroruid = "[e.file][e.line]"
 	var/last_seen = GLOB.error_last_seen[erroruid]
 	var/cooldown = GLOB.error_cooldown[erroruid] || 0
@@ -106,3 +138,16 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 	if(GLOB.error_cache)
 		GLOB.error_cache.logError(e, desclines, e_src = e_src)
 #endif
+
+/client/proc/throw_runtime()
+	set name = "Throw Runtime"
+	set desc = "Throws a runtime, what did you expect?"
+	set category = "Debug"
+
+	if(!check_rights(R_MAINTAINER))
+		return
+
+	throw_runtime_inner(1337, 0)
+
+/client/proc/throw_runtime_inner(x, y)
+	to_chat(usr, "[x]/[y]=[x/y]")


### PR DESCRIPTION
## What Does This PR Do
Tweaks runtime logging to not include proc arguments in the call stack

Before:
![image](https://user-images.githubusercontent.com/25063394/218313716-b21bfd04-1add-4ba4-8a0d-5d9f609f0624.png)

After:
![image](https://user-images.githubusercontent.com/25063394/218313722-f0b6aa8e-4ebf-416c-87f8-b60aa7380cb3.png)

**Note the change in the `call stack:` section, how procs no longer include their args**

## Why It's Good For The Game
I was recently made aware that lines like this exist in the runtime logs

`[2023-02-11T19:58:28]   HTTP (/datum/controller/subsystem/http): create async request("post", "https://discordapp.com/api/web...", "{\"content\":\"**\[paradise_ma...", /list (/list), null)` 

As we can see, theres half a webhook link here, meaning runtime logs are a potential for having secrets leaked. I dont like that. After this PR is merged, all existing secrets will be rotated.

**Note for concerned players** - There is no evidence in runtime logs to show that the database credentials have ever been logged, and even if they had been, the game database does not contain anything overtly personal, the game DB credentials cannot access any of the other databases (forums for example), and the database isn't accessible without the management VPN anyway, which only 2 people have.

## Testing
Threw a runtime, see images above

## Changelog
:cl: AffectedArc07
fix: Fixed runtimes including potentially sensitive information
/:cl:
