### PR TITLE
Fixes runtime with Chitinous Armor being punched

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -496,7 +496,7 @@
 		var/obj/item/I = hitby
 		if(istype(I, /obj/item/circular_saw))
 			armor_durability -= 25 // saws used to cut away armor through an interaction, so let's keep them somewhat more effective
-		else if(I.damtype == BURN)
+		else if(istype(I) && I.damtype == BURN)
 			armor_durability -= damage * 2
 		else
 			armor_durability -= damage

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -498,6 +498,8 @@
 			armor_durability -= 25 // saws used to cut away armor through an interaction, so let's keep them somewhat more effective
 		else if(istype(I) && I.damtype == BURN)
 			armor_durability -= damage * 2
+		else if(!damage)
+			armor_durability--
 		else
 			armor_durability -= damage
 	if(armor_durability <= 0)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -498,7 +498,7 @@
 			armor_durability -= 25 // saws used to cut away armor through an interaction, so let's keep them somewhat more effective
 		else if(istype(I) && I.damtype == BURN)
 			armor_durability -= damage * 2
-		else if(!damage)
+		else if(!istype(I))
 			armor_durability--
 		else
 			armor_durability -= damage

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -496,12 +496,14 @@
 		var/obj/item/I = hitby
 		if(istype(I, /obj/item/circular_saw))
 			armor_durability -= 25 // saws used to cut away armor through an interaction, so let's keep them somewhat more effective
-		else if(istype(I) && I.damtype == BURN)
-			armor_durability -= damage * 2
-		else if(!istype(I))
-			armor_durability--
+		else if(istype(I))
+			if(I.damtype == BURN)
+				armor_durability -= damage * 2
+			else
+				armor_durability -= damage
 		else
-			armor_durability -= damage
+			armor_durability--
+		
 	if(armor_durability <= 0)
 		visible_message("<span class='warning'>[owner]'s chitinous armor collapses in clumps onto the ground.</span>")
 		new /obj/effect/decal/cleanable/shreds(owner.loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a runtime, because fists don't have a set damage or damage type. Woopsies.
Fists do 1 damage to Chitinous Armor, by the way. It's a feature, reason below:
https://www.youtube.com/watch?v=WHujzgKlPqM&ab_channel=Hemotoksin
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtimes bad, and anyone who decides to beat the shit out of an armored cling can have one armor_durability damage. As a treat.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/71326864/221395373-e8f1db4b-e494-4d84-b181-ead6e01328fa.png)
![image](https://user-images.githubusercontent.com/71326864/221395384-6ac9f49a-1608-496a-b60f-e7d1f93efaec.png)

## Testing
<!-- How did you test the PR, if at all? -->
See above.
## Changelog
:cl:
fix: Fixed a runtime with Cling Chitinous Armor being punched
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
