### PR TITLE
adds a message notice that you can no longer move as a slime 

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime_life.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_life.dm
@@ -123,6 +123,8 @@
 	if(bodytemperature < (T0C + 5)) // start calculating temperature damage etc
 		if(bodytemperature <= (T0C - 40)) // stun temperature
 			Tempstun = TRUE
+			throw_alert("temp", /obj/screen/alert/cold, 3)
+			to_chat(src,"<span class='warning'>You suddenly freeze up, you cannot move!</span>")
 
 		if(bodytemperature <= (T0C - 50)) // hurt temperature
 			if(bodytemperature <= 50) // sqrting negative numbers is bad
@@ -131,6 +133,8 @@
 				adjustBruteLoss(round(sqrt(bodytemperature)) * 2)
 
 	else
+		if(Tempstun)
+			to_chat(src,"<span class='warning'>You suddenly unthaw!</span>")
 		Tempstun = FALSE
 
 	updatehealth("handle environment")

--- a/code/modules/mob/living/simple_animal/slime/slime_life.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_life.dm
@@ -124,7 +124,7 @@
 		if(bodytemperature <= (T0C - 40)) // stun temperature
 			Tempstun = TRUE
 			throw_alert("temp", /obj/screen/alert/cold, 3)
-			to_chat(src,"<span class='warning'>You suddenly freeze up, you cannot move!</span>")
+			to_chat(src,"<span class='userdanger'>You suddenly freeze up, you cannot move!</span>")
 
 		if(bodytemperature <= (T0C - 50)) // hurt temperature
 			if(bodytemperature <= 50) // sqrting negative numbers is bad


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
closes #20589 (not a bug, just poorly communicated)

## Why It's Good For The Game
the fact you're about to die due to becoming a slime popsicle probably should be communicated to the player

## Testing
Compiled and ran
## Changelog
:cl:
tweak: Slimes get a message when they can no longer move due to temp changes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
