### PR TITLE
Fixed a runtime preventing the crafting of donk pocket boxes

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -472,9 +472,9 @@
 	name = "Donk Pocket Box"
 	result = list(/obj/item/storage/box/donkpockets/empty)
 	time = 10
-	reqs = list(/obj/item/storage/box,
-				/obj/item/stack/sheet/plastic,
-				/obj/item/stack/sheet/metal)
+	reqs = list(/obj/item/storage/box = 1,
+				/obj/item/stack/sheet/plastic = 1,
+				/obj/item/stack/sheet/metal = 1)
 	category = CAT_MISC
 
 /datum/crafting_recipe/flashlight_eyes


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the list be properly assoc, so crafting doesn't runtime.
It specifically looks up indexes and requires a number, even if it's just 1.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Crafting should not runtime.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Eyeballs.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed a runtime preventing the crafting of donk pocket boxes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
