### PR TITLE
Ports SS220 AutoComplete for Documents

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -250,7 +250,7 @@
 
 /obj/item/paper/proc/updateinfolinks()
 	info_links = info
-	for(var/i in 1 to fields)
+	for(var/i in 1 to length(fields))
 		var/write_1 = "<font face=\"[deffont]\"><a href='?src=[UID()];write=[i]'>write</a></font>"
 		var/write_2 = "<font face=\"[deffont]\"><a href='?src=[UID()];auto_write=[i]'><span style=\"color: #409F47; font-size: 10px\">\[a\]</span></a></font>"
 		addtofield(i, "[write_1][write_2]", 1)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -312,6 +312,16 @@
 		return
 	if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr))))
 		return // If paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
+/*
+	t = checkhtml(t)
+	// check for exploits
+	for(var/bad in paper_blacklist)
+		if(findtext(t,bad))
+			to_chat(usr, "<span class='notice'>You think to yourself, \</span>"Hm.. this is only paper...\"")
+			log_admin("PAPER: [key_name(usr)] tried to use forbidden word in [src]: [bad].")
+			message_admins("PAPER: [key_name_admin(usr)] tried to use forbidden word in [src]: [bad].")
+			return
+*/
 	input_element = parsepencode(input_element, item_write, usr) // Encode everything from pencode to html
 	if(id != "end")
 		addtofield(text2num(id), input_element) // He wants to edit a field, let him.
@@ -366,6 +376,8 @@
 		topic_href_write(id, input_element)
 	if(href_list["write"] )
 		var/id = href_list["write"]
+		// var/t = strip_html_simple(input(usr, "What text do you wish to add to " + (id=="end" ? "the end of the paper" : "field "+id) + "?", "[name]", null),8192) as message
+		// var/t =  strip_html_simple(input("Enter what you want to write:", "Write", null, null)  as message, MAX_MESSAGE_LEN)
 		var/input_element = input("Enter what you want to write:", "Write", null, null) as message
 		topic_href_write(id, input_element)
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -251,12 +251,11 @@
 /obj/item/paper/proc/updateinfolinks()
 	info_links = info
 	var/i = 0
-	for(i=1, i<=fields, i++)
+	for(i = 1, i <= fields, i++)
 		var/write_1 = "<font face=\"[deffont]\"><A href='?src=[UID()];write=[i]'>write</A></font>"
 		var/write_2 = "<font face=\"[deffont]\"><A href='?src=[UID()];auto_write=[i]'><span style=\"color: #409F47; font-size: 10px\">\[A\]</span></A></font>"
 		addtofield(i, "[write_1][write_2]", 1)
-	info_links = info_links + "<font face=\"[deffont]\"><A href='?src=[UID()];write=end'>write</A></font>"
-
+	info_links = info_links + "<font face=\"[deffont]\"><A href='?src=[UID()];write=end'>write</A></font>" + "<font face=\"[deffont]\"><A href='?src=[UID()];auto_write=end'><span style=\"color: #409F47; font-size: 10px\">\[A\]</span></A></font>"
 
 /obj/item/paper/proc/clearpaper()
 	info = null
@@ -306,30 +305,22 @@
 		\[time\] : Inserts the current station time in HH:MM:SS.<br>
 	</BODY></HTML>"}, "window=paper_help")
 
-/obj/item/paper/proc/topic_href_write(var/id, var/input_element)
+/obj/item/paper/proc/topic_href_write(id, input_element)
 	var/obj/item/item_write = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
 	add_hiddenprint(usr) // No more forging nasty documents as someone else, you jerks
 	if(!istype(item_write, /obj/item/pen) && !istype(item_write, /obj/item/toy/crayon))
 		return
-
-	// if paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
- 	if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr))))
-		return
-
+	if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr))))
+		return // If paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
 	input_element = parsepencode(input_element, item_write, usr) // Encode everything from pencode to html
-
 	if(id != "end")
 		addtofield(text2num(id), input_element) // He wants to edit a field, let him.
 	else
 		info += input_element // Oh, he wants to edit to the end of the file, let him.
-
 	populatefields()
 	updateinfolinks()
-
-	item_write.on_write(src,usr)
-
+	item_write.on_write(src, usr)
 	show_content(usr, forceshow = 1, infolinks = 1)
-
 	update_icon()
 
 /obj/item/paper/Topic(href, href_list)
@@ -338,57 +329,44 @@
 		return
 	if(href_list["auto_write"])
 		var/id = href_list["auto_write"]
-
- var/const/sign_text = "\[Sign\]"
- var/const/time_text = "\[Write current time\]"
- var/const/date_text = "\[Write current date\]"
- var/const/num_text = "\[Write account number\]"
- var/const/pin_text = "\[Write PIN\]"
- var/const/station_text = "\[Write station name\]"
-
- text items in the menu
-		var/list/menu_list = list()
- menu_list. Add(usr.real_name) //the real name of the character, even if it is hidden
-
- if the player is masked or the name is different a new answer option is added
-		if (usr.real_name != usr.name || usr.name != "unknown")
- menu_list. Add("[usr.name]")
-
- menu_list. Add(usr.job, //current work
- num_text, //account number
- pin_text, //pin code number
- sign_text, //signature
- time_text, //time
- date_text, //date
- station_text, // station name
-			usr.gender,		//пол
-			usr.dna.species	//раса
+		var/const/sign_text = "\[Sign\]"
+		var/const/time_text = "\[Current time\]"
+		var/const/date_text = "\[Current date\]"
+		var/const/num_text = "\[Account number\]"
+		var/const/pin_text = "\[PIN\]"
+		var/const/station_text = "\[Station name\]"
+		var/list/menu_list = list() //text items in the menu
+		menu_list.Add(usr.real_name) //the real name of the character, even if it is hidden
+		if(usr.real_name != usr.name || usr.name != "unknown") //if the player is masked or the name is different a new answer option is added
+			menu_list.Add("[usr.name]")
+		menu_list.Add(usr.job, //current job
+			num_text, //account number
+			pin_text, //pin code number
+			sign_text, //signature
+			time_text, //time
+			date_text, //date
+			station_text, // station name
+			usr.gender, //current gender
+			usr.dna.species //current species
 		)
-
- var/input_element = input("Select the text you want to add:", "Select item") as null|anything in menu_list
-
- format selected menu items in pencode and internal data
-		switch(input_element)
-			if (sign_text)
+		var/input_element = input("Select the text you want to add:", "Select item") as null|anything in menu_list
+		switch(input_element) //format selected menu items in pencode and internal data
+			if(sign_text)
 				input_element = "\[sign\]"
-			if (time_text)
+			if(time_text)
 				input_element = "\[time\]"
-			if (date_text)
+			if(date_text)
 				input_element = "\[date\]"
-			if (station_text)
+			if(station_text)
 				input_element = "\[station\]"
-			if (num_text)
+			if(num_text)
 				input_element = usr.mind.initial_account.account_number
-			if (pin_text)
-				input_element = usr.mind.initial_account.remote_access_pin
-
+			if(pin_text)
+				input_element = usr.mind.initial_account.account_pin
 		topic_href_write(id, input_element)
-
-
 	if(href_list["write"] )
 		var/id = href_list["write"]
-		var/input_element =  input("Enter what you want to write:", "Write", null, null)  as message
-
+		var/input_element = input("Enter what you want to write:", "Write", null, null) as message
 		topic_href_write(id, input_element)
 
 /obj/item/paper/attackby(obj/item/P, mob/living/user, params)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -251,8 +251,10 @@
 /obj/item/paper/proc/updateinfolinks()
 	info_links = info
 	var/i = 0
-	for(i=1,i<=fields,i++)
-		addtofield(i, "<font face=\"[deffont]\"><A href='?src=[UID()];write=[i]'>write</A></font>", 1)
+	for(i=1, i<=fields, i++)
+		var/write_1 = "<font face=\"[deffont]\"><A href='?src=[UID()];write=[i]'>write</A></font>"
+		var/write_2 = "<font face=\"[deffont]\"><A href='?src=[UID()];auto_write=[i]'><span style=\"color: #409F47; font-size: 10px\">\[A\]</span></A></font>"
+		addtofield(i, "[write_1][write_2]", 1)
 	info_links = info_links + "<font face=\"[deffont]\"><A href='?src=[UID()];write=end'>write</A></font>"
 
 
@@ -304,53 +306,91 @@
 		\[time\] : Inserts the current station time in HH:MM:SS.<br>
 	</BODY></HTML>"}, "window=paper_help")
 
-/obj/item/paper/Topic(href, href_list)
-	..()
-	if(!usr || (usr.stat || usr.restrained()))
+/obj/item/paper/proc/topic_href_write(var/id, var/input_element)
+	var/obj/item/item_write = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
+	add_hiddenprint(usr) // No more forging nasty documents as someone else, you jerks
+	if(!istype(item_write, /obj/item/pen))
+		if(!istype(item_write, /obj/item/toy/crayon))
+			return
+
+	// if paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
+ 	if(src.loc != usr && !src. Adjacent(usr) && ! ((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr)) ) )
 		return
 
-	if(href_list["write"])
+	input_element = parsepencode(input_element, item_write, usr) // Encode everything from pencode to html
+
+	if(id!="end")
+		addtofield(text2num(id), input_element) // He wants to edit a field, let him.
+	else
+		info += input_element // Oh, he wants to edit to the end of the file, let him.
+
+	populatefields()
+	updateinfolinks()
+
+	item_write.on_write(src,usr)
+
+	show_content(usr, forceshow = 1, infolinks = 1)
+
+	update_icon()
+
+/obj/item/paper/Topic(href, href_list)
+	 .. ()
+	if(!usr || (usr.stat || usr.restrained()))
+		return
+	if(href_list["auto_write"])
+		var/id = href_list["auto_write"]
+
+ var/const/sign_text = "\[Sign\]"
+ var/const/time_text = "\[Write current time\]"
+ var/const/date_text = "\[Write current date\]"
+ var/const/num_text = "\[Write account number\]"
+ var/const/pin_text = "\[Write PIN\]"
+ var/const/station_text = "\[Write station name\]"
+
+ text items in the menu
+		var/list/menu_list = list()
+ menu_list. Add(usr.real_name) //the real name of the character, even if it is hidden
+
+ if the player is masked or the name is different a new answer option is added
+		if (usr.real_name != usr.name || usr.name != "unknown")
+ menu_list. Add("[usr.name]")
+
+ menu_list. Add(usr.job, //current work
+ num_text, //account number
+ pin_text, //pin code number
+ sign_text, //signature
+ time_text, //time
+ date_text, //date
+ station_text, // station name
+			usr.gender,		//пол
+			usr.dna.species	//раса
+		)
+
+ var/input_element = input("Select the text you want to add:", "Select item") as null|anything in menu_list
+
+ format selected menu items in pencode and internal data
+		switch(input_element)
+			if (sign_text)
+				input_element = "\[sign\]"
+			if (time_text)
+				input_element = "\[time\]"
+			if (date_text)
+				input_element = "\[date\]"
+			if (station_text)
+				input_element = "\[station\]"
+			if (num_text)
+				input_element = usr.mind.initial_account.account_number
+			if (pin_text)
+				input_element = usr.mind.initial_account.remote_access_pin
+
+		topic_href_write(id, input_element)
+
+
+	if(href_list["write"] )
 		var/id = href_list["write"]
-		//var/t = strip_html_simple(input(usr, "What text do you wish to add to " + (id=="end" ? "the end of the paper" : "field "+id) + "?", "[name]", null),8192) as message
-		//var/t =  strip_html_simple(input("Enter what you want to write:", "Write", null, null)  as message, MAX_MESSAGE_LEN)
-		var/t =  input("Enter what you want to write:", "Write", null, null)  as message
-		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
-		add_hiddenprint(usr) // No more forging nasty documents as someone else, you jerks
-		if(!is_pen(i))
-			if(!istype(i, /obj/item/toy/crayon))
-				return
+		var/input_element =  input("Enter what you want to write:", "Write", null, null)  as message
 
-
-		// if paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
-		if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr)) ) )
-			return
-/*
-		t = checkhtml(t)
-
-		// check for exploits
-		for(var/bad in paper_blacklist)
-			if(findtext(t,bad))
-				to_chat(usr, "<span class='notice'>You think to yourself, \</span>"Hm.. this is only paper...\"")
-				log_admin("PAPER: [key_name(usr)] tried to use forbidden word in [src]: [bad].")
-				message_admins("PAPER: [key_name_admin(usr)] tried to use forbidden word in [src]: [bad].")
-				return
-*/
-		t = parsepencode(t, i, usr) // Encode everything from pencode to html
-
-		if(id!="end")
-			addtofield(text2num(id), t) // He wants to edit a field, let him.
-		else
-			info += t // Oh, he wants to edit to the end of the file, let him.
-
-		populatefields()
-		updateinfolinks()
-
-		i.on_write(src,usr)
-
-		show_content(usr, forceshow = 1, infolinks = 1)
-
-		update_icon()
-
+		topic_href_write(id, input_element)
 
 /obj/item/paper/attackby(obj/item/P, mob/living/user, params)
 	..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -251,11 +251,11 @@
 /obj/item/paper/proc/updateinfolinks()
 	info_links = info
 	var/i = 0
-	for(i = 1, i <= fields, i++)
-		var/write_1 = "<font face=\"[deffont]\"><A href='?src=[UID()];write=[i]'>write</A></font>"
-		var/write_2 = "<font face=\"[deffont]\"><A href='?src=[UID()];auto_write=[i]'><span style=\"color: #409F47; font-size: 10px\">\[A\]</span></A></font>"
+	for(var/i in 1 to fields)
+		var/write_1 = "<font face=\"[deffont]\"><a href='?src=[UID()];write=[i]'>write</a></font>"
+		var/write_2 = "<font face=\"[deffont]\"><a href='?src=[UID()];auto_write=[i]'><span style=\"color: #409F47; font-size: 10px\">\[a\]</span></a></font>"
 		addtofield(i, "[write_1][write_2]", 1)
-	info_links = info_links + "<font face=\"[deffont]\"><A href='?src=[UID()];write=end'>write</A></font>" + "<font face=\"[deffont]\"><A href='?src=[UID()];auto_write=end'><span style=\"color: #409F47; font-size: 10px\">\[A\]</span></A></font>"
+	info_links = info_links + "<font face=\"[deffont]\"><a href='?src=[UID()];write=end'>write</a></font>" + "<font face=\"[deffont]\"><a href='?src=[UID()];auto_write=end'><span style=\"color: #409F47; font-size: 10px\">\[a\]</span></a></font>"
 
 /obj/item/paper/proc/clearpaper()
 	info = null
@@ -310,18 +310,8 @@
 	add_hiddenprint(usr) // No more forging nasty documents as someone else, you jerks
 	if(!istype(item_write, /obj/item/pen) && !istype(item_write, /obj/item/toy/crayon))
 		return
-	if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr))))
+	if(loc != usr && !Adjacent(usr) && !((istype(loc, /obj/item/clipboard) || istype(loc, /obj/item/folder)) && (loc.loc == usr || loc.Adjacent(usr))))
 		return // If paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
-/*
-	t = checkhtml(t)
-	// check for exploits
-	for(var/bad in paper_blacklist)
-		if(findtext(t,bad))
-			to_chat(usr, "<span class='notice'>You think to yourself, \</span>"Hm.. this is only paper...\"")
-			log_admin("PAPER: [key_name(usr)] tried to use forbidden word in [src]: [bad].")
-			message_admins("PAPER: [key_name_admin(usr)] tried to use forbidden word in [src]: [bad].")
-			return
-*/
 	input_element = parsepencode(input_element, item_write, usr) // Encode everything from pencode to html
 	if(id != "end")
 		addtofield(text2num(id), input_element) // He wants to edit a field, let him.
@@ -330,7 +320,7 @@
 	populatefields()
 	updateinfolinks()
 	item_write.on_write(src, usr)
-	show_content(usr, forceshow = 1, infolinks = 1)
+	show_content(usr, forceshow = TRUE, infolinks = TRUE)
 	update_icon()
 
 /obj/item/paper/Topic(href, href_list)
@@ -376,8 +366,6 @@
 		topic_href_write(id, input_element)
 	if(href_list["write"] )
 		var/id = href_list["write"]
-		// var/t = strip_html_simple(input(usr, "What text do you wish to add to " + (id=="end" ? "the end of the paper" : "field "+id) + "?", "[name]", null),8192) as message
-		// var/t =  strip_html_simple(input("Enter what you want to write:", "Write", null, null)  as message, MAX_MESSAGE_LEN)
 		var/input_element = input("Enter what you want to write:", "Write", null, null) as message
 		topic_href_write(id, input_element)
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -250,7 +250,6 @@
 
 /obj/item/paper/proc/updateinfolinks()
 	info_links = info
-	var/i = 0
 	for(var/i in 1 to fields)
 		var/write_1 = "<font face=\"[deffont]\"><a href='?src=[UID()];write=[i]'>write</a></font>"
 		var/write_2 = "<font face=\"[deffont]\"><a href='?src=[UID()];auto_write=[i]'><span style=\"color: #409F47; font-size: 10px\">\[a\]</span></a></font>"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -309,17 +309,16 @@
 /obj/item/paper/proc/topic_href_write(var/id, var/input_element)
 	var/obj/item/item_write = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
 	add_hiddenprint(usr) // No more forging nasty documents as someone else, you jerks
-	if(!istype(item_write, /obj/item/pen))
-		if(!istype(item_write, /obj/item/toy/crayon))
-			return
+	if(!istype(item_write, /obj/item/pen) && !istype(item_write, /obj/item/toy/crayon))
+		return
 
 	// if paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
- 	if(src.loc != usr && !src. Adjacent(usr) && ! ((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr)) ) )
+ 	if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/clipboard) || istype(src.loc, /obj/item/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr))))
 		return
 
 	input_element = parsepencode(input_element, item_write, usr) // Encode everything from pencode to html
 
-	if(id!="end")
+	if(id != "end")
 		addtofield(text2num(id), input_element) // He wants to edit a field, let him.
 	else
 		info += input_element // Oh, he wants to edit to the end of the file, let him.
@@ -334,7 +333,7 @@
 	update_icon()
 
 /obj/item/paper/Topic(href, href_list)
-	 .. ()
+	..()
 	if(!usr || (usr.stat || usr.restrained()))
 		return
 	if(href_list["auto_write"])

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -309,7 +309,7 @@
 	add_hiddenprint(usr) // No more forging nasty documents as someone else, you jerks
 	if(!istype(item_write, /obj/item/pen) && !istype(item_write, /obj/item/toy/crayon))
 		return
-	if(loc != usr && !Adjacent(usr) && !((istype(loc, /obj/item/clipboard) || istype(loc, /obj/item/folder)) && (loc.loc == usr || loc.Adjacent(usr))))
+	if(loc != usr && !Adjacent(usr) && !((istype(loc, /obj/item/clipboard) || istype(loc, /obj/item/folder)) && (usr in get_turf(src) || loc.Adjacent(usr))))
 		return // If paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
 	input_element = parsepencode(input_element, item_write, usr) // Encode everything from pencode to html
 	if(id != "end")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Port from https://github.com/ss220-space/Paradise/pull/934
![image](https://user-images.githubusercontent.com/77684085/220947539-47acb37a-c35d-4420-9ce4-9da2cc20634a.png)

You can now click a small button located next to the text editing to automaticaly fill it with the following information: Current name, job, signature, account number, PIN, station name, date, time, gender, species.


## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This will hopefully make filling paperwork more easier for those that are not accustomed to it.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/77684085/220946072-9eed4bf8-bbdf-4d63-a6a8-28b929524eea.mp4


## Testing
<!-- How did you test the PR, if at all? -->
- See video above
## Changelog
:cl: Henri215, PhantornRU
add: You can now use the new autocomplete feature when writing on a paper (the small "A" located next to "write")
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
