### PR TITLE
Space cleaner works on IPCs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -55,6 +55,7 @@
 	color = "#61C2C2"
 	harmless = TRUE
 	taste_description = "floor cleaner"
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, volume)
 	if(iseffect(O))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the synthetic flag to the space cleaner reagent.

## Why It's Good For The Game
All space cleaner does is clean. You can't get addicted to it nor does it have an effect on mob life, so it doesn't make sense for it to not work on IPCs, resulting in janitors being stuck with soap and giving them a rub.

## Images of changes
https://user-images.githubusercontent.com/80771500/221379427-e5319eb5-639e-4311-8b30-b03db245d894.mp4

## Testing
Made a mess, had an IPC roll on it, and spray some space cleaner on it.

## Changelog
:cl:
tweak: Space cleaner works on machine people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
