### PR TITLE
Fixes stacks with dynamic icon states vanishing in-hand when amount > 1

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -34,6 +34,8 @@
 
 /obj/item/stack/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()
+	if(dynamic_icon_state) //If we have a dynamic icon state, we don't want item states to follow the same pattern.
+		item_state = initial(icon_state)
 	if(new_amount != null)
 		amount = new_amount
 	while(amount > max_amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The `item_state` (on-mob inhands) for stacks are just the `icon_state`, this is not what we want for dynamic `icon_state` as we just want the base single item sprite. We don't have the dynamics for on-mob inhands so they were vanishing.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Materials vanishing with more than one
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned, held stacks with 50 things in and looked at them.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed stacks with dynamic icons states vanishing in-hand when the amount was more than one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
