### PR TITLE
Removes slime people and kidan from the syndicate M.A.G.I.C mirror

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -124,7 +124,7 @@
 		if("Body")
 			if(organ_warn)
 				to_chat(user, "<span class='boldwarning'>Using the mirror will destroy any non biochip implants in you!</span>")
-			var/list/race_list = list("Human", "Tajaran", "Skrell", "Unathi", "Diona", "Vulpkanin", "Nian", "Slime People", "Grey", "Drask", "Kidan")
+			var/list/race_list = list("Human", "Tajaran", "Skrell", "Unathi", "Diona", "Vulpkanin", "Nian", "Grey", "Drask")
 
 			var/datum/ui_module/appearance_changer/AC = ui_users[user]
 			if(!AC)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -127,8 +127,7 @@
 				to_chat(user, "<span class='boldwarning'>Using the mirror will destroy any non biochip implants in you!</span>")
 			var/list/race_list = list("Human", "Tajaran", "Skrell", "Unathi", "Diona", "Vulpkanin", "Nian", "Grey", "Drask")
 			if(actually_magical)
-				race_list += "Vox"
-				race_list += "Plasmaman"
+				race_list = list("Human", "Tajaran", "Skrell", "Unathi", "Diona", "Vulpkanin", "Nian", "Grey", "Drask", "Vox", "Plasmaman", "Kidan")
 
 			var/datum/ui_module/appearance_changer/AC = ui_users[user]
 			if(!AC)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -97,6 +97,7 @@
 	icon_state = "magic_mirror"
 	var/options = list("Name", "Body", "Voice")
 	var/organ_warn = FALSE
+	var/actually_magical = TRUE
 
 /obj/structure/mirror/magic/attack_hand(mob/user)
 	if(!ishuman(user) || broken)
@@ -125,6 +126,9 @@
 			if(organ_warn)
 				to_chat(user, "<span class='boldwarning'>Using the mirror will destroy any non biochip implants in you!</span>")
 			var/list/race_list = list("Human", "Tajaran", "Skrell", "Unathi", "Diona", "Vulpkanin", "Nian", "Grey", "Drask")
+			if(actually_magical)
+				race_list += "Vox"
+				race_list += "Plasmaman"
 
 			var/datum/ui_module/appearance_changer/AC = ui_users[user]
 			if(!AC)
@@ -174,4 +178,5 @@
 	desc = "The M.A.G.I.C mirror will let you change your species in a flash! Be careful, any implants (not biochips) in you will be destroyed on use."
 	options = list("Body")
 	organ_warn = TRUE
+	actually_magical = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

removes kidan and slime people from syndicate magic mirror

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

When I added the magic mirror for nukies, karma species were avoided for sanity, and for balance.

Most karma species (now karma is gone) are fine, vox and plasmamen currently are not in this list, and would be fine, but would need vox / plasmamen tanks there.

However, slime people and kidan, which are in the list before this pr, have to go. Slime people nukies would grant access of no bones for nukies, which would be incredibly strong. Kidan nukies get 20% less brute damage, which is why I was suggested to remove that.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed species did not show up

## Changelog
:cl:
tweak: Kidan and slime people are no longer valid nuclear agent species (again)
fix: Wizards can be vox / plasmamen again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
