### PR TITLE
middle click overrides no longer also override alt-click if the middle click action fails to resolve

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -325,13 +325,6 @@
 	A.AltClick(src)
 	return
 
-// See click_override.dm
-/mob/living/AltClickOn(atom/A)
-	if(middleClickOverride)
-		middleClickOverride.onClick(A, src)
-	else
-		..()
-
 /atom/proc/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
 	var/turf/T = get_turf(src)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -319,11 +319,16 @@
 
 /*
 	Alt click
-	Unused except for AI
 */
 /mob/proc/AltClickOn(atom/A)
 	A.AltClick(src)
 	return
+
+// See click_override.dm
+/mob/living/AltClickOn(atom/A)
+	if(middleClickOverride && middleClickOverride.onClick(A, src))
+		return
+	..()
 
 /atom/proc/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -46,23 +46,23 @@
 
 /datum/middleClickOverride/power_gloves/onClick(atom/A, mob/living/carbon/human/user)
 	if(A == user || user.a_intent == INTENT_HELP || user.a_intent == INTENT_GRAB)
-		return
+		return FALSE
 	if(user.incapacitated())
-		return
+		return FALSE
 	var/obj/item/clothing/gloves/color/yellow/power/P = user.gloves
 	if(world.time < P.last_shocked + P.shock_delay)
 		to_chat(user, "<span class='warning'>The gloves are still recharging.</span>")
-		return
+		return FALSE
 	var/turf/T = get_turf(user)
 	var/obj/structure/cable/C = locate() in T
 	if(!P.unlimited_power)
 		if(!C || !istype(C))
 			to_chat(user, "<span class='warning'>There is no cable here to power the gloves.</span>")
-			return
+			return FALSE
 	var/turf/target_turf = get_turf(A)
 	if(get_dist(T, target_turf) > P.shock_range)
 		to_chat(user, "<span class='warning'>The target is too far away.</span>")
-		return
+		return FALSE
 	target_turf.hotspot_expose(2000, 400)
 	playsound(user.loc, 'sound/effects/eleczap.ogg', 40, 1)
 
@@ -99,6 +99,7 @@
 		next_shocked.Cut()
 
 	P.last_shocked = world.time
+	return TRUE
 
 /**
  * # Callback invoker middle click override datum
@@ -114,4 +115,5 @@
 	callback = _callback
 
 /datum/middleClickOverride/callback_invoker/onClick(atom/A, mob/living/user)
-	callback.Invoke(user, A)
+	if(callback.Invoke(user, A))
+		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Middle click overrides no longer also override alt click if the middle click action fails to resolve

## Why It's Good For The Game
When you're using one of the few middle click overrides in the game (Adminstuff, Cling stings, power gloves), you probably expect this just to be middle click, right? Well it also covers alt-click which causes a whole bunch of issues with alt-click keybinds like looking in your bag or crawling into vents, this sucks so if it fails let's just have it do alt-click things. 

~~If you do not have a mouse 3 option for any reason, good time to speak up as well. ~~
Forgot trackpad users

## Testing
Compiled and ran
## Changelog
:cl:
tweak: Middle click override actions with Alt-click no longer trigger if the actual ability fails to resolve (you can now ventcrawl with a sting out)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
