### PR TITLE
blows up pancakes with mind

### DIFF
--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -453,12 +453,16 @@
 /obj/item/reagent_containers/food/snacks/pancake/attack_tk(mob/user)
 	if(src in user.tkgrabbed_objects)
 		to_chat(user, "<span class='notice'>You start channeling psychic energy into [src].</span>")
-		if(do_after_once(user, 4 SECONDS, target = src, attempt_cancel_message = "You stop channeling psychic energy into [src]."))
-			visible_message("<span class='danger'>[src] suddenly combust!</span>", "<span class='warning'>You combust [src] with your mind!</span>")
+		visible_message("<span class='danger'>The syrup on [src] starts to boil...</span>")
+		if(do_after_once(user, 4 SECONDS, target = src))
+			visible_message("<span class='danger'>[src] suddenly combust!</span>")
+			to_chat(user, "<span class='warning'>You combust [src] with your mind!</span>")
 			explosion(get_turf(src), light_impact_range = 2, flash_range = 2)
 			add_attack_logs(user, src, "blew up [src] with TK", ATKLOG_ALL)
 			qdel(src)
 			return
+		to_chat(user, "<span class='notice'>You decide against the destruction of [src].</span>")
+		return
 	return ..()
 
 /obj/item/reagent_containers/food/snacks/pancake/berry_pancake

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -454,7 +454,7 @@
 	if(src in user.tkgrabbed_objects)
 		to_chat(user, "<span class='notice'>You start channeling psychic energy into [src].</span>")
 		if(do_after_once(user, 4 SECONDS, target = src, attempt_cancel_message = "You stop channeling psychic energy into [src]."))
-			visible_message("<span class='danger'>[src] suddenly combust!", "<span class='warning'>You combust [src] with your mind!</span>")
+			visible_message("<span class='danger'>[src] suddenly combust!</span>", "<span class='warning'>You combust [src] with your mind!</span>")
 			explosion(get_turf(src), light_impact_range = 2, flash_range = 2)
 			add_attack_logs(user, src, "blew up [src] with TK", ATKLOG_ALL)
 			qdel(src)

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -450,6 +450,17 @@
 	bitesize = 2
 	list_reagents = list("nutriment" = 3, "sugar" = 3)
 
+/obj/item/reagent_containers/food/snacks/pancake/attack_tk(mob/user)
+	if(src in user.tkgrabbed_objects)
+		to_chat(user, "<span class='notice'>You start channeling psychic energy into [src].</span>")
+		if(do_after_once(user, 4 SECONDS, target = src, attempt_cancel_message = "You stop channeling psychic energy into [src]."))
+			visible_message("<span class='danger'>[src] suddenly combust!", "<span class='warning'>You combust [src] with your mind!</span>")
+			explosion(get_turf(src), light_impact_range = 2, flash_range = 2)
+			add_attack_logs(user, src, "blew up [src] with TK", ATKLOG_ALL)
+			qdel(src)
+			return
+	return ..()
+
 /obj/item/reagent_containers/food/snacks/pancake/berry_pancake
 	name = "berry pancake"
 	desc = "A pancake loaded with berries."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new TK interaction with pancakes
Takes four seconds of standing still, must be done purposefully by swapping hands and grabbing again, causes a low yield explosion and destroys the targeted pancakes. 

## Why It's Good For The Game
https://www.youtube.com/watch?v=XBlJmWfsgOM

More silly interactions are good and small and stupid details make SS13 endlessly replayable. I hope to god someone actually uses this in a traitor run because that would be so fucking funny and possibly effective. 

## Video

https://user-images.githubusercontent.com/96800819/224503069-e85cd20e-bab1-4c96-b87b-48e7a2395aa3.mp4

## Testing
Compiled and ran
## Changelog
:cl:
add: You can now blow up pancakes with your mind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
