### PR TITLE
Fixes vendors not updating icons when depowered

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -866,7 +866,7 @@
 	atom_say(message)
 
 /obj/machinery/economy/vending/power_change()
-	..()
+	. = ..()
 	if(stat & (BROKEN|NOPOWER))
 		set_light(0)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As advertised by the title.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Less people confused about why they can't interact with things that seem to be turned on but actually aren't.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled, smacked an APC with a captain ID and turned equipment off, observed the fading light signaling multiple vendors' last final moments of life until they are fed power noms again
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Vendors now again visually turn off when they lose power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
