### PR TITLE
Freshens up floodlights to not be 10 years old

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -52,7 +52,7 @@
 		cell.update_icon(UPDATE_ICON_STATE)
 
 		cell = null
-		to_chat(user, "You remove the power cell.")
+		to_chat(user, "<span class='warning'>You remove the power cell.</span>")
 		if(on)
 			on = FALSE
 			visible_message("<span class='warning'>[src] shuts down due to lack of power!</span>")
@@ -66,10 +66,10 @@
 		set_light(0)
 	else
 		if(!cell)
-			to_chat(user, "<span class='warning'>[src] doesn't do anything! <b>Seems</b> like it lacks a power cell.</span>")
+			to_chat(user, "<span class='warning'>You try to turn on [src] but nothing happens! Seems like it <b>lacks a power cell</b>.</span>")
 			return
 		if(cell.charge <= 0)
-			to_chat(user, "<span class='warning'>[src] hardly glows at all! <b>Seems</b> like the power cell is empty.</span>")
+			to_chat(user, "<span class='warning'>[src] hardly glows at all! Seems like the <b>power cell is empty</b>.</span>")
 			return
 		on = TRUE
 		to_chat(user, "<span class='notice'>You turn on the light.</span>")
@@ -90,20 +90,20 @@
 	if(istype(W, /obj/item/stock_parts/cell))
 		if(open)
 			if(cell)
-				to_chat(user, "There is a power cell already installed.")
+				to_chat(user, "<span class='warning'>There is a power cell already installed.</span>")
 			else
 				playsound(loc, W.usesound, 50, 1)
 				user.drop_item()
 				W.loc = src
 				cell = W
-				to_chat(user, "You insert the power cell.")
+				to_chat(user, "<span class='notice'>You insert the power cell.</span>")
 		update_icon(UPDATE_ICON_STATE)
 		return
 	return ..()
 
 /obj/machinery/floodlight/screwdriver_act(mob/living/user, obj/item/I)
 	if(open)
-		to_chat(user, "The screws aren't long enough to reach the holes.")
+		to_chat(user, "<span class='warning'>The screws aren't long enough to reach the holes.</span>")
 		return TRUE
 
 	if(!I.use_tool(src, user, volume = I.tool_volume))
@@ -113,26 +113,26 @@
 		return
 
 	if(unlocked)
-		to_chat(user, "You screw the battery panel in place.")
+		to_chat(user, "<span class='notice'>You screw the battery panel in place.</span>")
 	else
-		to_chat(user, "You unscrew the battery panel.")
+		to_chat(user, "<span class='notice'>You unscrew the battery panel.</span>")
 	unlocked = !unlocked
 	update_icon(UPDATE_ICON_STATE)
 	return TRUE
 
 /obj/machinery/floodlight/crowbar_act(mob/living/user, obj/item/I)
 	if(!unlocked)
-		to_chat(user, "The cover is screwed tightly down.")
+		to_chat(user, "<span class='notice'>The cover is screwed tightly down.</span>")
 		return TRUE
 
 	if(!I.use_tool(src, user, volume = I.tool_volume))
 		return
 
 	if(open)
-		to_chat(user, "You pry the panel closed.")
+		to_chat(user, "<span class='notice'>You pry the panel closed.</span>")
 		open = FALSE
 	else
-		to_chat(user, "You pry the panel open.")
+		to_chat(user, "<span class='notice'>You pry the panel open.</span>")
 		open = TRUE
 	update_icon(UPDATE_ICON_STATE)
 	return TRUE

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -122,17 +122,17 @@
 
 /obj/machinery/floodlight/crowbar_act(mob/living/user, obj/item/I)
 	if(!unlocked)
-		to_chat(user, "The cover is screwed tightly down")
+		to_chat(user, "The cover is screwed tightly down.")
 		return TRUE
 
 	if(!I.use_tool(src, user, volume = I.tool_volume))
 		return
 
 	if(open)
-		to_chat(user, "You pry the panel closed")
+		to_chat(user, "You pry the panel closed.")
 		open = FALSE
 	else
-		to_chat(user, "You pry the panel open")
+		to_chat(user, "You pry the panel open.")
 		open = TRUE
 	update_icon(UPDATE_ICON_STATE)
 	return TRUE

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -92,7 +92,7 @@
 			if(cell)
 				to_chat(user, "<span class='warning'>There is a power cell already installed.</span>")
 			else
-				playsound(loc, W.usesound, 50, 1)
+				playsound(loc, W.usesound, 50, TRUE)
 				user.drop_item()
 				W.loc = src
 				cell = W

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -31,7 +31,7 @@
 
 /obj/machinery/floodlight/process()
 	if(on)
-		if(!cell.use(use))
+		if(cell && !cell.use(use))
 			on = FALSE
 			update_icon(UPDATE_ICON_STATE)
 			set_light(0)
@@ -103,7 +103,7 @@
 
 /obj/machinery/floodlight/screwdriver_act(mob/living/user, obj/item/I)
 	if(open)
-		to_chat(user, "<span class='warning'>The screws aren't long enough to reach the holes.</span>")
+		to_chat(user, "<span class='warning'>The screws can't reach while its open.</span>")
 		return TRUE
 
 	if(!I.use_tool(src, user, volume = I.tool_volume))
@@ -130,10 +130,9 @@
 
 	if(open)
 		to_chat(user, "<span class='notice'>You pry the panel closed.</span>")
-		open = FALSE
 	else
 		to_chat(user, "<span class='notice'>You pry the panel open.</span>")
-		open = TRUE
+	open = !open
 	update_icon(UPDATE_ICON_STATE)
 	return TRUE
 

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -66,10 +66,10 @@
 		set_light(0)
 	else
 		if(!cell)
-			to_chat(user, "<span class='warning'>[src] doesn't do anything! <b>seems</b> like it lacks a power cell.</span>")
+			to_chat(user, "<span class='warning'>[src] doesn't do anything! <b>Seems</b> like it lacks a power cell.</span>")
 			return
 		if(cell.charge <= 0)
-			to_chat(user, "<span class= 'warning'>[src] hardly glows at all! <b>seems</b> like the power cell is empty.</span>")
+			to_chat(user, "<span class='warning'>[src] hardly glows at all! <b>Seems</b> like the power cell is empty.</span>")
 			return
 		on = TRUE
 		to_chat(user, "<span class='notice'>You turn on the light.</span>")
@@ -103,7 +103,7 @@
 
 /obj/machinery/floodlight/screwdriver_act(mob/living/user, obj/item/I)
 	if(open)
-		to_chat(user, "the screws aren't long enough to reach the holes.")
+		to_chat(user, "The screws aren't long enough to reach the holes.")
 		return TRUE
 
 	if(!I.use_tool(src, user, volume = I.tool_volume))
@@ -129,10 +129,10 @@
 		return
 
 	if(open)
-		to_chat(user, "you pry the panel closed")
+		to_chat(user, "You pry the panel closed")
 		open = FALSE
 	else
-		to_chat(user, "you pry the panel open")
+		to_chat(user, "You pry the panel open")
 		open = TRUE
 	update_icon(UPDATE_ICON_STATE)
 	return TRUE
@@ -151,9 +151,9 @@
 /obj/machinery/floodlight/examine(mob/user)
 	. = ..()
 	if(!unlocked)
-		. +="<span class='notice'>The panel is <b>screwed</b> shut."
+		. +="<span class='notice'>The panel is <b>screwed</b> shut.</span>"
 	else
 		if(open)
-			. +="<span class='notice'>The panel is <b>pried</b> open, looks like you could fit a cell in there."
+			. +="<span class='notice'>The panel is <b>pried</b> open, looks like you could fit a cell in there.</span>"
 		else
-			. +="<span class='notice'>The panel looks like it could be <b>pried</b> open, or <b>screwed</b> shut."
+			. +="<span class='notice'>The panel looks like it could be <b>pried</b> open, or <b>screwed</b> shut.</span>"

--- a/code/modules/supply/supply_packs/pack_emergency.dm
+++ b/code/modules/supply/supply_packs/pack_emergency.dm
@@ -113,3 +113,10 @@
 	containertype = /obj/structure/closet/crate
 	containername = "special ops crate"
 	hidden = TRUE
+
+/datum/supply_packs/emergency/floodlight
+	name = "Emergency Flood Light"
+	contains = list(/obj/machinery/floodlight)
+	cost = 250
+	containertype = /obj/structure/largecrate
+	containername = "Emergency flood light"

--- a/code/modules/supply/supply_packs/pack_emergency.dm
+++ b/code/modules/supply/supply_packs/pack_emergency.dm
@@ -119,4 +119,4 @@
 	contains = list(/obj/machinery/floodlight)
 	cost = 250
 	containertype = /obj/structure/largecrate
-	containername = "Emergency flood light"
+	containername = "emergency flood light"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Refactors the tool interaction code as well as some power drain code.
Adds sounds to tool interactions.
Lowers Light range from 20, to 10(about one and a half screens)
Increases the power draw from 5, to 30(around 11 minutes of use for high capacity cell)  
Adds detailed inspections to show that you can remove the cells from the floodlight, and if it lacks a cell, or is out of power.
And lets you buy more floodlights from cargo, 250 credits, for a single one. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As of right now, floodlights are absurdly old, powerful, and not very intuitive, this PR (hopefully) lowers how stupidly strong they are against two antag sub types they directly counter, and makes them more usable for power outages, as well as makes it a little more easy to figure out how to replace the cells. 

## Testing
<!-- How did you test the PR, if at all? -->
Booted up local testing server, messed with the floodlights for a bit, made sure the high capacity cell(the one it spawns with) lasted about 10 minutes, overshot by one minute, not that big of a deal. I would like to note, that im only 90% sure the others should last an extra 11 minutes per upgrade, if you want to prove me wrong, go right ahead.. i'd rather not sit and watch a light for tens of minutes..
Made sure inspecting gave the correct details.
Made sure you couldn't do tool steps out of order.
Made sure you could wrench it down and back up.
Annnd finally made sure it was in cargo, for the correct amount, and came in the nice wooden box.
## Changelog
:cl:
add: Added tool sounds to the flood light.
add: Added the emergency floodlight to the cargo catalog for 250 credits, under the emergency tab.
tweak: Floodlights light range is now 10 (about a screen and a half)
tweak: Floodlights now last roughly 11 minutes with a high capacity cell, doubling each upgrade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->

## additional notes
Correct me if the first change log should be a tweak rather than addition, add just sounds better.

And a **_big_** thanks to Lewcc, Vi3trice, and Snowball, for helping me figure out a good chunk of the coding jargon!