### PR TITLE
Holy water no longer turns into unholy water when cultbladed

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -41,9 +41,7 @@
 			else // Targeting someone else
 				to_chat(user, "<span class='cult'>You remove the taint from [M].</span>")
 				to_chat(M, "<span class='cult'>[user] removes the taint from your body.</span>")
-				var/amount = M.reagents.get_reagent_amount("holywater")
 				M.reagents.del_reagent("holywater")
-				M.reagents.add_reagent("unholywater", amount)
 				add_attack_logs(user, M, "Hit with [src], removing the holy water from them")
 		return FALSE
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title

## Why It's Good For The Game
Yeah so being able to convert any number of holy water instantly into a quite absurd antistun is probably bad, especially when holy water is really easy to come by 

## Testing
Compiled 
## Changelog
:cl:
tweak: Cult blades no longer turn holy water into unholy water when striking a cultist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
