### PR TITLE
Fixes gamma armoury hatch cheese

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -87461,19 +87461,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "map" = (
-/obj/machinery/door/airlock/hatch/gamma{
-	locked = 1;
-	req_access_txt = "1";
-	power_state = 0
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/impassable/gamma,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -72011,12 +72011,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "nwC" = (
-/obj/machinery/door/airlock/hatch/gamma{
-	locked = 1;
-	req_access_txt = "1";
-	power_state = 0
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/impassable/gamma,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -3589,12 +3589,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northeast)
 "auh" = (
-/obj/machinery/door/airlock/hatch/gamma{
-	locked = 1;
-	req_access_txt = "1";
-	power_state = 0
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -3605,6 +3599,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/door/poddoor/impassable/gamma,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -1270,12 +1270,7 @@
 	},
 /area/security/brig)
 "agt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch/gamma{
-	locked = 1;
-	req_access_txt = "1";
-	power_state = 0
-	},
+/obj/machinery/door/poddoor/impassable/gamma,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/code/datums/spells/knock.dm
+++ b/code/datums/spells/knock.dm
@@ -26,8 +26,6 @@
 			INVOKE_ASYNC(src, PROC_REF(try_open_closet), C)
 
 /obj/effect/proc_holder/spell/aoe/knock/proc/try_open_airlock(obj/machinery/door/door)
-	if(istype(door, /obj/machinery/door/airlock/hatch/gamma))
-		return
 	if(istype(door, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/A = door
 		A.unlock(TRUE)	//forced because it's magic!

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -383,45 +383,6 @@
 	hackProof = TRUE
 	aiControlDisabled = AICONTROLDISABLED_ON
 
-/obj/machinery/door/airlock/hatch/gamma
-	name = "gamma level hatch"
-	hackProof = TRUE
-	aiControlDisabled = AICONTROLDISABLED_ON
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-	is_special = TRUE
-
-/obj/machinery/door/airlock/hatch/gamma/attackby(obj/C, mob/user, params)
-	if(!issilicon(user))
-		if(isElectrified())
-			if(shock(user, 75))
-				return
-	if(istype(C, /obj/item/detective_scanner))
-		return
-
-	if(istype(C, /obj/item/grenade/plastic/c4))
-		to_chat(user, "The hatch is coated with a product that prevents the shaped charge from sticking!")
-		return
-
-	if(istype(C, /obj/item/mecha_parts/mecha_equipment/rcd) || istype(C, /obj/item/rcd))
-		to_chat(user, "The hatch is made of an advanced compound that cannot be deconstructed using an RCD.")
-		return
-
-	add_fingerprint(user)
-
-/obj/machinery/door/airlock/hatch/gamma/welder_act(mob/user, obj/item/I)
-	if(shock_user(user, 75))
-		return
-	if(operating || !density)
-		return
-	. = TRUE
-	if(!I.use_tool(src, user, 0, amount = 0, volume = I.tool_volume))
-		return
-	welded = !welded
-	visible_message("<span class='notice'>[user] [welded ? null : "un"]welds [src]!</span>",\
-					"<span class='notice'>You [welded ? null : "un"]weld [src]!</span>",\
-					"<span class='warning'>You hear welding.</span>")
-	update_icon()
-
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/airlocks/hatch/maintenance.dmi'

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -26,6 +26,9 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	move_resist = INFINITY
 
+/obj/machinery/door/poddoor/impassable/gamma
+	name = "gamma armory hatch"
+
 /obj/machinery/door/poddoor/impassable/emag_act(mob/user)
 	to_chat(user, "<span class='notice'>The electronic systems in this door are far too advanced for your primitive hacking peripherals.</span>")
 	return
@@ -63,7 +66,7 @@
 /obj/machinery/door/poddoor/try_to_crowbar(mob/user, obj/item/I)
 	if(!density)
 		return
-	if(!hasPower())
+	if(!hasPower() && !(resistance_flags & INDESTRUCTIBLE))
 		to_chat(user, "<span class='notice'>You start forcing [src] open...</span>")
 		if(do_after(user, 50 * I.toolspeed, target = src))
 			if(!hasPower())

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -29,6 +29,12 @@
 /obj/machinery/door/poddoor/impassable/gamma
 	name = "gamma armory hatch"
 
+/obj/machinery/door/poddoor/impassable/hostile_lockdown()
+	return
+
+/obj/machinery/door/poddoor/impassable/disable_lockdown()
+	return
+
 /obj/machinery/door/poddoor/impassable/emag_act(mob/user)
 	to_chat(user, "<span class='notice'>The electronic systems in this door are far too advanced for your primitive hacking peripherals.</span>")
 	return
@@ -142,6 +148,12 @@
 	desc = "A heavy duty blast door that opens mechanically. Looks even tougher than usual."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	move_resist = INFINITY
+
+/obj/machinery/door/poddoor/multi_tile/impassable/hostile_lockdown()
+	return
+
+/obj/machinery/door/poddoor/multi_tile/impassable/disable_lockdown()
+	return
 
 /obj/machinery/door/poddoor/multi_tile/impassable/emag_act(mob/user)
 	to_chat(user, "<span class='notice'>The electronic systems in this door are far too advanced for your primitive hacking peripherals.</span>")

--- a/code/modules/admin/misc_admin_procs.dm
+++ b/code/modules/admin/misc_admin_procs.dm
@@ -824,14 +824,14 @@ GLOBAL_VAR_INIT(gamma_ship_location, 1) // 0 = station , 1 = space
 	if(GLOB.gamma_ship_location == 1)
 		fromArea = locate(/area/shuttle/gamma/space)
 		toArea = locate(/area/shuttle/gamma/station)
-		for(var/obj/machinery/door/airlock/hatch/gamma/H in GLOB.airlocks)
-			H.unlock(TRUE)
+		for(var/obj/machinery/door/poddoor/impassable/gamma/H in GLOB.airlocks)
+			H.open()
 		GLOB.major_announcement.Announce("Central Command has deployed the Gamma Armory shuttle.", new_sound = 'sound/AI/commandreport.ogg')
 	else
 		fromArea = locate(/area/shuttle/gamma/station)
 		toArea = locate(/area/shuttle/gamma/space)
-		for(var/obj/machinery/door/airlock/hatch/gamma/H in GLOB.airlocks)
-			H.lock(TRUE)
+		for(var/obj/machinery/door/poddoor/impassable/gamma/H in GLOB.airlocks)
+			H.close() //DOOR STUCK
 		GLOB.major_announcement.Announce("Central Command has recalled the Gamma Armory shuttle.", new_sound = 'sound/AI/commandreport.ogg')
 	fromArea.move_contents_to(toArea)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes gamma armoury hatches from weird airlock subtypes to impassable blast doors, operated solely when the shuttle is moved.
Makes impassable blast doors unable to be pried when power is off. (why was this a thing?)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Being able to bypass armoury rwalls by tinkering with a single door is a no-no. This finally fixes it.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried prying blast doors
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Tweaked gamma armoury hatch to be a blast door
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
