### PR TITLE
Implement the long face button

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -39,7 +39,8 @@
 	pda = /obj/item/pda/captain
 	backpack_contents = list(
 		/obj/item/storage/box/ids = 1,
-		/obj/item/melee/classic_baton/telescopic = 1
+		/obj/item/melee/classic_baton/telescopic = 1,
+		/obj/item/longfacebutton = 1
 	)
 	implants = list(/obj/item/implant/mindshield)
 	backpack = /obj/item/storage/backpack/captain

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1586,4 +1586,5 @@
 		if(!user.unEquip(user.wear_mask))
 			qdel(user.wear_mask)
 		user.equip_to_slot_if_possible(magichead, slot_wear_mask, TRUE, TRUE)
-		qdel(src)
+
+	qdel(src)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1556,3 +1556,34 @@
 	throwforce = 0
 	breakouttime = 0
 	ignoresClumsy = TRUE
+
+/*
+ *Long Face Button
+ */
+
+/obj/item/longfacebutton
+	name = "long face button"
+	desc = "Press in case of feeling unhappy or disappointed. One time use only!"
+	icon = 'icons/obj/assemblies.dmi'
+	icon_state = "bigred"
+	item_state = "electronic"
+	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/longfacebutton/attack_self(mob/user)
+	GLOB.major_announcement.Announce("The captain of [station_name()] is feeling pretty bummed out. Give them a pep talk!", "Why the long face?")
+	if(user)
+		to_chat(user, "<span class='warning'>You share your feelings with the entire crew!</span>")
+		message_admins("[ADMIN_LOOKUPFLW(user)] gave nearly everyone horse masks using April Fool's item!")
+
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		to_chat(H, "<span class='warning'>You feel pretty bad about this whole shift.</span>")
+		if(H.dna.species.name == "Vox" || H.dna.species.name == "Plasmaman")
+			to_chat(H, "<span class='warning'>But at least better than these other unfortunate souls!</span>")
+			continue
+		var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
+		magichead.flags |= NODROP | DROPDEL	//curses!
+		magichead.flags_inv = null	//so you can still see their face
+		if(!user.unEquip(user.wear_mask))
+			qdel(user.wear_mask)
+		user.equip_to_slot_if_possible(magichead, slot_wear_mask, TRUE, TRUE)
+		qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
It implements the long face button and gives it to the captain.
The long face button shares the feelings of sadness with everyone.
Sadly, has no effect on certain species, because they are too emotionally distant.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The captain is a stressful job and it's really easy to feel bummed out by the round. This button will let everyone know that the captain is feeling bad and, hopefully, they'll address the issue appropriately.

## Testing
<!-- How did you test the PR, if at all? -->
It compiled, it made an announcement and it gave everyone the long face (plasmamen and vox excluded, because I don't like them)

## Changelog
:cl:
add: the long face button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
