### PR TITLE
Buffs Mediborg abductor module to affect medihypo

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -240,7 +240,8 @@
 		/obj/item/FixOVein = /obj/item/FixOVein/alien,
 		/obj/item/bonesetter = /obj/item/bonesetter/alien,
 		/obj/item/circular_saw = /obj/item/circular_saw/alien,
-		/obj/item/surgicaldrill = /obj/item/surgicaldrill/alien
+		/obj/item/surgicaldrill = /obj/item/surgicaldrill/alien,
+		/obj/item/reagent_containers/borghypo = /obj/item/reagent_containers/borghypo/abductor
 	)
 
 /obj/item/borg/upgrade/syndicate

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -35,7 +35,7 @@
 /obj/item/reagent_containers/borghypo/abductor
 	charge_cost = 40
 	recharge_time = 3
-	reagent_ids = list("salglu_solution", "epinephrine", "hydrocodone", "spaceacillin", "charcoal", "mannitol", "salbutamol","corazone")
+	reagent_ids = list("salglu_solution", "epinephrine", "hydrocodone", "spaceacillin", "charcoal", "mannitol", "salbutamol", "corazone")
 	bypass_protection = 1
 
 /obj/item/reagent_containers/borghypo/Initialize(mapload)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -32,6 +32,12 @@
 	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone")
 	bypass_protection = 1
 
+/obj/item/reagent_containers/borghypo/abductor
+	charge_cost = 40
+	recharge_time = 3
+	reagent_ids = list("salglu_solution", "epinephrine", "hydrocodone", "spaceacillin", "charcoal", "mannitol", "salbutamol","corazone")
+	bypass_protection = 1
+
 /obj/item/reagent_containers/borghypo/Initialize(mapload)
 	. = ..()
 	for(var/R in reagent_ids)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Buffs abductor cyborg medical module to affect the medihypo. Reduces Recharge time from 10->6 seconds, Recharge energy cost from 50->40, adds Corazone to the list of ingredients it can inject, and allows the hypo to pierce armor. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Allows Corazone to be made and used when heart surgeries will be needed as abductors are around. Also allows for medical cyborgs to spend less time waiting for their chemicals to regen. Also allows for the cyborg hypospray to penetrate armor as a experimental change.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned as a mediborg, injected people and saw the usual 10 second time and 50 energy cost. Applied the module, observed a new 6 second time, 40 energy cost, and corazone added to the list of chemicals. 
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Buffs abductor cyborg medical module to affect the medihypo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
