### PR TITLE
Allows you to mute soundfiles from specific admins

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -288,6 +288,7 @@ CREATE TABLE `player` (
   `colourblind_mode` VARCHAR(48) NOT NULL DEFAULT 'None' COLLATE 'utf8mb4_general_ci',
   `keybindings` LONGTEXT COLLATE 'utf8mb4_unicode_ci' DEFAULT NULL,
   `server_region` VARCHAR(32) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
+  `muted_adminsounds_ckeys` MEDIUMTEXT NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`),
   KEY `lastseen` (`lastseen`),

--- a/SQL/updates/45-46.sql
+++ b/SQL/updates/45-46.sql
@@ -1,0 +1,4 @@
+# Updating SQL from 45 to 46 -AffectedArc07
+# Adds a way to mute soundfiles from specific admins
+ALTER TABLE `player`
+	ADD COLUMN `muted_adminsounds_ckeys` MEDIUMTEXT NULL DEFAULT NULL AFTER `server_region`;

--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -380,7 +380,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 45
+#define SQL_VERSION 46
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_EMPTY(sounds_cache)
 			uploaded_sound.volume = 100 * M.client.prefs.get_channel_volume(CHANNEL_ADMIN)
 
 			var/this_uid = M.client.UID()
-			to_chat(M, "<span class='boldannounce'>[ckey] played <code>[S]</code> (<a href='?src=[this_uid];action=silenceSound'>SILENCE</a>) (<a href='?src=[this_uid];action=muteAdmin&a=[ckey]'>MUTE THIS ADMIN</a>)</span>")
+			to_chat(M, "<span class='boldannounce'>[ckey] played <code>[S]</code> (<a href='?src=[this_uid];action=silenceSound'>SILENCE</a>) (<a href='?src=[this_uid];action=muteAdmin&a=[ckey]'>ALWAYS SILENCE THIS ADMIN</a>)</span>")
 			SEND_SOUND(M, uploaded_sound)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Global Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -26,14 +26,24 @@ GLOBAL_LIST_EMPTY(sounds_cache)
 	if(alert("Are you sure?\nSong: [S]\nNow you can also play this sound using \"Play Server Sound\".", "Confirmation request" ,"Play", "Cancel") == "Cancel")
 		return
 
+	if(holder.fakekey)
+		if(alert("Playing this sound will expose your real ckey despite being in stealth mode. You sure?", "Double check" ,"Play", "Cancel") == "Cancel")
+			return
+
+
 	log_admin("[key_name(src)] played sound [S]")
 	message_admins("[key_name_admin(src)] played sound [S]", 1)
 
 	for(var/mob/M in GLOB.player_list)
 		if(M.client.prefs.sound & SOUND_MIDI)
+			if(ckey in M.client.prefs.admin_sound_ckey_ignore)
+				continue // This player has this admin muted
 			if(isnewplayer(M) && (M.client.prefs.sound & SOUND_LOBBY))
 				M.stop_sound_channel(CHANNEL_LOBBYMUSIC)
 			uploaded_sound.volume = 100 * M.client.prefs.get_channel_volume(CHANNEL_ADMIN)
+
+			var/this_uid = M.client.UID()
+			to_chat(M, "<span class='boldannounce'>[ckey] played <code>[S]</code> (<a href='?src=[this_uid];action=silenceSound'>SILENCE</a>) (<a href='?src=[this_uid];action=muteAdmin&a=[ckey]'>MUTE THIS ADMIN</a>)</span>")
 			SEND_SOUND(M, uploaded_sound)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Global Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -181,7 +181,7 @@
 		if("muteAdmin")
 			usr.stop_sound_channel(CHANNEL_ADMIN)
 			prefs.admin_sound_ckey_ignore |= href_list["a"]
-			to_chat(usr, "You will no longer head admin playsounds from <code>[href_list["a"]]</code>. To remove them, go to Preferences --&gt; <code>Manage Admin Sound Mutes</code>.")
+			to_chat(usr, "You will no longer hear admin playsounds from <code>[href_list["a"]]</code>. To remove them, go to Preferences --&gt; <code>Manage Admin Sound Mutes</code>.")
 			prefs.save_preferences(src)
 			return
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -172,6 +172,18 @@
 	switch(href_list["action"])
 		if("openLink")
 			src << link(href_list["link"])
+			return
+
+		if("silenceSound")
+			usr.stop_sound_channel(CHANNEL_ADMIN)
+			return
+
+		if("muteAdmin")
+			usr.stop_sound_channel(CHANNEL_ADMIN)
+			prefs.admin_sound_ckey_ignore |= href_list["a"]
+			to_chat(usr, "You will no longer head admin playsounds from <code>[href_list["a"]]</code>. To remove them, go to Preferences --&gt; <code>Manage Admin Sound Mutes</code>.")
+			prefs.save_preferences(src)
+			return
 
 	//fun fact: Topic() acts like a verb and is executed at the end of the tick like other verbs. So we have to queue it if the server is
 	//overloaded

--- a/code/modules/client/login_processing/10-load_preferences.dm
+++ b/code/modules/client/login_processing/10-load_preferences.dm
@@ -27,7 +27,8 @@
 		ghost_darkness_level,
 		colourblind_mode,
 		keybindings,
-		server_region
+		server_region,
+		muted_adminsounds_ckeys
 		FROM player
 		WHERE ckey=:ckey"}, list(
 			"ckey" = C.ckey

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -126,6 +126,8 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	var/list/keybindings_overrides = null
 	/// Player's region override for routing optimisation
 	var/server_region = null
+	/// List of admin ckeys this player wont hear sounds from
+	var/list/admin_sound_ckey_ignore = list()
 
 /datum/preferences/New(client/C, datum/db_query/Q) // Process our query
 	parent = C

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -3,6 +3,7 @@
 	// Check ../login_processing/10-load_preferences.dm
 
 	//general preferences
+	var/raw_muted_admins
 	while(query.NextRow())
 		ooccolor = query.item[1]
 		UI_style = query.item[2]
@@ -27,6 +28,7 @@
 		colourblind_mode = query.item[21]
 		keybindings = init_keybindings(raw = query.item[22])
 		server_region = query.item[23]
+		raw_muted_admins = query.item[24]
 
 	lastchangelog_2 = lastchangelog // Clone please
 
@@ -49,6 +51,12 @@
 	screentip_color = sanitize_hexcolor(screentip_color, initial(screentip_color))
 	ghost_darkness_level = sanitize_integer(ghost_darkness_level, 0, 255, initial(ghost_darkness_level))
 	colourblind_mode = sanitize_inlist(colourblind_mode, list(COLOURBLIND_MODE_NONE, COLOURBLIND_MODE_DEUTER, COLOURBLIND_MODE_PROT, COLOURBLIND_MODE_TRIT), COLOURBLIND_MODE_NONE)
+
+	if(length(raw_muted_admins))
+		try
+			admin_sound_ckey_ignore = json_decode(raw_muted_admins)
+		catch
+			admin_sound_ckey_ignore = list() // Invalid JSON, handle safely please
 
 	// Sanitize the region
 	if(!(server_region in GLOB.configuration.system.region_map))
@@ -89,7 +97,8 @@
 		ghost_darkness_level=:ghost_darkness_level,
 		colourblind_mode=:colourblind_mode,
 		keybindings=:keybindings,
-		server_region=:server_region
+		server_region=:server_region,
+		muted_adminsounds_ckeys=:muted_adminsounds_ckeys
 		WHERE ckey=:ckey"}, list(
 			// OH GOD THE PARAMETERS
 			"ooccolour" = ooccolor,
@@ -115,6 +124,7 @@
 			"keybindings" = json_encode(keybindings_overrides),
 			"ckey" = C.ckey,
 			"server_region" = server_region,
+			"muted_adminsounds_ckeys" = json_encode(admin_sound_ckey_ignore),
 		))
 
 	if(!query.warn_execute())

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -373,3 +373,20 @@
 	prefs.toggles2 ^= PREFTOGGLE_2_DANCE_DISCO
 	prefs.save_preferences(src)
 	to_chat(usr, "You will [(prefs.toggles2 & PREFTOGGLE_2_DANCE_DISCO) ? "now" : "no longer"] dance to the radiant dance machine.")
+
+/client/verb/manage_adminsound_mutes()
+	set name = "Manage Admin Sound Mutes"
+	set category = "Preferences"
+	set desc = "Manage admins that you wont hear played audio from"
+
+	if(!length(prefs.admin_sound_ckey_ignore))
+		to_chat(usr, "You have no admins with muted sounds.")
+		return
+
+	var/choice  = input(usr, "Select an admin to unmute sounds from.", "Pick an admin") as null|anything in prefs.admin_sound_ckey_ignore
+	if(!choice)
+		return
+
+	prefs.admin_sound_ckey_ignore -= choice
+	to_chat(usr, "You will now hear sounds from <code>[choice]</code> again.")
+	prefs.save_preferences(src)

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -145,7 +145,7 @@ ipc_screens = [
 # Enable/disable the database on a whole
 sql_enabled = false
 # SQL version. If this is a mismatch, round start will be delayed
-sql_version = 45
+sql_version = 46
 # SQL server address. Can be an IP or DNS name
 sql_address = "127.0.0.1"
 # SQL server port


### PR DESCRIPTION
## What Does This PR Do
Allows players to see which admin played a soundfile, as well as the option to mute sounds from that specific admin without disabling the entire system.

![image](https://user-images.githubusercontent.com/25063394/223221973-f6036616-c98e-48dc-b21c-40151d1d78d7.png)


## Why It's Good For The Game
I wont beat about the bush, there are some admins who only play shitposts with the playsound feature. This lets players ignore sounds from said people while not having to disable the entire system.

## Testing
- Played a soundfile with no mute (heard it)
- Played a soundfile with a mute (did not hear it)
- Saving and loading the preference worked
- Removing admins from the mutelist works

## Changelog
:cl: AffectedArc07
add: Added the ability to silence admin soundfiles from specific admins without disabling the entire system
/:cl:

---

# Sidenote ramble

Stop calling them admin MIDIs. 99% of plays arent even MIDIs, MIDIs dont even make sound on their own, its just a way of storing note data. This hurts the inner music nerd in me and I am tired of it. 