### PR TITLE
fixes gutlunch udders not properly GCing

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -28,7 +28,7 @@
 	stop_automated_movement_when_pulled = TRUE
 	can_collar = TRUE
 	blood_volume = BLOOD_VOLUME_NORMAL
-	var/obj/item/udder/udder = null
+	var/obj/item/udder/cow/udder = null
 	gender = FEMALE
 	footstep_type = FOOTSTEP_MOB_SHOE
 
@@ -133,7 +133,7 @@
 	can_collar = TRUE
 	gold_core_spawnable = FRIENDLY_SPAWN
 	blood_volume = BLOOD_VOLUME_NORMAL
-	var/obj/item/udder/udder = null
+	var/obj/item/udder/cow/udder = null
 	gender = FEMALE
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST
 	footstep_type = FOOTSTEP_MOB_SHOE
@@ -143,14 +143,13 @@
 	. = ..()
 
 /mob/living/simple_animal/cow/Destroy()
-	qdel(udder)
-	udder = null
+	QDEL_NULL(udder)
 	return ..()
 
 /mob/living/simple_animal/cow/attackby(obj/item/O, mob/user, params)
 	if(stat == CONSCIOUS && istype(O, /obj/item/reagent_containers/glass))
 		udder.milkAnimal(O, user)
-		return 1
+		return TRUE
 	else
 		return ..()
 
@@ -498,10 +497,9 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 /obj/item/udder
 	name = "udder"
 
-/obj/item/udder/New()
-	create_reagents(50)
-	reagents.add_reagent("milk", 20)
+/obj/item/udder/Initialize(mapload)
 	. = ..()
+	create_reagents(50)
 
 /obj/item/udder/proc/generateMilk()
 	if(prob(5))
@@ -517,3 +515,9 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 		user.visible_message("[user] milks [src] using \the [O].", "<span class='notice'>You milk [src] using \the [O].</span>")
 	else
 		to_chat(user, "<span class='danger'>The udder is dry. Wait a bit longer...</span>")
+
+/obj/item/udder/cow
+
+/obj/item/udder/cow/Initialize(mapload)
+	. = ..()
+	reagents.add_reagent("milk", 20)

--- a/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
@@ -95,11 +95,6 @@
 /obj/item/udder/gutlunch
 	name = "nutrient sac"
 
-/obj/item/udder/gutlunch/Initialize(mapload)
-	. = ..()
-	reagents = new(50)
-	reagents.my_atom = src
-
 /obj/item/udder/gutlunch/generateMilk()
 	if(prob(60))
 		reagents.add_reagent("cream", rand(2, 5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes gutlunch udders not properly GCing

## Why It's Good For The Game
Having two reagent datums exist in the same obj causes issues and some minor memory leakage (One was set on init, then overwritten on new), this is bad because:
```
[2023-03-22T20:26:13] Path: /obj/item/udder/gutlunch
[2023-03-22T20:26:13] 	Failures: 28
[2023-03-22T20:26:13] 	qdel() Count: 28
[2023-03-22T20:26:13] 	Destroy() Cost: 3.084ms
[2023-03-22T20:26:13] 	Total Hard Deletes 27
[2023-03-22T20:26:13] 	Time Spent Hard Deleting: 527.125ms
```
This PR repaths the cow udder and prevents the gutlunch from making "fake" reagent datums that don't really exist

## Testing
Compiled, ran, milked some simple animals
