### PR TITLE
Changelings are no longer gibbed by SR

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -770,9 +770,6 @@
 			if(M.stat == DEAD)
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
 					if(M.mind && M.mind.has_antag_datum(/datum/antagonist/changeling))
-						var/when_revive = rand(2 SECONDS, 10 SECONDS)
-						M.do_jitter_animation(1000, when_revive) // jitter until they get revived
-						addtimer(CALLBACK(src, PROC_REF(revive_changeling), M), when_revive)
 						return
 					M.delayed_gib()
 					return
@@ -808,23 +805,6 @@
 					add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 					SSblackbox.record_feedback("tally", "players_revived", 1, "strange_reagent")
 	..()
-
-/datum/reagent/medicine/strange_reagent/proc/revive_changeling(mob/living/carbon/human/changeling)
-	changeling.revive()
-	changeling.visible_message("<span class='warning'>[changeling] suddenly bolts upwards!</span>")
-	changeling.adjustStaminaLoss(50)
-	changeling.adjustCloneLoss(20)
-	changeling.setOxyLoss(0)
-	changeling.adjustBruteLoss(rand(0, 10))
-	changeling.adjustFireLoss(rand(0, 10))
-	changeling.decaylevel = 0
-	for(var/datum/antagonist/changeling/cling_mind in changeling.mind.antag_datums)
-		cling_mind.chem_charges += 40
-	for(var/obj/item/organ/O in (changeling.bodyparts))
-		if(!O.vital && prob(20))
-			O.necrotize(FALSE)
-			if(O.status & ORGAN_DEAD)
-				O.germ_level = INFECTION_LEVEL_THREE
 
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -769,7 +769,7 @@
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
-					if(M.mind && M.mind.has_antag_datum(/datum/antagonist/changeling))
+					if(ischangeling(M))
 						return
 					M.delayed_gib()
 					return

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -815,8 +815,8 @@
 	changeling.adjustStaminaLoss(50)
 	changeling.adjustCloneLoss(20)
 	changeling.setOxyLoss(0)
-	changeling.adjustBruteLoss(rand(0, 10) - changeling.getBruteLoss())
-	changeling.adjustFireLoss(rand(0, 10) - changeling.getFireLoss())
+	changeling.adjustBruteLoss(rand(0, 10))
+	changeling.adjustFireLoss(rand(0, 10))
 	changeling.decaylevel = 0
 	for(var/datum/antagonist/changeling/cling_mind in changeling.mind.antag_datums)
 		cling_mind.chem_charges += 40

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -769,6 +769,11 @@
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
+					if(M.mind && M.mind.has_antag_datum(/datum/antagonist/changeling))
+						var/when_revive = rand(2 SECONDS, 10 SECONDS)
+						M.do_jitter_animation(1000, when_revive) // jitter until they get revived
+						addtimer(CALLBACK(src, PROC_REF(revive_changeling), M), when_revive)
+						return
 					M.delayed_gib()
 					return
 				if(!M.ghost_can_reenter())
@@ -803,6 +808,23 @@
 					add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 					SSblackbox.record_feedback("tally", "players_revived", 1, "strange_reagent")
 	..()
+
+/datum/reagent/medicine/strange_reagent/proc/revive_changeling(mob/living/carbon/human/changeling)
+	changeling.revive()
+	changeling.visible_message("<span class='warning'>[changeling] suddenly bolts upwards!</span>")
+	changeling.adjustStaminaLoss(50)
+	changeling.adjustCloneLoss(20)
+	changeling.setOxyLoss(0)
+	changeling.adjustBruteLoss(rand(0, 10) - changeling.getBruteLoss())
+	changeling.adjustFireLoss(rand(0, 10) - changeling.getFireLoss())
+	changeling.decaylevel = 0
+	for(var/datum/antagonist/changeling/cling_mind in changeling.mind.antag_datums)
+		cling_mind.chem_charges += 40
+	for(var/obj/item/organ/O in (changeling.bodyparts))
+		if(!O.vital && prob(20))
+			O.necrotize(FALSE)
+			if(O.status & ORGAN_DEAD)
+				O.germ_level = INFECTION_LEVEL_THREE
 
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changelings are no longer gibbed by sr. 
~~SR now revives changelings regardless of damage taken and has different effects when used below a gibbing health threshold:~~
~~The changeling will first start to jitter like it's going to gib, then revive. This is a full aheal so limbs and organs will be replaced, after that the changeling will take 0-10 burn and brute damage, 20 clone damage, and 50 stamina damage, and gain 40 chemicals to use. Then the changelings external organs all have a 20% chance to become necrotic, which basically forces them to revive at some later point due to the effects of necrosis letting SR still have some impact.~~

## Why It's Good For The Game
I've gotten back into sec and a couple of things about changelings have become abundantly clear
1. Clings are only good at combat, literally fails at everything else (account number moment)
2. The cremator, gibbers, and shuttles used to kill clings are already almost always available, you're never not going to have a way to kill a cling.
3. Even though other options are available; you literally need to honor rule out of SR not to use it. It is by far the most effective solution to every cling related issue by a longshot and is very easy to get.  

This is a problem because SR gibbing fucking sucks. It removes a cling from a round instantly which makes it just feel really awful as an officer and a cling. Clings removing cremator or gibber doesn't matter if they have the funny pill in their pocket. Getting the most effective option without any investment is the most lukewarm experience possible and magic drug may not always be in your favor. 

## Testing
DD my beloved 
## Changelog
:cl:
tweak: SR gibbing on clings removed 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
