### PR TITLE
Gives the Syndicate Space Base plastitanium windows

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -72,10 +72,8 @@
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
 "aj" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/plastitanium,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "ap" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -470,10 +468,8 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/bar)
 "fe" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/plastitanium,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/chemistry)
 "ff" = (
 /obj/machinery/cryopod/offstation,
@@ -752,10 +748,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/plastitanium,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/telecomms)
 "hS" = (
 /obj/structure/cable{
@@ -1060,14 +1054,12 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "kE" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/plastitanium,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/telecomms)
 "kI" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
@@ -1486,7 +1478,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1991,7 +1983,7 @@
 	},
 /obj/structure/window/plasmareinforced,
 /obj/structure/grille,
-/turf/simulated/floor/engine/vacuum,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "vJ" = (
 /obj/structure/closet/l3closet,
@@ -2832,7 +2824,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "EM" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2882,7 +2874,7 @@
 	},
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/engine/vacuum,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "EX" = (
 /turf/simulated/floor/plasteel{
@@ -3144,10 +3136,8 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "Hv" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/plastitanium,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "HB" = (
 /obj/structure/sink{
@@ -4090,9 +4080,7 @@
 /area/ruin/unpowered/syndicate_space_base/dormitories)
 "RM" = (
 /obj/effect/spawner/window/plastitanium,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/virology)
 "RN" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -4579,7 +4567,7 @@
 	},
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/engine/vacuum,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "XS" = (
 /obj/structure/table/glass,
@@ -4654,11 +4642,9 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "YC" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/plastitanium,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/chemistry)
 "YJ" = (
 /obj/structure/table,
@@ -4738,7 +4724,7 @@
 /obj/machinery/computer/general_air_control/large_tank_control{
 	inlet_injector_autolink_id = "syndiebase_mix_in";
 	outlet_vent_autolink_id = "syndiebase_mix_out";
-	autolink_sensors = list("syndiebase_mix_sensor" = "Burn Mix")
+	autolink_sensors = list("syndiebase_mix_sensor"="Burn Mix")
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)


### PR DESCRIPTION
gah

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Replaces the regular reinforced windows at the Syndicate spacebase with plastitanium ones, also replaces the viro ones with spawners

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Consistency good, syndicate aesthetic good

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
<img width="175" alt="image" src="https://user-images.githubusercontent.com/80979251/227730874-877be3db-ecd2-412a-98f6-62b05c56f6e5.png">
<img width="73" alt="image" src="https://user-images.githubusercontent.com/80979251/227730881-c148c755-c88d-46b8-9324-5b8ce7ef18e7.png">


## Testing
<!-- How did you test the PR, if at all? -->
Untested - this is a very simple map change and will HOPEFULLY not blow up in my face

## Changelog
:cl:
tweak: The Syndicate has found room in the budget to give their space-based research outposts proper windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
