### PR TITLE
Fixes dish drive beam

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -128,7 +128,9 @@
 		visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams [disposed] stored item\s into the nearby [bin.name].</span>")
 		playsound(src, 'sound/items/pshoom.ogg', 15, TRUE)
 		playsound(bin, 'sound/items/pshoom.ogg', 15, TRUE)
-		Beam(bin, icon_state = "rped_upgrade", time = 5)
+		Beam(bin, icon_state = "rped_upgrade", icon = 'icons/effects/effects.dmi', time = 5)
 		bin.update_icon()
 		flick("synthesizer_beam", src)
+	else if (manual)
+		to_chat(usr, "<span class='notice'>There are no disposable items to be beamed.</span>")
 	time_since_dishes = world.time + 60 SECONDS

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -131,6 +131,6 @@
 		Beam(bin, icon_state = "rped_upgrade", icon = 'icons/effects/effects.dmi', time = 5)
 		bin.update_icon()
 		flick("synthesizer_beam", src)
-	else if (manual)
+	else if(manual)
 		to_chat(usr, "<span class='notice'>There are no disposable items to be beamed.</span>")
 	time_since_dishes = world.time + 60 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixed the dish drive beam not having an icon.
Added feedback when there are no disposable items inside the dish drive.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Lack of feedback made me think for a few minutes that the dish drive was broken.
Beam with no beam icon is no beam, and must BEam fixed.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/77684085/222927525-93b4b250-5280-47ac-9317-e096584ddcad.mp4


## Testing
<!-- How did you test the PR, if at all? -->
- See video above
## Changelog
:cl:
tweak: Added feedback when there are no disposable items inside the dish drive
fix: Fixed the dish drive beam not having an icon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
