### PR TITLE
Renames Strange Reagent to Lazarus Reagent

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -281,7 +281,7 @@
 				// Medchem
 				/obj/item/storage/pill_bottle/random_meds/labelled = 100, // random medical and other chems
 				/obj/item/reagent_containers/glass/bottle/reagent/omnizine = 50,
-				/obj/item/reagent_containers/glass/bottle/reagent/strange_reagent = 50,
+				/obj/item/reagent_containers/glass/bottle/reagent/lazarus_reagent = 50,
 
 				// Surgery
 				/obj/item/scalpel/laser/manager = 100,

--- a/code/game/objects/items/weapons/bee_briefcase.dm
+++ b/code/game/objects/items/weapons/bee_briefcase.dm
@@ -42,7 +42,7 @@
 				if(A.id == "blood")
 					if(!(A.data["donor"] in blood_list))
 						blood_list += A.data["donor"]
-				if(A.id == "strange_reagent")		//RELOAD THE BEES (1 bee per 1 unit, max 15 bees)
+				if(A.id == "lazarus_reagent")		//RELOAD THE BEES (1 bee per 1 unit, max 15 bees)
 					if(bees_left < 15)
 						bees_left = min(15, round((bees_left + A.volume), 1))	//No partial bees, max 15 bees in case at any given time
 						to_chat(user, "<span class='warning'>The buzzing inside the briefcase intensifies as new bees form inside.</span>")
@@ -65,7 +65,7 @@
 			next_sound = world.time + 90
 			playsound(loc, sound_file, 35)
 
-		//Release up to 5 bees per use. Without using strange reagent, that means two uses. WITH strange reagent, you can get more if you don't release the last bee
+		//Release up to 5 bees per use. Without using Lazarus Reagent, that means two uses. WITH Lazarus Reagent, you can get more if you don't release the last bee
 		for(var/bee = min(5, bees_left), bee > 0, bee--)
 			var/mob/living/simple_animal/hostile/poison/bees/syndi/B = new /mob/living/simple_animal/hostile/poison/bees/syndi(get_turf(user)) // RELEASE THE BEES!
 			B.master_and_friends = blood_list.Copy()	//Doesn't automatically add the person who opens the case, so the bees will attack the user unless they gave their blood

--- a/code/modules/hydroponics/hydroponics_tray.dm
+++ b/code/modules/hydroponics/hydroponics_tray.dm
@@ -710,7 +710,7 @@
 		adjustPests(rand(2,4))
 
 	// FEED ME SEYMOUR
-	if(S.has_reagent("strange_reagent", 1))
+	if(S.has_reagent("lazarus_reagent", 1))
 		spawnplant()
 
 	// The best stuff there is. For testing/debugging.
@@ -982,7 +982,7 @@
 	weedlevel = clamp(weedlevel + adjustamt, 0, 10)
 	plant_hud_set_weed()
 
-/obj/machinery/hydroponics/proc/spawnplant() // why would you put strange reagent in a hydro tray you monster I bet you also feed them blood
+/obj/machinery/hydroponics/proc/spawnplant() // why would you put Lazarus Reagent in a hydro tray you monster I bet you also feed them blood
 	var/list/livingplants = list(/mob/living/simple_animal/hostile/tree, /mob/living/simple_animal/hostile/killertomato)
 	var/chosen = pick(livingplants)
 	var/mob/living/simple_animal/hostile/C = new chosen(get_turf(src))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -800,7 +800,7 @@
 
 					M.grab_ghost()
 					M.update_revive()
-					add_attack_logs(M, M, "Revived with Lazarus Reagent") //Yes, the logs say you revived yourself.
+					add_attack_logs(M, M, "Revived with lazarus reagent") //Yes, the logs say you revived yourself.
 					SSblackbox.record_feedback("tally", "players_revived", 1, "lazarus_reagent")
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -734,10 +734,10 @@
 			M.emote("collapse")
 	return list(effect, update_flags)
 
-/datum/reagent/medicine/strange_reagent
-	name = "Strange Reagent"
-	id = "strange_reagent"
-	description = "A glowing green fluid highly reminiscent of nuclear waste."
+/datum/reagent/medicine/lazarus_reagent
+	name = "Lazarus Reagent"
+	id = "lazarus_reagent"
+	description = "A bioluminescent green fluid that seems to move on its own."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.2
@@ -745,14 +745,14 @@
 	harmless = FALSE
 	var/revive_type = SENTIENCE_ORGANIC //So you can't revive boss monsters or robots with it
 
-/datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/M)
+/datum/reagent/medicine/lazarus_reagent/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(10))
 		update_flags |= M.adjustBruteLoss(2*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
-/datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method = REAGENT_TOUCH, volume)
+/datum/reagent/medicine/lazarus_reagent/reaction_mob(mob/living/M, method = REAGENT_TOUCH, volume)
 	if(volume < 1)
 		// gotta pay to play
 		return ..()
@@ -762,7 +762,7 @@
 			return
 		if(SM.stat == DEAD)
 			SM.revive()
-			SM.loot.Cut() //no abusing strange reagent for farming unlimited resources
+			SM.loot.Cut() //no abusing Lazarus Reagent for farming unlimited resources
 			SM.visible_message("<span class='warning'>[SM] seems to rise from the dead!</span>")
 
 	if(iscarbon(M))
@@ -800,8 +800,8 @@
 
 					M.grab_ghost()
 					M.update_revive()
-					add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
-					SSblackbox.record_feedback("tally", "players_revived", 1, "strange_reagent")
+					add_attack_logs(M, M, "Revived with Lazarus Reagent") //Yes, the logs say you revived yourself.
+					SSblackbox.record_feedback("tally", "players_revived", 1, "lazarus_reagent")
 	..()
 
 /datum/reagent/medicine/mannitol

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -188,10 +188,10 @@
 	mix_message = "Tiny white crystals precipitate out of the solution."
 	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'
 
-/datum/chemical_reaction/strange_reagent
-	name = "Strange Reagent"
-	id = "strange_reagent"
-	result = "strange_reagent"
+/datum/chemical_reaction/lazarus_reagent
+	name = "Lazarus Reagent"
+	id = "lazarus_reagent"
+	result = "lazarus_reagent"
 	required_reagents = list("omnizine" = 1, "holywater" = 1, "mutagen" = 1)
 	result_amount = 3
 	mix_message = "The substance begins moving on its own somehow."
@@ -200,7 +200,7 @@
 	name = "Life"
 	id = "life"
 	result = null
-	required_reagents = list("strange_reagent" = 1, "synthflesh" = 1, "blood" = 1)
+	required_reagents = list("lazarus_reagent" = 1, "synthflesh" = 1, "blood" = 1)
 	result_amount = 1
 	min_temp = T0C + 100
 
@@ -210,7 +210,7 @@
 /datum/chemical_reaction/life/friendly
 	name = "Life (Friendly)"
 	id = "life_friendly"
-	required_reagents = list("strange_reagent" = 1, "synthflesh" = 1, "sugar" = 1)
+	required_reagents = list("lazarus_reagent" = 1, "synthflesh" = 1, "sugar" = 1)
 
 /datum/chemical_reaction/life/friendly/on_reaction(datum/reagents/holder, created_volume)
 	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (friendly)", FRIENDLY_SPAWN)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -183,7 +183,7 @@
 	name = "corgium"
 	id = "corgium"
 	result = null
-	required_reagents = list("nutriment" = 1, "colorful_reagent" = 1, "strange_reagent" = 1, "blood" = 1)
+	required_reagents = list("nutriment" = 1, "colorful_reagent" = 1, "lazarus_reagent" = 1, "blood" = 1)
 	result_amount = 3
 	min_temp = T0C + 100
 
@@ -196,7 +196,7 @@
 	name = "Flaptonium"
 	id = "flaptonium"
 	result = null
-	required_reagents = list("egg" = 1, "colorful_reagent" = 1, "chicken_soup" = 1, "strange_reagent" = 1, "blood" = 1)
+	required_reagents = list("egg" = 1, "colorful_reagent" = 1, "chicken_soup" = 1, "lazarus_reagent" = 1, "blood" = 1)
 	result_amount = 5
 	min_temp = T0C + 100
 	mix_message = "The substance turns an airy sky-blue and foams up into a new shape."

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -30,7 +30,7 @@
 	name = "Bee Explosion"
 	id = "beesplosion"
 	result = null
-	required_reagents = list("honey" = 1, "strange_reagent" = 1, "radium" = 1)
+	required_reagents = list("honey" = 1, "lazarus_reagent" = 1, "radium" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/beesplosion/on_reaction(datum/reagents/holder, created_volume)

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -240,7 +240,7 @@
 	list_reagents = list("omnizine" = 50)
 
 /obj/item/reagent_containers/glass/bottle/reagent/lazarus_reagent
-	name = "Lazarus Reagent bottle"
+	name = "lazarus reagent bottle"
 	desc = "A bottle of glowing fluid."
 	list_reagents = list("lazarus_reagent" = 30)
 

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -239,10 +239,10 @@
 	desc = "A reagent bottle. Contains Omnizine."
 	list_reagents = list("omnizine" = 50)
 
-/obj/item/reagent_containers/glass/bottle/reagent/strange_reagent
-	name = "strange reagent bottle"
+/obj/item/reagent_containers/glass/bottle/reagent/lazarus_reagent
+	name = "Lazarus Reagent bottle"
 	desc = "A bottle of glowing fluid."
-	list_reagents = list("strange_reagent" = 30)
+	list_reagents = list("lazarus_reagent" = 30)
 
 ////////////////////Traitor Poison Bottle//////////////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Progress towards #20532 

This PR renames strange reagent to lazarus reagent, both in the code and in name. It also makes the description a little more unique, though I'm not sure if anyone reads those.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
"Strange Reagent" is a bad name for a chemical. It doesn't give any hint at what it actually does or reference anything. Take cryoxadone; while it's not a real medicine, its name - specifically, the prefix "cryo-" hints towards what it does. Capulettum is another example; it references Romeo and Juliet while still sounding like a real medicine. Styptic Powder is another good example of a name - it's literally a real medicine that does the same thing as it does in game.

However, "Strange Reagent" doesn't give any hints at all towards what it does. If you're playing for the first time as a doctor, there's no indication that strange reagent is the _only_ way to revive people in some situations. However, naming it "Lazarus Reagent" preserves the esoteric feel of the chemical, makes it more clear, and references another item in-game (mining's lazarus injectors).

To connect to my design document, while I believe this PR could stand entirely on its own, in conjunction with the other changes the name change is even more pertinent - both so it's not confused with the theoretical Sanguine Reagent, and since it'd probably be used more, the above reasoning(s) are even more important.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It's just a name change, but I still loaded in and used it successfully.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Strange Reagent is now Lazarus Reagent. It functions identically to how it did before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->