### PR TITLE
Removes the teleportation function from tracking implants

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -211,28 +211,6 @@
 			"x" = T.x,
 			"y" = T.y,
 			"z" = T.z)
-
-	for(var/obj/item/implant/tracking/I in GLOB.tracked_implants)
-		if(!I.implanted || !ismob(I.loc))
-			continue
-		else
-			var/mob/M = I.loc
-			if(M.stat == DEAD)
-				if(M.timeofdeath + 6000 < world.time)
-					continue
-			var/turf/T = get_turf(M)
-			if(!T)	continue
-			if(!is_teleport_allowed(T.z))	continue
-			var/tmpname = M.real_name
-			if(areaindex[tmpname])
-				tmpname = "[tmpname] ([++areaindex[tmpname]])"
-			else
-				areaindex[tmpname] = 1
-			L[tmpname] = list(
-				"name" = tmpname,
-				"x" = T.x,
-				"y" = T.y,
-				"z" = T.z)
 	return L
 
 /**

--- a/code/game/objects/items/weapons/implants/implantfluff.dm
+++ b/code/game/objects/items/weapons/implants/implantfluff.dm
@@ -93,7 +93,7 @@
 	name = "Nanotrasen RFID Tracking Bio-chip"
 	life = "Unknown, known to last up to a few years."
 	notes = "Tracking bio-chips are Neuro-safe! Makes use of a specialized shell that will melt and disintegrate into bio-safe elements in the event of a malfunction. "
-	function = "Continuously transmits a low power signal. Can be used for tracking and teleporting to the user."
+	function = "Continuously transmits a low power signal. Can be used for tracking the user."
 
 /datum/implant_fluff/traitor
 	name = "Syndicate Type E Mindslave Bio-chip"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As mentioned in the title, this PR removes the ability to teleport to people who have had a tracking implant implanted. You can still monitor the user's location.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Tracking implants are mostly used by security for permanent prisoners. They make escape attempts even more difficult than they already are.

Not only do you have to survive space or fight security without any equipment to escape from perma, but you also have to deal with the fact that the security officers know your location AND are able to teleport to you.

This makes successful escape attempts almost impossible, as security can simply teleport to the EoCs and kill them in an instant.

By removing the ability to teleport to prisoners who have had a tracking implant implanted, sec can no longer simply click on the teleporter console and end the prisoners escape attempt. They will either need some coordination because someone will have to tell them the location of the perma-escapee, or they will have to grab the tracking device from the armoury.

This gives the perma-prisoners the opportunity to escape from security, because sec actually has to track them. At the same time, however, the function of the tracking implants - namely tracking - is preserved. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Ran and tried to teleport to an implanted person.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
del: Removed the ability to teleport to tracking implants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
