### PR TITLE
Adds clown borgs, created by cmagging a cyborg endoskeleton

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -286,6 +286,9 @@
 
 			M.brainmob.mind.transfer_to(O)
 
+			if(HAS_TRAIT(src, TRAIT_CMAGGED))
+				O.force_modules = "Clown" // we getting silly out here
+
 			if(O.mind && O.mind.special_role && !M.syndiemmi)
 				O.mind.store_memory("As a cyborg, you must obey your silicon laws and master AI above all else. Your objectives will consider you to be dead.")
 				to_chat(O, "<span class='userdanger'>You have been robotized!</span>")
@@ -323,6 +326,11 @@
 	if(is_pen(W))
 		to_chat(user, "<span class='warning'>You need to use a multitool to name [src]!</span>")
 	return
+
+/obj/item/robot_parts/robot_suit/cmag_act(mob/user)
+	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
+		to_chat(user, "<span class='notice'>You smear the bananium ooze all over [src]. The new cyborg who uses this shell will love it or hate it.</span>")
+		ADD_TRAIT(src, TRAIT_CMAGGED, CLOWN_EMAG)
 
 /obj/item/robot_parts/robot_suit/proc/Interact(mob/user)
 			var/t1 = "Designation: <A href='?src=[UID()];Name=1'>[(created_name ? "[created_name]" : "Default Cyborg")]</a><br>\n"

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -88,6 +88,38 @@
 	playsound(loc, 'sound/machines/click.ogg', 10, 1)
 	new currently_dispensing(T)
 
+#warn add an emag effect like it makes hellwater cookies or somethin + refactor into a RSF thingy
+
+/obj/item/cookiesynth
+	name = "\improper Cookie Synthesizer"
+	desc = "A self-recharging device used to rapidly deploy cookies."
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "rcd"
+	var/cooldown = 0
+	var/cooldowndelay = 10 SECONDS
+	var/dispensing_type = /obj/item/reagent_containers/food/snacks/cookie
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/cookiesynth/attackby()
+	return
+
+/obj/item/cookiesynth/afterattack(atom/A, mob/user, proximity)
+	if(cooldown > world.time)
+		return
+	if(!proximity)
+		return
+	if(!(istype(A, /obj/structure/table) || isturf(A)))
+		return
+	if(isrobot(user))
+		var/mob/living/silicon/robot/R = user
+		if(!R.cell || !R.cell.use(POWER_HIGH))
+			to_chat(user, "<span class='warning'>You do not have enough power to use [src].</span>")
+			return
+	playsound(loc, 'sound/machines/click.ogg', 10, 1)
+	to_chat(user, "<span class='notice'>Cookie dispensed.</span>")
+	new dispensing_type(get_turf(A))
+	cooldown = world.time + cooldowndelay
+
 #undef POWER_NONE
 #undef POWER_LOW
 #undef POWER_HIGH

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -110,3 +110,8 @@
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
 	icon_state = "soapsyndie"
 	cleanspeed = 10 //much faster than mop so it is useful for traitors who want to clean crime scenes
+
+/obj/item/soap/nanotrasen/shitty
+	name = "odd smelling soap"
+	desc = "Well it's soap, doesn't look to be very good soap."
+	cleanspeed = 200 // good luck!

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -346,7 +346,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/static/list/special_modules = list(
 		"Combat" = image('icons/mob/robots.dmi', "security-radial"),
 		"Security" = image('icons/mob/robots.dmi', "security-radial"),
-		"Destroyer" = image('icons/mob/robots.dmi', "droidcombat"))
+		"Destroyer" = image('icons/mob/robots.dmi', "droidcombat"),
+		"Clown" = image('icons/mob/robots.dmi', "xeno-radial"))
 
 	if(mmi?.alien)
 		return list("Hunter" = image('icons/mob/robots.dmi', "xeno-radial"))
@@ -439,6 +440,10 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			module_sprites = list(
 				"Xeno-Hu" = image('icons/mob/robots.dmi', "xenoborg-state-a")
 			)
+		if("Clown")
+			module_sprites = list(
+				"Xeno-Hu" = image('icons/mob/robots.dmi', "xenoborg-state-a")
+			)
 
 	if(custom_sprite && check_sprite("[ckey]-[selected_module]"))
 		module_sprites["Custom"] = image('icons/mob/custom_synthetic/custom-synthetic.dmi', "[ckey]-[selected_module]")
@@ -490,6 +495,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			status_flags &= ~CANPUSH
 		if("Hunter")
 			module = new /obj/item/robot_module/alien/hunter(src)
+		if("Clown")
+			module = new /obj/item/robot_module/clown(src)
 
 	if(!module)
 		return FALSE

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -728,6 +728,22 @@
 	. = ..()
 	R.add_language("xenocommon", 1)
 
+// Cmag/Clown cyborg module.
+#warn add an emag module
+/obj/item/robot_module/clown
+	name = "comical cyborg module"
+	module_type = "Clown"
+	basic_modules = list(
+		/obj/item/toy/flash,
+		/obj/item/bikehorn/airhorn,
+		/obj/item/gun/throw/piecannon,
+		/obj/item/toy/crayon/rainbow,
+		/obj/item/clown_recorder,
+		/obj/item/soap/nanotrasen/shitty,
+		/obj/item/cookiesynth
+	)
+	emag_modules = list(/obj/item/reagent_containers/spray/alien/acid)
+
 // Maintenance drone module.
 /obj/item/robot_module/drone
 	name = "drone module"

--- a/code/modules/projectiles/guns/throw/pielauncher.dm
+++ b/code/modules/projectiles/guns/throw/pielauncher.dm
@@ -34,3 +34,12 @@
 /obj/item/gun/throw/piecannon/process_chamber()
 	..()
 	update_icon(UPDATE_ICON_STATE)
+
+/obj/item/gun/throw/piecannon/attack_self(mob/user)
+	if(!isrobot(user) || get_ammocount() == max_capacity)
+		return
+	var/mob/living/silicon/robot/robot_user = user
+	if(robot_user.cell && robot_user.cell.use(400))
+		var/obj/item/reagent_containers/food/snacks/pie/P = new /obj/item/reagent_containers/food/snacks/pie(src)
+		loaded_projectiles += P
+		process_chamber()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds clown borgs, cmagging a cyborg endoskeleton will cause the next cyborg inserted to become a clown borg
These cyborgs are largely useless, with a toy flash, cookie dispenser, and the worlds worst soap as their "redeeming" qualities. 

TODO:

- [ ] Sprites 
- [ ] Stuff I have as #warn in code

## Why It's Good For The Game
Aside from this being pretty funny and fitting with the Cmag well, this is a way people can reduce the production of borgs in a round, forcing robos who aren't observant to reconstruct a borg.
Or uh, making a bunch cuz funny borg which is very clownlike.
When I finish the emag modules they'll be actually quite threatening, and someone buying an emag and cmag at the same time is really funny. 

## Testing
Right now it works
## Changelog
:cl:
add: Clown borgs! Made by applying a cmag to a borg endoskeleton
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
