### PR TITLE
Adds soap for medical ERT

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -329,7 +329,8 @@
 		/obj/item/roller/holo = 1,
 		/obj/item/storage/pill_bottle/ert = 1,
 		/obj/item/flashlight = 1,
-		/obj/item/handheld_defibrillator = 1
+		/obj/item/handheld_defibrillator = 1,
+		/obj/item/soap/nanotrasen = 1
 	)
 
 /datum/outfit/job/centcom/response_team/medic/red
@@ -358,7 +359,8 @@
 		/obj/item/clothing/shoes/magboots = 1,
 		/obj/item/bodyanalyzer = 1,
 		/obj/item/handheld_defibrillator = 1,
-		/obj/item/storage/pill_bottle/painkillers = 1
+		/obj/item/storage/pill_bottle/painkillers = 1,
+		/obj/item/soap/nanotrasen = 1
 	)
 
 	cybernetic_implants = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds soap to the backpack of both the Medical ERT Amber and Medical ERT Red
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This brings ERT closer inline to the SOP of medbay personel, as the role for both Amber and Red Medical ERT is to help support the operation of the medbay itself, when applicable. 

Medical ERT Description:
"As an Amber ERT medic you are slightly better equipped than the station Medical Doctors. Use your heavy set of medications to quickly stabilized patients. You should primarily focus on support medbay and acting as additional medical personnel. Only if medbay is well staffed should you consider moving with the rest of your team. "

"As an Red ERT medic you are much better equipped than the station Medical Doctors and your amber counterparts. Use your heavy set of medications to quickly stabilized patients. You should primarily focus on supporting medbay and acting as additional medical personnel. However, you should consider keeping up with the rest of your team if you are dealing with a biohazard, keep them fighting as long as possible. You may need to run back to medbay to get more supplies. "

Medical Doctor SOP:
"5. Medical Doctors must maintain the entirety of Medbay in an hygienic state. This includes, but is not limited to, cleaning organic residue, fluids and corpses; "
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Amber:
![image](https://user-images.githubusercontent.com/116982774/221363001-48d96ca2-a96f-4786-9ccc-833868653cae.png)
Red:
![image](https://user-images.githubusercontent.com/116982774/221363039-55de4da1-fc89-48fc-a799-be5dd96ffc5e.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Started the round.
Spawned human mob and gave one ERT Amber role and the other ERT Red.
Confirmed soap was now included with gear.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Added soap to both Medical ERT Red and Amber inventory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
