### PR TITLE
Emagged deepfryer no longer tries to deepfry grabs

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -190,9 +190,7 @@
 		to_chat(user, "<span class='warning'>Close the panel first!</span>")
 		return
 	if(istype(I, /obj/item/grab))
-		if (can_grab_attack(I, user, TRUE))
-			special_attack_grab(I, user)
-			return
+		return special_attack_grab(I, user)
 	if(!checkValid(I, user))
 		return
 	if(!burns)

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -110,8 +110,6 @@
 	if(on)
 		to_chat(user, "<span class='notice'>[src] is still active!</span>")
 		return FALSE
-	if(istype(check, /obj/item/grab))
-		return can_grab_attack(check, user, TRUE)  // tell the user here
 	if(has_specials && checkSpecials(check))
 		return TRUE
 	if(istype(check, /obj/item/reagent_containers/food/snacks) || emagged)
@@ -191,6 +189,10 @@
 	if(panel_open)
 		to_chat(user, "<span class='warning'>Close the panel first!</span>")
 		return
+	if(istype(I, /obj/item/grab))
+		if (can_grab_attack(I, user, TRUE))
+			special_attack_grab(I, user)
+			return
 	if(!checkValid(I, user))
 		return
 	if(!burns)
@@ -207,8 +209,7 @@
 			else
 				L.death()
 		break
-	if(istype(I, /obj/item/grab))
-		return special_attack_grab(I, user)
+
 	addtimer(CALLBACK(src, PROC_REF(finish_cook), I, user), cooktime)
 
 /obj/machinery/cooker/proc/finish_cook(obj/item/I, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where the emagged deepfryer would try to deepfry a grab instead of the face of the person you are grabbing.

fix: #20677
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Emag deepfryer
Grab Skrell
Deepfry Skrell's face, not the abstract grab
Smells like burnt fish.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Trying to deepfry someone's face no longer causes you to deepfry the grab instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
