### PR TITLE
Full Belts No Longer Fit in Bags

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -104,9 +104,10 @@
 
 /obj/item/storage/belt/utility/chief
 	name = "advanced toolbelt"
-	desc = "Holds tools, looks snazzy"
+	desc = "Holds tools, looks snazzy, and fits nicely into a bag"
 	icon_state = "utilitybelt_ce"
 	item_state = "utility_ce"
+	storable = TRUE
 
 /obj/item/storage/belt/utility/chief/full/populate_contents()
 	new /obj/item/screwdriver/power(src)
@@ -335,7 +336,7 @@
 
 /obj/item/storage/belt/military/traitor
 	name = "tool-belt"
-	desc = "Can hold various tools. This model seems to have additional compartments."
+	desc = "Can hold various tools. This model seems to have additional compartments and folds up rather nicely into a bag."
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	use_item_overlays = TRUE // So it will still show tools in it in case sec get lazy and just glance at it.
@@ -358,7 +359,6 @@
 	storage_slots = 30
 	max_combined_w_class = 60
 	display_contents_with_number = TRUE
-	storable = TRUE
 	can_hold = list(
 		/obj/item/grenade,
 		/obj/item/lighter,

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -13,8 +13,11 @@
 	/// Do we have overlays for items held inside the belt?
 	var/use_item_overlays = FALSE
 	var/storable = FALSE
+	var/large = FALSE
 
 /obj/item/storage/belt/proc/update_weight()
+	if(large)
+		return
 	if(!length(contents) || storable)
 		w_class = WEIGHT_CLASS_NORMAL
 	else
@@ -86,11 +89,13 @@
 	new /obj/item/wirecutters(src)
 	new /obj/item/stack/cable_coil/random(src, 30)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/utility/full/multitool/populate_contents()
 	..()
 	new /obj/item/multitool(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/utility/atmostech/populate_contents()
 	new /obj/item/screwdriver(src)
@@ -101,6 +106,7 @@
 	new /obj/item/t_scanner(src)
 	new /obj/item/extinguisher/mini(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/utility/chief
 	name = "advanced toolbelt"
@@ -118,6 +124,7 @@
 	new /obj/item/extinguisher/mini(src)
 	new /obj/item/analyzer(src)
 	update_icon()
+	update_weight()
 	//much roomier now that we've managed to remove two tools
 
 /obj/item/storage/belt/utility/syndi_researcher // A cool looking belt thats essentially a syndicate toolbox
@@ -134,6 +141,7 @@
 	new /obj/item/multitool/red(src)
 	new /obj/item/stack/cable_coil(src, 30, COLOR_RED)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/medical
 	name = "medical belt"
@@ -198,6 +206,8 @@
 	new /obj/item/FixOVein(src)
 	new /obj/item/surgicaldrill(src)
 	new /obj/item/cautery(src)
+	update_weight()
+	update_weight()
 
 /obj/item/storage/belt/medical/response_team/populate_contents()
 	new /obj/item/reagent_containers/food/pill/salbutamol(src)
@@ -208,6 +218,7 @@
 	new /obj/item/reagent_containers/food/pill/salicylic(src)
 	new /obj/item/reagent_containers/food/pill/salicylic(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/botany
 	name = "botanist belt"
@@ -269,6 +280,7 @@
 	new /obj/item/flash(src)
 	new /obj/item/melee/baton/loaded(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/security/response_team/populate_contents()
 	new /obj/item/reagent_containers/spray/pepper(src)
@@ -277,6 +289,7 @@
 	new /obj/item/melee/classic_baton/telescopic(src)
 	new /obj/item/grenade/flashbang(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/security/response_team_gamma/populate_contents()
 	new /obj/item/melee/baton/loaded(src)
@@ -285,6 +298,7 @@
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/grenade/flashbang(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/security/webbing
 	name = "security webbing"
@@ -309,6 +323,7 @@
 	for(var/I in 1 to 6)
 		new /obj/item/soulstone(src)
 	update_icon()
+	update_weight()
 
 
 /obj/item/storage/belt/champion
@@ -350,6 +365,7 @@
 	new /obj/item/wirecutters(src, "red")
 	new /obj/item/stack/cable_coil(src, 30, COLOR_RED)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/grenade
 	name = "grenadier belt"
@@ -377,6 +393,7 @@
 		new /obj/item/grenade/syndieminibomb(src)
 	new /obj/item/grenade/chem_grenade/facid(src) //1
 	new /obj/item/grenade/chem_grenade/saringas(src) //1
+	update_weight()
 
 /obj/item/storage/belt/grenade/tactical // Traitor bundle version
 	name = "tactical grenadier belt"
@@ -392,6 +409,7 @@
 		new /obj/item/grenade/frag(src)
 		new /obj/item/grenade/empgrenade(src) // Two of each
 	new /obj/item/grenade/syndieminibomb(src) // One minibomb
+	update_weight()
 
 /obj/item/storage/belt/military/abductor
 	name = "agent belt"
@@ -408,6 +426,7 @@
 	new /obj/item/wirecutters/abductor(src)
 	new /obj/item/multitool/abductor(src)
 	new /obj/item/stack/cable_coil(src, 30, COLOR_WHITE)
+	update_weight()
 
 /obj/item/storage/belt/military/assault
 	name = "assault belt"
@@ -424,6 +443,7 @@
 	new /obj/item/ammo_box/magazine/m45(src)
 	new /obj/item/ammo_box/magazine/m45(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/military/assault/marines/elite/full/populate_contents()
 	new /obj/item/ammo_box/magazine/m556/arg(src)
@@ -432,6 +452,7 @@
 	new /obj/item/ammo_box/magazine/m45(src)
 	new /obj/item/ammo_box/magazine/m45(src)
 	update_icon()
+	update_weight()
 /obj/item/storage/belt/janitor
 	name = "janibelt"
 	desc = "A belt used to hold most janitorial supplies."
@@ -460,6 +481,7 @@
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/lazarus
 	name = "trainer's belt"
@@ -471,6 +493,7 @@
 	max_combined_w_class = 6
 	storage_slots = 6
 	can_hold = list(/obj/item/mobcapsule)
+	large = TRUE
 
 /obj/item/storage/belt/lazarus/Initialize(mapload)
 	. = ..()
@@ -507,6 +530,7 @@
 /obj/item/storage/belt/bandolier/full/populate_contents()
 	for(var/I in 1 to 8)
 		new /obj/item/ammo_casing/shotgun/rubbershot(src)
+	update_weight()
 
 /obj/item/storage/belt/bandolier/update_icon_state()
 	icon_state = "[initial(icon_state)]_[min(length(contents), 8)]"
@@ -552,6 +576,7 @@
 		W.max_charges = initial(W.max_charges)
 		W.charges = W.max_charges
 	update_icon()
+	update_weight()
 
 /obj/item/storage/belt/fannypack
 	name = "fannypack"
@@ -620,6 +645,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	max_w_class = WEIGHT_CLASS_BULKY
 	can_hold = list(/obj/item/melee/rapier)
+	large = TRUE
 
 /obj/item/storage/belt/rapier/populate_contents()
 	new /obj/item/melee/rapier(src)
@@ -679,6 +705,7 @@
 	max_combined_w_class = 21 // = 14 * 1.5, not 14 * 2.  This is deliberate
 	origin_tech = "bluespace=5;materials=4;engineering=4;plasmatech=5"
 	can_hold = list()
+	large = TRUE
 
 /obj/item/storage/belt/bluespace/owlman
 	name = "Owlman's utility belt"
@@ -793,6 +820,7 @@
 
 	new /obj/item/analyzer(src)
 	new /obj/item/healthanalyzer(src)
+	update_weight()
 
 /obj/item/storage/belt/mining
 	name = "explorer's webbing"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -12,9 +12,17 @@
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
 	/// Do we have overlays for items held inside the belt?
 	var/use_item_overlays = FALSE
+	var/storable = FALSE
+
+/obj/item/storage/belt/proc/update_weight()
+	if(!length(contents) || storable)
+		w_class = WEIGHT_CLASS_NORMAL
+	else
+		w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/belt/update_overlays()
 	. = ..()
+	update_weight()
 	if(!use_item_overlays)
 		return
 	for(var/obj/item/I in contents)
@@ -23,10 +31,6 @@
 		var/image/belt_image = image(icon, I.belt_icon)
 		belt_image.color = I.color
 		. += belt_image
-	if(!length(contents))
-		w_class = WEIGHT_CLASS_NORMAL
-	else
-		w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/belt/proc/can_use()
 	return is_equipped()
@@ -335,6 +339,7 @@
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	use_item_overlays = TRUE // So it will still show tools in it in case sec get lazy and just glance at it.
+	storable = TRUE
 
 /obj/item/storage/belt/military/traitor/hacker/populate_contents()
 	new /obj/item/screwdriver(src, "red")
@@ -353,6 +358,7 @@
 	storage_slots = 30
 	max_combined_w_class = 60
 	display_contents_with_number = TRUE
+	storable = TRUE
 	can_hold = list(
 		/obj/item/grenade,
 		/obj/item/lighter,

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -12,8 +12,8 @@
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
 	/// Do we have overlays for items held inside the belt?
 	var/use_item_overlays = FALSE
-	var/storable = FALSE
-	var/large = FALSE
+	var/storable = FALSE //bypasses the "belt in bag" prevention
+	var/large = FALSE //ignores update_weight() if TRUE
 
 /obj/item/storage/belt/proc/update_weight()
 	if(large)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -23,6 +23,10 @@
 		var/image/belt_image = image(icon, I.belt_icon)
 		belt_image.color = I.color
 		. += belt_image
+	if(!length(contents))
+		w_class = WEIGHT_CLASS_NORMAL
+	else
+		w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/belt/proc/can_use()
 	return is_equipped()

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -382,6 +382,12 @@
 					to_chat(usr, "<span class='warning'>[src] rejects [I] because of its contents.</span>")
 				return FALSE
 
+	if(istype(src, /obj/item/storage/belt) && isstorage(loc)) //You shouldnt be able to bypass belt in bag storage
+		if(!(istype(src, /obj/item/storage/belt/military/traitor) || istype(src, /obj/item/storage/belt/utility/chief)))
+			if(!stop_messages)
+				to_chat(usr, "<span class='warning'>You cant seem to fit [I] into [src].</span>")
+			return FALSE
+
 	if(I.w_class > max_w_class)
 		if(!stop_messages)
 			to_chat(usr, "<span class='warning'>[I] is too big for [src].</span>")
@@ -406,12 +412,6 @@
 		to_chat(usr, "<span class='warning'>[I] is stuck to your hand, you can't put it in [src]</span>")
 		return FALSE
 
-	return TRUE
-
-	if(istype(src, /obj/item/storage/belt) && src.loc == /obj/item/storage) //You shouldnt be able to bypass belt in bag storage
-		if(!stop_messages)
-			to_chat(usr, "<span class='warning'>You cant seem to fit [I] into [src].</span>")
-		return FALSE
 	return TRUE
 
 /**

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -408,6 +408,12 @@
 
 	return TRUE
 
+	if(istype(src, /obj/item/storage/belt) && src.loc == /obj/item/storage) //You shouldnt be able to bypass belt in bag storage
+		if(!stop_messages)
+			to_chat(usr, "<span class='warning'>You cant seem to fit [I] into [src].</span>")
+		return FALSE
+	return TRUE
+
 /**
   * Handles items being inserted into a storage container.
   *


### PR DESCRIPTION
## What Does This PR Do
Belts with items inside them no longer fit in bags. Empty belts can still be bagged, but items will not fit inside them.

The Traitor Belt and the CE's Advanced Toolbelt can be stored inside a bag and used, as they are stealthy/advanced.

## Why It's Good For The Game
Belts create a lot of problems for the dreaded "storage creep". This looks to cut down on the ability to store SecBelts (for Ammo/Batons) and ToolBelts (easy tool storage) inside your bags.

Belts are BELTS for a reason. They allow Normal Sized items to fit inside a Normal Sized storage container. They should have some downsides.

## Testing
I put on a ton of belts.

Checks were put in place to ensure you cant do fucky things with Bluespace/Lazarus belts, since they actually do get a `w_class` of Bulky already.

## Changelog
:cl:
tweak: belts can now only be stored in bags while empty.
tweak: the CE's belt and the Traitor Belt can be used while in a bag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
