### PR TITLE
Prevents large E-bows from being holstered

### DIFF
--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -136,6 +136,7 @@
 	materials = list(MAT_METAL=4000)
 	origin_tech = "combat=4;magnets=4;syndicate=2"
 	suppressed = FALSE
+	can_holster = FALSE // it's large after all
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	empty_state = "crossbowlarge_empty"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Prevents the large E-bows produced via science guncrafting from being holstered in a shoulder holster.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Most large guns were prevented from holster a while ago, this one may have been left out. Either way, it makes sense it wouldn't fit in the holster like the mini version would, and having replicable e-bows in holsters is... very strong.
## Images
![image](https://user-images.githubusercontent.com/71326864/221330303-8ac10ad0-1774-4ae5-81f4-e62861b5893b.png)
## Testing
<!-- How did you test the PR, if at all? -->
See above
## Changelog
:cl:
tweak: Large E-bows can no longer be holstered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
