### PR TITLE
most reagent dispensers are no longer automatically anchored

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -98,6 +98,7 @@
 	icon_state = "fuel"
 	reagent_id = "fuel"
 	tank_volume = 4000
+	anchored = TRUE
 	var/obj/item/assembly_holder/rig = null
 	var/accepts_rig = 1
 
@@ -299,7 +300,6 @@
 /obj/structure/reagent_dispensers/fueltank/chem
 	icon_state = "fuel_chem"
 	can_be_unwrenched = FALSE
-	anchored = TRUE
 	density = FALSE
 	accepts_rig = FALSE
 	tank_volume = 1000

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -240,6 +240,7 @@
 	icon_state = "water_cooler"
 	tank_volume = 500
 	reagent_id = "water"
+	anchored = TRUE
 	var/paper_cups = 25 //Paper cups left from the cooler
 
 /obj/structure/reagent_dispensers/water_cooler/examine(mob/user)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
 	density = TRUE
-	anchored = TRUE
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	container_type = DRAINABLE | AMOUNT_VISIBLE
 	max_integrity = 300
@@ -231,6 +230,7 @@
 	icon_state = "pepper"
 	density = FALSE
 	can_be_unwrenched = FALSE
+	anchored = TRUE
 	reagent_id = "condensedcapsaicin"
 
 /obj/structure/reagent_dispensers/water_cooler
@@ -274,12 +274,14 @@
 	All Captains carefully guard the disk needed to detonate them - at least, the sign says they do. There seems to be a tap on the back."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "nuclearbomb0"
+	anchored = TRUE
 
 /obj/structure/reagent_dispensers/virusfood
 	name = "virus food dispenser"
 	desc = "A dispenser of low-potency virus mutagenic."
 	icon_state = "virus_food"
 	can_be_unwrenched = FALSE
+	anchored = TRUE
 	density = FALSE
 	reagent_id = "virusfood"
 
@@ -288,6 +290,7 @@
 	desc = "Refills space cleaner bottles."
 	icon_state = "cleaner"
 	can_be_unwrenched = FALSE
+	anchored = TRUE
 	density = FALSE
 	tank_volume = 5000
 	reagent_id = "cleaner"
@@ -295,6 +298,7 @@
 /obj/structure/reagent_dispensers/fueltank/chem
 	icon_state = "fuel_chem"
 	can_be_unwrenched = FALSE
+	anchored = TRUE
 	density = FALSE
 	accepts_rig = FALSE
 	tank_volume = 1000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
most reagent dispensers are no longer automatically anchored. This applies to stuff like the fuel tanks and water tanks in maintenance. This does not apply to wall dispensers or the beer keg (because it's funny). 


## Why It's Good For The Game
So this was changed in a previous PR that allowed these to be anchored. Honestly I don't think this needs to be the case anymore, people putting all the tanks in one fuckoff area was still an issue after the PR went through and only stopped being an issue later down the line, and environmental combat is cool. Slip stuns are thankfully no longer a thing so water is infinitely less annoying now as well. 

I don't think this will affect balance much except give people more options (like a perma escapee running from sec) in niche situations. 
## Testing
Compiled and ran
## Changelog
:cl:
tweak: most reagent dispensers are no longer automatically anchored
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
