### PR TITLE
Tweaks and Fixes to Slip Shoes

### DIFF
--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -126,24 +126,25 @@
 	if(slot == slot_shoes)
 		return TRUE
 
-/obj/item/clothing/shoes/clown_shoes/slippers/proc/slide_one(mob/living/user, progress, prev_dir)
+/obj/item/clothing/shoes/clown_shoes/slippers/proc/slide_one(mob/living/user, progress, prev_dir , prev_flags)
 	user.dir = prev_dir
 	step(user, user.dir)
 	if(progress == slide_distance)
-		user.pass_flags -= PASSMOB | PASSTABLE
 		user.stand_up()
+		user.pass_flags = prev_flags
 
 /obj/item/clothing/shoes/clown_shoes/slippers/ui_action_click(mob/living/user, action)
     if(recharging_time > world.time)
         to_chat(user, "<span class='warning'>The boot's internal propulsion needs to recharge still!</span>")
         return
     var/prev_dir = user.dir
-    user.pass_flags += PASSMOB | PASSTABLE
+    var/old_pass = user.pass_flags
+    user.pass_flags |= (PASSMOB | PASSTABLE)
     playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE, 1)
     recharging_time = world.time + recharging_rate
     user.lay_down()
     for(var/crossed in 1 to slide_distance)
-        addtimer(CALLBACK(src, PROC_REF(slide_one), user, crossed, prev_dir), crossed)
+        addtimer(CALLBACK(src, PROC_REF(slide_one), user, crossed, prev_dir), crossed, old_pass)
 
 
 /obj/item/clothing/shoes/clown_shoes/slippers/toggle_waddle(mob/living/user)

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -151,7 +151,7 @@
 	if(!enabled_waddle)
 		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
 		enabled_waddle = TRUE
-		slowdown = SHOES_SLOWDOWN+1
+		slowdown = SHOES_SLOWDOWN + 1
 	else
 		to_chat(user, "<span class='notice'>You switch on the waddle dampeners, [src] no longer slow you down!</span>")
 		enabled_waddle = FALSE

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -70,7 +70,7 @@
 
 /obj/item/clothing/shoes/clown_shoes
 	name = "clown shoes"
-	desc = "The prankster's standard-issue clowning shoes. Damn they're huge! Ctrl-click to toggle the waddle dampeners!"
+	desc = "The prankster's standard-issue clowning shoes. Damn they're huge! <span class='notice'>Ctrl-click to toggle the waddle dampeners!</span>"
 	icon_state = "clown"
 	item_state = "clown_shoes"
 	slowdown = SHOES_SLOWDOWN+1
@@ -116,6 +116,8 @@
 
 /obj/item/clothing/shoes/clown_shoes/slippers
 	actions_types = list(/datum/action/item_action/slipping)
+	enabled_waddle = FALSE
+	slowdown = 0
 	var/slide_distance = 6
 	var/recharging_rate = 8 SECONDS
 	var/recharging_time = 0
@@ -124,30 +126,31 @@
 	if(slot == slot_shoes)
 		return TRUE
 
-/obj/item/clothing/shoes/clown_shoes/slippers/ui_action_click(mob/living/user, action)
-	if(recharging_time > world.time)
-		to_chat(user, "<span class='warning'>The boot's internal propulsion needs to recharge still!</span>")
-		return
-	var/prev_dir = user.dir
-	var/prev_pass_flags = user.pass_flags
-	user.pass_flags |= PASSMOB
-	user.Weaken(4 SECONDS)
+/obj/item/clothing/shoes/clown_shoes/slippers/proc/slide_one(mob/living/user, progress, prev_dir)
 	user.dir = prev_dir
-	playsound(src, 'sound/effects/stealthoff.ogg', 50, TRUE, 1)
-	recharging_time = world.time + recharging_rate
-	user.visible_message("<span class='warning'>[user] slips forward!</span>")
-	for(var/i in 1 to slide_distance)
-		step(user, user.dir)
-		sleep(1)
-	user.SetWeakened(0)
-	user.pass_flags = prev_pass_flags
+	step(user, user.dir)
+	if(progress == slide_distance)
+		user.pass_flags -= PASSMOB | PASSTABLE
+		user.stand_up()
+
+/obj/item/clothing/shoes/clown_shoes/slippers/ui_action_click(mob/living/user, action)
+    if(recharging_time > world.time)
+        to_chat(user, "<span class='warning'>The boot's internal propulsion needs to recharge still!</span>")
+        return
+    var/prev_dir = user.dir
+    user.pass_flags += PASSMOB | PASSTABLE
+    playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE, 1)
+    recharging_time = world.time + recharging_rate
+    user.lay_down()
+    for(var/crossed in 1 to slide_distance)
+        addtimer(CALLBACK(src, PROC_REF(slide_one), user, crossed, prev_dir), crossed)
 
 
 /obj/item/clothing/shoes/clown_shoes/slippers/toggle_waddle(mob/living/user)
 	if(!enabled_waddle)
 		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
 		enabled_waddle = TRUE
-		slowdown = initial(slowdown)
+		slowdown = SHOES_SLOWDOWN+1
 	else
 		to_chat(user, "<span class='notice'>You switch on the waddle dampeners, [src] no longer slow you down!</span>")
 		enabled_waddle = FALSE

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -144,7 +144,7 @@
     recharging_time = world.time + recharging_rate
     user.lay_down()
     for(var/crossed in 1 to slide_distance)
-        addtimer(CALLBACK(src, PROC_REF(slide_one), user, crossed, prev_dir), crossed, old_pass)
+        addtimer(CALLBACK(src, PROC_REF(slide_one), user, crossed, prev_dir, old_pass), crossed)
 
 
 /obj/item/clothing/shoes/clown_shoes/slippers/toggle_waddle(mob/living/user)


### PR DESCRIPTION
## What Does This PR Do + Why It's Good For The Game
This does the following to the clown traitor item slip shoes:
- **Performing a tactical slip no longer drops held items:** This was a dumb oversight I had when I added this, it is very crippling and makes the item annoying to use.
- **The shoes start with their waddle-dampeners active (no slowdown and waddling), you can still de-activate them with ctrl-click:** Some people do not know you can turn off the slowdown with ctrl-click and instead opt to not use the item. Is it baby-proofing? yeah. But I imagine that 9/10 you wont want slowdown anyway.
- **Removes the visible message "X slips forward!" when performing a slip:** There was really no reason for this message, regular slips don't have a chat message, this one shouldn't either.
- **Slips can now pass through tables:** Adding this as an additional possibility for performing sweet getaways, you'll have to prepare some table formations to take full use of this though.
- **Slipper now instantly stands up after a slip is finished:** This was always the intended behavior, but with crawling added it had the consequence of a do_after to stand up, which was very annoying.

## Images of changes
![iMZzB9pUYm](https://user-images.githubusercontent.com/48032385/226590875-2f681642-c48a-47ba-9fae-f9f29170ac0b.gif)


## Testing
1- Put on the shoes of enemies and walked a mile in their shoes.
2- My enemies' shoes are C-class contraband, how jolly.
3- Slipped under whoever I crossed along the side-walk.
4- The gun I stole from a police officer did not drop while I slipped under them.

## Changelog
:cl:
add: Clown traitor shoes can now slip through tables.
del: Clown traitor shoes no longer have a visible message.
fix: Clown traitor shoes make you stand up instantly after slipping.
fix: Clown traitor shoes no longer make you drop your held items after slipping.
tweak: Clown traitor shoes start with their waddle-dampeners on.
/:cl: