### PR TITLE
Forcemoves, instead of setting loc, for ghost notifications.

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -607,7 +607,7 @@ so as to remain in compliance with the most up-to-date laws."
 			if(NOTIFY_JUMP)
 				var/turf/T = get_turf(target)
 				if(T && isturf(T))
-					G.loc = T
+					G.forceMove(T)
 			if(NOTIFY_FOLLOW)
 				G.ManualFollow(target)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where ghosts who are orbiting something when clicking certain ghost notifications will get teleported back to their original orbit location. You've probably noticed this issue the most with manifest runes and the chaplain's salt shaker, among other things.
Changing loc directly, instead of using forceMove, doesn't fire the signals that orbit code uses to remove your orbit, so it tries to pull you back to whatever you're orbiting. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Getting repeatedly pulled back when you meant to orbit on one tile is kind of annoying, and another late side-effect from my orbiting refactor (oops lmao).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Clicking some ghost alerts will no longer cause you to teleport back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
