### PR TITLE
Allows click-dragging onto meat spikes

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -77,7 +77,7 @@
 
 /obj/structure/kitchenspike/proc/start_spike(mob/living/victim, mob/user)
 	if(has_buckled_mobs())
-		to_chat(user, "<span class = 'danger'>The spike already has something on it, finish collecting its meat first!</span>")
+		to_chat(user, "<span class='danger'>The spike already has something on it, finish collecting its meat first!</span>")
 		return
 	victim.visible_message(
 		"<span class='danger'>[user] tries to slam [victim] onto the meat spike!</span>",

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -72,7 +72,7 @@
 		return
 	if(isanimal(user) && victim != user)
 		return // animals cannot put mobs other than themselves onto spikes
-	src.add_fingerprint(user)
+	add_fingerprint(user)
 	start_spike(victim, user)
 
 /obj/structure/kitchenspike/proc/start_spike(mob/living/victim, mob/user)

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -114,10 +114,6 @@
 	victim.pixel_y = victim.get_standard_pixel_y_offset(180)
 	return TRUE
 
-/obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/living/user)
-	// This will never run because meatspikes have density = TRUE
-	return
-
 /obj/structure/kitchenspike/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
 	if(buckled_mob)
 		var/mob/living/M = buckled_mob

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -68,7 +68,7 @@
 	return ..()
 
 /obj/structure/kitchenspike/MouseDrop_T(mob/living/victim, mob/living/user)
-	if(get_dist(user, src) > 1 || get_dist(user, victim) > 1 || isAI(user))
+	if (!user.Adjacent(src) || !user.Adjacent(victim) || isAI(user))
 		return
 	if(isanimal(user) && victim != user)
 		return // animals cannot put mobs other than themselves onto spikes

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -63,19 +63,30 @@
 		return
 	if(!istype(G, /obj/item/grab) || !G.affecting)
 		return
+	if(isliving(G.affecting))
+		start_spike(G.affecting, user)
+	return ..()
+
+/obj/structure/kitchenspike/MouseDrop_T(mob/living/victim, mob/living/user)
+	if(get_dist(user, src) > 1 || get_dist(user, victim) > 1 || isAI(user))
+		return
+	if(isanimal(user) && victim != user)
+		return // animals cannot put mobs other than themselves onto spikes
+	src.add_fingerprint(user)
+	start_spike(victim, user)
+
+/obj/structure/kitchenspike/proc/start_spike(mob/living/victim, mob/user)
 	if(has_buckled_mobs())
 		to_chat(user, "<span class = 'danger'>The spike already has something on it, finish collecting its meat first!</span>")
 		return
-	if(isliving(G.affecting))
-		if(!has_buckled_mobs())
-			if(do_mob(user, src, 120))
-				var/mob/living/affected = G.affecting
-				if(spike(affected))
-					affected.visible_message("<span class='danger'>[user] slams [affected] onto the meat spike!</span>", "<span class='userdanger'>[user] slams you onto the meat spike!</span>", "<span class='italics'>You hear a squishy wet noise.</span>")
-		return
-	return ..()
+	victim.visible_message(
+		"<span class='danger'>[user] tries to slam [victim] onto the meat spike!</span>",
+		"<span class='userdanger'>[user] tries to slam you onto the meat spike!</span>"
+	)
+	if(do_mob(user, src, 120))
+		end_spike(victim, user)
 
-/obj/structure/kitchenspike/proc/spike(mob/living/victim)
+/obj/structure/kitchenspike/proc/end_spike(mob/living/victim, mob/user)
 
 	if(!istype(victim))
 		return FALSE
@@ -87,6 +98,11 @@
 	playsound(loc, 'sound/effects/splat.ogg', 25, 1)
 	victim.forceMove(drop_location())
 	victim.emote("scream")
+	victim.visible_message(
+		"<span class='danger'>[user] slams [victim] onto the meat spike!</span>",
+		"<span class='userdanger'>[user] slams you onto the meat spike!</span>",
+		"<span class='italics'>You hear a squishy wet noise.</span>"
+	)
 	if(ishuman(victim))
 		var/mob/living/carbon/human/H = victim
 		H.add_splatter_floor()
@@ -98,8 +114,8 @@
 	victim.pixel_y = victim.get_standard_pixel_y_offset(180)
 	return TRUE
 
-
-/obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/living/user) //Don't want them getting put on the rack other than by spiking
+/obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/living/user)
+	// This will never run because meatspikes have density = TRUE
 	return
 
 /obj/structure/kitchenspike/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -83,7 +83,7 @@
 		"<span class='danger'>[user] tries to slam [victim] onto the meat spike!</span>",
 		"<span class='userdanger'>[user] tries to slam you onto the meat spike!</span>"
 	)
-	if(do_mob(user, src, 120))
+	if(do_mob(user, src, 12 SECONDS))
 		end_spike(victim, user)
 
 /obj/structure/kitchenspike/proc/end_spike(mob/living/victim, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Enabled an alternative method of moving mobs onto meat-spikes. You can now click-and-drag in addition to the old method. (The old method was use grab intent to grab, then click the meat-spike similar to "tabling")
I also added a message in chat when you initiate the action, so that a potential victim can see the message and react.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This is more in line with other similar actions such as: buckling someone to a chair or bed, stuffing someone in disposals, or putting someone in a gibber.
This is especially important as chef is a role intended for beginners, so making chef-related actions more intuitive will help beginners learn quickly and not get frustrated.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Open Questions
- Should I add a message to admins when a player slams someone onto a meat spike? This is what the gibber does, for example.
- Should I remove or edit the user_buckle_mob function? I think it will only ever run in very rare circumstances because you can't "pull" someone onto the same tile as a meatspike, and default buckling requires your victim to be in the same tile.

## Testing
- [x] Click dragging an animal/monkey onto the meat hooks works
- [x] Grab intent + click meathook still works
- [x] Freeing an animal by clicking the meathook still works
- [x] Trying to put an animal on a meathook that already has an animal gives an error message
- [x] Moving or switching items in hands while trying to hook an animal cancels the actions
- [x] Can't click+drag if not adjacent
- [x] Fingerprint code works
- [x] Click-drag still works, even if meatspike is built in same tile as the victim

Untested:
- [ ] Victim moving cancels the action
- [ ] Victim message says "You" instead of victim's name in chatlog
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: GnomeDePlume
add: Players can now click+drag mobs onto meat spikes in addition to the old method (grab intent mob + click meat-spike)
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
