### PR TITLE
Adds a salt weakness to slimes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/slimepeople.dm
+++ b/code/modules/mob/living/carbon/human/species/slimepeople.dm
@@ -193,6 +193,15 @@
 	else
 		to_chat(H, "<span class='warning'>You need to hold still in order to regrow a limb!</span>")
 
+/datum/species/slime/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	if(R.id == "sodiumchloride")
+		H.adjustFireLoss(0.5)
+		if(prob(25))
+			H.adjustBrainLoss(0.5)
+		to_chat(H, "<span class='warning'>Your insides are burning!</span>")
+		return TRUE
+	return ..()
+
 #undef SLIMEPERSON_COLOR_SHIFT_TRIGGER
 #undef SLIMEPERSON_ICON_UPDATE_PERIOD
 #undef SLIMEPERSON_BLOOD_SCALING_FACTOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Slime people now suffer burn damage from salt (sodium chloride). There is also a possibility (25%) that they may suffer minor brain damage.

(Note: This PR was inspired by #8297)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Salt damage nerfs slimes a bit and also adds a new unique interaction with a chemical that can make gameplay more unique for slimes.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Ran it.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Slimes now suffer burn damage from salt and there is a possibility that they may also suffer brain damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
