### PR TITLE
tweaks the MK-II (stock) Ripley to be quicker then the specialized, fire-fighting variant

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -3,9 +3,9 @@
 	name = "APLU \"Ripley\""
 	icon_state = "ripley"
 	initial_icon = "ripley"
-	step_in = 4 //Move speed, lower is faster.
-	var/fast_pressure_step_in = 2 //step_in while in normal pressure conditions
-	var/slow_pressure_step_in = 4 //step_in while in better pressure conditions
+	step_in = 3 //Move speed, lower is faster.
+	var/fast_pressure_step_in = 1.75 //step_in while in normal pressure conditions
+	var/slow_pressure_step_in = 3 //step_in while in better pressure conditions
 	max_temperature = 20000
 	max_integrity = 200
 	lights_power = 7

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -4,8 +4,10 @@
 	icon_state = "ripley"
 	initial_icon = "ripley"
 	step_in = 3 //Move speed, lower is faster.
-	var/fast_pressure_step_in = 1.75 //step_in while in normal pressure conditions
-	var/slow_pressure_step_in = 3 //step_in while in better pressure conditions
+	/// step_in while in normal pressure conditions
+	var/fast_pressure_step_in = 1.75
+	/// step_in while in better pressure conditions
+	var/slow_pressure_step_in = 3
 	max_temperature = 20000
 	max_integrity = 200
 	lights_power = 7


### PR DESCRIPTION
## What Does This PR Do
Changes the MK1 Ripley's indoors and outdoors speeds to be 3 and 1.75 respectively.

## Why It's Good For The Game

Gives robo's a reason to build the regular (yellow) Ripley over the Firefighter - which is supposed to be a specialized variant for fighting fires, not outright superior in almost all respects to the stock model. (The firefighter has, more HP, much more armour and is lavaproof over the MK1. Let's make the MK1 a little speedier.)

## Testing
None, it's a single value change lol.

## Changelog
:cl:
tweak: Aliens fans rejoice! The yellow, stock 'powerloader Ripley' is moderately quicker compared to it's more specialized cousin.
/:cl:
