### PR TITLE
Allows human mobs to alt+click to unlock APC and Air Alarms

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -1112,7 +1112,7 @@
 	qdel(src)
 
 /obj/machinery/alarm/AltClick(mob/user)
-	if(Adjacent(user)  && allowed(user) && !wires.is_cut(WIRE_IDSCAN))
+	if(Adjacent(user) && allowed(user) && !wires.is_cut(WIRE_IDSCAN))
 		locked = !locked
 		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] the Air Alarm interface.</span>")
 	else

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -1111,6 +1111,13 @@
 		new /obj/item/stack/cable_coil(loc, 3)
 	qdel(src)
 
+/obj/machinery/alarm/AltClick(mob/user)
+	if(Adjacent(user)  && allowed(user) && !wires.is_cut(WIRE_IDSCAN))
+		locked = !locked
+		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] the Air Alarm interface.</span>")
+	else
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+
 /obj/machinery/alarm/examine(mob/user)
 	. = ..()
 	switch(buildstage)

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -362,6 +362,10 @@
 	else
 		return ..()
 
+/obj/machinery/power/apc/AltClick(mob/user)
+	if(Adjacent(user))
+		togglelock(user)
+
 /obj/machinery/power/apc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
 	if(stat & BROKEN)
 		return damage_amount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This adds the ability for crewmembers with access to alt-click to unlock or lock an APC or Air Alarm.
It also adds an examine text that tells you the state of the APC or Air Alarms lock.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This functionality has existed for secure lockers, so why not at it to APC and Air Alarm, and not having to swipe your ID to unlock things.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
https://user-images.githubusercontent.com/21987702/228848508-e168480c-52d0-4bb5-a279-503f22820f20.mp4

## Testing
<!-- How did you test the PR, if at all? -->
See Images of changes
![image](https://user-images.githubusercontent.com/21987702/231082364-3f1f4461-2037-42a8-af09-c48b2f3ba2e7.png)


## Changelog
:cl: ppi
add: Allows crewmembers with access to Alt + Click to unlock APC and Air Alarms.
add: Crewmembers can now examine APC or Air Alarms to see their lock status.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
