### PR TITLE
makes clingstings GC

### DIFF
--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -14,7 +14,7 @@
 
 /datum/middleClickOverride/proc/onClick(atom/A, mob/living/user)
 	user.middleClickOverride = null
-	return 1
+	return TRUE
 	/* Note, when making a new click override it is ABSOLUTELY VITAL that you set the source's clickOverride to null at some point if you don't want them to be stuck with it forever.
 	Calling the super will do this for you automatically, but if you want a click override to NOT clear itself after the first click, you must do it at some other point in the code*/
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -11,6 +11,8 @@
 	click_override = new(CALLBACK(src, PROC_REF(try_to_sting)))
 
 /datum/action/changeling/sting/Destroy(force, ...)
+	if(cling.owner.current && cling.owner.current.middleClickOverride == click_override) // this is a very scuffed way of doing this honestly
+		cling.owner.current.middleClickOverride = null
 	QDEL_NULL(click_override)
 	if(cling.chosen_sting == src)
 		cling.chosen_sting = null

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -11,8 +11,6 @@
 	click_override = new(CALLBACK(src, PROC_REF(try_to_sting)))
 
 /datum/action/changeling/sting/Destroy(force, ...)
-	if(cling.owner.current.middleClickOverride == click_override)
-		cling.owner.current.middleClickOverride = null
 	QDEL_NULL(click_override)
 	if(cling.chosen_sting == src)
 		cling.chosen_sting = null

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -48,6 +48,7 @@
 				qdel(S)
 			else
 				S.be_replaced()
+	QDEL_NULL(middleClickOverride)
 	if(mind?.current == src)
 		mind.current = null
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes clingstings not GCing, fixes clingstings runtiming in destroy

## Why It's Good For The Game
This is a mob var why the hell are we clearing this on a action datum delete... Also current is actually nulled now so

## Testing
Guess who found out that mobs with antag datums aren't properly GCing as well! But yes this works