### PR TITLE
Real cere webmap link

### DIFF
--- a/code/modules/mapping/cerestation.dm
+++ b/code/modules/mapping/cerestation.dm
@@ -2,4 +2,4 @@
 	fluff_name = "NSS Farragus"
 	technical_name = "CereStation"
 	map_path = "_maps/map_files/cerestation/cerestation.dmm"
-	webmap_url = "https://affectedarc07.co.uk/cere.html"
+	webmap_url = "https://affectedarc07.github.io/SS13WebMap/Paradise/CereStation/"


### PR DESCRIPTION
## What Does This PR Do
Moves the cere webmap link to a real webmap not the scuffed non-updating ones

## Why It's Good For The Game
Its a real map now, it should have a real webmap

## Testing
None. Its a webedit.

## Changelog
:cl: AffectedArc07
add: The webmap link for CereStation / NSS Farragus is now a proper webmap
/:cl:
