### PR TITLE
cleans up some giant spider code, moves verbs to action buttons

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -231,7 +231,7 @@
 		visible_message("<span class='notice'>[src] begins to secrete a sticky substance around [cocoon_target].</span>")
 		stop_automated_movement = TRUE
 		walk(src, 0)
-		if(!do_after_once(src, 5 SECONDS, target = cocoon_target, attempt_cancel_message = "You stop wrapping the [cocoon_target]."))
+		if(!do_after_once(src, 5 SECONDS, target = cocoon_target, attempt_cancel_message = "You stop wrapping [cocoon_target]."))
 			return
 		if(cocoon_target && isturf(cocoon_target.loc) && get_dist(src, cocoon_target) <= 1)
 			var/obj/structure/spider/cocoon/C = new(cocoon_target.loc)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -254,7 +254,7 @@
 					continue
 				if(L.stat != DEAD)
 					continue
-				large_cocoon = 1
+				large_cocoon = TRUE
 				L.loc = C
 				C.pixel_x = L.pixel_x
 				C.pixel_y = L.pixel_y

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -233,7 +233,7 @@
 		walk(src, 0)
 		if(!do_after_once(src, 5 SECONDS, target = cocoon_target, attempt_cancel_message = "You stop wrapping the [cocoon_target]."))
 			return
-		if(cocoon_target && isturf(cocoon_target.loc) && get_dist(src,cocoon_target) <= 1)
+		if(cocoon_target && isturf(cocoon_target.loc) && get_dist(src, cocoon_target) <= 1)
 			var/obj/structure/spider/cocoon/C = new(cocoon_target.loc)
 			var/large_cocoon = 0
 			C.pixel_x = cocoon_target.pixel_x

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -244,7 +244,7 @@
 			for(var/obj/structure/S in C.loc)
 				if(!S.anchored)
 					S.loc = C
-					large_cocoon = 1
+					large_cocoon = TRUE
 			for(var/obj/machinery/M in C.loc)
 				if(!M.anchored)
 					M.loc = C

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -258,7 +258,7 @@
 				C.pixel_x = L.pixel_x
 				C.pixel_y = L.pixel_y
 				fed++
-				visible_message("<span class='danger'>\the [src] sticks a proboscis into \the [L] and sucks a viscous substance out.</span>")
+				visible_message("<span class='danger'>[src] sticks a proboscis into [L] and sucks a viscous substance out.</span>")
 
 				break
 			if(large_cocoon)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -236,7 +236,7 @@
 			return
 		if(cocoon_target && isturf(cocoon_target.loc) && get_dist(src, cocoon_target) <= 1)
 			var/obj/structure/spider/cocoon/C = new(cocoon_target.loc)
-			var/large_cocoon = 0
+			var/large_cocoon = FALSE
 			C.pixel_x = cocoon_target.pixel_x
 			C.pixel_y = cocoon_target.pixel_y
 			for(var/obj/item/I in C.loc)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -202,8 +202,6 @@
 		return
 	new /obj/structure/spider/stickyweb(T)
 	stop_automated_movement = FALSE
-
-
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/wrap_target()
 	if(!cocoon_target)
 		var/list/choices = list()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -278,7 +278,7 @@
 	stop_automated_movement = TRUE
 	if(!do_after_once(src, 4 SECONDS, target = loc, attempt_cancel_message = "You stop laying eggs."))
 		return
-	var/obj/structure/spider/eggcluster/C = new /obj/structure/spider/eggcluster(src.loc)
+	var/obj/structure/spider/eggcluster/C = new /obj/structure/spider/eggcluster(loc)
 	C.faction = faction.Copy()
 	C.master_commander = master_commander
 	C.xenobiology_spawned = xenobiology_spawned

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -122,7 +122,7 @@
 
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/GiveUp(C)
 	spawn(100)
-		if(cocoon_target == C && get_dist(src,cocoon_target) > 1)
+		if(cocoon_target == C && get_dist(src, cocoon_target) > 1)
 			cocoon_target = null
 		stop_automated_movement = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -38,7 +38,16 @@
 	attack_sound = 'sound/weapons/bite.ogg'
 	gold_core_spawnable = HOSTILE_SPAWN
 	var/venom_per_bite = 0 // While the /poison/ type path remains as-is for consistency reasons, we're really talking about venom, not poison.
-	var/busy = 0
+
+/mob/living/simple_animal/hostile/poison/giant_spider/Initialize(mapload)
+	. = ..()
+	var/datum/action/innate/web_giant_spider/web_action = new()
+	web_action.Grant(src)
+
+/mob/living/simple_animal/hostile/poison/giant_spider/Destroy()
+	for(var/datum/action/innate/web_giant_spider/web_action in actions)
+		web_action.Remove(src)
+	return ..()
 
 /mob/living/simple_animal/hostile/poison/giant_spider/AttackingTarget()
 	// This is placed here, NOT on /poison, because the other subtypes of /poison/ already override AttackingTarget() completely, and as such it would do nothing but confuse people there.
@@ -72,6 +81,20 @@
 	var/atom/cocoon_target
 	var/fed = 0
 
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/Initialize(mapload)
+	. = ..()
+	var/datum/action/innate/wrap_giant_spider/wrap_action = new()
+	wrap_action.Grant(src)
+	var/datum/action/innate/lay_eggs_giant_spider/egg_action = new()
+	egg_action.Grant(src)
+
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/Destroy()
+	for(var/datum/action/innate/wrap_giant_spider/wrap_action in actions)
+		wrap_action.Remove(src)
+	for(var/datum/action/innate/lay_eggs_giant_spider/egg_action in actions)
+		egg_action.Remove(src)
+	return ..()
+
 //hunters have the most poison and move the fastest, so they can find prey
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter
 	desc = "Furry and black, it makes you shudder to look at it. This one has sparkling purple eyes."
@@ -89,7 +112,7 @@
 	. = ..()
 	if(AIStatus == AI_IDLE)
 		//1% chance to skitter madly away
-		if(!busy && prob(1))
+		if(prob(1))
 			stop_automated_movement = TRUE
 			Goto(pick(urange(20, src, 1)), move_to_delay)
 			spawn(50)
@@ -99,21 +122,18 @@
 
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/GiveUp(C)
 	spawn(100)
-		if(busy == MOVING_TO_TARGET)
-			if(cocoon_target == C && get_dist(src,cocoon_target) > 1)
-				cocoon_target = null
-			busy = 0
-			stop_automated_movement = FALSE
+		if(cocoon_target == C && get_dist(src,cocoon_target) > 1)
+			cocoon_target = null
+		stop_automated_movement = FALSE
 
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/handle_automated_movement() //Hacky and ugly.
 	if(..())
 		var/list/can_see = view(src, 10)
-		if(!busy && prob(30))	//30% chance to stop wandering and do something
+		if(prob(30))	//30% chance to stop wandering and do something
 			//first, check for potential food nearby to cocoon
 			for(var/mob/living/C in can_see)
 				if(C.stat && !istype(C, /mob/living/simple_animal/hostile/poison/giant_spider) && !C.anchored)
 					cocoon_target = C
-					busy = MOVING_TO_TARGET
 					Goto(C, move_to_delay)
 					//give up if we can't reach them after 10 seconds
 					GiveUp(C)
@@ -121,11 +141,11 @@
 			//second, spin a sticky spiderweb on this tile
 			var/obj/structure/spider/stickyweb/W = locate() in get_turf(src)
 			if(!W)
-				Web()
+				create_web()
 			else
 				//third, lay an egg cluster there
 				if(fed)
-					LayEggs()
+					lay_spider_eggs()
 				else
 					//fourthly, cocoon any nearby items so those pesky pinkskins can't use them
 					for(var/obj/O in can_see)
@@ -134,43 +154,57 @@
 
 						if(isitem(O) || isstructure(O) || ismachinery(O))
 							cocoon_target = O
-							busy = MOVING_TO_TARGET
 							stop_automated_movement = TRUE
 							Goto(O, move_to_delay)
 							//give up if we can't reach them after 10 seconds
 							GiveUp(O)
 
-		else if(busy == MOVING_TO_TARGET && cocoon_target)
+		else if(cocoon_target)
 			if(get_dist(src, cocoon_target) <= 1)
-				Wrap()
+				wrap_target()
 
 	else
-		busy = 0
 		stop_automated_movement = FALSE
 
-/mob/living/simple_animal/hostile/poison/giant_spider/verb/Web()
-	set name = "Lay Web"
-	set category = "Spider"
-	set desc = "Spread a sticky web to slow down prey."
+/datum/action/innate/web_giant_spider
+	name = "Lay Web"
+	icon_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "stickyweb1"
 
-	var/T = src.loc
+/datum/action/innate/web_giant_spider/Activate()
+	var/mob/living/simple_animal/hostile/poison/giant_spider/user = owner
+	user.create_web()
 
-	if(busy != SPINNING_WEB)
-		busy = SPINNING_WEB
-		src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance.</span>")
-		stop_automated_movement = TRUE
-		spawn(40)
-			if(busy == SPINNING_WEB && src.loc == T)
-				new /obj/structure/spider/stickyweb(T)
-			busy = 0
-			stop_automated_movement = FALSE
+/datum/action/innate/wrap_giant_spider
+	name = "Wrap"
+	icon_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "cocoon_large1"
+
+/datum/action/innate/wrap_giant_spider/Activate()
+	var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/user = owner
+	user.wrap_target()
+
+/datum/action/innate/lay_eggs_giant_spider
+	name = "Lay Eggs"
+	icon_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "eggs"
+
+/datum/action/innate/lay_eggs_giant_spider/Activate()
+	var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/user = owner
+	user.lay_spider_eggs()
+
+/mob/living/simple_animal/hostile/poison/giant_spider/proc/create_web()
+	var/T = loc
+
+	visible_message("<span class='notice'>[src] begins to secrete a sticky substance.</span>")
+	stop_automated_movement = TRUE
+	if(!do_after_once(src, 4 SECONDS, target = loc, attempt_cancel_message = "You stop spinning a web."))
+		return
+	new /obj/structure/spider/stickyweb(T)
+	stop_automated_movement = FALSE
 
 
-/mob/living/simple_animal/hostile/poison/giant_spider/nurse/verb/Wrap()
-	set name = "Wrap"
-	set category = "Spider"
-	set desc = "Wrap up prey to feast upon and objects for safe keeping."
-
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/wrap_target()
 	if(!cocoon_target)
 		var/list/choices = list()
 		for(var/mob/living/L in view(1, src))
@@ -195,74 +229,65 @@
 			to_chat(src, "<span class='warning'>No suitable dead prey or wrappable objects found nearby.")
 			return
 
-	if(cocoon_target && busy != SPINNING_COCOON)
-		busy = SPINNING_COCOON
-		src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance around \the [cocoon_target].</span>")
+	if(cocoon_target)
+		visible_message("<span class='notice'>[src] begins to secrete a sticky substance around [cocoon_target].</span>")
 		stop_automated_movement = TRUE
-		walk(src,0)
-		spawn(50)
-			if(busy == SPINNING_COCOON)
-				if(cocoon_target && isturf(cocoon_target.loc) && get_dist(src,cocoon_target) <= 1)
-					var/obj/structure/spider/cocoon/C = new(cocoon_target.loc)
-					var/large_cocoon = 0
-					C.pixel_x = cocoon_target.pixel_x
-					C.pixel_y = cocoon_target.pixel_y
-					for(var/obj/item/I in C.loc)
-						I.loc = C
-					for(var/obj/structure/S in C.loc)
-						if(!S.anchored)
-							S.loc = C
-							large_cocoon = 1
-					for(var/obj/machinery/M in C.loc)
-						if(!M.anchored)
-							M.loc = C
-							large_cocoon = 1
-					for(var/mob/living/L in C.loc)
-						if(istype(L, /mob/living/simple_animal/hostile/poison/giant_spider))
-							continue
-						if(L.stat != DEAD)
-							continue
-						large_cocoon = 1
-						L.loc = C
-						C.pixel_x = L.pixel_x
-						C.pixel_y = L.pixel_y
-						fed++
-						visible_message("<span class='danger'>\the [src] sticks a proboscis into \the [L] and sucks a viscous substance out.</span>")
+		walk(src, 0)
+		if(!do_after_once(src, 5 SECONDS, target = cocoon_target, attempt_cancel_message = "You stop wrapping the [cocoon_target]."))
+			return
+		if(cocoon_target && isturf(cocoon_target.loc) && get_dist(src,cocoon_target) <= 1)
+			var/obj/structure/spider/cocoon/C = new(cocoon_target.loc)
+			var/large_cocoon = 0
+			C.pixel_x = cocoon_target.pixel_x
+			C.pixel_y = cocoon_target.pixel_y
+			for(var/obj/item/I in C.loc)
+				I.loc = C
+			for(var/obj/structure/S in C.loc)
+				if(!S.anchored)
+					S.loc = C
+					large_cocoon = 1
+			for(var/obj/machinery/M in C.loc)
+				if(!M.anchored)
+					M.loc = C
+					large_cocoon = 1
+			for(var/mob/living/L in C.loc)
+				if(istype(L, /mob/living/simple_animal/hostile/poison/giant_spider))
+					continue
+				if(L.stat != DEAD)
+					continue
+				large_cocoon = 1
+				L.loc = C
+				C.pixel_x = L.pixel_x
+				C.pixel_y = L.pixel_y
+				fed++
+				visible_message("<span class='danger'>\the [src] sticks a proboscis into \the [L] and sucks a viscous substance out.</span>")
 
-						break
-					if(large_cocoon)
-						C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
-			cocoon_target = null
-			busy = 0
-			stop_automated_movement = FALSE
+				break
+			if(large_cocoon)
+				C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
+	cocoon_target = null
+	stop_automated_movement = FALSE
 
-/mob/living/simple_animal/hostile/poison/giant_spider/nurse/verb/LayEggs()
-	set name = "Lay Eggs"
-	set category = "Spider"
-	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
-
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/lay_spider_eggs()
 	var/obj/structure/spider/eggcluster/E = locate() in get_turf(src)
 	if(E)
 		to_chat(src, "<span class='notice'>There is already a cluster of eggs here!</span>")
-	else if(!fed)
+		return
+	if(!fed)
 		to_chat(src, "<span class='warning'>You are too hungry to do this!</span>")
-	else if(busy != LAYING_EGGS)
-		busy = LAYING_EGGS
-		src.visible_message("<span class='notice'>\the [src] begins to lay a cluster of eggs.</span>")
-		stop_automated_movement = TRUE
-		spawn(50)
-			if(busy == LAYING_EGGS)
-				E = locate() in get_turf(src)
-				if(!E)
-					var/obj/structure/spider/eggcluster/C = new /obj/structure/spider/eggcluster(src.loc)
-					C.faction = faction.Copy()
-					C.master_commander = master_commander
-					C.xenobiology_spawned = xenobiology_spawned
-					if(ckey)
-						C.player_spiders = TRUE
-					fed--
-			busy = 0
-			stop_automated_movement = FALSE
+		return
+	visible_message("<span class='notice'>[src] begins to lay a cluster of eggs.</span>")
+	stop_automated_movement = TRUE
+	if(!do_after_once(src, 4 SECONDS, target = loc, attempt_cancel_message = "You stop laying eggs."))
+		return
+	var/obj/structure/spider/eggcluster/C = new /obj/structure/spider/eggcluster(src.loc)
+	C.faction = faction.Copy()
+	C.master_commander = master_commander
+	C.xenobiology_spawned = xenobiology_spawned
+	if(ckey)
+		C.player_spiders = TRUE
+	fed--
+	stop_automated_movement = FALSE
 
 #undef SPINNING_WEB
 #undef LAYING_EGGS

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -248,7 +248,7 @@
 			for(var/obj/machinery/M in C.loc)
 				if(!M.anchored)
 					M.loc = C
-					large_cocoon = 1
+					large_cocoon = TRUE
 			for(var/mob/living/L in C.loc)
 				if(istype(L, /mob/living/simple_animal/hostile/poison/giant_spider))
 					continue

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -262,7 +262,7 @@
 
 				break
 			if(large_cocoon)
-				C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
+				C.icon_state = pick("cocoon_large1", "cocoon_large2", "cocoon_large3")
 	cocoon_target = null
 	stop_automated_movement = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -202,6 +202,7 @@
 		return
 	new /obj/structure/spider/stickyweb(T)
 	stop_automated_movement = FALSE
+
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/wrap_target()
 	if(!cocoon_target)
 		var/list/choices = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces a bunch of spawn() with do_after_once
Moves verbs to action buttons

## Why It's Good For The Game
Usability good, cleaner code good
Being able to use action buttons rather than verbs will more easily let players know they can actually use those said abilities. 

## Testing
Compiled and ran

## Changelog
:cl:
tweak: Giant spider verbs now use action buttons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
