### PR TITLE
Reduces heat damage for Drasks from 300% to 200%.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -45,7 +45,7 @@
 	heat_level_1 = 310 //Default 370 - Higher is better
 	heat_level_2 = 340 //Default 400
 	heat_level_3 = 400 //Default 460
-	heatmod = 2 // 3.5 * more damage from body temp
+	heatmod = 2 // 3 * more damage from body temp
 
 	flesh_color = "#a3d4eb"
 	reagent_tag = PROCESS_ORG

--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -45,7 +45,7 @@
 	heat_level_1 = 310 //Default 370 - Higher is better
 	heat_level_2 = 340 //Default 400
 	heat_level_3 = 400 //Default 460
-	heatmod = 3 // 4.5 * more damage from body temp
+	heatmod = 2 // 3.5 * more damage from body temp
 
 	flesh_color = "#a3d4eb"
 	reagent_tag = PROCESS_ORG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Buffs Drasks by reducing their heat modifier from 300% to 200%.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Drasks are currently probably one of the weakest species. With a 300% heat modifier, they take a total of 450% additional damage from fire (due to the 150% burn damage modifier). This PR scales the damage down without buffing Drasks too much.
At the same time, the 200% heat modifier in the wiki is now correct.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled and ran it.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Reduced heat damage of Drasks from 300% to 200%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
