### PR TITLE
Brings up most heads of staff roles from requiring 20 hours of playtime to 50 hours of playtime

### DIFF
--- a/code/game/jobs/job/engineering_jobs.dm
+++ b/code/game/jobs/job/engineering_jobs.dm
@@ -19,7 +19,7 @@
 						ACCESS_HEADS, ACCESS_CONSTRUCTION, ACCESS_SEC_DOORS,
 						ACCESS_CE, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_TCOMSAT, ACCESS_MINISAT, ACCESS_MINERAL_STOREROOM)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_ENGINEERING = 4800)
+	exp_map = list(EXP_TYPE_ENGINEERING = 3000)
 	outfit = /datum/outfit/job/chief_engineer
 	important_information = "This role requires you to coordinate a department. You are required to be familiar with Standard Operating Procedure (Engineering), basic job duties, and act professionally (roleplay)."
 

--- a/code/game/jobs/job/engineering_jobs.dm
+++ b/code/game/jobs/job/engineering_jobs.dm
@@ -19,7 +19,7 @@
 						ACCESS_HEADS, ACCESS_CONSTRUCTION, ACCESS_SEC_DOORS,
 						ACCESS_CE, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_TCOMSAT, ACCESS_MINISAT, ACCESS_MINERAL_STOREROOM)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_ENGINEERING = 1200)
+	exp_map = list(EXP_TYPE_ENGINEERING = 4800)
 	outfit = /datum/outfit/job/chief_engineer
 	important_information = "This role requires you to coordinate a department. You are required to be familiar with Standard Operating Procedure (Engineering), basic job duties, and act professionally (roleplay)."
 

--- a/code/game/jobs/job/medical_jobs.dm
+++ b/code/game/jobs/job/medical_jobs.dm
@@ -17,7 +17,7 @@
 			ACCESS_CHEMISTRY, ACCESS_VIROLOGY, ACCESS_CMO, ACCESS_SURGERY, ACCESS_RC_ANNOUNCE,
 			ACCESS_KEYCARD_AUTH, ACCESS_SEC_DOORS, ACCESS_PSYCHIATRIST, ACCESS_MAINT_TUNNELS, ACCESS_PARAMEDIC, ACCESS_MINERAL_STOREROOM)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_MEDICAL = 4800)
+	exp_map = list(EXP_TYPE_MEDICAL = 3000)
 	outfit = /datum/outfit/job/cmo
 	important_information = "This role requires you to coordinate a department. You are required to be familiar with Standard Operating Procedure (Medical), basic job duties, and act professionally (roleplay)."
 

--- a/code/game/jobs/job/medical_jobs.dm
+++ b/code/game/jobs/job/medical_jobs.dm
@@ -17,7 +17,7 @@
 			ACCESS_CHEMISTRY, ACCESS_VIROLOGY, ACCESS_CMO, ACCESS_SURGERY, ACCESS_RC_ANNOUNCE,
 			ACCESS_KEYCARD_AUTH, ACCESS_SEC_DOORS, ACCESS_PSYCHIATRIST, ACCESS_MAINT_TUNNELS, ACCESS_PARAMEDIC, ACCESS_MINERAL_STOREROOM)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_MEDICAL = 1200)
+	exp_map = list(EXP_TYPE_MEDICAL = 4800)
 	outfit = /datum/outfit/job/cmo
 	important_information = "This role requires you to coordinate a department. You are required to be familiar with Standard Operating Procedure (Medical), basic job duties, and act professionally (roleplay)."
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -19,7 +19,7 @@
 					ACCESS_RESEARCH, ACCESS_ROBOTICS, ACCESS_XENOBIOLOGY, ACCESS_AI_UPLOAD,
 					ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_TCOMSAT, ACCESS_GATEWAY, ACCESS_XENOARCH, ACCESS_MINISAT, ACCESS_MAINT_TUNNELS, ACCESS_MINERAL_STOREROOM, ACCESS_NETWORK)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_SCIENCE = 4800)
+	exp_map = list(EXP_TYPE_SCIENCE = 3000)
 	// All science-y guys get bonuses for maxing out their tech.
 	required_objectives = list(
 		/datum/job_objective/further_research

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -19,7 +19,7 @@
 					ACCESS_RESEARCH, ACCESS_ROBOTICS, ACCESS_XENOBIOLOGY, ACCESS_AI_UPLOAD,
 					ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_TCOMSAT, ACCESS_GATEWAY, ACCESS_XENOARCH, ACCESS_MINISAT, ACCESS_MAINT_TUNNELS, ACCESS_MINERAL_STOREROOM, ACCESS_NETWORK)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_SCIENCE = 1200)
+	exp_map = list(EXP_TYPE_SCIENCE = 4800)
 	// All science-y guys get bonuses for maxing out their tech.
 	required_objectives = list(
 		/datum/job_objective/further_research

--- a/code/game/jobs/job/security_jobs.dm
+++ b/code/game/jobs/job/security_jobs.dm
@@ -19,7 +19,7 @@
 						ACCESS_RESEARCH, ACCESS_ENGINE, ACCESS_MINING, ACCESS_MEDICAL, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING,
 						ACCESS_HEADS, ACCESS_HOS, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_GATEWAY, ACCESS_WEAPONS)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_SECURITY = 4800)
+	exp_map = list(EXP_TYPE_SECURITY = 3000)
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/hos
 	important_information = "This role requires you to coordinate a department. You are required to be familiar with Standard Operating Procedure (Security), Space Law, basic job duties, and act professionally (roleplay)."

--- a/code/game/jobs/job/security_jobs.dm
+++ b/code/game/jobs/job/security_jobs.dm
@@ -19,7 +19,7 @@
 						ACCESS_RESEARCH, ACCESS_ENGINE, ACCESS_MINING, ACCESS_MEDICAL, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING,
 						ACCESS_HEADS, ACCESS_HOS, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_GATEWAY, ACCESS_WEAPONS)
 	minimal_player_age = 21
-	exp_map = list(EXP_TYPE_SECURITY = 1200)
+	exp_map = list(EXP_TYPE_SECURITY = 4800)
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/hos
 	important_information = "This role requires you to coordinate a department. You are required to be familiar with Standard Operating Procedure (Security), Space Law, basic job duties, and act professionally (roleplay)."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Brings up CMO, HOS, RD, and CE from a 20 hour playtime req to an 50 hour playtime req (Captain and AI also may get a bump up)

## Why It's Good For The Game
This is something that's been coming for awhile frankly put, I'm not gonna sugarcoat it but extremely bald command is just too common now.

When playing as a head role you are expected to be at least somewhat competent, which is often not the case due to the frankly awful hour req on these jobs.

You don't really improve while playing as a head role if you don't know what you're doing, you're not able to be relied upon by other crew, and you're probably gonna have an awful time equivalent to the experience of very quickly falling down the stairs and landing facedown. Bald command should be an exception, not the rule. With this PR hopefully less newbie people should jump in to command roles expecting them to be easy. 
   
## Testing
Compiled 
## Changelog
:cl:
tweak: HOS, CE, RD, and CMO have all been brought up to an 50 hour lock from 20 hour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
