### PR TITLE
Fixes Ian and Runtime not GCing

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -46,6 +46,10 @@
 	SSpersistent_data.register(src)
 	..()
 
+/mob/living/simple_animal/pet/cat/Runtime/Destroy()
+	SSpersistent_data.registered_atoms -= src
+	return ..()
+
 /mob/living/simple_animal/pet/cat/Runtime/persistent_load()
 	read_memory()
 	deploy_the_cats()
@@ -62,7 +66,6 @@
 /mob/living/simple_animal/pet/cat/Runtime/death()
 	if(can_die())
 		write_memory(TRUE)
-		SSpersistent_data.registered_atoms -= src // We just saved. Dont save at round end
 	return ..()
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/read_memory()

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -403,9 +403,12 @@
 	. = ..()
 	SSpersistent_data.register(src)
 
+/mob/living/simple_animal/pet/dog/corgi/Ian/Destroy()
+	SSpersistent_data.registered_atoms -= src
+	return ..()
+
 /mob/living/simple_animal/pet/dog/corgi/Ian/death()
 	write_memory(TRUE)
-	SSpersistent_data.registered_atoms -= src // We already wrote here, dont overwrite!
 	..()
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/persistent_load()


### PR DESCRIPTION
## What Does This PR Do

Fixes the last reference to Ian and Runtime before they are deleted.

...or so I hope, persistent data is an @AffectedArc07 thing, I'm sorry if this is dumb

## Why It's Good For The Game

Things should be GCing and I should only close issues when they are fully fixed (#19152)

## Testing

1. Enabled GC ref finder options in `_compile_options.dm`
2. Spawned in Ian and Runtime
3. Deleted them
4. Waited 5-10 minutes
5. Checked gc_debug.log
6. No logs about them failing to GC
