### PR TITLE
Supply crate item stack fix

### DIFF
--- a/code/modules/supply/supply_pack.dm
+++ b/code/modules/supply/supply_pack.dm
@@ -45,7 +45,7 @@
 		if(!typepath)
 			continue
 		var/atom/A = new typepath(crate)
-		if(isstack(A))
+		if(isstack(A) && amount)
 			var/obj/item/stack/mats = A
 			mats.amount = amount
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR Fixes #20676, where certain stacked items were not appearing inside of cargo shuttle crates correctly.  
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It fixes a bug, allowing for stacked items that are contained within cargo shuttle crates to spawn within the crates correctly. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested two ways:

Ordered multiple crates at cargo that contained children of /obj/item/stack and tested to see if those items contained the correct amount and functioned properly.

Used the create crate verb to create crates that contained children of /obj/item/stack and tested if the items were functioning properly.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: fixed a line of code allowing items to appear within the crates in the right amount
/:cl:

Credit goes to @Contrabang for providing a solution to this issue.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
