### PR TITLE
Fixes a runtime with mindless revolutionaries

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -510,7 +510,7 @@ emp_act
 											"<span class='combat userdanger'>[src] has been knocked down!</span>")
 							KnockDown(10 SECONDS)
 							AdjustConfused(30 SECONDS)
-						if(prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
+						if(mind && prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
 							SSticker.mode.remove_revolutionary(mind)
 
 					if(bloody)//Apply blood

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -510,7 +510,7 @@ emp_act
 											"<span class='combat userdanger'>[src] has been knocked down!</span>")
 							KnockDown(10 SECONDS)
 							AdjustConfused(30 SECONDS)
-						if(mind && prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
+						if(mind && prob(I.force + ((100 - health) / 2)) && src != user && I.damtype == BRUTE)
 							SSticker.mode.remove_revolutionary(mind)
 
 					if(bloody)//Apply blood


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes this runtime by making sure the potential rev has a mind first.
```
[2023-03-05T18:09:28] Runtime in revolution.dm,254: Cannot read null.current
[2023-03-05T18:09:28]   proc name: remove revolutionary (/datum/game_mode/proc/remove_revolutionary)
[2023-03-05T18:09:28]   usr: *REDACTED USER*
[2023-03-05T18:09:28]   usr.loc: The floor (60,160,6) (/turf/simulated/floor/plasteel)
[2023-03-05T18:09:28]   src: Trifecta (/datum/game_mode/trifecta)
[2023-03-05T18:09:28]   call stack:
[2023-03-05T18:09:28]   Trifecta (/datum/game_mode/trifecta): remove_revolutionary
[2023-03-05T18:09:28]   the monkey (299) (/mob/living/carbon/human): attacked_by
[2023-03-05T18:09:28]   the stechkin pistol (/obj/item/gun/projectile/automatic/pistol): attack
[2023-03-05T18:09:28]   the stechkin pistol (/obj/item/gun/projectile/automatic/pistol): attack
[2023-03-05T18:09:28]   the monkey (299) (/mob/living/carbon/human): attackby
[2023-03-05T18:09:28]   the monkey (299) (/mob/living/carbon/human): attackby
[2023-03-05T18:09:28]   the stechkin pistol (/obj/item/gun/projectile/automatic/pistol): melee_attack_chain
```

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Runtimes are bad and can cause unintended behavior

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, attacked a monkey in the head a lot with no runtimes

## Changelog
Nothing player-facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
