### PR TITLE
gives constructs an intent swapping hud

### DIFF
--- a/code/_onclick/hud/constructs.dm
+++ b/code/_onclick/hud/constructs.dm
@@ -61,3 +61,8 @@
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_construct_pull
+	var/obj/screen/using
+	using = new /obj/screen/act_intent/simple_animal()
+	using.icon_state = mymob.a_intent
+	static_inventory += using
+	action_intent = using


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
title

## Why It's Good For The Game
See reasoning in #20624 

## Testing
Compiled and ran
## Changelog
:cl:
tweak: Constructs now have an intent hud
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
