### PR TITLE
xenoborgs can now select any normal borg module as well as the hunter module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -350,7 +350,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		"Hunter" = image('icons/mob/robots.dmi', "xeno-radial"))
 
 	if(mmi?.alien)
-		force_modules = list("Hunter") + standard_modules.Copy() // standard PLUS hunter
+		if(!length(force_modules))
+			force_modules = list("Hunter") + standard_modules.Copy() // standard PLUS hunter
 
 	// Return a list of `force_modules`, with the associated images from the other lists.
 	if(length(force_modules))

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -350,7 +350,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		"Hunter" = image('icons/mob/robots.dmi', "xeno-radial"))
 
 	if(mmi?.alien)
-		force_modules = list("Hunter", "Engineering", "Janitor", "Medical", "Mining", "Service") // standard PLUS hunter
+		force_modules = list("Hunter") + standard_modules.Copy() // standard PLUS hunter
 
 	// Return a list of `force_modules`, with the associated images from the other lists.
 	if(length(force_modules))

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -334,7 +334,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
   *
   * By default this returns the Engineering, Janitor, Medical, Mining, and Service modules.
   * If there are any [/mob/living/silicon/robot/var/force_modules] set, then they are returned instead.
-  * If the MMI has a xenomorph brain in it ([/obj/item/mmi/var/alien]), then only the "Hunter" module is returned.
+  * If the MMI has a xenomorph brain in it ([/obj/item/mmi/var/alien]), then only the "Hunter" and standard modules is returned.
   */
 /mob/living/silicon/robot/proc/get_module_types()
 	var/static/list/standard_modules = list(
@@ -346,10 +346,11 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/static/list/special_modules = list(
 		"Combat" = image('icons/mob/robots.dmi', "security-radial"),
 		"Security" = image('icons/mob/robots.dmi', "security-radial"),
-		"Destroyer" = image('icons/mob/robots.dmi', "droidcombat"))
+		"Destroyer" = image('icons/mob/robots.dmi', "droidcombat"),
+		"Hunter" = image('icons/mob/robots.dmi', "xeno-radial"))
 
 	if(mmi?.alien)
-		return list("Hunter" = image('icons/mob/robots.dmi', "xeno-radial"))
+		force_modules = list("Hunter", "Engineering", "Janitor", "Medical", "Mining", "Service") // standard PLUS hunter
 
 	// Return a list of `force_modules`, with the associated images from the other lists.
 	if(length(force_modules))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
title

## Why It's Good For The Game
Yall ever actually played as a xenoborg? Shit sucks. I'm working on a rework right now but I feel actual pain for anyone that has had "viagra spray" as the main form of entertainment 

## Testing
yes
## Changelog
:cl:
tweak: Xenoborgs can also be any standard borg module as well as hunter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
