### PR TITLE
Update all space ruins with window spawners.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -14,8 +14,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "ac" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -68,8 +67,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "ag" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "ah" = (
@@ -83,8 +81,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "ak" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;

--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -483,8 +483,7 @@
 	},
 /area/ruin/space/unpowered)
 "bc" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
 "bd" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
@@ -31,8 +31,7 @@
 /turf/simulated/wall,
 /area/ruin/space/powered)
 "g" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "h" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
@@ -84,8 +84,7 @@
 /turf/simulated/wall/mineral/titanium/interior,
 /area/ruin/space/djstation)
 "am" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -94,8 +93,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/djstation)
 "an" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -107,8 +105,7 @@
 /turf/simulated/wall/mineral/titanium/interior,
 /area/ruin/space/djstation)
 "ap" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -125,8 +122,7 @@
 /turf/simulated/wall/mineral/titanium/interior,
 /area/ruin/space/djstation)
 "as" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -271,8 +267,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/djstation)
 "aK" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -286,8 +281,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/djstation)
 "aL" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/ruin/space/djstation)
 "aM" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -23,13 +23,12 @@
 /turf/simulated/wall/r_wall,
 /area/ruin/space/unpowered)
 "ah" = (
-/obj/structure/grille,
 /obj/machinery/door/poddoor{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
 	id_tag = "Awaybiohazard";
 	name = "Acid-Proof biohazard containment door"
 	},
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "ai" = (
@@ -251,8 +250,7 @@
 	name = "Acid-Proof containment chamber blast door"
 	},
 /obj/structure/cable,
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "aF" = (
@@ -641,8 +639,7 @@
 	id_tag = "Awaylab";
 	name = "Acid-Proof containment chamber blast door"
 	},
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "br" = (
@@ -1015,8 +1012,7 @@
 	},
 /area/ruin/space/unpowered)
 "bX" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "bY" = (
@@ -1335,8 +1331,7 @@
 	name = "Acid-Proof containment chamber blast door"
 	},
 /obj/structure/cable,
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "cD" = (
@@ -1529,8 +1524,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "cU" = (
@@ -1907,12 +1901,11 @@
 	},
 /area/ruin/space/unpowered)
 "dD" = (
-/obj/structure/grille,
 /obj/machinery/door/poddoor{
 	id_tag = "AwayRD";
 	name = "privacy shutter"
 	},
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "dE" = (
@@ -2958,8 +2951,7 @@
 	},
 /area/ruin/space/unpowered)
 "fM" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
@@ -3026,8 +3018,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "fU" = (
-/obj/structure/grille,
-/obj/structure/window/full/basic,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "fV" = (
@@ -4233,12 +4224,11 @@
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/ruin/space/powered)
 "iA" = (
-/obj/structure/grille,
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
 	name = "\improper HOSTILE ATMOSPHERE AHEAD"
 	},
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "iB" = (
@@ -4917,9 +4907,8 @@
 /turf/simulated/floor/carpet,
 /area/ruin/space/unpowered)
 "kg" = (
-/obj/structure/grille,
 /obj/structure/disposalpipe/segment,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "kh" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -53,8 +53,7 @@
 /turf/simulated/wall,
 /area/ruin/space/onehalf/dorms_med)
 "ah" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/dorms_med)
 "ai" = (
@@ -435,8 +434,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/drone_bay)
 "bc" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/drone_bay)
@@ -618,8 +616,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/drone_bay)
 "bt" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/drone_bay)
 "bu" = (
@@ -811,8 +808,7 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/onehalf/hallway)
 "cc" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "onehalf bridge";
 	name = "bridge blast door"
@@ -895,8 +891,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "co" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -947,8 +942,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/abandonedbridge)
 "cu" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -1018,8 +1012,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/abandonedbridge)
 "cD" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1127,8 +1120,7 @@
 /turf/template_noop,
 /area/ruin/space/onehalf/hallway)
 "cU" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/hallway)
 "cV" = (
@@ -1150,8 +1142,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/abandonedbridge)
 "cY" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -1223,8 +1214,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/hallway)
 "dk" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -1240,8 +1230,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/abandonedbridge)
 "dl" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1255,8 +1244,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/abandonedbridge)
 "dm" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1276,8 +1264,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/onehalf/abandonedbridge)
 "dn" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -9,24 +9,21 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/space/nearstation)
 "ad" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
 "ae" = (
 /turf/simulated/wall,
 /area/ruin/unpowered)
 "af" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "ag" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/powered)
 "ah" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/powered)
 "ai" = (
@@ -177,13 +174,11 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/powered/bar)
 "aQ" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/bar)
 "aR" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/wall,
 /area/ruin/space/powered/bar)
 "aS" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -4088,8 +4088,7 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
 "RM" = (
-/obj/structure/grille,
-/obj/structure/window/full/plastitanium,
+/obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -61,8 +61,7 @@
 /turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
 /area/ruin/space/derelict/bridge)
 "an" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
 	id_tag = "rusbridge";
@@ -82,8 +81,7 @@
 /area/ruin/space/derelict/bridge)
 "aq" = (
 /obj/effect/landmark/burnturf,
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
 	id_tag = "rusbridge";
@@ -94,8 +92,7 @@
 /area/ruin/space/derelict/bridge)
 "ar" = (
 /obj/effect/landmark/damageturf,
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
 	id_tag = "rusbridge";
@@ -105,8 +102,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/bridge)
 "as" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "ruslockcom";
 	layer = 3;
@@ -1137,8 +1133,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "cS" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "floorscorched2"
 	},
@@ -1452,8 +1447,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "dF" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "ruslocksec";
 	layer = 2.9;
@@ -1474,8 +1468,7 @@
 	},
 /area/ruin/space/derelict/hallway/primary)
 "dH" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/crew_quarters)
 "dI" = (
@@ -1944,8 +1937,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "eL" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "ruslock";
 	layer = 3;
@@ -2073,8 +2065,7 @@
 	},
 /area/ruin/space/derelict/hallway/primary)
 "fa" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "ruslock";
 	layer = 3;
@@ -2374,8 +2365,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "fG" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/arrival)
 "fH" = (
@@ -3379,8 +3369,7 @@
 	},
 /area/ruin/space/derelict/hallway/primary)
 "if" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
+/obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/hallway/primary)
 "ig" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -255,8 +255,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "aU" = (
-/obj/structure/window/full/reinforced,
-/obj/structure/grille,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/wood,
 /area/ruin/space/unpowered)
 "aV" = (
@@ -264,15 +263,13 @@
 /turf/simulated/floor/wood,
 /area/ruin/space/unpowered)
 "aW" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
 	},
 /area/ruin/space/unpowered)
 "aX" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/wood,
 /area/ruin/space/unpowered)
 "aY" = (

--- a/_maps/map_files/RandomZLevels/evil_santa.dmm
+++ b/_maps/map_files/RandomZLevels/evil_santa.dmm
@@ -117,8 +117,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/challenge/main)
 "au" = (
-/obj/structure/grille,
-/obj/structure/window/full/basic,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/awaymission/challenge/main)
 "av" = (


### PR DESCRIPTION
## What Does This PR Do
This PR swaps out grill/window stacks with the appropriate window spawner for all space ruins (and `evil_santa.dmm`).

## Why It's Good For The Game
Part of map conformance changes needed to push #19875 along.

## Testing
Added maps to space ruin config, spawned in and gave a pass over several ruins to ensure no weirdness.

Tech debt stuff, no changelog.