### PR TITLE
Translator implants no longer bypass muting effects

### DIFF
--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -115,7 +115,8 @@ GLOBAL_LIST_INIT(soapy_words, list(
 /mob/living/carbon/human/handle_speech_problems(list/message_pieces, verb)
 	var/span = ""
 	var/obj/item/organ/internal/cyberimp/brain/speech_translator/translator = locate(/obj/item/organ/internal/cyberimp/brain/speech_translator) in internal_organs
-	if(translator)
+
+	if(translator && !HAS_TRAIT(src, TRAIT_MUTE))
 		if(translator.active)
 			span = translator.speech_span
 			for(var/datum/multilingual_say_piece/S in message_pieces)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Translator implants no longer allow you to bypass mute effects

## Why It's Good For The Game
This was thought to be an exploit for quite awhile, but turns out it's actually intended. For a feature that's not a good sign.
Vampires suddenly needing to figure out how they hell they're gonna deal with a grey (in a way that doesn't involve just killing them) is frustrating, and being able to ignore muting effects is quite weird if you say, chose mute as a roundstart disability. 

## Testing
Compiled and ran, mutes remained muted
## Changelog
:cl:
tweak: Translators no longer bypass mutes
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
