### PR TITLE
Adds more robust labeller/rename logging

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -375,7 +375,7 @@
 #define EXPLOSION_BLOCK_PROC -1
 
 // Defines for investigate to prevent typos and for styling
-#define INVESTIGATE_LABEL "labels"
+#define INVESTIGATE_RENAME "renames"
 
 #define INVESTIGATE_BOMB "bombs"
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1231,7 +1231,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	var/logged_name = initial(name)
 	if(t)
 		logged_name = "[use_prefix ? "[prefix][t]" : t]"
-	investigate_log("[key_name(user)] renamed \"[src]\" ([ADMIN_VV(src, "VV")]) as \"[logged_name]\".", INVESTIGATE_RENAME)
+	investigate_log("[key_name(user)] ([ADMIN_FLW(user,"FLW")]) renamed \"[src]\" ([ADMIN_VV(src, "VV")]) as \"[logged_name]\".", INVESTIGATE_RENAME)
 
 	if(actually_rename)
 		if(t == "")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1226,6 +1226,13 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 
 	t = sanitize(copytext(t, 1, MAX_NAME_LEN))
+
+	// Logging
+	var/logged_name = initial(name)
+	if(t)
+		logged_name = "[use_prefix ? "[prefix][t]" : t]"
+	investigate_log("[key_name(user)] renamed \"[src]\" ([ADMIN_VV(src, "VV")]) as \"[logged_name]\".", INVESTIGATE_RENAME)
+
 	if(actually_rename)
 		if(t == "")
 			name = "[initial(name)]"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -29,7 +29,7 @@
 
 	user.visible_message("<span class='notice'>[user] labels [A] as [label].</span>", \
 						"<span class='notice'>You label [A] as [label].</span>")
-	investigate_log("[key_name(user)] labelled [A] ([ADMIN_VV(A, "VV")]) as [label] at [COORD(A.loc)] [ADMIN_JMP(A)].", INVESTIGATE_LABEL) // Investigate goes BEFORE rename so the original name is preserved in the log
+	investigate_log("[key_name(user)] labelled \"[A]\" ([ADMIN_VV(A, "VV")]) with \"[label]\" at [COORD(A.loc)] [ADMIN_JMP(A)].", INVESTIGATE_RENAME) // Investigate goes BEFORE rename so the original name is preserved in the log
 	A.AddComponent(/datum/component/label, label)
 	playsound(A, 'sound/items/handling/component_pickup.ogg', 20, TRUE)
 	labels_left--

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -29,7 +29,7 @@
 
 	user.visible_message("<span class='notice'>[user] labels [A] as [label].</span>", \
 						"<span class='notice'>You label [A] as [label].</span>")
-	investigate_log("[key_name(user)] labelled [A] as [label].", INVESTIGATE_LABEL) // Investigate goes BEFORE rename so the original name is preserved in the log
+	investigate_log("[key_name(user)] labelled [A] ([ADMIN_VV(A, "VV")]) as [label] at [COORD(A.loc)] [ADMIN_JMP(A)].", INVESTIGATE_LABEL) // Investigate goes BEFORE rename so the original name is preserved in the log
 	A.AddComponent(/datum/component/label, label)
 	playsound(A, 'sound/items/handling/component_pickup.ogg', 20, TRUE)
 	labels_left--

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -29,7 +29,7 @@
 
 	user.visible_message("<span class='notice'>[user] labels [A] as [label].</span>", \
 						"<span class='notice'>You label [A] as [label].</span>")
-	investigate_log("[key_name(user)] labelled \"[A]\" ([ADMIN_VV(A, "VV")]) with \"[label]\" at [COORD(A.loc)] [ADMIN_JMP(A)].", INVESTIGATE_RENAME) // Investigate goes BEFORE rename so the original name is preserved in the log
+	investigate_log("[key_name(user)] ([ADMIN_FLW(user,"FLW")]) labelled \"[A]\" ([ADMIN_VV(A, "VV")]) with \"[label]\" at [COORD(A.loc)] [ADMIN_JMP(A)].", INVESTIGATE_RENAME) // Investigate goes BEFORE rename so the original name is preserved in the log
 	A.AddComponent(/datum/component/label, label)
 	playsound(A, 'sound/items/handling/component_pickup.ogg', 20, TRUE)
 	labels_left--


### PR DESCRIPTION
## What Does This PR Do

Adds three links (FLW, VV, JMP) and coords to labeller logs in the Investigate-Round-Objects menu. This allows admins to jump to the location of the labelling/renaming and to quickly undo things should the labels be rule-breaking.

Adds logging to `rename_interactive()`.

## Why It's Good For The Game

You only need one player to serial-label a bunch of items with the n-word to see why we need shortcuts for these.

## Images of changes

Old:

![image](https://user-images.githubusercontent.com/33333517/220666084-f22564e4-1320-4be2-bade-5b7358a0f9b1.png)

New:

![image](https://user-images.githubusercontent.com/33333517/220679376-efc4e17c-fc80-496d-9c97-63f761b4be39.png)

## Testing

1. Spawn in as an assistant
2. Spawn a `/obj/item/hand_labeler`
3. Label a bunch of items
4. Take pen out of PDA, rename guns and containers
5. Admin -> Investigate Round Objects

## Changelog
:cl:
tweak: Admin logging for renaming objects was improved.
/:cl:
