### PR TITLE
Fixes a bug that allowed turret guns to be fired by mobs.

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -29,7 +29,6 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/projectile/automatic/l6_saw,
 	/obj/item/gun/projectile/automatic/m90,
 	/obj/item/gun/energy/alien,
-	/obj/item/gun/energy/gun/turret,
 	/obj/item/gun/energy/pulse/carbine,
 	/obj/item/gun/energy/decloner,
 	/obj/item/gun/energy/mindflayer,

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1031,6 +1031,9 @@
 	if(G.trigger_guard != TRIGGER_GUARD_ALLOW_ALL && !IsAdvancedToolUser() && !issmall(src))
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 0
+	if(G.trigger_guard == TRIGGER_GUARD_NONE)
+		to_chat(src, "<span class='warning'>This gun is only built to be fired by machines!</span>")
+		return 0
 	return 1
 
 /mob/living/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1030,10 +1030,10 @@
 /mob/living/proc/can_use_guns(obj/item/gun/G)
 	if(G.trigger_guard != TRIGGER_GUARD_ALLOW_ALL && !IsAdvancedToolUser() && !issmall(src))
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return 0
+		return FALSE
 	if(G.trigger_guard == TRIGGER_GUARD_NONE)
 		to_chat(src, "<span class='warning'>This gun is only built to be fired by machines!</span>")
-		return 0
+		return FALSE
 	return 1
 
 /mob/living/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
TRIGGER_GUARD_NONE was a trigger_guard var applied to energy gun turrets that was meant to make it so no one could fire them and they were only usable inside a turret. However it was not fully implemented so while the var existed, it didn't do anything. This PR makes it so guns with the TRIGGER_GUARD_NONE var cannot be fired by mobs. In practice this means the Hybrid turret gun you could get from destroyed turrets will not be able to be fired, so no more tasers for crew.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs are bad. Also tasers were removed for a reason, people should not be able to get them again by destroying turrets.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Testing
-Started private server
-Attempted to fire a normal gun as a human, it worked
-Attempted to fire a normal gun as a monkey, it worked
-Attempted to fire a normal gun as an abductor, it did not work
-Attempted to fire a turret gun as a human, it did not work
-Attempted to fire a turret gun as a monkey, it did not work
-Attempted to fire a turret gun as an abductor, it did not work
-Spawned in a energy turret, it fired as normal
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
del: Hybrid turret gun cannot be spawned by wizard's summon guns spell
tweak: Hybrid turret gun cannot be fired
fix: TRIGGER_GUARD_NONE works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
