### PR TITLE
Bumps RUSTG + CI to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run_linters:
     name: Run Linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup Cache
@@ -39,7 +39,7 @@ jobs:
 
   compile_all_maps:
     name: Compile All Maps
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup Cache
@@ -56,7 +56,7 @@ jobs:
 
   unit_tests_and_sql:
     name: Unit Tests + SQL Validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false # Let all map tests run to completion
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
-          sudo apt install libssl1.1:i386
+          sudo apt install libssl:i386
           ldd librust_g.so
       - name: Start Redis
         uses: supercharge/redis-github-action@1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
-          sudo apt install libssl:i386
+          sudo apt install libssl-dev:i386
           ldd librust_g.so
       - name: Start Redis
         uses: supercharge/redis-github-action@1.4.0


### PR DESCRIPTION
## What Does This PR Do
Bumps RUSTG to a copy built on Ubuntu 22.04 and the CI to use `ubuntu-22.04` instead of `ubuntu-20.04`

<summary>Details for nerds</summary>
<details>
20.04 uses `libssl1` for its functionality. 22.04 uses `libssl3` for its functionality, and that is statically linked to RUSTG when it is built, and you cant easily install `libssl1` on 22.04, so we have to bump the library. Given this is the latest LTS, we may as well.
</details>

## Why It's Good For The Game
Stuff should work

## Testing
We will find out when CI runs. This is also running on prod.

## Changelog
:cl: AffectedArc07
experiment: Server libraries updated for Ubuntu 22.04. It may not work on older versions.
/:cl:
