### PR TITLE
Donk Pockets cool over time

### DIFF
--- a/code/modules/food_and_drinks/food/foods/misc_food.dm
+++ b/code/modules/food_and_drinks/food/foods/misc_food.dm
@@ -114,9 +114,22 @@
 	filling_color = "#DEDEAB"
 	list_reagents = list("nutriment" = 4)
 	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
+	var/warm = TRUE
+
+/obj/item/reagent_containers/food/snacks/warmdonkpocket/Initialize(mapload)
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(donk_cool)), 420 SECONDS)
+
+/obj/item/reagent_containers/food/snacks/warmdonkpocket/proc/donk_cool()
+	name = "cold Donk-pocket"
+	desc = "The food of choice for the seasoned traitor. This one is cold."
+	warm = FALSE
 
 /obj/item/reagent_containers/food/snacks/warmdonkpocket/Post_Consume(mob/living/M)
-	M.reagents.add_reagent("omnizine", 15)
+	if(warm)
+		M.reagents.add_reagent("omnizine", 15)
+	else
+		M.reagents.add_reagent("weak_omnizine", 5)
 
 /obj/item/reagent_containers/food/snacks/warmdonkpocket_weak
 	name = "lukewarm Donk-pocket"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Warm Donk Pockets will now cool over time, and in seven minutes will become cold donk pockets. Cold donk pockets are sad, yielding only five diluted omnizine as compared to the fifteen omnizine warm donk pockets yield. They presently cannot be reheated (due to proteins denaturing as it cools or something), but this can be changed if requested.
This also does not affect any other donk pockets, just the heated regular ones.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Donk pockets are stupid strong, did ya know? You warm them up once, they last forever, and heal for 150 in several damage types. Also, the donk pocket box has _always_ said that these things cool in seven minutes, so we may as well have it actually work.
The five diluted omnizine is actually a bit more than miners get in their lukewarm donks, but let's just say that because the omnizine was activated more recently it's not so diluted/denatured.
## Testing
<!-- How did you test the PR, if at all? -->
Made sure it worked, added the appropriate amount of reagents, all that jazz.
## Changelog
:cl:
tweak: Warm Donk Pockets cool over time and lose potency.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
