### PR TITLE
adds the mecha ion thruster

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -45,18 +45,10 @@
 	leg_overload_coeff = 100
 	operation_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
-	max_equip = 4
+	max_equip = 5
 	maxsize = 2
 	starting_voice = /obj/item/mecha_modkit/voice/syndicate
 	destruction_sleep_duration = 2 SECONDS
-
-/obj/mecha/combat/gygax/dark/GrantActions(mob/living/user, human_occupant = 0)
-	. = ..()
-	thrusters_action.Grant(user, src)
-
-/obj/mecha/combat/gygax/dark/RemoveActions(mob/living/user, human_occupant = 0)
-	. = ..()
-	thrusters_action.Remove(user)
 
 /obj/mecha/combat/gygax/dark/loaded/Initialize(mapload)
 	. = ..()
@@ -67,6 +59,8 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/thrusters
 	ME.attach(src)
 
 /obj/mecha/combat/gygax/dark/add_cell()

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -15,20 +15,18 @@
 	add_req_access = 0
 	internal_damage_threshold = 25
 	force = 45
-	max_equip = 5
+	max_equip = 6
 	starting_voice = /obj/item/mecha_modkit/voice/nanotrasen
 	destruction_sleep_duration = 2 SECONDS
 	emag_proof = TRUE //no stealing CC mechs.
 
 /obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = 0)
 	. = ..()
-	thrusters_action.Grant(user, src)
 	smoke_action.Grant(user, src)
 	zoom_action.Grant(user, src)
 
 /obj/mecha/combat/marauder/RemoveActions(mob/living/user, human_occupant = 0)
 	. = ..()
-	thrusters_action.Remove(user)
 	smoke_action.Remove(user)
 	zoom_action.Remove(user)
 
@@ -44,6 +42,8 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/thrusters
+	ME.attach(src)
 
 /obj/mecha/combat/marauder/ares
 	name = "Ares"
@@ -55,7 +55,7 @@
 	armor = list(melee = 50, bullet = 40, laser = 20, energy = 20, bomb = 20, bio = 100, rad = 60, fire = 100, acid = 100)
 	max_temperature = 40000
 	wreckage = /obj/structure/mecha_wreckage/ares
-	max_equip = 4
+	max_equip = 5
 	emag_proof = FALSE //Gamma armory can be stolen however.
 
 /obj/mecha/combat/marauder/ares/loaded/Initialize(mapload)
@@ -67,6 +67,8 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster(src)
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/thrusters
 	ME.attach(src)
 
 /obj/mecha/combat/marauder/seraph
@@ -104,7 +106,8 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
-
+	ME = new /obj/item/mecha_parts/mecha_equipment/thrusters
+	ME.attach(src)
 
 /obj/mecha/combat/marauder/mauler
 	desc = "Heavy-duty, combat exosuit, developed off of the existing Marauder model."
@@ -127,4 +130,6 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/thrusters
 	ME.attach(src)

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -447,9 +447,11 @@
 	. = ..()
 	START_PROCESSING(SSobj, src)
 	M.add_thrusters()
+	M.thruster_count++
 
 /obj/item/mecha_parts/mecha_equipment/thrusters/detach(atom/moveto)
 	chassis.remove_thrusters()
+	chassis.thruster_count--
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
 

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -450,8 +450,8 @@
 	M.thruster_count++
 
 /obj/item/mecha_parts/mecha_equipment/thrusters/detach(atom/moveto)
-	chassis.remove_thrusters()
 	chassis.thruster_count--
+	chassis.remove_thrusters()
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
 
@@ -467,7 +467,7 @@
 		thrusters_action.Grant(occupant, src)
 
 /obj/mecha/proc/remove_thrusters()
-	if(occupant)
+	if(occupant && !thruster_count)
 		thrusters_action.Remove(occupant)
 
 #undef MECH_GRAVCAT_MODE_GRAVSLING

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -434,6 +434,39 @@
 	if(..())
 		radiation_pulse(get_turf(src), rad_per_cycle)
 
+/obj/item/mecha_parts/mecha_equipment/thrusters
+	name = "exosuit ion thrusters"
+	desc = "ion thrusters to be attached to an exosuit. Drains power even while not in flight."
+	icon_state = "tesla"
+	origin_tech = "powerstorage=4;engineering=4"
+	range = 0
+	energy_drain = 20
+	selectable = FALSE
+
+/obj/item/mecha_parts/mecha_equipment/thrusters/attach(obj/mecha/M)
+	. = ..()
+	START_PROCESSING(SSobj, src)
+	M.add_thrusters()
+
+/obj/item/mecha_parts/mecha_equipment/thrusters/detach(atom/moveto)
+	chassis.remove_thrusters()
+	. = ..()
+	STOP_PROCESSING(SSobj, src)
+
+/obj/item/mecha_parts/mecha_equipment/thrusters/process()
+	if(!chassis)
+		STOP_PROCESSING(SSobj, src)
+	if(!energy_drain || !chassis.thrusters_active)
+		return
+	chassis.use_power(energy_drain)
+
+/obj/mecha/proc/add_thrusters()
+	if(occupant)
+		thrusters_action.Grant(occupant, src)
+
+/obj/mecha/proc/remove_thrusters()
+	if(occupant)
+		thrusters_action.Remove(occupant)
 
 #undef MECH_GRAVCAT_MODE_GRAVSLING
 #undef MECH_GRAVCAT_MODE_GRAVPUSH

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -436,7 +436,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/thrusters
 	name = "exosuit ion thrusters"
-	desc = "ion thrusters to be attached to an exosuit. Drains power even while not in flight."
+	desc = "Ion thrusters to be attached to an exosuit. Drains power even while not in flight."
 	icon_state = "tesla"
 	origin_tech = "powerstorage=4;engineering=4"
 	range = 0

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -256,6 +256,7 @@
 		return 1
 	if(thrusters_active && movement_dir && use_power(step_energy_drain))
 		step_in = initial(step_in) / thruster_count
+		new /obj/effect/particle_effect/ion_trails(get_turf(src), dir)
 		return 1
 
 	var/atom/movable/backup = get_spacemove_backup()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -84,6 +84,9 @@
 	var/melee_cooldown = 10
 	var/melee_can_hit = 1
 
+	/// How many ion thrusters we got on this bad boy
+	var/thruster_count = 0
+
 	// Action vars
 	var/defence_mode = FALSE
 	var/defence_mode_deflect_chance = 35
@@ -252,6 +255,7 @@
 	if(.)
 		return 1
 	if(thrusters_active && movement_dir && use_power(step_energy_drain))
+		step_in = initial(step_in) / thruster_count
 		return 1
 
 	var/atom/movable/backup = get_spacemove_backup()
@@ -297,6 +301,10 @@
 			last_message = world.time
 		return 0
 
+	if(thrusters_active && has_gravity(src))
+		thrusters_active = FALSE
+		to_chat(occupant, "<span class='notice'>Thrusters automatically disabled.</span>")
+		step_in = initial(step_in)
 	var/move_result = 0
 	var/move_type = 0
 	if(internal_damage & MECHA_INT_CONTROL_LOST)

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -156,6 +156,8 @@
 		return
 	if(chassis.get_charge() > 0)
 		chassis.thrusters_active = !chassis.thrusters_active
+		if(!chassis.thrusters_active)
+			chassis.step_in = initial(chassis.step_in)
 		button_icon_state = "mech_thrusters_[chassis.thrusters_active ? "on" : "off"]"
 		chassis.log_message("Toggled thrusters.")
 		chassis.occupant_message("<font color='[chassis.thrusters_active ? "blue" : "red"]'>Thrusters [chassis.thrusters_active ? "en" : "dis"]abled.")

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -19,6 +19,8 @@
 	internals_action.Grant(user, src)
 	lights_action.Grant(user, src)
 	stats_action.Grant(user, src)
+	for(var/obj/item/mecha_parts/mecha_equipment/thrusters/thrusters in equipment)
+		add_thrusters()
 
 /obj/mecha/proc/RemoveActions(mob/living/user, human_occupant = 0)
 	if(human_occupant)
@@ -26,6 +28,8 @@
 	internals_action.Remove(user)
 	lights_action.Remove(user)
 	stats_action.Remove(user)
+	for(var/obj/item/mecha_parts/mecha_equipment/thrusters/thrusters in equipment)
+		remove_thrusters()
 
 /datum/action/innate/mecha
 	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUNNED | AB_CHECK_CONSCIOUS

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -19,7 +19,7 @@
 	internals_action.Grant(user, src)
 	lights_action.Grant(user, src)
 	stats_action.Grant(user, src)
-	for(var/obj/item/mecha_parts/mecha_equipment/thrusters/thrusters in equipment)
+	if(locate(/obj/item/mecha_parts/mecha_equipment/thrusters) in equipment)
 		add_thrusters()
 
 /obj/mecha/proc/RemoveActions(mob/living/user, human_occupant = 0)
@@ -28,8 +28,7 @@
 	internals_action.Remove(user)
 	lights_action.Remove(user)
 	stats_action.Remove(user)
-	for(var/obj/item/mecha_parts/mecha_equipment/thrusters/thrusters in equipment)
-		remove_thrusters()
+	thrusters_action.Remove(user)
 
 /datum/action/innate/mecha
 	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUNNED | AB_CHECK_CONSCIOUS

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -982,7 +982,7 @@
 
 /datum/design/mecha_thruster
 	name = "Heavy-duty Exosuit Ion Thruster"
-	desc = "Allows for further control in zero gravity enviroments."
+	desc = "Allows for further control in zero gravity environments."
 	id = "mech_thruster"
 	build_type = MECHFAB
 	req_tech = list("engineering" = 6, "magnets" = 5, "materials" = 5)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -980,6 +980,17 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
+/datum/design/mecha_thruster
+	name = "Heavy-duty Exosuit Ion Thruster"
+	desc = "Allows for further control in zero gravity enviroments."
+	id = "mech_thruster"
+	build_type = MECHFAB
+	req_tech = list("engineering" = 6, "magnets" = 5, "materials" = 5)
+	build_path = /obj/item/mecha_parts/mecha_equipment/thrusters
+	materials = list(MAT_METAL = 15000, MAT_PLASMA = 3000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
+
 //Cyborg Upgrade Modules
 
 /datum/design/borg_upgrade_reset


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds the mecha ion thruster, a new exofab made mecha upgrade 
made with 15k metal, 3000 plasma, and 6 engineering and two other level 5s
Takes 20 units of charge per processing cycle to use (roughly 2 seconds) + the movement per tile power (This means that if you're going fast you're gonna get DRAINED)
- [x] Make the speed you go scale with amount installed (i think it would be funny)
- [x] Test it more 

## Why It's Good For The Game
~SPACE MECHS!~
Gives people a new way to ball with space combat, sucks currently so giving people more options will lead to ~less space clings~ more options in combat
Also pods were cool concept wise and this is just cooler pods imo

## Testing
It works
## Changelog
:cl:
add: Ion thrusters for mechs are now available at RND
tweak: all previous mechs with a natural ion jetpack now start with one as equipment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
