### PR TITLE
Fixes t-ray scanners and map editing

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -15,6 +15,7 @@
 
 #define SPACE_LAYER 1.5
 #define GRASS_UNDER_LAYER 1.6
+#define MAP_EDITOR_TURF_LAYER 1.6999
 #define PLATING_LAYER 1.7
 #define LATTICE_LAYER 1.701
 #define DISPOSAL_PIPE_LAYER 1.71
@@ -24,7 +25,6 @@
 #define ABOVE_PLATING_LAYER 1.76 // generic for /obj/hide
 #define TRAY_SCAN_LAYER_OFFSET 0.5 // place images above TURF_LAYER
 //#define TURF_LAYER 2 //For easy recordkeeping; this is a byond define
-#define TRANSPARENT_TURF_LAYER 2
 #define ABOVE_TRANSPARENT_TURF_LAYER 2.01 // put wire terminals here if T.transparent_floor
 #define MID_TURF_LAYER 2.02
 #define HIGH_TURF_LAYER 2.03

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -15,6 +15,7 @@
 
 #define SPACE_LAYER 1.5
 #define GRASS_UNDER_LAYER 1.6
+/// Which layer turfs appear on by default in the map editor. Should be unique!
 #define MAP_EDITOR_TURF_LAYER 1.6999
 #define PLATING_LAYER 1.7
 #define LATTICE_LAYER 1.701

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -22,6 +22,7 @@
 #define WIRE_LAYER 1.73
 #define WIRE_TERMINAL_LAYER 1.75
 #define ABOVE_PLATING_LAYER 1.76 // generic for /obj/hide
+#define TRAY_SCAN_LAYER_OFFSET 0.5 // place images above TURF_LAYER
 //#define TURF_LAYER 2 //For easy recordkeeping; this is a byond define
 #define TRANSPARENT_TURF_LAYER 2
 #define ABOVE_TRANSPARENT_TURF_LAYER 2.01 // put wire terminals here if T.transparent_floor

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -2,7 +2,7 @@
 	//Liquid fuel is used for things that used to rely on volatile fuels or plasma being contained to a couple tiles.
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "fuel"
-	layer = LATTICE_LAYER
+	layer = ABOVE_NORMAL_TURF_LAYER
 	var/amount = 1 //Basically moles.
 
 /obj/effect/decal/cleanable/liquid_fuel/Initialize(mapload, amt = 1)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -57,6 +57,9 @@ REAGENT SCANNER
 			var/mutable_appearance/MA = new(O)
 			MA.alpha = 128
 			MA.dir = O.dir
+			if(MA.layer < TURF_LAYER)
+				MA.layer += TRAY_SCAN_LAYER_OFFSET
+			MA.plane = GAME_PLANE
 			I.appearance = MA
 			t_ray_images += I
 	if(length(t_ray_images))

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -242,7 +242,7 @@
 	icon_state = "weeds"
 	base_icon_state = "weeds"
 	max_integrity = 15
-	layer = WIRE_TERMINAL_LAYER
+	layer = ABOVE_ICYOVERLAY_LAYER
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_ALIEN_RESIN, SMOOTH_GROUP_ALIEN_WEEDS)
 	canSmoothWith = list(SMOOTH_GROUP_ALIEN_WEEDS, SMOOTH_GROUP_WALLS)

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -12,7 +12,7 @@
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	smoothing_groups = list(SMOOTH_GROUP_TURF)
-	layer = PLATING_LAYER
+	real_layer = PLATING_LAYER
 
 /turf/simulated/floor/plating/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/simulated/floor/transparent.dm
+++ b/code/game/turfs/simulated/floor/transparent.dm
@@ -14,7 +14,6 @@
 	heavyfootstep = FOOTSTEP_GLASS_BAREFOOT
 	light_power = 0.25
 	light_range = 2
-	layer = TRANSPARENT_TURF_LAYER
 	keep_dir = FALSE
 	intact = FALSE
 	transparent_floor = TRUE

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -164,7 +164,8 @@
 	canSmoothWith = list(SMOOTH_GROUP_MINERAL_WALLS, SMOOTH_GROUP_ASTEROID_WALLS)
 	mine_time = 6 SECONDS
 	color = COLOR_ANCIENT_ROCK
-	layer = TURF_LAYER
+	layer = MAP_EDITOR_TURF_LAYER
+	real_layer = TURF_LAYER
 	should_reset_color = FALSE
 	mineralAmt = 2
 	mineralType = /obj/item/stack/ore/glass/basalt/ancient

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -8,6 +8,10 @@
 	var/slowdown = 0 //negative for faster, positive for slower
 	var/transparent_floor = FALSE //used to check if pipes should be visible under the turf or not
 
+	// set if the turf should appear on a different layer while in-game and map editing, otherwise use normal layer
+	var/real_layer = TURF_LAYER
+	layer = MAP_EDITOR_TURF_LAYER
+
 	///Icon-smoothing variable to map a diagonal wall corner with a fixed underlay.
 	var/list/fixed_underlay = null
 
@@ -48,6 +52,9 @@
 	if(initialized)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	initialized = TRUE
+
+	if(layer == MAP_EDITOR_TURF_LAYER)
+		layer = real_layer
 
 	// by default, vis_contents is inherited from the turf that was here before
 	vis_contents.Cut()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -8,7 +8,7 @@
 	var/slowdown = 0 //negative for faster, positive for slower
 	var/transparent_floor = FALSE //used to check if pipes should be visible under the turf or not
 
-	// set if the turf should appear on a different layer while in-game and map editing, otherwise use normal layer
+	/// Set if the turf should appear on a different layer while in-game and map editing, otherwise use normal layer.
 	var/real_layer = TURF_LAYER
 	layer = MAP_EDITOR_TURF_LAYER
 

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -23,6 +23,8 @@ Pipelines + Other Objects -> Pipe network
 
 	/// Can this be unwrenched?
 	var/can_unwrench = FALSE
+	/// Can this be put under a tile?
+	var/can_be_undertile = FALSE
 	/// If the machine is currently operating or not.
 	var/on = FALSE
 	/// The amount of pressure the machine wants to operate at.
@@ -189,7 +191,7 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/attackby(obj/item/W, mob/user)
 	var/turf/T = get_turf(src)
 	if(can_unwrench && istype(W, /obj/item/wrench))
-		if(T.transparent_floor && istype(src, /obj/machinery/atmospherics/pipe) && layer != GAS_PIPE_VISIBLE_LAYER) //pipes on GAS_PIPE_VISIBLE_LAYER are above the transparent floor and should be interactable
+		if(level == 1 && T.transparent_floor && istype(src, /obj/machinery/atmospherics/pipe))
 			to_chat(user, "<span class='danger'>You can't interact with something that's under the floor!</span>")
 			return
 		if(level == 1 && isturf(T) && T.intact)
@@ -278,11 +280,10 @@ Pipelines + Other Objects -> Pipe network
 	initialize_directions = P
 	var/turf/T = loc
 	if(!T.transparent_floor)
-		level = T.intact ? 2 : 1
+		level = (T.intact || !can_be_undertile) ? 2 : 1
 	else
 		level = 2
-		plane = GAME_PLANE
-		layer = GAS_PIPE_VISIBLE_LAYER
+	update_icon_state()
 	add_fingerprint(usr)
 	if(!SSair.initialized) //If there's no atmos subsystem, we can't really initialize pipenets
 		SSair.machinery_to_construct.Add(src)

--- a/code/modules/atmospherics/machinery/pipes/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipe.dm
@@ -8,6 +8,8 @@
 	damage_deflection = 12
 	var/alert_pressure = 80*ONE_ATMOSPHERE //minimum pressure before check_pressure(...) should be called
 
+	can_be_undertile = TRUE
+
 	//Buckling
 	can_buckle = TRUE
 	buckle_requires_restraints = TRUE


### PR DESCRIPTION
## What Does This PR Do
Fixes issues introduced by [PR#20503](https://github.com/ParadiseSS13/Paradise/pull/20503), the t-ray scanner now functions properly and you can once again see pipes and wires in StrongDMM. Fixes #20722. Fixes #20738. Fixes #20760. This PR is an alternative to [PR#20721](https://github.com/ParadiseSS13/Paradise/pull/20721), do not merge both of them.

## Why It's Good For The Game
Fixes. It's better than [PR#20721](https://github.com/ParadiseSS13/Paradise/pull/20721) because it maintains functionality that I require for [Pulse Demon](https://github.com/ParadiseSS13/Paradise/pull/20577), where the other does not.

## Images of changes
![fix-tray-scanner](https://user-images.githubusercontent.com/126365777/227801601-08e7fd38-6e9b-462f-86e8-20e841c0d40f.PNG)
![fix-map-editor](https://user-images.githubusercontent.com/126365777/227801602-efcae591-d0e0-4e1f-b3b0-769fce56054f.PNG)

## Testing
Tested the t-ray scanner (and goggles) and StrongDMM.

## Changelog
:cl:
fix: t-ray scanner works again
/:cl:
