### PR TITLE
fixes a forcebolt runtime

### DIFF
--- a/code/modules/projectiles/projectile/force.dm
+++ b/code/modules/projectiles/projectile/force.dm
@@ -8,9 +8,9 @@
 /obj/item/projectile/forcebolt/strong
 	name = "force bolt"
 
-/obj/item/projectile/forcebolt/on_hit(atom/target, blocked = 0)
+/obj/item/projectile/forcebolt/on_hit(atom/movable/target, blocked = 0)
 	. = ..()
-	if(blocked < 100)
+	if(istype(target) && blocked < 100)
 		var/obj/T = target
 		var/throwdir = get_dir(firer,target)
 		T.throw_at(get_edge_target_turf(target, throwdir),10,10)

--- a/code/modules/projectiles/projectile/force.dm
+++ b/code/modules/projectiles/projectile/force.dm
@@ -11,6 +11,5 @@
 /obj/item/projectile/forcebolt/on_hit(atom/movable/target, blocked = 0)
 	. = ..()
 	if(istype(target) && blocked < 100)
-		var/obj/T = target
-		var/throwdir = get_dir(firer,target)
-		T.throw_at(get_edge_target_turf(target, throwdir),10,10)
+		var/throwdir = get_dir(firer, target)
+		target.throw_at(get_edge_target_turf(target, throwdir), 10, 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes this runtime:
```
[2023-02-25T22:20:10] Runtime in force.dm,16: undefined proc or verb /turf/simulated/wall/indestructible/syndicate/throw at(). 
   proc name: on hit (/obj/item/projectile/forcebolt/on_hit)
   src: the force bolt (/obj/item/projectile/forcebolt)
   src.loc: the floor (225,139,1) (/turf/simulated/floor/plasteel)
   call stack:
   the force bolt (/obj/item/projectile/forcebolt): on_hit
   the wall (225,140,1) (/turf/simulated/wall/indestructible/syndicate): bullet_act
   the wall (225,140,1) (/turf/simulated/wall/indestructible/syndicate): bullet_act
   the wall (225,140,1) (/turf/simulated/wall/indestructible/syndicate): bullet_act
   the force bolt (/obj/item/projectile/forcebolt): Bump
   the wall (225,140,1) (/turf/simulated/wall/indestructible/syndicate): Enter
   the force bolt (/obj/item/projectile/forcebolt): Move
   the force bolt (/obj/item/projectile/forcebolt): pixel_move
   the force bolt (/obj/item/projectile/forcebolt): process
   Projectiles (/datum/controller/subsystem/processing/projectiles): fire
   Projectiles (/datum/controller/subsystem/processing/projectiles): ignite
   Master (/datum/controller/master): RunQueue
   Master (/datum/controller/master): Loop
   Master (/datum/controller/master): StartProcessing
```
## Why It's Good For The Game
turfs? Never heard of them
