### PR TITLE
harvesters are now glass cannons

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -291,8 +291,8 @@
 	icon_living = "harvester"
 	maxHealth = 40
 	health = 40
-	melee_damage_lower = 30
-	melee_damage_upper = 35
+	melee_damage_lower = 20
+	melee_damage_upper = 25
 	attacktext = "prods"
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	attack_sound = 'sound/weapons/tap.ogg'

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -289,10 +289,10 @@
 	desc = "A harbinger of enlightenment. It'll be all over soon."
 	icon_state = "harvester"
 	icon_living = "harvester"
-	maxHealth = 60
-	health = 60
-	melee_damage_lower = 1
-	melee_damage_upper = 5
+	maxHealth = 40
+	health = 40
+	melee_damage_lower = 30
+	melee_damage_upper = 35
 	attacktext = "prods"
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	attack_sound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Harvester damage increased to 25-20 from 5-1
Harvester health decreased from 60 to 40

## Why It's Good For The Game
Outside of smoke and removing atmos from every single area on and off station, harvesters don't really do anything. Got internals? Harvesters are fucked, and that makes playing harvester kinda a drag, especially for what should be an end of round high point. An increase in melee damage will just let them actually do things, and the decrease in health will let crew fight them and let them make real progress until the shuttle leaves.

## Testing
compiled and ran.  
## Changelog
:cl:
tweak: Harvesters now deal 25 melee damage
tweak: Harvesters now only have 40 health 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
