### PR TITLE
Fixes layer issues caused by  #20503

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -16,12 +16,6 @@
 #define SPACE_LAYER 1.5
 #define GRASS_UNDER_LAYER 1.6
 #define PLATING_LAYER 1.7
-#define LATTICE_LAYER 1.701
-#define DISPOSAL_PIPE_LAYER 1.71
-#define GAS_PIPE_HIDDEN_LAYER 1.72
-#define WIRE_LAYER 1.73
-#define WIRE_TERMINAL_LAYER 1.75
-#define ABOVE_PLATING_LAYER 1.76 // generic for /obj/hide
 //#define TURF_LAYER 2 //For easy recordkeeping; this is a byond define
 #define TRANSPARENT_TURF_LAYER 2
 #define ABOVE_TRANSPARENT_TURF_LAYER 2.01 // put wire terminals here if T.transparent_floor
@@ -34,8 +28,14 @@
 #define BULLET_HOLE_LAYER 2.06
 #define ABOVE_NORMAL_TURF_LAYER 2.08
 #define ABOVE_ICYOVERLAY_LAYER 2.11
-#define GAS_SCRUBBER_OFFSET -0.001
+#define LATTICE_LAYER 2.2
+#define ABOVE_PLATING_LAYER 2.25 // generic for /obj/hide
+#define DISPOSAL_PIPE_LAYER 2.3
+#define GAS_PIPE_HIDDEN_LAYER 2.35
+#define WIRE_LAYER 2.4
+#define WIRE_TERMINAL_LAYER 2.45
 #define GAS_PIPE_VISIBLE_LAYER 2.47
+#define GAS_SCRUBBER_OFFSET -0.001
 #define GAS_PIPE_SCRUB_OFFSET 0.001
 #define GAS_PIPE_SUPPLY_OFFSET 0.002
 #define GAS_FILTER_OFFSET 0.003


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes layer issues caused by #20503

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
#20503 brought along issues, where all piping, power cables and disposals was set to be one layer below.
This meant it broke your map editor of choice, as you would need to remove turf to be able to see it.
This fixes it, as well as setting the safe layer to be at the bottom.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
In-game view of the safe, some pipes and a piece of cable below the player character.
![image](https://user-images.githubusercontent.com/21987702/227788227-5d7f50cf-a0a4-47c3-a395-0bc83141db08.png)
Strongdmm view of part of the service region of cerestation with all things below floortiles visibible
![image](https://user-images.githubusercontent.com/21987702/227788344-ad6a925f-753c-43ab-9982-acf49f3ab707.png)


## Testing
<!-- How did you test the PR, if at all? -->
Checked in game, and via strongdmm that everything was and is visible.

## Changelog
:cl: ppi
fix: Fixes an issue that made t-ray scanner and optical t-ray goggles unable to see pipes, cable and disposals under floor tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
