### PR TITLE
Balances skeletons by adding a subtype

### DIFF
--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -220,7 +220,6 @@
 #define isplasmaman(A) (is_species(A, /datum/species/plasmaman))
 #define isshadowperson(A) (is_species(A, /datum/species/shadow))
 #define isskeleton(A) (is_species(A, /datum/species/skeleton))
-#define isbrittleskeleton(A) (is_species(A, /datum/species/skeleton/brittle))
 #define ishumanbasic(A) (is_species(A, /datum/species/human))
 #define isunathi(A) (is_species(A, /datum/species/unathi))
 #define istajaran(A) (is_species(A, /datum/species/tajaran))

--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -220,6 +220,7 @@
 #define isplasmaman(A) (is_species(A, /datum/species/plasmaman))
 #define isshadowperson(A) (is_species(A, /datum/species/shadow))
 #define isskeleton(A) (is_species(A, /datum/species/skeleton))
+#define isbrittleskeleton(A) (is_species(A, /datum/species/skeleton/brittle))
 #define ishumanbasic(A) (is_species(A, /datum/species/human))
 #define isunathi(A) (is_species(A, /datum/species/unathi))
 #define istajaran(A) (is_species(A, /datum/species/tajaran))

--- a/code/datums/components/spooky.dm
+++ b/code/datums/components/spooky.dm
@@ -34,7 +34,7 @@
 /datum/component/spooky/proc/spectral_change(mob/living/carbon/human/H, mob/user)
 	if((H.getStaminaLoss() > 95) && (!istype(H.dna.species, /datum/species/diona) && !istype(H.dna.species, /datum/species/machine) && !istype(H.dna.species, /datum/species/slime) && !istype(H.dna.species, /datum/species/golem) && !istype(H.dna.species, /datum/species/plasmaman) && !istype(H.dna.species, /datum/species/skeleton)))
 		H.Stun(40 SECONDS)
-		H.set_species(/datum/species/skeleton)
+		H.set_species(/datum/species/skeleton) //Makes the OP skelly
 		H.visible_message("<span class='warning'>[H] has given up on life as a mortal.</span>")
 		var/T = get_turf(H)
 		if(too_spooky)

--- a/code/datums/components/spooky.dm
+++ b/code/datums/components/spooky.dm
@@ -34,7 +34,7 @@
 /datum/component/spooky/proc/spectral_change(mob/living/carbon/human/H, mob/user)
 	if((H.getStaminaLoss() > 95) && (!istype(H.dna.species, /datum/species/diona) && !istype(H.dna.species, /datum/species/machine) && !istype(H.dna.species, /datum/species/slime) && !istype(H.dna.species, /datum/species/golem) && !istype(H.dna.species, /datum/species/plasmaman) && !istype(H.dna.species, /datum/species/skeleton)))
 		H.Stun(40 SECONDS)
-		H.set_species(/datum/species/skeleton) //Makes the OP skelly
+		H.set_species(/datum/species/skeleton) // Makes the OP skelly
 		H.visible_message("<span class='warning'>[H] has given up on life as a mortal.</span>")
 		var/T = get_turf(H)
 		if(too_spooky)

--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -69,7 +69,7 @@
 
 			lich.real_name = M.mind.name
 			M.mind.transfer_to(lich)
-			lich.set_species(/datum/species/skeleton)
+			lich.set_species(/datum/species/skeleton/lich) //Wizard variant
 			to_chat(lich, "<span class='warning'>Your bones clatter and shutter as they're pulled back into this world!</span>")
 			cooldown_handler.recharge_duration += 1 MINUTES
 			var/mob/old_body = current_body
@@ -121,7 +121,7 @@
 				current_body = M.mind.current
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
-					H.set_species(/datum/species/skeleton)
+					H.set_species(/datum/species/skeleton/lich)
 					H.unEquip(H.wear_suit)
 					H.unEquip(H.head)
 					H.unEquip(H.shoes)

--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -69,7 +69,7 @@
 
 			lich.real_name = M.mind.name
 			M.mind.transfer_to(lich)
-			lich.set_species(/datum/species/skeleton/lich) //Wizard variant
+			lich.set_species(/datum/species/skeleton/lich) // Wizard variant
 			to_chat(lich, "<span class='warning'>Your bones clatter and shutter as they're pulled back into this world!</span>")
 			cooldown_handler.recharge_duration += 1 MINUTES
 			var/mob/old_body = current_body

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -704,7 +704,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	if(heresy)
 		spawnheresy(M)//oh god why
 	else
-		M.set_species(/datum/species/skeleton)
+		M.set_species(/datum/species/skeleton) //OP skellybones
 		M.visible_message("<span class = 'warning'> A massive amount of flesh sloughs off [M] and a skeleton rises up!</span>")
 		M.grab_ghost() // yoinks the ghost if its not in the body
 		M.revive()

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -704,7 +704,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	if(heresy)
 		spawnheresy(M)//oh god why
 	else
-		M.set_species(/datum/species/skeleton) //OP skellybones
+		M.set_species(/datum/species/skeleton) // OP skellybones
 		M.visible_message("<span class = 'warning'> A massive amount of flesh sloughs off [M] and a skeleton rises up!</span>")
 		M.grab_ghost() // yoinks the ghost if its not in the body
 		M.revive()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -544,13 +544,14 @@
 /obj/effect/mob_spawn/human/skeleton
 	name = "skeletal remains"
 	mob_name = "skeleton"
-	mob_species = /datum/species/skeleton
+	mob_species = /datum/species/skeleton/brittle
 	mob_gender = NEUTER
 
 /obj/effect/mob_spawn/human/skeleton/alive
 	death = FALSE
 	roundstart = FALSE
 	icon = 'icons/effects/blood.dmi'
+	mob_species = /datum/species/skeleton
 	icon_state = "remains"
 	description = "Be a spooky scary skeleton."	//not mapped in anywhere so admin spawner, who knows what they'll use this for.
 	flavour_text = "By unknown powers, your skeletal remains have been reanimated! Walk this mortal plain and terrorize all living adventurers who dare cross your path."

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -94,6 +94,9 @@
 /mob/living/carbon/human/skeleton/Initialize(mapload)
 	. = ..(mapload, /datum/species/skeleton)
 
+/mob/living/carbon/human/skeleton/lich/Initialize(mapload)
+	. = ..(mapload, /datum/species/skeleton/lich)
+
 /mob/living/carbon/human/skeleton/brittle/Initialize(mapload)
 	. = ..(mapload, /datum/species/skeleton/brittle)
 

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -94,6 +94,9 @@
 /mob/living/carbon/human/skeleton/Initialize(mapload)
 	. = ..(mapload, /datum/species/skeleton)
 
+/mob/living/carbon/human/skeleton/brittle/Initialize(mapload)
+	. = ..(mapload, /datum/species/skeleton/brittle)
+
 /mob/living/carbon/human/kidan/Initialize(mapload)
 	. = ..(mapload, /datum/species/kidan)
 

--- a/code/modules/mob/living/carbon/human/species/skeleton_species.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton_species.dm
@@ -35,7 +35,7 @@
 
 	/// How much brute and burn does milk heal per handle_reagents()
 	var/milk_heal_amount = 4
-	// How likely (in %) are we to heal a fracture?
+	/// How likely (in %) are we to heal a fracture?
 	var/milk_fracture_repair_probability = 5
 
 /datum/species/skeleton/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)

--- a/code/modules/mob/living/carbon/human/species/skeleton_species.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton_species.dm
@@ -1,7 +1,7 @@
 /// The OG skellybones, quite OP. As of this comment, only available through ash-drake loot (2023-03-07)
 /datum/species/skeleton
-	name = "Skeleton"
-	name_plural = "Skeletons"
+	name = "Ancient Skeleton"
+	name_plural = "Ancient Skeletons"
 
 	blurb = "Spoopy and scary."
 

--- a/code/modules/mob/living/carbon/human/species/skeleton_species.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton_species.dm
@@ -1,3 +1,4 @@
+/// The OG skellybones, quite OP. As of this comment, only available through ash-drake loot (2023-03-07)
 /datum/species/skeleton
 	name = "Skeleton"
 	name_plural = "Skeletons"
@@ -53,9 +54,15 @@
 
 	return ..()
 
+/// Wizard subtype, subtype to allow balancing separately from other skellies
+/datum/species/skeleton/lich
+	name = "Lich"
+	name_plural = "Liches"
+
+/// The most common (and weakest) type, legion corpses and skeleton map spawners are these
 /datum/species/skeleton/brittle
 	name = "Brittle Skeleton"
 	name_plural = "Brittle Skeletons"
 	inherent_traits = list(TRAIT_RESISTHEAT, TRAIT_NOBREATH, TRAIT_RESISTHIGHPRESSURE, TRAIT_RADIMMUNE, TRAIT_PIERCEIMMUNE, TRAIT_NOHUNGER, TRAIT_XENO_IMMUNE)
-	milk_heal_amount = 1
-	milk_fracture_repair_probability = 1
+	milk_heal_amount = 0.66 //on par with saline-glucose (after averaging that out)
+	milk_fracture_repair_probability = 0 //no bone juice here

--- a/code/modules/mob/living/carbon/human/species/skeleton_species.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton_species.dm
@@ -32,11 +32,16 @@
 		"brain" = /obj/item/organ/internal/brain/golem,
 	) //Has default darksight of 2.
 
+	/// How much brute and burn does milk heal per handle_reagents()
+	var/milk_heal_amount = 4
+	// How likely (in %) are we to heal a fracture?
+	var/milk_fracture_repair_probability = 5
+
 /datum/species/skeleton/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	// Crazylemon is still silly
 	if(R.id == "milk")
-		H.heal_overall_damage(4, 4)
-		if(prob(5)) // 5% chance per proc to find a random limb, and mend it
+		H.heal_overall_damage(milk_heal_amount, milk_heal_amount)
+		if(prob(milk_fracture_repair_probability)) // 5% chance per proc to find a random limb, and mend it
 			var/list/our_organs = H.bodyparts.Copy()
 			shuffle(our_organs)
 			for(var/obj/item/organ/external/L in our_organs)
@@ -47,3 +52,11 @@
 		return TRUE
 
 	return ..()
+
+/datum/species/skeleton/brittle
+	name = "Brittle Skeleton"
+	name_plural = "Brittle Skeletons"
+	blurb = "Spoopy and scary."
+	inherent_traits = list(TRAIT_RESISTHEAT, TRAIT_NOBREATH, TRAIT_RESISTHIGHPRESSURE, TRAIT_RADIMMUNE, TRAIT_PIERCEIMMUNE, TRAIT_NOHUNGER, TRAIT_XENO_IMMUNE)
+	milk_heal_amount = 1
+	milk_fracture_repair_probability = 1

--- a/code/modules/mob/living/carbon/human/species/skeleton_species.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton_species.dm
@@ -56,7 +56,6 @@
 /datum/species/skeleton/brittle
 	name = "Brittle Skeleton"
 	name_plural = "Brittle Skeletons"
-	blurb = "Spoopy and scary."
 	inherent_traits = list(TRAIT_RESISTHEAT, TRAIT_NOBREATH, TRAIT_RESISTHIGHPRESSURE, TRAIT_RADIMMUNE, TRAIT_PIERCEIMMUNE, TRAIT_NOHUNGER, TRAIT_XENO_IMMUNE)
 	milk_heal_amount = 1
 	milk_fracture_repair_probability = 1

--- a/code/modules/mob/living/carbon/human/species/skeleton_species.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton_species.dm
@@ -64,5 +64,5 @@
 	name = "Brittle Skeleton"
 	name_plural = "Brittle Skeletons"
 	inherent_traits = list(TRAIT_RESISTHEAT, TRAIT_NOBREATH, TRAIT_RESISTHIGHPRESSURE, TRAIT_RADIMMUNE, TRAIT_PIERCEIMMUNE, TRAIT_NOHUNGER, TRAIT_XENO_IMMUNE)
-	milk_heal_amount = 0.66 //on par with saline-glucose (after averaging that out)
+	milk_heal_amount = 0.66 // On par with saline-glucose (after averaging that out)
 	milk_fracture_repair_probability = 0 //no bone juice here

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -327,7 +327,7 @@
 	mob_name = "ashen skeleton"
 	mob_gender = NEUTER
 	husk = FALSE
-	mob_species = /datum/species/skeleton
+	mob_species = /datum/species/skeleton/brittle
 	mob_color = "#454545"
 
 //Legion infested mobs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Companion and partial alternative to https://github.com/ParadiseSS13/Paradise/pull/20528
Adds brittle skeletons, a less powerful version that is more common.
Brittle skeletons heal 0.66 brute and burn per tick with milk (same as salglu when taken on average), as opposed to 4. They have no chance of healing a fracture, down from 5%. They do not have inherent low pressure or cold resistance, making spacewalks more difficult.

Adds lich skeleton, a subtype now used in wizard stuff to make it easier for balance tweaks in future.

Renames OG skeleton species to "Ancient Skeleton" to make it clearer that these things are stronk

Lavaland ashen skeleton corpses are now the brittle variant.
Roundstart dead skeleton spawners are now the brittle variant.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Getting an envy's knife or being a changeling usually means free access to lavaland skeletons that are quite strong.
This PR means users can still be goofy skeletons if they wish, just a less strong variant.
The original, stronger, skeleton variant is still available as ash drake loot and for wizards in various forms.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Doot
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Changed some common skeleton mobs to be a weaker subtype for balance reasons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
