### PR TITLE
makes revive runes not kick out the dead in some cases

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -621,7 +621,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		if(mob_to_revive.ghost_can_reenter())
 			mob_to_revive.grab_ghost()
 
-	if(!mob_to_revive.client || mob_to_revive.client.is_afk())
+	if(!mob_to_revive.get_ghost() || mob_to_revive.client.is_afk())
 		set waitfor = FALSE
 		to_chat(user, "<span class='cult'>[mob_to_revive] was revived, but their mind is lost! Seeking a lost soul to replace it.</span>")
 		var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Would you like to play as a revived Cultist?", ROLE_CULTIST, TRUE, poll_time = 20 SECONDS, source = /obj/item/melee/cultblade/dagger)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -621,7 +621,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		if(mob_to_revive.ghost_can_reenter())
 			mob_to_revive.grab_ghost()
 
-	if(!mob_to_revive.get_ghost() || mob_to_revive.client.is_afk())
+	if(!mob_to_revive.get_ghost() || mob_to_revive.client && mob_to_revive.client.is_afk())
 		set waitfor = FALSE
 		to_chat(user, "<span class='cult'>[mob_to_revive] was revived, but their mind is lost! Seeking a lost soul to replace it.</span>")
 		var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Would you like to play as a revived Cultist?", ROLE_CULTIST, TRUE, poll_time = 20 SECONDS, source = /obj/item/melee/cultblade/dagger)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes revive runes not kick out the person being revived in rare cases

## Why It's Good For The Game
A revivable person shouldn't get kicked outta the round because they ghosted too fast
The more and more cult code I read the more and more I'm convinced this was more of a straight point compared to anything really adjusted to para. 

## Testing
Compiled
## Changelog
:cl:
fix: Cult revive runes should no longer kick you out of your body if you're holding a movement key
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
