### PR TITLE
Allows Red ERT Borgs spawned through the game panel to select the Security Module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -1425,6 +1425,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 
 /mob/living/silicon/robot/ert/red
 	eprefix = "Red"
+	force_modules = list("Security", "Engineering", "Medical")
 	default_cell_type = /obj/item/stock_parts/cell/hyper
 
 /mob/living/silicon/robot/ert/gamma

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -146,8 +146,8 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 /client/proc/create_response_team_part_1(new_gender, new_species, role, turf/spawn_location)
 	if(role == "Cyborg")
 		var/mob/living/silicon/robot/ert/R = new GLOB.active_team.borg_path(spawn_location)
-		if(GLOB.active_team.cyborg_security_permitted)
-			R.force_modules = list("Security", "Engineering", "Medical")
+		if(!GLOB.active_team.cyborg_security_permitted)
+			R.force_modules = list("Engineering", "Medical")
 		return R
 
 	var/mob/living/carbon/human/M = new(null)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR makes it so robot/ert/red spawned by the game panel spawn with the ability to choose the Security module, without changing how cyborgs spawned as an ERT work - their ability to select a module is tied to whether the admin spawning the ERT enabled the security module. This is done by inversing the way the security module being allowed is done, making it so the subtype has the module by default but removing it if the security module is not selected.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Admins spawning in red ERT borgs have to do some real fanangling to get them to select the security module as the way the code implements it is by force changing the available modules as the team spawns. This way now, if an admin spawns a red ERT they will by default have the Security module as an option. If an admin wants to spawn borgs manually WITHOUT letting them select this, they can either use the Amber ERT spawn option (which will lack it) and change the borg's name or can simply instruct the players to select something else.
Also Tourte made me do it.
## Testing
<!-- How did you test the PR, if at all? -->
Spawned robot/ert/red, checked modules, batons there.
Spawned an ERT team without security module enabled on red with one borg, checked borg, no security module.
## Changelog
:cl:
tweak: Allows Red ERT Borgs spawned through the game panel to select the Security Module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
