### PR TITLE
Nerfs Unholy Water (Thank god no pun intended)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -364,11 +364,12 @@
 /datum/reagent/fuel/unholywater/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(iscultist(M))
+		M.AdjustDrowsy(-10 SECONDS)
 		update_flags |= M.adjustBrainLoss(-3, FALSE)
-		update_flags |= M.adjustToxLoss(-1.5, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
-		update_flags |= M.adjustOxyLoss(-1.5, FALSE)
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
+		update_flags |= M.adjustToxLoss(-2, FALSE)
+		update_flags |= M.adjustFireLoss(-3, FALSE)
+		update_flags |= M.adjustOxyLoss(-2, FALSE)
+		update_flags |= M.adjustBruteLoss(-3, FALSE)
 	else
 		update_flags |= M.adjustBrainLoss(3, FALSE)
 		update_flags |= M.adjustToxLoss(1, FALSE)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -364,15 +364,10 @@
 /datum/reagent/fuel/unholywater/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(iscultist(M))
-		M.AdjustDrowsy(-10 SECONDS)
-		M.AdjustParalysis(-2 SECONDS)
-		M.AdjustStunned(-4 SECONDS)
-		M.AdjustWeakened(-4 SECONDS)
-		M.AdjustKnockDown(-4 SECONDS)
-		update_flags |= M.adjustStaminaLoss(-25, FALSE)
-		update_flags |= M.adjustToxLoss(-1, FALSE)
+		update_flags |= M.adjustBrainLoss(-3, FALSE)
+		update_flags |= M.adjustToxLoss(-1.5, FALSE)
 		update_flags |= M.adjustFireLoss(-1, FALSE)
-		update_flags |= M.adjustOxyLoss(-1, FALSE)
+		update_flags |= M.adjustOxyLoss(-1.5, FALSE)
 		update_flags |= M.adjustBruteLoss(-1, FALSE)
 	else
 		update_flags |= M.adjustBrainLoss(3, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the Drowsy, Paralysis, Stunned, Weakened, and Knockdown buffs unholy water gives in exchange for being a good healing item. Adds brain loss fixing and buffs tox and oxy loss minorly.

## Why It's Good For The Game
A completely cracked item that is easy to produce and completely forces lethal combat due to its multiple anti stuns. Cultist should not have a free better meth due to having an already vast arsenal of escape tools and defensive options at their disposal. Unholy water now serves as a useful to-go healing item that can heal you when your out on the prowl and away from the cult base.


## Testing
yes sir tested i do concur

## Changelog
:cl: Octus
tweak: unholy water now fixes braindamage overtime
tweak: unholy water tweaked oxy, brute, burn tox loss for better healing
tweak: unholy water no longer provides stun resistance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
