### PR TITLE
Fixes organ removal mid-surgery causing stuck surgeries

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -8,6 +8,7 @@
 	steps = list(/datum/surgery_step/generic/amputate)
 	possible_locs = list(BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_GROIN)
 	requires_organic_bodypart = TRUE
+	cancel_on_organ_change = FALSE  // don't stop the surgery when removing limbs
 
 /datum/surgery/amputation/can_start(mob/user, mob/living/carbon/target)
 	. = ..()
@@ -25,6 +26,7 @@
 		/datum/surgery_step/limb/attach,
 		/datum/surgery_step/limb/connect
 	)
+	cancel_on_organ_change = FALSE
 	possible_locs = list(BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_GROIN)
 
 /datum/surgery/reattach/can_start(mob/user, mob/living/carbon/target)
@@ -74,7 +76,7 @@
 	steps = list(
 		/datum/surgery_step/proxy/robo_limb_attach
 	)
-
+	cancel_on_organ_change = FALSE
 	possible_locs = list(BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_GROIN)
 
 

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -244,6 +244,8 @@
 	if(!istype(owner))
 		return
 
+	SEND_SIGNAL(owner, COMSIG_CARBON_LOSE_ORGAN, src)
+
 	owner.internal_organs -= src
 
 	var/obj/item/organ/external/affected = owner.get_organ(parent_organ)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -150,6 +150,8 @@
 /obj/item/organ/external/replaced(mob/living/carbon/human/target)
 	owner = target
 	loc = null
+	if(iscarbon(owner))
+		SEND_SIGNAL(owner, COMSIG_CARBON_GAIN_ORGAN, src)
 	if(istype(owner))
 		if(!isnull(owner.bodyparts_by_name[limb_name]))
 			log_debug("Duplicate organ in slot \"[limb_name]\", mob '[target]'")
@@ -750,6 +752,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	if(!owner)
 		return
+
+	SEND_SIGNAL(owner, COMSIG_CARBON_LOSE_ORGAN, src)
 	var/mob/living/carbon/human/victim = owner
 
 	if(status & ORGAN_SPLINTED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #19661, where organs being dropped mid-surgery would sometimes cause surgeries to become stuck, necessitating an aheal.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Another surgery bug patched is always a good thing. More IPC surgery love.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Logged in, started surgery on an IPC and dropped the limb I started surgery on, it canceled the surgery.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Losing a limb that a surgical operation is being performed on will now cancel said surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
