### PR TITLE
Pimpin' ride floor buffer now can be toggled on/off v2

### DIFF
--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -64,12 +64,13 @@
 
 /obj/vehicle/janicart/post_buckle_mob(mob/living/M)
 	. = ..()
-	if(buffer_installed)
-		var/datum/action/floor_buffer/floorbuffer_action = new(src)
-		if(has_buckled_mobs())
-			floorbuffer_action.Grant(M)
-		else
-			floorbuffer_action.Remove(M)
+	if(!buffer_installed)
+		return
+	var/datum/action/floor_buffer/floorbuffer_action = new(src)
+	if(has_buckled_mobs())
+		floorbuffer_action.Grant(M)
+	else
+		floorbuffer_action.Remove(M)
 
 /obj/vehicle/janicart/post_unbuckle_mob(mob/living/M)
 	for(var/datum/action/floor_buffer/floorbuffer_action in M.actions)

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -5,6 +5,10 @@
 	icon_state = "pussywagon"
 	key_type = /obj/item/key/janitor
 	var/obj/item/storage/bag/trash/mybag
+	var/buffer_installed = FALSE
+	/// How much speed the janicart loses while the buffer is active
+	var/buffer_delay = 1
+	/// Does it clean the tile under it?
 	var/floorbuffer = FALSE
 
 /obj/vehicle/janicart/Destroy()
@@ -30,11 +34,9 @@
 					buckled_mob.pixel_x = 12
 					buckled_mob.pixel_y = 7
 
-
 /obj/item/key/janitor
 	desc = "A keyring with a small steel key, and a pink fob reading \"Pussy Wagon\"."
 	icon_state = "keyjanitor"
-
 
 /obj/item/janiupgrade
 	name = "floor buffer upgrade"
@@ -43,9 +45,40 @@
 	icon_state = "upgrade"
 	origin_tech = "materials=3;engineering=4"
 
+/datum/action/floor_buffer
+	name = "Toggle Floor Buffer"
+	desc = "Movement speed is decreased while active."
+	icon_icon = 'icons/obj/vehicles.dmi'
+	button_icon_state = "upgrade"
+
+/datum/action/floor_buffer/Trigger()
+	. = ..()
+	var/obj/vehicle/janicart/J = target
+	if(!J.floorbuffer)
+		J.floorbuffer = TRUE
+		J.vehicle_move_delay += J.buffer_delay
+	else
+		J.floorbuffer = FALSE
+		J.vehicle_move_delay -= J.buffer_delay
+	to_chat(usr, "<span class='notice'>The floor buffer is now [J.floorbuffer ? "active" : "deactivated"].</span>")
+
+/obj/vehicle/janicart/post_buckle_mob(mob/living/M)
+	. = ..()
+	if(buffer_installed)
+		var/datum/action/floor_buffer/floorbuffer_action = new(src)
+		if(has_buckled_mobs())
+			floorbuffer_action.Grant(M)
+		else
+			floorbuffer_action.Remove(M)
+
+/obj/vehicle/janicart/post_unbuckle_mob(mob/living/M)
+	for(var/datum/action/floor_buffer/floorbuffer_action in M.actions)
+		floorbuffer_action.Remove(M)
+	return ..()
+
 /obj/vehicle/janicart/Move(atom/OldLoc, Dir)
 	. = ..()
-	if(floorbuffer)
+	if(floorbuffer && has_buckled_mobs())
 		var/turf/tile = loc
 		if(isturf(tile))
 			tile.clean_blood()
@@ -53,13 +86,10 @@
 				if(E.is_cleanable())
 					qdel(E)
 
-
-
 /obj/vehicle/janicart/examine(mob/user)
 	. = ..()
-	if(floorbuffer)
+	if(buffer_installed)
 		. += "It has been upgraded with a floor buffer."
-
 
 /obj/vehicle/janicart/attackby(obj/item/I, mob/user, params)
 	var/fail_msg = "<span class='notice'>There is already one of those in [src].</span>"
@@ -76,10 +106,10 @@
 		update_icon(UPDATE_OVERLAYS)
 		return
 	if(istype(I, /obj/item/janiupgrade))
-		if(floorbuffer)
+		if(buffer_installed)
 			to_chat(user, fail_msg)
 			return
-		floorbuffer = TRUE
+		buffer_installed = TRUE
 		qdel(I)
 		to_chat(user,"<span class='notice'>You upgrade [src] with [I].</span>")
 		update_icon(UPDATE_OVERLAYS)
@@ -93,9 +123,8 @@
 	. = ..()
 	if(mybag)
 		. += "cart_garbage"
-	if(floorbuffer)
+	if(buffer_installed)
 		. += "cart_buffer"
-
 
 /obj/vehicle/janicart/attack_hand(mob/user)
 	if(..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Reopening https://github.com/ParadiseSS13/Paradise/pull/20382 since it now got one approval.

Pimpin' ride floor buffer now can be toggled on/off and the movement speed is decreased while active.
Pimpin' ride floor buffer no longer works if theres no one driving it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

1. Pimpin' rides are supposed to be made of dead janitor cyborgs, it makes sense for their floor buffers to work the same way.
2. Being able to toggle your buffer is useful is there is something on the way you dont want to clean by accident.
3. The current cleaning speed of the pimpin' ride (with floor buffer + vtec) is too much if you compare it after the recent tweaks made to janitors/janiborgs.

Pulling an entire vehicle to bypass his speed limitations so you can use his buffer at faster speed doesnt look to be intended.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://user-images.githubusercontent.com/77684085/229138965-7e5451b4-45bf-485c-ba7e-569d55f58be7.mp4


## Testing
<!-- How did you test the PR, if at all? -->
See video above
## Changelog
:cl:
tweak: Pimpin' ride floor buffer now can be toggled on/off and the movement speed is decreased while active
tweak: Pimpin' ride floor buffer no longer works if theres no one driving it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
