### PR TITLE
Fixes Thermo-Machine Power Consumption

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -150,7 +150,7 @@
 	power_state = use_type
 
 /obj/machinery/proc/update_idle_power_consumption(channel = power_channel, amount)
-	if(power_state == ACTIVE_POWER_USE)
+	if(power_state == IDLE_POWER_USE)
 		machine_powernet.adjust_static_power(power_channel, amount - idle_power_consumption)
 	idle_power_consumption = amount
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -10,6 +10,9 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 80, ACID = 30)
 	layer = OBJ_LAYER
 
+	idle_power_consumption = 500
+	active_power_consumption = 0
+
 	var/icon_state_off = "freezer"
 	var/icon_state_on = "freezer_1"
 	var/icon_state_open = "freezer-o"
@@ -105,12 +108,14 @@
 
 	//todo: have current temperature affected. require power to bring down current temperature again
 
-	var/temperature_delta= abs(old_temperature - air_contents.temperature)
+	var/temperature_delta = abs(old_temperature - air_contents.temperature)
 	if(temperature_delta > 1)
-		update_active_power_consumption(power_channel, (heat_capacity * temperature_delta) / 10 + idle_power_consumption)
-		parent.update = 1
+		var/new_active_consumption = (temperature_delta * 25) * min(log(10, air_contents.temperature) - 1, 1)
+		update_active_power_consumption(power_channel, new_active_consumption + idle_power_consumption)
+		change_power_mode(ACTIVE_POWER_USE)
+		parent.update = TRUE
 	else
-		update_active_power_consumption(power_channel, idle_power_consumption)
+		change_power_mode(IDLE_POWER_USE)
 	return 1
 
 /obj/machinery/atmospherics/unary/thermomachine/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## What Does This PR Do
unfucks the maths on thermo machines
Fixes #20461

Now power consumption for using heaters/coolers has minimum power consumption and scaled with the temperature differential + the magnitude of the current temperature.

## Why It's Good For The Game
A single heater can no longer out consume the entire station by a magnitude of 3

## Testing
Ran a test server and tried out different settings

## Changelog
:cl:
fix: thermo machines no longer consume power at the same rate as a medium-sized metropolitan city
/:cl: