### PR TITLE
Fixes runtimes with less than 2 proc arguments runtiming

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -35,13 +35,14 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 
 		// First split on the colon
 		var/list/inner_split = splittext(original_line, ": ")
-		var/source_half = "[inner_split[1]]: "
-		var/proc_half = inner_split[2]
-		var/proc_name = splittext(proc_half, "(")[1] // Put a ) here to stop the bracket colouriser whining
+		if(length(inner_split) >= 2)
+			var/source_half = "[inner_split[1]]: "
+			var/proc_half = inner_split[2]
+			var/proc_name = splittext(proc_half, "(")[1] // Put a ) here to stop the bracket colouriser whining
 
-		proc_name = replacetext(proc_name, " ", "_") // Put the underscores back because BYOND removes them for some reason
+			proc_name = replacetext(proc_name, " ", "_") // Put the underscores back because BYOND removes them for some reason
 
-		sanitize_splitlines[i] = "[source_half][proc_name]"
+			sanitize_splitlines[i] = "[source_half][proc_name]"
 
 	e.desc = sanitize_splitlines.Join("\n")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #20452

## Why It's Good For The Game
I would like to see runtimes thank you

## Testing
it does

## Changelog
:cl:
fix: [Coder] Runtimes with less than 2 proc arguments are properly logged again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
