### PR TITLE
Adds a death alarm for ERT Jani Red

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -517,6 +517,10 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	)
 
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
+	)
+
 /datum/outfit/job/centcom/response_team/janitorial/gamma
 	name = "RT Janitor (Gamma)"
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/janitor/gamma


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a death alarm for the ERT Red Janitor.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This brings the ERT Red Janitor in line with all other Red Team members, who all currently have death alarms. ERT members should be valued the same, regardless of their assigned role on the team. This allows for other team members to know quickly, if a member is lost, in what is probably an already chaotic situation. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Created an ERT Red Janitor and tested to see if their death alarm sounded when they died.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: added a death alarm to the ert red jani
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
