### PR TITLE
Makes the slot machine emaggable

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -13,6 +13,11 @@
 
 	var/datum/money_account/user_account
 
+	/// Used to handle bolting/unbolting the emagged machine while someone is using it
+	var/emagged_game_in_progress = FALSE
+	/// The %chance of winning money and resetting the emagged state
+	var/emagged_win_chance = 1
+
 /obj/machinery/economy/slot_machine/Initialize(mapload)
 	. = ..()
 	reconnect_database()
@@ -71,6 +76,9 @@
 		playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 		addtimer(CALLBACK(src, PROC_REF(spin_slots), usr.name), 25)
 
+		if(emagged)
+			emagged_spinning(usr)
+
 /obj/machinery/economy/slot_machine/proc/spin_slots(userName)
 	switch(rand(1, 5000))
 		if(1)
@@ -118,4 +126,70 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+	// This prevents the emagged machine to be moved while someone is playing on it.
+	if(emagged_game_in_progress)
+		return
 	default_unfasten_wrench(user, I)
+
+// Emag behaviour below. When the machine is emagged, it'll stun and anchor its user, spin them, then throw them away.
+// With a chance of "emagged_win_chance", the machine resets its emagged state and throws money at the user.
+/obj/machinery/economy/slot_machine/emag_act(user)
+	if(emagged)
+		to_chat(user, "<span class='notice'>[src] is unresponsive. It is probably already modified.</span>")
+		return
+	playsound(loc, 'sound/effects/sparks4.ogg', 75, 1)
+	emagged = TRUE
+	to_chat(user, "<span class='notice'>You engage the reverse-gripping mechanism on the machine's handle.</span>")
+	log_game("[key_name(user)] emagged [src]")
+
+// The spinning and throwing away is handled here, with a possible call to winning
+/obj/machinery/economy/slot_machine/proc/emagged_spinning(mob/living/user)
+	to_chat(user, "<span class='danger'>As you grip the handle of the machine, it grips back at you, and starts to wildly spin you around!</span>")
+	user.SpinAnimation(speed = 2, loops = 6)
+	emagged_game_in_progress = TRUE
+
+	// Make sure the machine is anchored to avoid people cheesing it
+	if(!anchored)
+		atom_say("Deploying safety bolts.")
+		anchored = TRUE
+
+	// Stun them, there is no escape from this unless you get teleported
+	user.anchored = TRUE
+	user.SetStunned(12, TRUE)
+
+	// No cheesing with buckling ourselves, this spinning is too fast for seatbelts
+	if(user.buckled)
+		user.buckled.unbuckle_mob(user, force = TRUE)
+
+	// Check if the machine and the user are still next to each other
+	if(!do_after(user, delay = 12, target = src, use_default_checks = FALSE))
+		user.anchored = FALSE
+		emagged_game_in_progress = FALSE
+		return
+
+	// Find the right direction and throw the user away from the machine
+	to_chat(user, "<span class='danger'>The handle suddenly lets you go!</span>")
+	user.anchored = FALSE
+	var/user_direction = get_dir(src, user)
+	var/turf/throw_direction = get_edge_target_turf(user, user_direction)
+	user.throw_at(throw_direction, 6, 10)
+
+	// Reset the machine
+	emagged_game_in_progress = FALSE
+
+	// Are we the lucky winner?
+	if(prob(emagged_win_chance))
+		addtimer(CALLBACK(src, PROC_REF(emagged_winning), user), 1 SECONDS)
+
+// With a chance of "emagged_win_chance", we win some money and reset the machine to a non-emagged state
+/obj/machinery/economy/slot_machine/proc/emagged_winning(user)
+		// Notify nearby people
+		atom_say("ERROR ERROR ERROR. Entering safe mode. Disabling reverse-gripping mechanism!")
+		playsound(loc, 'sound/machines/bell.ogg', 55, 1)
+
+		// This resets us back to normal
+		emagged = FALSE
+
+		// Reward the winner
+		var/obj/item/reward_to_throw = new /obj/item/stack/spacecash/c100(get_turf(src))
+		reward_to_throw.throw_at(user, 6, 10)


### PR DESCRIPTION
## What Does This PR Do

Makes the slot machine emaggable.

1. Emagging the slot machine will show a message for the emagger and toggles its emagged state.
2. Emagged slot machines work as usual (you can still win the jackpot with it). However, after each pull, it does the following:
   - It stuns, anchors, and unbuckles the user, then starts to spin them.
   - After about 1 second, the user is thrown away from the machine, causing some serious brute damage. Doing this multiple times in a row _will_ lead to an IB.
   - With a 1 in 100 chance, the machine malfunctions, throws 100 creds at the player, then resets its emagged state.
3. Machine behaviour:
   - While a game is ongoing, if the machine was previously unanchored, it will anchor itself. Wrenching it will not work either.
   - If the user or the machine gets further away from each other more than one tile, neither the throwing away nor the potential jackpot will occur. (This is possible via teleportation, admin tools, or other creative methods.)

General usage:

https://user-images.githubusercontent.com/33333517/222504568-9b6c49a9-91cb-4bbf-b42c-311c9b9a12ec.mp4

...

No issues if the machine or the user moves away:

https://user-images.githubusercontent.com/33333517/222506853-168e80a0-683a-4e84-a639-8fb6cf22ec5c.mp4

## Why It's Good For The Game

More funky usage for the emag, more random behaviour, more people getting IBs for their greed.

## Images of changes

See the video above.

## Testing

Made the video above.

## Changelog
:cl:
add: The slot machine can be now emagged.
/:cl:
