### PR TITLE
Stops combat RCDs blowing up from malf ai power.

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -666,6 +666,9 @@
 	explosion(src, 0, 0, 3, 1, flame_range = 1)
 	qdel(src)
 
+/obj/item/rcd/combat/detonate_pulse()
+	return
+
 /obj/item/rcd/preloaded
 	matter = 100
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Prevents the combat rcd from blowing up from the.. rcd blowing up ability ~~im sorry im tried~~ 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Stops the poor engineering room for ert being blown up. And since combat RCDs are usually a admin only thing, aside from the occasional times the traders have it, I don't overly see why these ones should be counted within the power.

## Testing
<!-- How did you test the PR, if at all? -->
booted up test server, made sure normal rcds still blew up, and combat ones did not.
## Changelog
:cl:
tweak: Malf AI power 'destroy RCDs' no longer blows up combat rcds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
