### PR TITLE
Balances the borghydro

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -15,7 +15,7 @@
 	var/charge_cost = 50
 	/// Used for delay with the recharge time, each charge tick is worth 2 seconds of real time
 	var/charge_tick = 0
-	/// Time it takes for reagents to recharge, *2 and you get how many seconds it will additionally take from 2
+	/// How many SSobj ticks it takes for the reagents to recharge by 10 units
 	var/recharge_time = 3
 	/// Can the autohypo inject through thick materials?
 	var/bypass_protection = 0

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -9,14 +9,14 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = null
 	/// It doesn't matter what reagent is used in the autohypos, so we don't!
-	var/total_reagents = 100
+	var/total_reagents = 50
 	/// Maximum reagents that the base autohypo can store
-	var/maximum_reagents = 100
+	var/maximum_reagents = 50
 	var/charge_cost = 50
 	/// Used for delay with the recharge time, each charge tick is worth 2 seconds of real time
 	var/charge_tick = 0
 	/// Time it takes for reagents to recharge, *2 and you get how many seconds it will additionally take from 2
-	var/recharge_time = 2
+	var/recharge_time = 3
 	/// Can the autohypo inject through thick materials?
 	var/bypass_protection = 0
 	var/choosen_reagent = "salglu_solution"
@@ -50,10 +50,10 @@
 	desc = "An experimental piece of Syndicate technology used to produce powerful restorative nanites used to very quickly restore injuries of all types. Also metabolizes potassium iodide, for radiation poisoning, and hydrocodone, for field surgery and pain relief."
 	icon_state = "borghypo_s"
 	charge_cost = 20
-	recharge_time = 1 // No time to recharge
+	recharge_time = 2 // No time to recharge
 	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone")
-	total_reagents = 60
-	maximum_reagents = 60
+	total_reagents = 30
+	maximum_reagents = 30
 	bypass_protection = TRUE
 	choosen_reagent = "syndicate_nanites"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Total chemicals in the base borg hydro brought down to 50 from 100, chem restoration reduced
Total chemicals in the syndicate borg brought down to 30 from 60, chem restoration reduced

## Why It's Good For The Game
So uh, I was expecting that PR to be tmed rather than full merged, it wasn't so I gotta do this here. Right now the borg hydro is broken out the ass, you recharge chemicals faster than you can actually use them in most cases and even if you are, you can wait under a minute to get all your chemicals back. Everyone in your general area getting healing + complete pain slowdown immunity is absolutely crazy and there needs to be some restriction to it. 

## Testing
Compiled and filled a skrell with chemicals

## Changelog
:cl:
tweak: Cyborg hypospray's total chemicals have been halfed, restoration rate for those chemicals reduced 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
