### PR TITLE
Adds a cooldown for setting alert level through comms console

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -29,7 +29,7 @@
 
 	var/message_cooldown
 	var/centcomm_message_cooldown
-	var/alert_level_cooldown
+	var/alert_level_cooldown = 0
 	var/tmp_alertlevel = 0
 
 	var/stat_msg1

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -29,6 +29,7 @@
 
 	var/message_cooldown
 	var/centcomm_message_cooldown
+	var/alert_level_cooldown
 	var/tmp_alertlevel = 0
 
 	var/stat_msg1
@@ -122,7 +123,11 @@
 			else if(!ishuman(usr))
 				to_chat(usr, "<span class='warning'>Security measures prevent you from changing the alert level.</span>")
 				return
+			else if(alert_level_cooldown > world.time)
+				to_chat(usr, "<span class='warning'>Please allow at least one minute between manual changes to the alert level.</span>")
+				return
 
+			alert_level_cooldown = world.time + 60 SECONDS
 			var/mob/living/carbon/human/H = usr
 			var/obj/item/card/id/I = H.get_idcard(TRUE)
 			if(istype(I))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a 1 minute cooldown for changing the alert level at a comms console.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Players can currently change the alert level really really fast and it's really really annoying, borderline deafening and spamming chat.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to change the alert level, got cooled down.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The communications console now has a 1m delay between changes of alert level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
