### PR TITLE
Food Cart now correctly no longer uses power.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -459,7 +459,9 @@
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "foodcart"
 	anchored = FALSE
-	power_state = NO_POWER_USE
+	requires_power = FALSE
+	idle_power_consumption = 0
+	active_power_consumption = 0
 	visible_contents = FALSE
 	face_while_pulling = FALSE
 	silicon_controllable = FALSE

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -460,8 +460,7 @@
 	icon_state = "foodcart"
 	anchored = FALSE
 	requires_power = FALSE
-	idle_power_consumption = 0
-	active_power_consumption = 0
+	power_state = NO_POWER_USE
 	visible_contents = FALSE
 	face_while_pulling = FALSE
 	silicon_controllable = FALSE


### PR DESCRIPTION
## What Does This PR Do
The Food Cart when it was reworked over a year ago was coded to not use power, or at-least that was what was intended. As it turns out it DOES need power in order to function as I found out quite recently.

![Code_e1cbiXCug7](https://user-images.githubusercontent.com/12178527/222244264-1f970904-127e-4e59-8547-39162b47c8cf.png)

I'm not quite sure what the above line does however it doesn't work as intended. If you wrench down the cart and turn off the APC the cart will cease to function trapping all the food inside. With the changes in this PR it now truly uses no power, at all, ever.

## Why It's Good For The Game
It's a cart not an actual vendor despite its subtype and food shouldn't be trapped inside if the power goes out in the area that it's wrenched down in. It was also intended that it wouldn't consume power from the beginning, just incorrectly/improperly done. This PR fixes that.

## Testing
1. I codeded it.
2. Booted test server.
3. Wrenched down Food Cart and proceeded to turn off the APC.
4. I could then still use the vendor.

## Changelog
:cl:
fix: Food Carts now correctly no longer need power to function.
/:cl:
