### PR TITLE
Fixes indestructible window smoothing

### DIFF
--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -182,13 +182,11 @@
 		QUEUE_SMOOTH(src)
 
 /turf/simulated/wall/indestructible/fakeglass/update_overlays()
-	. = ..()
-
 	if(!edge_overlay_file)
 		return
 
 	edge_overlay = mutable_appearance(edge_overlay_file, "[smoothing_junction]", layer + 0.1, appearance_flags = RESET_COLOR)
-	. += edge_overlay
+	return list(edge_overlay)
 
 /turf/simulated/wall/indestructible/fakeglass/brass
 	icon = 'icons/obj/smooth_structures/windows/clockwork_window.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes CC indestructible windows not smoothing with each other properly, they shouldn't have other overlays so doing this is fine I think.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Admin spawned stuff should look right
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Fixes this (kudos for dsdiy for pointing it out):
![image](https://user-images.githubusercontent.com/12197162/220428604-676e6b0b-3926-467c-a6ee-8dfaea720e36.png)


![image](https://user-images.githubusercontent.com/12197162/220429194-081405c8-e5a9-4fb6-acfa-0139e8419bd8.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned windows
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed improper smoothing on indestructible windows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
