### PR TITLE
Ghosts now don't call moved twice

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -8,14 +8,14 @@
 	update_z(null)
 	return ..()
 
-/mob/dead/forceMove(atom/destination)
+/mob/dead/forceMove(atom/destination, direction = NONE)
 	var/turf/old_turf = get_turf(src)
 	var/turf/new_turf = get_turf(destination)
 	if (old_turf?.z != new_turf?.z)
 		onTransitZ(old_turf?.z, new_turf?.z)
 	var/oldloc = loc
 	loc = destination
-	Moved(oldloc, NONE)
+	Moved(oldloc, direction)
 
 /mob/dead/onTransitZ(old_z,new_z)
 	..()

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -260,12 +260,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	setDir(direct)
 	ghostimage.setDir(dir)
 
-	var/oldloc = loc
-
 	if(NewLoc)
-		forceMove(NewLoc)
+		forceMove(NewLoc, direct)
 	else
-		forceMove(get_turf(src))  //Get out of closets and such as a ghost
+		forceMove(get_turf(src), direct)  //Get out of closets and such as a ghost
 		if((direct & NORTH) && y < world.maxy)
 			y++
 		else if((direct & SOUTH) && y > 1)
@@ -274,8 +272,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			x++
 		else if((direct & WEST) && x > 1)
 			x--
-
-	Moved(oldloc, direct)
 
 /mob/dead/observer/can_use_hands()	return 0
 


### PR DESCRIPTION
## What Does This PR Do
When testing I noticed that ghosts call `Moved` twice while moving. This might lead to some odd behaviour. I've not yet noticed any changes by removing the second moved call though.

## Why It's Good For The Game
You only moved once when moving :)

## Testing
Moved around as a ghost for a while. Checking parallax etc.

## Changelog
Didn't notice a functional change