### PR TITLE
Gives fleshmend a weakness to cold

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -381,7 +381,7 @@
 	check_effectiveness()
 	..()
 
-/datum/status_effect/fleshmend/proc/check_effectiveness()
+/datum/status_effect/fleshmend/proc/apply_new_fleshmend()
 	tolerance += 1
 	freezing = (owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
 	if(freezing)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -374,16 +374,20 @@
 	var/ticks = 0
 
 /datum/status_effect/fleshmend/on_apply()
-	tolerance += 1
-	freezing = (owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
-	active_instances += instance_duration
+	check_effectiveness()
 	return TRUE
 
 /datum/status_effect/fleshmend/refresh()
+	check_effectiveness()
+	..()
+
+/datum/status_effect/fleshmend/proc/check_effectiveness()
 	tolerance += 1
 	freezing = (owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
+	if(freezing)
+		to_chat(owner, "<span class='warning'>Our healing's effectiveness is reduced \
+			by our cold body!</span>")
 	active_instances += instance_duration
-	..()
 
 /datum/status_effect/fleshmend/tick()
 	if(length(active_instances) >= 1)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -374,11 +374,11 @@
 	var/ticks = 0
 
 /datum/status_effect/fleshmend/on_apply()
-	check_effectiveness()
+	apply_new_fleshmend()
 	return TRUE
 
 /datum/status_effect/fleshmend/refresh()
-	check_effectiveness()
+	apply_new_fleshmend()
 	..()
 
 /datum/status_effect/fleshmend/proc/apply_new_fleshmend()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -381,10 +381,7 @@
 
 /datum/status_effect/fleshmend/refresh()
 	tolerance += 1
-	if(owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
-		freezing = TRUE
-	else
-		freezing = FALSE
+	freezing = (owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
 	active_instances += instance_duration
 	..()
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -366,6 +366,8 @@
 	alert_type = null
 	/// This diminishes the healing of fleshmend the higher it is.
 	var/tolerance = 1
+	/// This diminishes the healing of fleshmend if the user is cold when it is activated
+	var/freezing = FALSE
 	var/instance_duration = 10 // in ticks
 	/// a list of integers, one for each remaining instance of fleshmend.
 	var/list/active_instances = list()
@@ -373,17 +375,29 @@
 
 /datum/status_effect/fleshmend/on_apply()
 	tolerance += 1
+	if(owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
+		freezing = TRUE
+	else
+		freezing = FALSE
 	active_instances += instance_duration
 	return TRUE
 
 /datum/status_effect/fleshmend/refresh()
 	tolerance += 1
+	if(owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
+		freezing = TRUE
+	else
+		freezing = FALSE
 	active_instances += instance_duration
 	..()
 
 /datum/status_effect/fleshmend/tick()
 	if(length(active_instances) >= 1)
-		var/heal_amount = 10 * length(active_instances) / tolerance
+		var/heal_amount
+		if(!freezing)
+			heal_amount = 10 * length(active_instances) / tolerance
+		else
+			heal_amount = 2 * length(active_instances) / tolerance
 		var/blood_restore = 30 * length(active_instances)
 		owner.heal_overall_damage(heal_amount, heal_amount, updating_health = FALSE)
 		owner.adjustOxyLoss(-heal_amount, FALSE)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -375,10 +375,7 @@
 
 /datum/status_effect/fleshmend/on_apply()
 	tolerance += 1
-	if(owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
-		freezing = TRUE
-	else
-		freezing = FALSE
+	freezing = (owner.bodytemperature + 50 <= owner.dna.species.body_temperature)
 	active_instances += instance_duration
 	return TRUE
 
@@ -393,11 +390,7 @@
 
 /datum/status_effect/fleshmend/tick()
 	if(length(active_instances) >= 1)
-		var/heal_amount
-		if(!freezing)
-			heal_amount = 10 * length(active_instances) / tolerance
-		else
-			heal_amount = 2 * length(active_instances) / tolerance
+		var/heal_amount = (length(active_instances) / tolerance) * (freezing ? 2 : 10)
 		var/blood_restore = 30 * length(active_instances)
 		owner.heal_overall_damage(heal_amount, heal_amount, updating_health = FALSE)
 		owner.adjustOxyLoss(-heal_amount, FALSE)

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -14,9 +14,6 @@
 	if(user.has_status_effect(STATUS_EFFECT_FLESHMEND))
 		to_chat(user, "<span class='warning'>Our healing's effectiveness is reduced \
 			by quick repeated use!</span>")
-	if(user.bodytemperature + 50 <= user.dna.species.body_temperature)
-		to_chat(user, "<span class='warning'>Our healing's effectiveness is reduced \
-			by our cold body!</span>")
 
 	user.apply_status_effect(STATUS_EFFECT_FLESHMEND)
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -14,7 +14,7 @@
 	if(user.has_status_effect(STATUS_EFFECT_FLESHMEND))
 		to_chat(user, "<span class='warning'>Our healing's effectiveness is reduced \
 			by quick repeated use!</span>")
-	if((user.bodytemperature + 50 <= user.dna.species.body_temperature))
+	if(user.bodytemperature + 50 <= user.dna.species.body_temperature)
 		to_chat(user, "<span class='warning'>Our healing's effectiveness is reduced \
 			by our cold body!</span>")
 

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -14,6 +14,9 @@
 	if(user.has_status_effect(STATUS_EFFECT_FLESHMEND))
 		to_chat(user, "<span class='warning'>Our healing's effectiveness is reduced \
 			by quick repeated use!</span>")
+	if((user.bodytemperature + 50 <= user.dna.species.body_temperature))
+		to_chat(user, "<span class='warning'>Our healing's effectiveness is reduced \
+			by our cold body!</span>")
 
 	user.apply_status_effect(STATUS_EFFECT_FLESHMEND)
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
If a Changeling's body temperature is 50 below their species' normal body temperature, their fleshmend will be significantly weakened on activation. This is indicated in the activation message, and stacks on top of the existing debuff for frequent activation. The regeneration is weakened enough that it will not out-regenerate space damage once you start building tolerance.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Changelings have an ability called organic space suit. Didn't you know?
Except they have NO reason at all to use it because, you can spam fleshmend super quickly in space to out-regenerate all taken damage with basically no penalties or reason to use the space suit. That is, fleshmend, which is already a significantly powerful ability on its own, also basically negates the purpose of another ability entirely. Thus, making fleshmend slightly less ridiculous in space (or cold environments) should help to make organic spacesuit at least slightly useful, for changelings who don't want to carry around a spacesuit but still want the option to flee to space, as fleshmend will no longer be the holy grail of it.
This also gives fleshmend a unique counter to people dealing with fleshmend-spamming clings - the temperature gun has seen significantly low use since it got turned into a gun "upgrade", so giving low-temperature a use against changelings may encourage that gun as a counter to particularly loud changelings.
## Testing
<!-- How did you test the PR, if at all? -->
Tested it with a bunch of stuff, removed the testing stuff, it still works as intended, lovely.
## Changelog
:cl:
tweak: Fleshmend is now weaker if the Changeling is cold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
