### PR TITLE
Vendor head squishes now use more consistent gib colors

### DIFF
--- a/code/game/machinery/vendors/vendor_crits.dm
+++ b/code/game/machinery/vendors/vendor_crits.dm
@@ -95,7 +95,13 @@
 	var/obj/item/organ/internal/brain/B = victim.get_int_organ_tag("brain")
 	if(H)
 		victim.visible_message("<span class='danger'>[H] gets crushed under [machine], and explodes in a shower of gore!</span>", "<span class='userdanger'>Oh f-</span>")
-		new /obj/effect/gibspawner/human(get_turf(victim))
+		var/gibspawner = /obj/effect/gibspawner/human
+		if(ismachineperson(victim))
+			gibspawner = /obj/effect/gibspawner/robot
+		else if(isalien(victim))
+			gibspawner = /obj/effect/gibspawner/xeno
+
+		new gibspawner(get_turf(victim))
 		H.drop_organs()
 		H.droplimb(TRUE)
 		H.disfigure()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Uses the correct gib spawners when someone gets their head squished by a vending machine, with IPCs exploding into a shower of robot parts. Fixes #20571.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Even if you squish them under a vending machine, IPCs should not explode into a shower of gore.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
splat
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Squished IPC heads under vending machines no longer conjure mystery human gibs, but instead create robo gibs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
