### PR TITLE
fixes a cult construct death runtime

### DIFF
--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -176,11 +176,9 @@ GLOBAL_LIST_EMPTY(all_cults)
 	if(!(cult_mind in cult)) // Not actually a cultist in the first place
 		return
 
-	var/mob/cultist
-	if(!target_mob)
+	var/mob/cultist = target_mob
+	if(!cultist)
 		cultist = cult_mind.current
-	else
-		cultist = target_mob
 	cult -= cult_mind
 	cultist.faction -= "cult"
 	cult_mind.special_role = null

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -172,11 +172,15 @@ GLOBAL_LIST_EMPTY(all_cults)
 		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Cultist)</span>")
 		return TRUE
 
-/datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = TRUE, remove_gear = FALSE)
+/datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = TRUE, remove_gear = FALSE, mob/target_mob)
 	if(!(cult_mind in cult)) // Not actually a cultist in the first place
 		return
 
-	var/mob/cultist = cult_mind.current
+	var/mob/cultist
+	if(!target_mob)
+		cultist = cult_mind.current
+	else
+		cultist = target_mob
 	cult -= cult_mind
 	cultist.faction -= "cult"
 	cult_mind.special_role = null

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -52,7 +52,7 @@
 
 /mob/living/simple_animal/hostile/construct/death(gibbed)
 	. = ..()
-	SSticker.mode.remove_cultist(mind, FALSE)
+	SSticker.mode.remove_cultist(show_message = FALSE, target_mob = src)
 
 /mob/living/simple_animal/hostile/construct/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -40,7 +40,7 @@
 
 /mob/living/simple_animal/shade/death(gibbed)
 	. = ..()
-	SSticker.mode.remove_cultist(mind, FALSE)
+	SSticker.mode.remove_cultist(show_message = FALSE, target_mob = src)
 
 /mob/living/simple_animal/shade/attackby(obj/item/O, mob/user)  //Marker -Agouri
 	if(istype(O, /obj/item/soulstone))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes this runtime `Runtime in cult_mode.dm,181: Cannot read null.faction`

## Why It's Good For The Game
Why the hell are we so reliant on current for stuff that really doesn't need to use current GNARG 
Common oldcoder L

## Testing
Looked for runtime, no runtime

## Changelog
:cl:
fix: Dead constructs no longer count for total cult amount 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
