### PR TITLE
fixes a lightgeist runtime + possible qdel loop

### DIFF
--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -293,7 +293,6 @@
 
 /mob/living/simple_animal/hostile/lightgeist/ghost()
 	qdel(src)
-	return ..()
 
 /obj/machinery/anomalous_crystal/refresher //Deletes and recreates a copy of the item, "refreshing" it.
 	activation_method = "touch"

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -291,9 +291,9 @@
 			L.heal_overall_damage(heal_power, heal_power)
 			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 
-/mob/living/simple_animal/hostile/lightgeist/ghostize()
-	if(..())
-		death()
+/mob/living/simple_animal/hostile/lightgeist/ghost()
+	qdel(src)
+	return ..()
 
 /obj/machinery/anomalous_crystal/refresher //Deletes and recreates a copy of the item, "refreshing" it.
 	activation_method = "touch"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes a possible qdel loop and this runtime: `Runtime in observer_base.dm,234: Cannot modify null.timeofdeath`
aghosting no longer deletes your body as a lightgeist

## Why It's Good For The Game
bugfix, and honestly aghosting shouldn't delete your body lol

## Changelog
:cl:
tweak: [ADMIN] Aghosting will no longer delete your body as a lightgeist
/:cl:


