### PR TITLE
Fixes re-admin runtime

### DIFF
--- a/code/modules/mob/mob_login_base.dm
+++ b/code/modules/mob/mob_login_base.dm
@@ -64,7 +64,7 @@
 
 
 	if((ckey in GLOB.de_admins) || (ckey in GLOB.de_mentors))
-		verbs += /client/proc/readmin
+		client.verbs += /client/proc/readmin
 
 	//Clear ability list and update from mob.
 	client.verbs -= GLOB.ability_verbs

--- a/code/modules/mob/new_player/new_player_login.dm
+++ b/code/modules/mob/new_player/new_player_login.dm
@@ -27,7 +27,7 @@
 	new_player_panel()
 
 	if((ckey in GLOB.de_admins) || (ckey in GLOB.de_mentors))
-		verbs += /client/proc/readmin
+		client.verbs += /client/proc/readmin
 
 	client?.playtitlemusic()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime caused by re-admin verbs being assigned to the mob, not the client. Meaning re-adminning runtimes after a de-adminned client disconnects and reconnects.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes bad and admins coming back good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
A bit hard to test, but seems to be working.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed re-adminning after closing and opening the client.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
