### PR TITLE
Adds detailed examine to the nuclear fission explosive

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -45,7 +45,8 @@ GLOBAL_VAR(bomb_set)
 	var/anchor_stage = NUKE_INTACT
 	///This is so that we can check if the internal components are sealed up properly when the outer hatch is closed.
 	var/core_stage = NUKE_CORE_EVERYTHING_FINE
-
+	///How many sheets of various metals we need to fix it
+	var/sheets_to_fix = 5
 
 /obj/machinery/nuclearbomb/syndicate
 	is_syndicate = TRUE
@@ -79,6 +80,33 @@ GLOBAL_VAR(bomb_set)
 			INVOKE_ASYNC(src, PROC_REF(explode))
 	return
 
+/obj/machinery/nuclearbomb/examine(mob/user)
+	. = ..()
+	// Anchors
+	switch(removal_stage)
+		if(NUKE_INTACT)
+			. += "<span class='notice'>The anchoring bolt covers are <b>welded shut</b>.</span>"
+		if(NUKE_COVER_OFF)
+			. += "<span class='notice'>The cover plate is <b>pried into</b> place.</span>"
+		if(NUKE_COVER_OPEN)
+			. += "<span class='notice'>The anchoring system sealant is <b>welded shut</b>.</span>"
+		if(NUKE_SEALANT_OPEN)
+			. += "<span class='notice'>The bolts are <b>wrenched</b> in place.</span>"
+		if(NUKE_UNWRENCHED)
+			. += "<span class='notice'>The device can be <b>pried off</b> its anchors.</span>"
+	if(!panel_open)
+		. += "<span class='notice'>The outer panel is <b>screwed shut</b>.</span>"
+	if(panel_open)
+		switch(removal_stage)
+			if(NUKE_CORE_EVERYTHING_FINE)
+				. += "<span class='notice'>The outer panel is <b>pried shut</b>.</span>"
+			if(NUKE_CORE_PANEL_EXPOSED)
+				. += "<span class='notice'>The outer plate can be fixed by <b>[sheets_to_fix] metal sheets</b>, while the inner core plate is <i>welded shut</i>.</span>"
+			if(NUKE_CORE_PANEL_UNWELDED)
+				. += "<span class='notice'>The inner core plate can be <b>welded shut</b> or it can be <i>pried open</i>.</span>"
+			if(NUKE_CORE_FULLY_EXPOSED)
+				. += "<span class='notice'>The inner core plate can be fixed by <b>[sheets_to_fix] titanium sheets</b>, [core ? "or the plutonium core can be <i>removed</i>" : "though the plutonium core is <i>missing</i>"].</span>"
+
 /obj/machinery/nuclearbomb/update_overlays()
 	. = ..()
 	underlays.Cut()
@@ -105,23 +133,31 @@ GLOBAL_VAR(bomb_set)
 			to_chat(user, "<span class='notice'>You need to deploy [src] first.</span>")
 		return
 	if(istype(O, /obj/item/stack/sheet/mineral/titanium) && removal_stage == NUKE_CORE_FULLY_EXPOSED)
+		var/obj/item/stack/S = O
+		if(S.get_amount() < sheets_to_fix)
+			to_chat(user, "<span class='warning'>You need at least [sheets_to_fix] sheets of titanium to repair [src]'s inner core plate!</span>")
+			return
 		if(do_after(user, 2 SECONDS, target = src))
-			var/obj/item/stack/S = O
-			if(!loc || !S || S.get_amount() < 5)
+			if(!loc || !S || S.get_amount() < sheets_to_fix)
 				return
-			S.use(5)
-			user.visible_message("<span class='notice'>[user] repairs [src]'s inner core plate.</span>", "<span class='notice'>You repair [src]'s inner core plate. The radiation is contained.</span>")
+			S.use(sheets_to_fix)
+			user.visible_message("<span class='notice'>[user] repairs [src]'s inner core plate.</span>", \
+								"<span class='notice'>You repair [src]'s inner core plate. The radiation is contained.</span>")
 			removal_stage = NUKE_CORE_PANEL_UNWELDED
 			if(core)
 				STOP_PROCESSING(SSobj, core)
 			return
 	if(istype(O, /obj/item/stack/sheet/metal) && removal_stage == NUKE_CORE_PANEL_EXPOSED)
 		var/obj/item/stack/S = O
+		if(S.get_amount() < sheets_to_fix)
+			to_chat(user, "<span class='warning'>You need at least [sheets_to_fix] sheets of metal to repair [src]'s outer core plate!</span>")
+			return
 		if(do_after(user, 2 SECONDS, target = src))
-			if(!loc || !S || S.get_amount() < 5)
+			if(!loc || !S || S.get_amount() < sheets_to_fix)
 				return
-			S.use(5)
-			user.visible_message("<span class='notice'>[user] repairs [src]'s outer core plate.</span>", "<span class='notice'>You repair [src]'s outer core plate.</span>")
+			S.use(sheets_to_fix)
+			user.visible_message("<span class='notice'>[user] repairs [src]'s outer core plate.</span>", \
+								"<span class='notice'>You repair [src]'s outer core plate.</span>")
 			removal_stage = NUKE_CORE_EVERYTHING_FINE
 			return
 	if(istype(O, /obj/item/nuke_core/plutonium) && removal_stage == NUKE_CORE_FULLY_EXPOSED)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -83,6 +83,8 @@ GLOBAL_VAR(bomb_set)
 /obj/machinery/nuclearbomb/examine(mob/user)
 	. = ..()
 	// Anchors
+	if(!panel_open)
+		. += "<span class='notice'>The outer panel is <b>screwed shut</b>.</span>"
 	switch(removal_stage)
 		if(NUKE_INTACT)
 			. += "<span class='notice'>The anchoring bolt covers are <b>welded shut</b>.</span>"
@@ -94,18 +96,14 @@ GLOBAL_VAR(bomb_set)
 			. += "<span class='notice'>The bolts are <b>wrenched</b> in place.</span>"
 		if(NUKE_UNWRENCHED)
 			. += "<span class='notice'>The device can be <b>pried off</b> its anchors.</span>"
-	if(!panel_open)
-		. += "<span class='notice'>The outer panel is <b>screwed shut</b>.</span>"
-	if(panel_open)
-		switch(removal_stage)
-			if(NUKE_CORE_EVERYTHING_FINE)
-				. += "<span class='notice'>The outer panel can be <b>pried open</b> or it can be <i>screwed</i> back on.</span>"
-			if(NUKE_CORE_PANEL_EXPOSED)
-				. += "<span class='notice'>The outer plate can be fixed by <b>[sheets_to_fix] metal sheets</b>, while the inner core plate is <i>welded shut</i>.</span>"
-			if(NUKE_CORE_PANEL_UNWELDED)
-				. += "<span class='notice'>The inner core plate can be <b>welded shut</b> or it can be <i>pried open</i>.</span>"
-			if(NUKE_CORE_FULLY_EXPOSED)
-				. += "<span class='notice'>The inner core plate can be fixed by <b>[sheets_to_fix] titanium sheets</b>, [core ? "or the plutonium core can be <i>removed</i>" : "though the plutonium core is <i>missing</i>"].</span>"
+		if(NUKE_CORE_EVERYTHING_FINE)
+			. += "<span class='notice'>The outer panel can be <b>pried open</b> or it can be <i>screwed</i> back on.</span>"
+		if(NUKE_CORE_PANEL_EXPOSED)
+			. += "<span class='notice'>The outer plate can be fixed by <b>[sheets_to_fix] metal sheets</b>, while the inner core plate is <i>welded shut</i>.</span>"
+		if(NUKE_CORE_PANEL_UNWELDED)
+			. += "<span class='notice'>The inner core plate can be <b>welded shut</b> or it can be <i>pried open</i>.</span>"
+		if(NUKE_CORE_FULLY_EXPOSED)
+			. += "<span class='notice'>The inner core plate can be fixed by <b>[sheets_to_fix] titanium sheets</b>, [core ? "or the plutonium core can be <i>removed</i>" : "though the plutonium core is <i>missing</i>"].</span>"
 
 /obj/machinery/nuclearbomb/update_overlays()
 	. = ..()

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -99,7 +99,7 @@ GLOBAL_VAR(bomb_set)
 	if(panel_open)
 		switch(removal_stage)
 			if(NUKE_CORE_EVERYTHING_FINE)
-				. += "<span class='notice'>The outer panel is <b>pried shut</b>.</span>"
+				. += "<span class='notice'>The outer panel can be <b>pried open</b> or it can be <i>screwed</i> back on.</span>"
 			if(NUKE_CORE_PANEL_EXPOSED)
 				. += "<span class='notice'>The outer plate can be fixed by <b>[sheets_to_fix] metal sheets</b>, while the inner core plate is <i>welded shut</i>.</span>"
 			if(NUKE_CORE_PANEL_UNWELDED)


### PR DESCRIPTION
## What Does This PR Do

Adds detailed examining to the nuclear fission explosive's anchors and panel actions.

Adds an extra check when fixing it so it instantly fails you if you don't have enough sheets.

Fixes #20533 (implements it, rather).

## Why It's Good For The Game

As the requester said, "not have to spend 20 minutes, a mhelp and a search on the wiki to actually get the core back in safely."

We use detailed examines for a lot of things involving states, such as girders, airlock assemblies, etc, this just brings the nuke up to date.

## Images of changes

Removal of core:

![image](https://user-images.githubusercontent.com/33333517/222688688-7442c95d-ca4f-457c-a19f-b1d091bbf154.png)

Unanchoring it:

![image](https://user-images.githubusercontent.com/33333517/222689053-7750582f-58b5-41c7-8991-828d3b31b809.png)

## Testing

1. Spawn a `/obj/machinery/nuclearbomb`
2. Spawn a `/obj/item/storage/belt/utility/full/multitool`
3. Spawn a `/obj/item/screwdriver/nuke`
4. Spawn a `/obj/item/clothing/glasses/welding/superior`
5. Do the steps the examine text says

## Changelog
:cl:
add: Added detailed examine text to the nuclear fission explosive.
/:cl:
