### PR TITLE
Functional cult structures have a cooldown upon creation

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -157,7 +157,7 @@
 /obj/structure/cult/functional/altar/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.altar_icon_state
-	cooldowntime = CULT_STRUCTURE_COOLDOWN
+	cooldowntime = world.time + CULT_STRUCTURE_COOLDOWN
 
 /obj/structure/cult/functional/forge
 	name = "daemon forge"

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -155,7 +155,7 @@
 /obj/structure/cult/functional/altar/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.altar_icon_state
-	cooldowntime = world.time + 600
+	cooldowntime = world.time + 60 SECONDS
 
 /obj/structure/cult/functional/forge
 	name = "daemon forge"

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -155,6 +155,7 @@
 /obj/structure/cult/functional/altar/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.altar_icon_state
+	cooldowntime = world.time + 600
 
 /obj/structure/cult/functional/forge
 	name = "daemon forge"

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -1,3 +1,4 @@
+/// The amount of time necessary for a structure to be able to produce items after being built
 #define CULT_STRUCTURE_COOLDOWN 60 SECONDS
 
 /obj/structure/cult

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -1,3 +1,5 @@
+#define CULT_STRUCTURE_COOLDOWN 60 SECONDS
+
 /obj/structure/cult
 	density = TRUE
 	anchored = TRUE
@@ -155,7 +157,7 @@
 /obj/structure/cult/functional/altar/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.altar_icon_state
-	cooldowntime = world.time + 60 SECONDS
+	cooldowntime = CULT_STRUCTURE_COOLDOWN
 
 /obj/structure/cult/functional/forge
 	name = "daemon forge"
@@ -347,3 +349,5 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 
 /obj/effect/gateway/Crossed(atom/movable/AM, oldloc)
 	return
+
+#undef CULT_STRUCTURE_COOLDOWN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cult structures now have a cooldown before being able to produce items upon creation. So making a flask of unholy water or blade takes time and isnt instant.

## Why It's Good For The Game
A rather exploited mechanic were I've seen players carry around 50 runed metal to make instant production factories mid fight. Using said factories to instantly restock on all their spent viel shifters, unholy water, shielded robes, and then proceeded to run back in and do it over and over. Not only is this pretty unhealthy, its also poorly balanced. This slows down cult in their arms production as well as giving a window before the cult war begins.


## Testing
tested it in server

## Changelog
:cl: Octus SabrelML GDNgit
tweak: Cult production structures now have a delay upon creation before producing anything
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
