### PR TITLE
Fixes some tool interactions for IPC surgeries

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -52,7 +52,7 @@
 		/datum/surgery_step/robotics/external/unscrew_hatch,
 		/datum/surgery_step/robotics/external/open_hatch,
 		/datum/surgery_step/proxy/cavity_manipulation/robotic,
-		/datum/surgery_step/cavity/close_space,
+		/datum/surgery_step/cavity/close_space/synth,
 		/datum/surgery_step/robotics/external/close_hatch
 	)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN)
@@ -199,6 +199,15 @@
 	)
 
 	return SURGERY_STEP_CONTINUE
+
+/datum/surgery_step/cavity/close_space/synth
+	name = "seal cavity"
+	allowed_tools = list(
+		TOOL_WELDER = 100,
+		/obj/item/scalpel/laser = 60,
+		TOOL_CAUTERY = 50,
+		/obj/item/lighter = 30,
+	)
 
 
 /datum/surgery_step/cavity/remove_item

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -21,7 +21,7 @@
 		/datum/surgery_step/robotics/external/unscrew_hatch,
 		/datum/surgery_step/robotics/external/open_hatch,
 		/datum/surgery_step/proxy/robotics/repair_limb,
-		/datum/surgery_step/extract_implant,
+		/datum/surgery_step/extract_implant/synth,
 		/datum/surgery_step/robotics/external/close_hatch
 	)
 	requires_organic_bodypart = FALSE
@@ -97,3 +97,7 @@
 			"<span class='notice'>You could not find anything inside [target]'s [affected.name].</span>"
 		)
 	return SURGERY_STEP_CONTINUE
+
+/datum/surgery_step/extract_implant/synth
+	allowed_tools = list(TOOL_WIRECUTTER = 100, TOOL_HEMOSTAT = 60)
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20578.

Bio-chip removal now uses **wirecutters** to remove implants, instead of a hemostat or crowbar.
Sealing up a cavity implant now uses a welder as the primary tool, with a cautery still working as a ghetto tool.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Surgeries should be consistent and not buggy, especially for robotics.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested surgeries on a created IPC, worked properly.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: IPC bio-chip removal now uses wirecutters on the removal step.
fix: Sealing an IPC's cavity implant now properly uses a welder as the primary tool, with cautery working as a ghetto tool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
