### PR TITLE
Properly charge IPC/IRCs in borg charger to full.

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -153,8 +153,8 @@
 			R.cell.charge = min(R.cell.charge + recharge_speed, R.cell.maxcharge)
 	else if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
-		if(H.get_int_organ(/obj/item/organ/internal/cell) && H.nutrition < 450)
-			H.set_nutrition(min(H.nutrition + recharge_speed_nutrition, 450))
+		if(H.get_int_organ(/obj/item/organ/internal/cell) && H.nutrition < NUTRITION_LEVEL_FULL - 1)
+			H.set_nutrition(min(H.nutrition + recharge_speed_nutrition, NUTRITION_LEVEL_FULL - 1))
 		if(repairs)
 			H.heal_overall_damage(repairs, repairs, TRUE, 0, 1)
 


### PR DESCRIPTION
## What Does This PR Do
This PR changes the borg charger's maximum nutrition value to `NUTRITION_LEVEL_FULL` (550) as opposed to the hardcoded value 450. The decrement by one is because the maximum nutrition value is considered "fat", when presumably it is only meant to be "fat" when _above_ full (in other words, the hud icon would temporarily change to "fat" before changing back to full). This would be a change to the range logic in `/mob/living/carbon/human/proc/handle_nutrition_alerts` but I clamped the range in the charger code to keep the change as isolated as possible.

## Why It's Good For The Game
When IPCs leave a borg charger, their hunger immediately immediately changes, despite the HUD alert logic intended to remain in the 'full' state until the mob's nutrition value is in the "fed" to "well_fed" range. For forever I thought this was an error in the HUD logic, but I finally realized it was because the borg charger doesn't charge to full.

## Testing
Before:

https://user-images.githubusercontent.com/59303604/226215161-f2571b00-2b1d-4bfe-ad76-6994213d47e8.mp4

After:

https://user-images.githubusercontent.com/59303604/226215171-29b3c516-ffc8-4e55-806f-f42bebc6a903.mp4


## Changelog
:cl:
fix: Borg chargers now properly charge IPCs/IRCs to full nutrition.
/:cl: