### PR TITLE
Adds internal turrets to the nuclear operative ship

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -5105,6 +5105,9 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
+/obj/item/radio/intercom/syndicate{
+	pixel_x = -28
+	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
 "rQ" = (
@@ -5388,10 +5391,8 @@
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/syndicate)
 "tg" = (
-/obj/item/radio/intercom/syndicate{
-	pixel_x = -28
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
+/obj/machinery/porta_turret/syndicate/pod/nuke_ship_interior,
+/turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
 "tj" = (
 /obj/structure/flora/bush,
@@ -59246,7 +59247,7 @@ tf
 KY
 tP
 ub
-KY
+tg
 KY
 KY
 KY
@@ -59490,7 +59491,7 @@ lA
 lQ
 KX
 KX
-KY
+tg
 nx
 gx
 gx
@@ -59499,7 +59500,7 @@ gx
 rP
 KX
 KX
-tg
+KX
 tw
 KX
 KX
@@ -60004,7 +60005,7 @@ lA
 lS
 KX
 mH
-KY
+tg
 nA
 iS
 iS
@@ -60274,7 +60275,7 @@ tf
 KY
 tT
 ue
-KY
+tg
 KY
 KY
 KY

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1105,3 +1105,6 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	health = 100
 	projectile = /obj/item/projectile/bullet/weakbullet3
 	eprojectile = /obj/item/projectile/bullet/weakbullet3
+
+/obj/machinery/porta_turret/syndicate/pod/nuke_ship_interior
+	health = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Adds 4 turrets to the inside of the nukie ship. These turrets are weakened versions that only shoot bullets that deal 20 damage instead of 60, albeit a slight health buff from 80 to 100. I'm kind of split on whether to include the back 2 turrets, but I feel like the front 2 are good, feedback is appreciated. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Its a bit silly having explorers break in every nuclear round and mess with the bomb in someway, even now that its tamper proof (please stop finding exploits). If we want to stop them from messing with it, we should go all the way.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Two turrets near the cockpit, 2 turrets near the nuke storage
![image](https://user-images.githubusercontent.com/91113370/224911557-a50eed89-2dea-496b-aafc-ea8d05b765fb.png)

Top turret range reaches down to about here
![image](https://user-images.githubusercontent.com/91113370/224912200-86ce1799-5ce8-45df-8fee-8684c76f4c3f.png)


## Testing
<!-- How did you test the PR, if at all? -->
Turrets worked inside the ship, didnt target nukies, did target nanotrasen employees.

## Changelog
:cl:
add: The nuclear operative's ship now has 4 weak internal turrets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
