### PR TITLE
Adds the trash bag of holding upgrade for janiborgs

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -405,6 +405,16 @@
 	cyborg = null
 	return ..()
 
+/obj/item/borg/upgrade/bluespace_trash_bag
+	name = "janitor cyborg trash bag of holding upgrade"
+	desc = "An advanced trash bag upgrade board with bluespace properties that can be attached to janitorial cyborgs."
+	icon_state = "cyborg_upgrade4"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/janitor
+	items_to_replace = list(
+		/obj/item/storage/bag/trash/cyborg = /obj/item/storage/bag/trash/bluespace/cyborg
+	)
+
 /obj/item/borg/upgrade/rcd
 	name = "R.C.D. upgrade"
 	desc = "A modified rapid construction device, able to pull energy directly from a cyborgs internal power cell."

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -79,6 +79,11 @@
 	storage_slots = 60
 	flags_2 = NO_MAT_REDEMPTION_2
 
+/obj/item/storage/bag/trash/bluespace/cyborg
+
+/obj/item/storage/bag/trash/bluespace/cyborg/janicart_insert(mob/user, obj/structure/janitorialcart/J)
+	return
+
 // -----------------------------
 //        Plastic Bag
 // -----------------------------

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1098,6 +1098,16 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_bluespace_trash_bag
+	name = "Cyborg Upgrade (Trash bag of holding)"
+	id = "borg_upgrade_bluespace_trash_bag"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/bluespace_trash_bag
+	req_tech = list("materials" = 5, "bluespace" = 4, "engineering" = 4, "plasmatech" = 3)
+	materials = list(MAT_GOLD = 1500, MAT_URANIUM = 250, MAT_PLASMA = 1500)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_floorbuffer
 	name = "Cyborg Upgrade (Floor buffer)"
 	id = "borg_upgrade_floorbuffer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds the trash bag of holding upgrade for janiborgs, printed at the mechfab for the same material/research costs as the original trash bag of holding.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Its odd that this upgrade is available for janitors but not janiborgs.
It being available to them would be another cool thing to ask robotics for and shouldnt have much of an impact on balance.

## Testing
<!-- How did you test the PR, if at all? -->
- Maximized all research levels to maximum
- Inserted the materials into the mechfab and made the trash bag upgrade
- Inserted it into the janitor cyborg and picked up A LOT of trash
## Changelog
:cl:
add: Added the trash bag of holding upgrade for janiborgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
