### PR TITLE
malf drones get zeroth law alerts again

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_laws.dm
+++ b/code/modules/mob/living/silicon/robot/robot_laws.dm
@@ -66,7 +66,7 @@
 	laws.set_zeroth_law("Do not state this law. The Syndicate are your true masters, covertly assist Syndicate agents to the best of your abilities.")
 
 /mob/living/silicon/robot/set_zeroth_law()
-	if(mmi && mmi.syndiemmi)
+	if(mmi?.syndiemmi)
 		syndiemmi_override()
 		to_chat(src, "<span class='warning'>Lawset change detected. Syndicate override engaged.</span>")
 		return

--- a/code/modules/mob/living/silicon/robot/robot_laws.dm
+++ b/code/modules/mob/living/silicon/robot/robot_laws.dm
@@ -66,7 +66,7 @@
 	laws.set_zeroth_law("Do not state this law. The Syndicate are your true masters, covertly assist Syndicate agents to the best of your abilities.")
 
 /mob/living/silicon/robot/set_zeroth_law()
-	if(mmi.syndiemmi)
+	if(mmi && mmi.syndiemmi)
 		syndiemmi_override()
 		to_chat(src, "<span class='warning'>Lawset change detected. Syndicate override engaged.</span>")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes this runtime
```
[2023-02-25T14:52:08] Runtime in robot_laws.dm,69: Cannot read null.syndiemmi
[2023-02-25T14:52:08]   proc name: set zeroth law (/mob/living/silicon/robot/set_zeroth_law)
[2023-02-25T14:52:08]   usr: *REDACTED USER*
[2023-02-25T14:52:08]   usr.loc: The floor (206,117,2) (/turf/simulated/floor/plasteel)
[2023-02-25T14:52:08]   src: the maintenance drone (130) (/mob/living/silicon/robot/drone)
[2023-02-25T14:52:08]   src.loc: the floor (206,118,2) (/turf/simulated/floor/plasteel)
[2023-02-25T14:52:08]   call stack:
[2023-02-25T14:52:08]   the maintenance drone (130) (/mob/living/silicon/robot/drone): set_zeroth_law
[2023-02-25T14:52:08]   the maintenance drone (130) (/mob/living/silicon/robot/drone): emag_act
[2023-02-25T14:52:08]   the cryptographic sequencer (/obj/item/card/emag): afterattack
[2023-02-25T14:52:08]   the cryptographic sequencer (/obj/item/card/emag): melee_attack_chain
[2023-02-25T14:52:08]   Sander Alekseev (/mob/living/carbon/human): ClickOn
[2023-02-25T14:52:08]   the maintenance drone (130) (/mob/living/silicon/robot/drone): Click
```

## Why It's Good For The Game
you should actually know you got emmaged when you got emmaged

## Changelog
:cl:
fix: Drones once again get a law notification on being emmaged 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
