### PR TITLE
Add feedback and glow to the medical wrench

### DIFF
--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -82,9 +82,11 @@
 
 /obj/item/wrench/medical/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is praying to the medical wrench to take [user.p_their()] soul. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	// TODO Make them glow with the power of the M E D I C A L W R E N C H
-	// during their ascension
-
+	user.add_filter("sacrifice_glow", 2, list("type" = "outline", "color" = "#55dcfdd2", "size" = 2))
+	var/filter = user.get_filter("sacrifice_glow")
+	// Pulse in and out
+	animate(filter, alpha = 110, time = 3, loop = -1)
+	animate(alpha = 40, time = 6)
 	// Stun stops them from wandering off
 	user.Stun(10 SECONDS)
 	playsound(loc, 'sound/effects/pray.ogg', 50, 1, -1)
@@ -101,9 +103,7 @@
 	var/obj/item/wrench/medical/W = new /obj/item/wrench/medical(loc)
 	W.add_fingerprint(user)
 	W.desc += " For some reason, it reminds you of [user.name]."
-
-	if(!user)
-		return
+	user.visible_message("<span class='suicide'>[user] turned into \a [W]!</span>")
 
 	user.dust()
 	return OBLITERATION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it clear that the medical wrench creates more of its brethen when someone suicides with it, and adds the glow that was originally intended for it.

## Why It's Good For The Game
The wrenches need more sacrifices, also removes a TODO.

## Images of changes
https://user-images.githubusercontent.com/80771500/225357068-f0a48cab-d61d-405e-9b0a-ae30ed639d07.mp4

![THEWRENCH](https://user-images.githubusercontent.com/80771500/225357278-39632479-cf23-4635-8679-7b8f10ddad01.PNG)


## Testing
Gave my soul to the wrench

## Changelog
:cl:
tweak: Added feedback when a player commits suicide to the medical wrench
tweak: Added a glow to the player when commiting suicide to the medical wrench
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
