### PR TITLE
Adds the camera failure event

### DIFF
--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -1,7 +1,7 @@
 /datum/event/camera_failure/start()
 	var/iterations = 1
 	var/list/cameras = GLOB.cameranet.cameras.Copy()
-	while(prob(round(100 / iterations)))
+	while(prob(100 / iterations))
 		var/obj/machinery/camera/C = pick_n_take(cameras)
 		if(!C)
 			break
@@ -9,4 +9,4 @@
 			continue
 		if(C.status)
 			C.toggle_cam(null, FALSE)
-		iterations *= 2.5
+		iterations *= 2

--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -1,0 +1,12 @@
+/datum/event/camera_failure/start()
+	var/iterations = 1
+	var/list/cameras = GLOB.cameranet.cameras.Copy()
+	while(prob(round(100 / iterations)))
+		var/obj/machinery/camera/C = pick_n_take(cameras)
+		if(!C)
+			break
+		if(!("SS13" in C.network))
+			continue
+		if(C.status)
+			C.toggle_cam(null, FALSE)
+		iterations *= 2.5

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -140,7 +140,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			50,		list(ASSIGNMENT_MEDICAL = 25), TRUE)
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			50,		list(ASSIGNMENT_MEDICAL = 25), TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Failure",	/datum/event/camera_failure,		100)
 	)
 
 /datum/event_container/moderate

--- a/paradise.dme
+++ b/paradise.dme
@@ -1619,6 +1619,7 @@
 #include "code\modules\events\apc_short.dm"
 #include "code\modules\events\blob_spawn.dm"
 #include "code\modules\events\brand_intelligence.dm"
+#include "code\modules\events\camerafailure.dm"
 #include "code\modules\events\carp_migration.dm"
 #include "code\modules\events\communications_blackout.dm"
 #include "code\modules\events\disease_outbreak.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Originally added by https://github.com/tgstation/tgstation/pull/9802
Adds the camera failure event, mundane (weight = 100) that is going to disable between 1 to 3 cameras the station has.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The mundane events are the most common and frequent ones, because of that we would benefit from having a bigger list of options to increase the variety in our rounds.
Having some cameras being disabled during the round would create work for the engineers and not make obvious that a camera that wasnt disabled roundstart was product of sabotage.

## Testing
<!-- How did you test the PR, if at all? -->
- Forced the event to trigger and verified it happening, with 1 to 3 cameras, with a few debugging tools
## Changelog
:cl: Henri237, theOperand
add: Added the camera failure event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
