### PR TITLE
Fixes wrongly set var on mixing bowls

### DIFF
--- a/code/game/objects/items/mixing_bowl.dm
+++ b/code/game/objects/items/mixing_bowl.dm
@@ -2,7 +2,7 @@
 /obj/item/mixing_bowl
 	name = "mixing bowl"
 	desc = "Mixing it up in the kitchen."
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mixing_bowl"
 	var/max_n_of_items = 25
@@ -137,12 +137,12 @@
 		return
 	if(prob(chance))
 		dirty = TRUE
-		flags = null
+		container_type = null
 		icon_state = dirty_icon
 
 /obj/item/mixing_bowl/proc/clean()
 	dirty = FALSE
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	icon_state = clean_icon
 
 /obj/item/mixing_bowl/wash(mob/user, atom/source)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes `OPENCONTAINER` a proper container flag rather than the base atom flag.

## Why It's Good For The Game
Fixes #20512. `OPENCONTAINER` was the equivalent of `NOBLUDGEON`, `AIRTIGHT`, and `HANDSLOW`, which made things... weird.

## Images of changes
![Salt](https://user-images.githubusercontent.com/80771500/221654293-b99f53a0-a6bb-40ec-a3fb-828af2470ccc.PNG)

## Testing
Added salt to a bowl

## Changelog
:cl:
fix: Adding condiments and probably other ingredient types works on mixing bowls
fix: Fix odd interations from mixing bowls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
