### PR TITLE
Fixes chasms showing lattice or lava when affected by an explosion

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -76,6 +76,9 @@
 		return TRUE
 	return FALSE
 
+/turf/simulated/floor/chasm/ex_act(severity)
+	return
+
 /turf/simulated/floor/chasm/proc/drop_stuff(AM)
 	. = 0
 	if(find_safeties())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #19760.
Chasms will no longer be modified by explosions, as they are supposed to be... empty space.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Considering the existance of gibonite, it is not uncommon for explosions to happen next to chasms. Before they used to visually change into lattice/lava, which was dangerous as it was simply a (reportedly) visual change. You would still fall to your death if walking over the modfied tiles, giving you a false sense of security.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Go down to lavaland, find and kill a tendril.
- Gibonite gaming.
- Drop down a couple of big explosions just to be sure.
- All chasm tiles remain the same.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: GoR
fix: Chasms no longer show lattice/lava when blown up.
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
