### PR TITLE
Prevents spawning of off-station mobs

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1167,7 +1167,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if((usr in GLOB.respawnable_list) && (stat == DEAD || isobserver(usr)))
 		var/list/creatures = list("Mouse")
 		for(var/mob/living/simple_animal/L in GLOB.alive_mob_list)
-			if(!(is_station_level(L.z) || is_admin_level(H.z))) // Prevents players from spawning in space
+			if(!(is_station_level(L.z) || is_admin_level(L.z))) // Prevents players from spawning in space
 				continue
 			if(L.npc_safe(src) && L.stat != DEAD && !L.key)
 				creatures += L

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1167,6 +1167,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if((usr in GLOB.respawnable_list) && (stat == DEAD || isobserver(usr)))
 		var/list/creatures = list("Mouse")
 		for(var/mob/living/simple_animal/L in GLOB.alive_mob_list)
+			if(!(is_station_level(L.z) || is_admin_level(H.z))) // Prevents players from spawning in space
+				continue
 			if(L.npc_safe(src) && L.stat != DEAD && !L.key)
 				creatures += L
 		var/picked = input("Please select an NPC to respawn as", "Respawn as NPC")  as null|anything in creatures


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Friendly mobs which can be chosen to respawn as, now only show on-station and centcomm level mobs. Centcomm/admin levels 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Prevents players as spawning as mobs on the syndicate space base and needing to ghost out and lose their respawning privileges.

## Testing
<!-- How did you test the PR, if at all? -->
Could spawn as on-station pets normally and Syndicat and Syndifox on nuclear gamemode. Could not spawn as mobs in space (i.e. syndicate station cow)

## Changelog
:cl:
tweak: Players can no longer spawn as mobs off-station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
