### PR TITLE
makes caseless ammo GC

### DIFF
--- a/code/modules/projectiles/guns/projectile_gun.dm
+++ b/code/modules/projectiles/guns/projectile_gun.dm
@@ -49,13 +49,13 @@
 		. += knife_overlay
 
 /obj/item/gun/projectile/process_chamber(eject_casing = 1, empty_chamber = 1)
-	var/obj/item/ammo_casing/AC = chambered //Find chambered round
-	if(isnull(AC) || !istype(AC))
+	var/obj/item/ammo_casing/ammo_chambered = chambered //Find chambered round
+	if(isnull(ammo_chambered) || !istype(ammo_chambered))
 		chamber_round()
 		return
-	if(eject_casing)
-		AC.loc = get_turf(src) //Eject casing onto ground.
-		AC.SpinAnimation(10, 1) //next gen special effects
+	if(eject_casing && !QDELETED(ammo_chambered))
+		ammo_chambered.loc = get_turf(src) //Eject casing onto ground.
+		ammo_chambered.SpinAnimation(10, 1) //next gen special effects
 		playsound(src, chambered.casing_drop_sound, 100, 1)
 	if(empty_chamber)
 		chambered = null

--- a/code/modules/projectiles/guns/projectile_gun.dm
+++ b/code/modules/projectiles/guns/projectile_gun.dm
@@ -50,11 +50,11 @@
 
 /obj/item/gun/projectile/process_chamber(eject_casing = 1, empty_chamber = 1)
 	var/obj/item/ammo_casing/ammo_chambered = chambered //Find chambered round
-	if(isnull(ammo_chambered) || !istype(ammo_chambered))
+	if(!istype(ammo_chambered))
 		chamber_round()
 		return
 	if(eject_casing && !QDELETED(ammo_chambered))
-		ammo_chambered.loc = get_turf(src) //Eject casing onto ground.
+		ammo_chambered.forceMove(get_turf(src)) //Eject casing onto ground.
 		ammo_chambered.SpinAnimation(10, 1) //next gen special effects
 		playsound(src, chambered.casing_drop_sound, 100, 1)
 	if(empty_chamber)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
makes ammo not forcemove a qdeleted object 
Makes ammo without a casing not play a sound effect of the casing being dropped
## Why It's Good For The Game
This is bad
```
[2023-03-26T21:24:45] QDEL: Path: /obj/item/ammo_casing/caseless/laser
[2023-03-26T21:24:45] 	Failures: 2543
[2023-03-26T21:24:45] 	qdel() Count: 3189
[2023-03-26T21:24:45] 	Destroy() Cost: 240.508ms
[2023-03-26T21:24:45] 	Total Hard Deletes 2543
[2023-03-26T21:24:45] 	Time Spent Hard Deleting: 7235.51ms
```
## Testing
it worked

## Changelog
:cl:
fix: Caseless ammo no longer plays the drop ammo sound effect on being fired
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
