### PR TITLE
Safety muzzle quality of life tweak

### DIFF
--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -109,10 +109,6 @@
 	var/unique_suck_id = H.UID()
 	var/blood = 0
 	var/blood_volume_warning = 9999 //Blood volume threshold for warnings
-	if(owner.current.is_muzzled())
-		to_chat(owner.current, "<span class='warning'>[owner.current.wear_mask] prevents you from biting [H]!</span>")
-		draining = null
-		return
 	add_attack_logs(owner.current, H, "vampirebit & is draining their blood.", ATKLOG_ALMOSTALL)
 	owner.current.visible_message("<span class='danger'>[owner.current] grabs [H]'s neck harshly and sinks in [owner.current.p_their()] fangs!</span>", "<span class='danger'>You sink your fangs into [H] and begin to drain [H.p_their()] blood.</span>", "<span class='notice'>You hear a soft puncture and a wet sucking noise.</span>")
 	if(!iscarbon(owner.current))

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -483,6 +483,9 @@
 		if(HAS_TRAIT(target, TRAIT_SKELETONIZED))
 			to_chat(user, "<span class='warning'>There is no blood in a skeleton!</span>")
 			return
+		if(user.is_muzzled() && !ismonkeybasic(target)) //this check allows safety muzzles to be useable on small mobs like monkeys
+			to_chat(user, "<span class='warning'>[user.wear_mask] prevents you from biting [target]!</span>")
+			return
 		//we're good to suck the blood, blaah
 		V.handle_bloodsucking(target)
 		add_attack_logs(user, target, "vampirebit")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Vampires with safety muzzles can now suck small mobs like monkeys, even while the muzzle is locked onto them.

## Why It's Good For The Game
The safety muzzle is a tool used by security to muzzle captured vampires so they can be put into the same confinement with non vampires. A useful item that makes security work less of a difficult task then it already is, it however has one major flaw. Vampires cannot suck anything, which means they cannot eat and will eventually need to be micromanaged to keep them alive, which defeats the entire purpose of this items existence.

Now muzzles let vamps in perma custody drink monkeys, this means less security micromanagement and headache, less vampires players dying in perma because they cannot eat, and less salt overall for both parties. I see this as a total win.


## Testing
tested in on server and works

## Changelog
:cl: Octus SabreML
tweak: safety muzzles now are big enough to fit monkey like carbon mobs to let vampires eat in perma
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
