### PR TITLE
Makes transparent mineral doors work

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -164,9 +164,12 @@
 	opacity = FALSE
 	rad_insulation = RAD_VERY_LIGHT_INSULATION
 
-/obj/structure/mineral_door/transparent/operate()
-	..()
-	set_opacity(0)
+/obj/structure/mineral_door/transparent/operate_update()
+	density = !density
+	state_open = !state_open
+	air_update_turf(1)
+	update_icon(UPDATE_ICON_STATE)
+	is_operating = FALSE
 
 /obj/structure/mineral_door/transparent/plasma
 	name = "plasma door"

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -167,7 +167,7 @@
 /obj/structure/mineral_door/transparent/operate_update()
 	density = !density
 	state_open = !state_open
-	air_update_turf(1)
+	air_update_turf(TRUE)
 	update_icon(UPDATE_ICON_STATE)
 	is_operating = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes transparent mineral doors. Previously they would start out transparent and be transparent whenever opening or closing actively, but the moment that they opened the first time their opacity would be set to opaque and thus whenever closed OR open they would be opaque. This was because opacity was simply inverted at the END of closing the door and transparent doors were set specifically to be transparent while opening, leading to a confusing result. To fix this, they're just always transparent now, as I assume was intended by the fact that they're called transparent 👍.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes diamond and plasma doors from being very very weird.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/71326864/223621085-3f3f195c-46cb-49b3-8a46-d6c4d5d24c8a.png)
## Testing
<!-- How did you test the PR, if at all? -->
Above image.
## Changelog
:cl:
fix: Fixed transparent mineral doors from becoming opaque whenever opened or closed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
