### PR TITLE
Removes the RCD from engi borgs base kit, and replaces it with a module upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -404,7 +404,7 @@
 	cyborg = null
 	return ..()
 
-/obj/item/borg/upgrade/RCD
+/obj/item/borg/upgrade/rcd
 	name = " R.C.D. upgrade"
 	desc = "A modified rapid construction device, able to pull energy directly from a cyborgs internal power cell."
 	icon_state = "cyborg_upgrade5"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -406,7 +406,7 @@
 	return ..()
 
 /obj/item/borg/upgrade/rcd
-	name = " R.C.D. upgrade"
+	name = "R.C.D. upgrade"
 	desc = "A modified rapid construction device, able to pull energy directly from a cyborgs internal power cell."
 	icon_state = "cyborg_upgrade5"
 	origin_tech = "engineering=4;materials=5;powerstorage=4"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -13,6 +13,7 @@
 	var/module_type = null
 	/// A list of items, and their replacements that this upgrade should replace on installation, in the format of `item_type_to_replace = replacement_item_type`.
 	var/list/items_to_replace = list()
+	/// A list of items to add, rather than replace
 	var/list/items_to_add = list()
 	/// A list of replacement items will need to be placed into a cyborg module's `special_rechargable` list after this upgrade is installed.
 	var/list/special_rechargables = list()
@@ -412,3 +413,9 @@
 	require_module = TRUE
 	module_type = /obj/item/robot_module/engineering
 	items_to_add = list(/obj/item/rcd/borg)
+
+/obj/item/borg/upgrade/rcd/after_install(mob/living/silicon/robot/R)
+	if(R.emagged) // Emagged engi-borgs have already have the RCD added.
+		return
+	R.module.remove_item_from_lists(/obj/item/rcd) // So emagging them in the future won't grant another RCD.
+	..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -13,6 +13,7 @@
 	var/module_type = null
 	/// A list of items, and their replacements that this upgrade should replace on installation, in the format of `item_type_to_replace = replacement_item_type`.
 	var/list/items_to_replace = list()
+	var/list/items_to_add = list()
 	/// A list of replacement items will need to be placed into a cyborg module's `special_rechargable` list after this upgrade is installed.
 	var/list/special_rechargables = list()
 
@@ -70,6 +71,10 @@
 
 		if(replacement_type in special_rechargables)
 			R.module.special_rechargables += replacement
+
+	for(var/item in items_to_add)
+		var/obj/item/replacement = new item(R.module)
+		R.module.basic_modules += replacement
 
 	R.module?.rebuild_modules()
 	return TRUE
@@ -398,3 +403,12 @@
 	cyborg.floorbuffer = FALSE
 	cyborg = null
 	return ..()
+
+/obj/item/borg/upgrade/RCD
+	name = " R.C.D upgrade"
+	desc = "A modified rapid construction device, able to pull energy directly from a cyborgs internal power cell."
+	icon_state = "cyborg_upgrade5"
+	origin_tech = "engineering=4;materials=5;powerstorage=4"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/engineering
+	items_to_add = list(/obj/item/rcd/borg)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -405,7 +405,7 @@
 	return ..()
 
 /obj/item/borg/upgrade/RCD
-	name = " R.C.D upgrade"
+	name = " R.C.D. upgrade"
 	desc = "A modified rapid construction device, able to pull energy directly from a cyborgs internal power cell."
 	icon_state = "cyborg_upgrade5"
 	origin_tech = "engineering=4;materials=5;powerstorage=4"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -382,7 +382,7 @@
 		/obj/item/stack/sheet/glass/cyborg,
 		/obj/item/stack/sheet/rglass/cyborg
 	)
-	emag_modules = list(/obj/item/borg/stun, /obj/item/restraints/handcuffs/cable/zipties/cyborg)
+	emag_modules = list(/obj/item/borg/stun, /obj/item/restraints/handcuffs/cable/zipties/cyborg, /obj/item/rcd/borg)
 	malf_modules = list(/obj/item/gun/energy/emitter/cyborg)
 	special_rechargables = list(/obj/item/extinguisher, /obj/item/weldingtool/largetank/cyborg, /obj/item/gun/energy/emitter/cyborg)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -359,7 +359,6 @@
 	module_actions = list(/datum/action/innate/robot_sight/meson)
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/rcd/borg,
 		/obj/item/rpd,
 		/obj/item/extinguisher,
 		/obj/item/weldingtool/largetank/cyborg,

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1108,6 +1108,16 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_rcd
+	name = "Cyborg Upgrade (Rapid Construction Device)"
+	id = "borg_upgrade_RCD"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/RCD
+	req_tech = list("materials" = 6, "engineering" = 5, "powerstorage" = 5)
+	materials = list(MAT_METAL=30000, MAT_GLASS=15000,)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracking Beacon"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1112,7 +1112,7 @@
 	name = "Cyborg Upgrade (Rapid Construction Device)"
 	id = "borg_upgrade_RCD"
 	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/RCD
+	build_path = /obj/item/borg/upgrade/rcd
 	req_tech = list("materials" = 6, "engineering" = 5, "powerstorage" = 5)
 	materials = list(MAT_METAL=30000, MAT_GLASS=15000,)
 	construction_time = 120


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
More or less the title. removes the RCD from engineering borgs base kit, and adds a new upgrade module that gives it back, with the level&matts requirements as follows: 
materials 6, engineering 5, and power storage 5.
matts: 30000 metal, and 15000 glass. 
Also adds a new var for _adding_ items rather than replacing for borgs.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The rcd is a extremely powerful tool, even more so for cyborgs, since they can deconstruct Rwalls with it, and being able to rapidly space, or un-space a room. on top of all of that, it is a rather lazy, and boring way to fix station damages. while it is fast, and sometimes the only option for somethings, like a SM delam, or something of similar destructive results, ideally RnD would have the required stuff to upgrade a borg to have the rcd. 
## Testing
<!-- How did you test the PR, if at all? -->
i ensured the engi borg did not have a rcd on round start, then spawned a upgrade, and put it into a borg testing both non engi, and engi to make sure it wont give janitor a rcd, and making sure that it did actually give the borg the rcd, and also made sure that it was in the mechfab with the correct level requirements, and also deconstructed into one less level for the three types than the requirement. 
## Changelog
:cl:
add: Added a new upgrade module for the engineering borg that gives them a RCD 
tweak: Engineering borgs no longer spawn with the RCD.
tweak: ERT&emaged engi borgs get the RCD upgrade.
/:cl:

## Additional notes
~~While i do see the concern with malf ai, if the ai is playing smartly, and not hacking risky apcs before their borgs have upgrades, i personally think that is more of a player issue rather than a game issue.
And for the borging machine, could fall under the same argument, and i do not entirely see why every new engineering borg would have the need to build a entire department sized room in about a minute, while also being the stunning backbone of the silicon team. 
Although adding a malf power to give borgs rcds may be something that could alleviate some of the concerns some of you may have with this pr.~~

## Edit
I've added the RCD to the emaged module list, mostly to give ert borgs the rcd on spawn, but will also help with malf ai. 