### PR TITLE
Putting nerds to bed

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -106,13 +106,17 @@
 		var/turf/T = loc
 		T.hotspot_expose(700, 5)
 
+/obj/item/candle/proc/unlight()
+	if(lit)
+		lit = FALSE
+		update_icon(UPDATE_ICON_STATE)
+		set_light(0)
+
 
 /obj/item/candle/attack_self(mob/user)
 	if(lit)
 		user.visible_message("<span class='notice'>[user] snuffs out [src].</span>")
-		lit = FALSE
-		update_icon(UPDATE_ICON_STATE)
-		set_light(0)
+		unlight()
 
 /obj/item/candle/eternal
 	desc = "A candle. This one seems to have an odd quality about the wax."

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -262,44 +262,17 @@
 	buckle_offset = 0
 	comfort = 0.5
 
-/obj/structure/bed/dogbed/proc/can_be_put_to_bed(mob/sleeper)
-	return ispet(sleeper)
-
-/obj/structure/bed/dogbed/shove_impact(mob/living/target, mob/living/attacker)
-	// no, you can't force vulps or taj to sleep in the dog bed.
-	if(!istype(target) || !can_be_put_to_bed(target))
-		return FALSE
-
-	target.visible_message(
-		"<span class='warning'>[attacker] puts [target] to bed!</span>",
-		"<span class='danger'>[attacker] pushes you into [src], and it feels so comfy you can't resist the urge to sleep!</span>"
-	)
-	target.Sleeping(target.mind ? 15 SECONDS : 2 MINUTES)
-	buckle_mob(target, TRUE)
-
-	return TRUE
-
 /obj/structure/bed/dogbed/ian
 	name = "Ian's bed"
 	desc = "Ian's bed! Looks comfy."
 	anchored = TRUE
-
-/obj/structure/bed/dogbed/ian/can_be_put_to_bed(mob/sleeper)
-	return iscorgi(sleeper)
 
 /obj/structure/bed/dogbed/renault
 	desc = "Renault's bed! Looks comfy. A foxy person needs a foxy pet."
 	name = "Renault's bed"
 	anchored = TRUE
 
-
-/obj/structure/bed/dogbed/renault/can_be_put_to_bed(mob/sleeper)
-	return istype(sleeper, /mob/living/simple_animal/pet/dog/fox)
-
 /obj/structure/bed/dogbed/runtime
 	desc = "A comfy-looking cat bed. You can even strap your pet in, in case the gravity turns off."
 	name = "Runtime's bed"
 	anchored = TRUE
-
-/obj/structure/bed/dogbed/runtime/can_be_put_to_bed(mob/sleeper)
-	return iscat(sleeper)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -115,7 +115,7 @@
 	target.forceMove(loc)
 	buckle_mob(target, TRUE)
 	if(!H.IsSleeping())
-		H.Sleeping((15 SECONDS) * sleep_ratio)
+		H.Sleeping(15 SECONDS * sleep_ratio)
 		add_attack_logs(attacker, target, "put to bed for [15 * sleep_ratio] seconds.")
 	H.emote("snore")
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -112,11 +112,11 @@
 			"<span class='notice'>You feel so cozy, you could probably stay here for a while...</span>"
 		)
 
-	add_attack_logs(attacker, target, "put to bed for [15 * sleep_ratio] seconds.")
-
 	target.forceMove(loc)
 	buckle_mob(target, TRUE)
-	H.Sleeping((15 SECONDS) * sleep_ratio)
+	if(!H.IsSleeping())
+		H.Sleeping((15 SECONDS) * sleep_ratio)
+		add_attack_logs(attacker, target, "put to bed for [15 * sleep_ratio] seconds.")
 	H.emote("snore")
 
 	for(var/mob/living/carbon/human/viewer in viewers())

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -274,8 +274,10 @@
 		"<span class='warning'>[attacker] puts [target] to bed!</span>",
 		"<span class='danger'>[attacker] pushes you into [src], and it feels so comfy you can't resist the urge to sleep!</span>"
 	)
-
-	target.Sleeping(15 SECONDS)
+	var/sleep_length = 2 MINUTES
+	if(target.mind)
+		// much less if you're actually conscious
+		target.Sleeping(15 SECONDS)
 	buckle_mob(target, TRUE)
 
 	return TRUE

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -274,10 +274,7 @@
 		"<span class='warning'>[attacker] puts [target] to bed!</span>",
 		"<span class='danger'>[attacker] pushes you into [src], and it feels so comfy you can't resist the urge to sleep!</span>"
 	)
-	var/sleep_length = 2 MINUTES
-	if(target.mind)
-		// much less if you're actually conscious
-		target.Sleeping(15 SECONDS)
+	target.Sleeping(target.mind ? 15 SECONDS : 2 MINUTES)
 	buckle_mob(target, TRUE)
 
 	return TRUE

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -68,6 +68,63 @@
 /obj/structure/bed/post_unbuckle_mob(mob/living/M)
 	M.pixel_y = M.get_standard_pixel_y_offset()
 
+/obj/structure/bed/shove_impact(mob/living/target, mob/living/attacker)
+	. = ..()
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/H = target
+
+	// only if you're wearing PJs
+	if(!istype(H.w_uniform, /obj/item/clothing/under/misc/pj))
+		return
+
+	// and there's a sheet on the bed
+	if(!locate(/obj/item/bedsheet) in loc)
+		return
+
+	var/sleep_ratio = 1
+
+	if(istype(H.shoes, /obj/item/clothing/shoes/slippers))
+		sleep_ratio *= 2
+		// take your shoes off first, you filthy animal
+		H.unEquip(H.shoes)
+
+	var/extinguished_candle = FALSE
+	for(var/obj/item/candle/C in range(2, src))
+		if(C.lit)
+			C.unlight()
+			extinguished_candle = TRUE
+
+	if(extinguished_candle)
+		sleep_ratio *= 2
+
+	// nighty night
+	target.visible_message(
+		"<span class='danger'>[attacker] puts [target] to bed!</span>",
+		"<span class='userdanger'>[attacker] shoves you under the covers, and you're out like a light!</span>",
+		"<span class='notice'>You hear someone getting into bed.</span>"
+	)
+
+	if(sleep_ratio > 1)
+		target.visible_message(
+			"<span class='notice'>[target] seems especially cozy...they won't be up for a while.</span>",
+			"<span class='notice'>You feel so cozy, you could probably stay here for a while...</span>"
+		)
+
+	add_attack_logs(attacker, target, "put to bed for [15 * sleep_ratio] seconds.")
+
+	target.forceMove(loc)
+	buckle_mob(target, TRUE)
+	H.Sleeping((15 SECONDS) * sleep_ratio)
+	H.emote("snore")
+
+	for(var/mob/living/carbon/human/viewer in viewers())
+		if(prob(50))
+			viewer.emote("yawn")
+
+	return TRUE
+
 /*
  * Roller beds
  */
@@ -205,17 +262,45 @@
 	buckle_offset = 0
 	comfort = 0.5
 
+/obj/structure/bed/dogbed/proc/can_be_put_to_bed(mob/sleeper)
+	return ispet(sleeper)
+
+/obj/structure/bed/dogbed/shove_impact(mob/living/target, mob/living/attacker)
+	// no, you can't force vulps or taj to sleep in the dog bed.
+	if(!istype(target) || !can_be_put_to_bed(target))
+		return FALSE
+
+	target.visible_message(
+		"<span class='warning'>[attacker] puts [target] to bed!</span>",
+		"<span class='danger'>[attacker] pushes you into [src], and it feels so comfy you can't resist the urge to sleep!</span>"
+	)
+
+	target.Sleeping(15 SECONDS)
+	buckle_mob(target, TRUE)
+
+	return TRUE
+
 /obj/structure/bed/dogbed/ian
 	name = "Ian's bed"
 	desc = "Ian's bed! Looks comfy."
 	anchored = TRUE
+
+/obj/structure/bed/dogbed/ian/can_be_put_to_bed(mob/sleeper)
+	return iscorgi(sleeper)
 
 /obj/structure/bed/dogbed/renault
 	desc = "Renault's bed! Looks comfy. A foxy person needs a foxy pet."
 	name = "Renault's bed"
 	anchored = TRUE
 
+
+/obj/structure/bed/dogbed/renault/can_be_put_to_bed(mob/sleeper)
+	return istype(sleeper, /mob/living/simple_animal/pet/dog/fox)
+
 /obj/structure/bed/dogbed/runtime
 	desc = "A comfy-looking cat bed. You can even strap your pet in, in case the gravity turns off."
 	name = "Runtime's bed"
 	anchored = TRUE
+
+/obj/structure/bed/dogbed/runtime/can_be_put_to_bed(mob/sleeper)
+	return iscat(sleeper)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -108,7 +108,7 @@
 
 	if(sleep_ratio > 1)
 		target.visible_message(
-			"<span class='notice'>[target] seems especially cozy...they won't be up for a while.</span>",
+			"<span class='notice'>[target] seems especially cozy...[target.p_they()] probably won't be up for a while.</span>",
 			"<span class='notice'>You feel so cozy, you could probably stay here for a while...</span>"
 		)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Shoving someone onto a bed while they're both wearing PJs and the bed has a bedsheet will put them right to sleep. Depending on some other comfort factors, they may sleep for a bit longer.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
![but-heres](https://user-images.githubusercontent.com/89928798/219448172-329eba9b-a2ba-483a-8597-d5f16454a9bd.gif)

It's another fun shove interaction. It takes a bit of setup, so it might be a bit hard to pull off if you're not trying to.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/219446278-e2325665-05a0-4175-9bdb-302049f6c99d.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Put some people to bed. 
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Being pushed into a made bed while wearing PJs will put you to sleep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
