### PR TITLE
Allows admins to freeze the SM

### DIFF
--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -99,11 +99,11 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 		radio.autosay("Alert: Unknown intervention has frozen causality around the crystal. It is not progressing in local timespace.", name, "Engineering", list(z))
 		GLOB.frozen_atom_list += src
 		processes = FALSE
-		overlays += freeze_overlay
+		add_overlay(freeze_overlay)
 	else
 		radio.autosay("Alert: Unknown intervention has ceased around the crystal. It has returned to the regular flow of time.", name, "Engineering", list(z))
 		GLOB.frozen_atom_list -= src
 		processes = TRUE
-		overlays -= freeze_overlay
+		cut_overlay(freeze_overlay)
 	message_admins("<span class='notice'>[key_name_admin(admin)] [processes ? "unfroze" : "froze"] a supermatter crystal</span>")
 	log_admin("[key_name(admin)] [processes ? "unfroze" : "froze"] a supermatter crystal")

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -92,3 +92,18 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 	else
 		message_admins("<span class='notice'>[key_name_admin(admin)] [frozen ? "froze" : "unfroze"] an empty [name]</span>")
 		log_admin("[key_name(admin)] [frozen ? "froze" : "unfroze"] an empty [name]")
+
+/obj/machinery/atmospherics/supermatter_crystal/admin_Freeze(client/admin)
+	var/obj/effect/overlay/adminoverlay/freeze_overlay = new
+	if(processes)
+		radio.autosay("Alert: Unknown intervention has frozen causality around the crystal. It is not progressing in local timespace.", name, "Engineering", list(z))
+		GLOB.frozen_atom_list += src
+		processes = FALSE
+		overlays += freeze_overlay
+	else
+		radio.autosay("Alert: Unknown intervention has ceased around the crystal. It has returned to the regular flow of time.", name, "Engineering", list(z))
+		GLOB.frozen_atom_list -= src
+		processes = TRUE
+		overlays -= freeze_overlay
+	message_admins("<span class='notice'>[key_name_admin(admin)] [processes ? "unfroze" : "froze"] a supermatter crystal</span>")
+	log_admin("[key_name(admin)] [processes ? "unfroze" : "froze"] a supermatter crystal")

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -211,6 +211,8 @@
 	SSair.atmos_machinery -= src
 	QDEL_NULL(radio)
 	GLOB.poi_list -= src
+	if(!processes)
+		GLOB.frozen_atom_list -= src
 	QDEL_NULL(countdown)
 	QDEL_NULL(soundloop)
 	return ..()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -303,6 +303,11 @@
 			SEND_SOUND(M, sound('sound/machines/engine_alert2.ogg')) // then send them the sound file
 	radio.autosay(speaking, name, null, list(z))
 	for(var/i in SUPERMATTER_COUNTDOWN_TIME to 0 step -10)
+		if(!processes) // Stop exploding if you're frozen by an admin, damn you
+			cut_overlay(causality_field, TRUE)
+			final_countdown = FALSE
+			damage = explosion_point - 1 // One point below exploding, so it will re-start the countdown once unfrozen
+			return
 		if(damage < explosion_point) // Cutting it a bit close there engineers
 			radio.autosay("[safe_alert] Failsafe has been disengaged.", name, null, list(z))
 			cut_overlay(causality_field, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Allows the admin freeze verb to also affect Supermatter Crystals, both the primary engine and shards, which prevents it from processing (and thus decreasing in integrity). Additionally, if frozen while in the 30-seconds before delamination, it returns the crystal to a single damage point before the explosion point is reached, so that the timer fully restarts after being unfrozen. Nothing changes to the integrity upon being unfrozen, so admins can change it back up while frozen if they determine the SM was sabotaged by a griefer or whatnot. 
It also gives a message over engineering comms (where the SM normally announces) indicating that an unknown force has frozen the SM, and overlays the crystal itself with an adminfreeze overlay. Hopefully this is sufficient to indicate to players that admin-stuff is happening.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Admins being able to handle people sabotaging the SM when they're not supposed to is good. From what I can tell, previously either you'd VV the processes variable to FALSE if you understood how the SM worked code-wise or you'd just delete it and make a new one if you had to fix it for admin reasons.
## Testing
<!-- How did you test the PR, if at all? -->
Tested it, it works.
## Changelog
:cl:
tweak: Admins can now Freeze the SM Crystal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
