### PR TITLE
Removes gatfruit from xenobiology/silver slime cores

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -171,7 +171,8 @@
 		/obj/item/reagent_containers/food/snacks/deepfryholder,
 		/obj/item/reagent_containers/food/snacks/chinese,
 		/obj/item/reagent_containers/food/snacks/human,
-		/obj/item/reagent_containers/food/snacks/monstermeat
+		/obj/item/reagent_containers/food/snacks/monstermeat,
+		/obj/item/reagent_containers/food/snacks/grown/shell/gatfruit
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes gatfruit from the silver slime extract

## Why It's Good For The Game
So uh, gatfruit. 
When used in hand/eaten it creates a syndicate 357 revolver for use, that is a 13 TC item that fits in a plant bag, they come loaded as well so you don't need to worry about ammo either. This is absurdly powerful and can easily deal with anything you want it to. It was eventually removed due to pretty obvious reasons.
Anyways xenobiology silver slime extracts can still get gatfruit, and therefore can get syndicate revolvers. Whenever gatfruit shows up in a round it is a mess, nobody enforces space law related to it because people have syndicate revolvers now, every antag needs to deal with 357 revolvers, and tiders have guns. The fact this is locked behind RNG is also frustrating for pretty obvious reasons.
~Next cult round I see where they make gatfruit will end in the death of many~

## Testing
Compiled and ran
## Changelog
:cl:
tweak: Gatfruit can no longer be obtained from silver slime extracts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
