### PR TITLE
fixes revolution not working

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -253,10 +253,6 @@
 	return 0
 */
 
-///Called when a mob changes Z-level
-/datum/game_mode/proc/transit_z(mob/living/player)
-	return
-
 /datum/game_mode/proc/num_players()
 	. = 0
 	for(var/mob/new_player/P in GLOB.player_list)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -20,6 +20,7 @@
 
 	var/finished = 0
 	var/max_headrevs = 3
+	var/check_counter = 0
 	var/list/datum/mind/heads_to_kill = list()
 	var/list/possible_revolutionaries = list()
 
@@ -78,14 +79,22 @@
 		SSshuttle.emergencyNoEscape = 1
 	..()
 
-//////////////////////////////////////////////////////////////////////////
-//Check if heads and head revolutionaries are still alive and on Z-level//
-//////////////////////////////////////////////////////////////////////////
-/datum/game_mode/revolution/transit_z(mob/living/player)
-	if(!finished)
-		var/list/heads = get_all_heads()
-		if(player.mind && ((player.mind in heads) || (player.mind in head_revolutionaries)))
-			SSticker.mode.check_win()
+/datum/game_mode/revolution/process() // to anyone who thinks "why don't we use a normal actually sane check here instead of process for checking Z level changes" It's because equip code is dogshit and you change z levels upon spawning in
+	check_counter++
+	if(check_counter >= 5)
+		if(!finished)
+			check_heads()
+		check_counter = 0
+	return FALSE
+
+/datum/game_mode/revolution/proc/check_heads()
+	var/list/heads = get_all_heads()
+	if(length(heads_to_kill) < length(heads))
+		var/list/new_heads = heads - heads_to_kill
+		for(var/datum/mind/head_mind in new_heads)
+			for(var/datum/mind/rev_mind in head_revolutionaries)
+				mark_for_death(rev_mind, head_mind)
+
 
 /datum/game_mode/proc/forge_revolutionary_objectives(datum/mind/rev_mind)
 	var/list/heads = get_living_heads()
@@ -273,7 +282,7 @@
 				"<span class='userdanger'>You have been brainwashed! You are no longer a revolutionary! Your memory is hazy from the time you were a rebel... the only thing you remember is the name of the one who brainwashed you...</span>")
 			rev_mind.current.Paralyse(10 SECONDS)
 		update_rev_icons_removed(rev_mind)
-			
+
 /////////////////////////////////////
 //Adds the rev hud to a new convert//
 /////////////////////////////////////

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1089,7 +1089,6 @@
 /mob/living/onTransitZ(old_z,new_z)
 	..()
 	update_z(new_z)
-	SSticker.mode.transit_z(src)
 
 /mob/living/rad_act(amount)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reverts part of #20327

## Why It's Good For The Game
Revolution is broken due to this, transit_z is called upon roundstart spawning in

## Testing
This is a partial revert
## Changelog
:cl:
fix: Revolution not instantly end
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
