### PR TITLE
Freedom Implant is now 5 TC instead of 6 TC

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1605,7 +1605,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A bio-chip injected into the body and later activated manually to break out of any restraints or grabs. Can be activated up to 4 times."
 	reference = "FI"
 	item = /obj/item/implanter/freedom
-	cost = 6
+	cost = 5
 
 /datum/uplink_item/implants/uplink
 	name = "Uplink Bio-chip"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -28,7 +28,7 @@
 		/obj/item/twohanded/garrote, // 6TC
 		/obj/item/door_remote/omni/access_tuner, // 6TC
 		/obj/item/clothing/glasses/chameleon/thermal, // 6TC
-		/obj/item/implanter/freedom, // 6TC
+		/obj/item/implanter/freedom, // 5TC
 		/obj/item/coin/gold, // 0TC
 		/obj/item/encryptionkey/syndicate) // 2TC
 
@@ -82,7 +82,7 @@
 		/obj/item/encryptionkey/syndicate) // 2TC
 
 	var/static/list/implant = list( // 41TC
-		/obj/item/implanter/freedom, // 6TC
+		/obj/item/implanter/freedom, // 5TC
 		/obj/item/implanter/uplink, // 14TC (ten free TC)
 		/obj/item/implanter/emp, // 1TC
 		/obj/item/implanter/adrenalin, // 8TC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the cost of freedoms be 5 TC instead of 6 TC, incredible.

## Why It's Good For The Game
Freedoms are not really worth 6TC for what they offer. Their usefulness has a lot of weaknesses that can easily be beaten. Reducing the cost by 1TC gives it some more wiggle room to play around with your build. Not a crazy buff but it helps the poor implant out from being a giant kill me sign after first use, and being more viable in pairing of other items.

## Testing
booted server, tried it in game, wow its price is different!

## Changelog
:cl: Octus
tweak: Freedoms now cost 5TC instead of 6TC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
