### PR TITLE
Add default key binding for Give and Whisper, remove default binding for Cycle Intents

### DIFF
--- a/code/datums/keybindings/carbon.dm
+++ b/code/datums/keybindings/carbon.dm
@@ -24,7 +24,7 @@
 
 /datum/keybinding/carbon/give_item
 	name = "Give Item (Toggle)"
-	keys = null
+	keys = list("G")
 
 /datum/keybinding/carbon/give_item/down(client/C)
 	. = ..()

--- a/code/datums/keybindings/living.dm
+++ b/code/datums/keybindings/living.dm
@@ -24,6 +24,7 @@
 
 /datum/keybinding/living/whisper
 	name = "Whisper"
+	keys = list("U")
 
 /datum/keybinding/living/whisper/down(client/C)
 	var/mob/M = C.mob

--- a/code/datums/keybindings/mob.dm
+++ b/code/datums/keybindings/mob.dm
@@ -41,7 +41,7 @@
 // Intents
 /datum/keybinding/mob/prev_intent
 	name = "Previous Intent"
-	keys = list("F")
+	keys = null
 
 /datum/keybinding/mob/prev_intent/down(client/C)
 	. = ..()
@@ -49,7 +49,7 @@
 
 /datum/keybinding/mob/next_intent
 	name = "Next Intent"
-	keys = list("G", "Insert")
+	keys = list("Insert")
 
 /datum/keybinding/mob/next_intent/down(client/C)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changed the default keybindings slightly. Give and Whisper now default to G and U respectively. 
I had to remove the default binding for Next Intent and Prev Intent. However, both can still receive custom bindings in the Game Prefs menu if desired.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Now that we removed the right click option for Give, you either need a hotkey or you need to click the Give verb in the IC tab. Clicking verbs in the IC tab is super annoying. Cycle intent hotkey is not that important, since you already have 1,2,3,4.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- [x] Tried giving an item. It told me the person wasn't responding, because I was all alone T_T
- [x] Used whisper hotkey
- [x] Bound cycle prev intent to F, works correctly
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: GnomeDePlume
add: Set default keybind for Give to G
add: Set default keybind for Whisper to U
del: Removed default keybind F (Previous Intent) and G (Next Intent). They can still be rebound in the Hotkeys menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
