### PR TITLE
fixes voice analyzer issues with clown´s different font speech

### DIFF
--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -28,7 +28,10 @@
 		return
 
 	if(listening)
-		recorded = msg
+		if(findtext(msg, "</span>"))
+			recorded = strip_html_properly("[msg]")
+		else
+			recorded = msg
 		recorded_type = type
 		listening = FALSE
 		var/turf/T = get_turf(src)	//otherwise it won't work in hand

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -29,7 +29,7 @@
 
 	if(listening)
 		if(findtext(msg, "</span>"))
-			recorded = strip_html_properly("[msg]")
+			recorded = strip_html_properly(msg)
 		else
 			recorded = msg
 		recorded_type = type


### PR DESCRIPTION
## What Does This PR Do
Fixes that when a clown sets a message for a voice analyzer the voice analyzer only activates when the clown says the message, no one else, and they said it EXACTLY the same as the set message

## Why It's Good For The Game
Fixes others not being able to interact with voice analyzers set by a clown and having to say it exactly the same is infruiating

## Testing
Recorded message as clown -> said something containing the recorded message as a clown -> it works
Recorded message as clown -> said something containing the recorded message as a non-clown -> it works
and vice versa

## Changelog
:cl:
fix: Fixed others not being able to activate voice analyzers set by a clown
fix: Fixed having to say a voice analyzers prerecorded message exactly the same in order for it to activate
/:cl: