### PR TITLE
PDA ID fix

### DIFF
--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -137,6 +137,13 @@ GLOBAL_LIST_EMPTY(PDAs)
 		var/datum/data/pda/P = A
 		P.pda = src
 
+/obj/item/pda/update_overlays()
+	. = ..()
+	if(id)
+		. += image('icons/goonstation/objects/pda_overlay.dmi', id.icon_state)
+	if(length(notifying_programs))
+		. += image('icons/obj/pda.dmi', "pda-r")
+
 /obj/item/pda/proc/close(mob/user)
 	SStgui.close_uis(src)
 
@@ -151,7 +158,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	if(can_use(usr))
 		start_program(find_program(/datum/data/pda/app/main_menu))
 		notifying_programs.Cut()
-		overlays -= image('icons/obj/pda.dmi', "pda-r")
+		update_icon(UPDATE_OVERLAYS)
 		to_chat(usr, "<span class='notice'>You press the reset button on \the [src].</span>")
 		SStgui.update_uis(src)
 	else
@@ -185,8 +192,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 			SStgui.update_uis(src)
 		else
 			id.forceMove(get_turf(src))
-		overlays -= image('icons/goonstation/objects/pda_overlay.dmi', id.icon_state)
 		id = null
+		update_icon(UPDATE_OVERLAYS)
 		playsound(src, 'sound/machines/terminal_eject.ogg', 50, TRUE)
 
 	if(ishuman(loc))
@@ -295,7 +302,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				if( can_use(user) )//If they can still act.
 					id_check(user, 2)
 					to_chat(user, "<span class='notice'>You put the ID into \the [src]'s slot.<br>You can remove it with ALT click.</span>")
-					overlays += image('icons/goonstation/objects/pda_overlay.dmi', C.icon_state)
+					update_icon(UPDATE_OVERLAYS)
 					SStgui.update_uis(src)
 
 	else if(istype(C, /obj/item/paicard) && !src.pai)

--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -40,14 +40,14 @@
 		pda.play_ringtone()
 
 	if(blink && !(src in pda.notifying_programs))
-		pda.overlays += image('icons/obj/pda.dmi', "pda-r")
+		pda.update_icon(UPDATE_OVERLAYS)
 		pda.notifying_programs |= src
 
 /datum/data/pda/proc/unnotify()
 	if(src in pda.notifying_programs)
 		pda.notifying_programs -= src
 		if(!pda.notifying_programs.len)
-			pda.overlays -= image('icons/obj/pda.dmi', "pda-r")
+			pda.update_icon(UPDATE_OVERLAYS)
 
 // An app has a button on the home screen and its own UI
 /datum/data/pda/app


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Address PDA sprites not updating correctly when removing ID after hot swapping with an additional ID. Fixes #20590
Refactors how PDA overlays are handled.  
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It is nice when the sprites update correctly. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested to see if the PDA sprite updated correctly after hot swapping and removing IDs. Checked to see if the PDA sprite updated correctly when receiving a notification. 
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes PDA ID sprites not updating after hot swapping and removing IDs
/:cl:

Special thanks to @Contrabang for guidance with this one!
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
