### PR TITLE
Syndie depot NPCs do not point at their fallen targets

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -182,7 +182,6 @@
 				continue
 			say("Target [body]... terminated.")
 			depotarea.list_add(body, depotarea.dead_list)
-			pointed(body)
 	else
 		scan_cycles++
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the point from the syndie depot NPC AI routine.

## Why It's Good For The Game
The verb queue system isn't meant for NPCs, and will throw a stack trace. Also, they're rude.

## Testing
Got killed by depot NPCs.

## Changelog
:cl:
tweak: Syndie depot NPCs do not point at targets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
