### PR TITLE
Improves ERP with petcollars

### DIFF
--- a/code/game/objects/items/collar.dm
+++ b/code/game/objects/items/collar.dm
@@ -6,6 +6,7 @@
 	var/tagname = null
 	var/obj/item/card/id/access_id
 	var/flipped = FALSE
+	var/rainbowed = FALSE
 
 /obj/item/petcollar/Destroy()
 	QDEL_NULL(access_id)
@@ -57,6 +58,9 @@
 	if(lowertext(tagname) == "dinnerbone")
 		flipped = TRUE
 		flip(user)
+	if(lowertext(tagname) == "jeb_")
+		rainbowed = TRUE
+		animate_rainbow_glow(user)
 	if(istype(user))
 		START_PROCESSING(SSobj, src)
 
@@ -70,6 +74,8 @@
 	STOP_PROCESSING(SSobj, src)
 	if(flipped)
 		flip(user)
+	if(rainbowed)
+		animate(user, transform = null, time = 5, color = "#ffffff", alpha = 255, pixel_y = 0, easing = ELASTIC_EASING)
 
 /obj/item/petcollar/process()
 	var/mob/living/simple_animal/M = loc

--- a/code/game/objects/items/collar.dm
+++ b/code/game/objects/items/collar.dm
@@ -5,6 +5,7 @@
 	item_color = "petcollar"
 	var/tagname = null
 	var/obj/item/card/id/access_id
+	var/flipped = FALSE
 
 /obj/item/petcollar/Destroy()
 	QDEL_NULL(access_id)
@@ -52,18 +53,31 @@
 		. += "There is [bicon(access_id)] \a [access_id] clipped onto it."
 
 /obj/item/petcollar/equipped(mob/living/simple_animal/user)
+
+	if(lowertext(tagname) == "dinnerbone")
+		flipped = TRUE
+		flip(user)
 	if(istype(user))
 		START_PROCESSING(SSobj, src)
+
+/obj/item/petcollar/proc/flip(mob/living/simple_animal/owner)
+	var/matrix/M = matrix(owner.transform)
+	M.Turn(180)
+	owner.transform = M
 
 /obj/item/petcollar/dropped(mob/living/simple_animal/user)
 	..()
 	STOP_PROCESSING(SSobj, src)
+	if(flipped)
+		flip(user)
 
 /obj/item/petcollar/process()
 	var/mob/living/simple_animal/M = loc
 	// if it wasn't intentionally unequipped but isn't being worn, possibly gibbed
 	if(istype(M) && src == M.pcollar && M.stat != DEAD)
 		return
+
+
 
 	var/area/pet_death_area = get_area(M)
 	var/obj/item/radio/headset/pet_death_announcer = new /obj/item/radio/headset(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Lets petcollars better support ERP (Extremely Rotated Pigs).
Setting a petcollar's name to `dinnerbone` and putting it onto a mob will rotate the mob 180 degrees.
(Also, setting a collar's name to `jeb_` will cause the mob to cycle rainbow colors)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Silly
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/229177287-0b63b6ab-1409-4e60-b5f4-816a918817cd.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
