### PR TITLE
Deletes the "Jump to mob" verb from ghosts

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -158,13 +158,12 @@
 #define ui_bot_pull "EAST-2:26,SOUTH:7"
 
 //Ghosts
-#define ui_ghost_jumptomob "SOUTH:6,CENTER-2"
-#define ui_ghost_orbit "SOUTH:6,CENTER-1"
-#define ui_ghost_reenter_corpse "SOUTH:6,CENTER"
-#define ui_ghost_teleport "SOUTH:6,CENTER+1"
-#define ui_ghost_respawn_list "SOUTH:6,CENTER+2"
-#define ui_ghost_respawn_mob "SOUTH:6+1,CENTER+2"
-#define ui_ghost_respawn_pai "SOUTH:6+2,CENTER+2"
+#define ui_ghost_orbit "SOUTH:6,CENTER-1.5"
+#define ui_ghost_reenter_corpse "SOUTH:6,CENTER-.5"
+#define ui_ghost_teleport "SOUTH:6,CENTER+.5"
+#define ui_ghost_respawn_list "SOUTH:6,CENTER+1.5"
+#define ui_ghost_respawn_mob "SOUTH:6+1,CENTER+1.5"
+#define ui_ghost_respawn_pai "SOUTH:6+2,CENTER+1.5"
 
 //HUD styles. Please ensure HUD_VERSIONS is the same as the maximum index. Index order defines how they are cycled in F12.
 #define HUD_STYLE_STANDARD 1

--- a/code/_onclick/hud/ghost_hud.dm
+++ b/code/_onclick/hud/ghost_hud.dm
@@ -10,14 +10,6 @@
 	. = ..()
 	flick(icon_state + "_anim", src)
 
-/obj/screen/ghost/jumptomob
-	name = "Jump to mob"
-	icon_state = "jumptomob"
-
-/obj/screen/ghost/jumptomob/Click()
-	var/mob/dead/observer/G = usr
-	G.jumptomob()
-
 /obj/screen/ghost/orbit
 	name = "Orbit"
 	icon_state = "orbit"
@@ -94,10 +86,6 @@
 /datum/hud/ghost/New(mob/owner)
 	..()
 	var/obj/screen/using
-
-	using = new /obj/screen/ghost/jumptomob()
-	using.screen_loc = ui_ghost_jumptomob
-	static_inventory += using
 
 	using = new /obj/screen/ghost/orbit()
 	using.screen_loc = ui_ghost_orbit

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -498,16 +498,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	setDir(2)//reset dir so the right directional sprites show up
 	return ..()
 
-/mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
-	set category = "Ghost"
-	set name = "Jump to Mob"
-	set desc = "Teleport to a mob"
-
-	if(isobserver(usr)) //Make sure they're an observer!
-		var/list/dest = getpois(mobs_only=TRUE) //Fill list, prompt user with list
-		var/datum/async_input/A = input_autocomplete_async(usr, "Enter a mob name: ", dest)
-		A.on_close(CALLBACK(src, PROC_REF(jump_to_mob)))
-
 /mob/dead/observer/proc/jump_to_mob(mob/M)
 	if(!M || !isobserver(usr))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title, this does NOT delete the admin input() version, just the seldom used ghost version
Closes #19294

## Why It's Good For The Game
This thing barely works anymore and has some seriously bad performance impact. If opened EVEN ONCE during a round it keeps a hard reference to every single mob currently in that round and causes them to GC fail and hard delete with 100ms+ deletion times. This is really bad and it's not worth saving.

## Changelog
:cl:
del: Removed the "Jump to mob" verb from ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
