### PR TITLE
adds empty donk box to crafting menu

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -475,6 +475,7 @@
 	reqs = list(/obj/item/storage/box,
 				/obj/item/stack/sheet/plastic,
 				/obj/item/stack/sheet/metal)
+	category = CAT_MISC
 
 /datum/crafting_recipe/flashlight_eyes
 	name = "Flashlight Eyes"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes an oversight where a category was left off of /datum/crafting_recipe/donk_box allowing for the crafting of empty Donk Pocket boxes in the crafting menu.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It fixes crafting for an item as it was intended to be.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Opened the crafting menu, confirmed that Donk Pocket box showed up in the proper category.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Tweaked code allowing Donk Pocket boxes to appear in the crafting menu under MISC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
