### PR TITLE
Balances the 357 revolver

### DIFF
--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -58,7 +58,7 @@
 		You will likely need to scavenge additional ammo or weapons aboard the station. <br><br>\
 		</i>Provides a .357 Revolver, 4 speedloaders of ammo, Ethereal Jaunt, Blink, Summon Item, No Clothes, and Bind Soul, with a unique outfit.<i>"
 	log_name = "GR"
-	items_path = list(/obj/item/gun/projectile/revolver, /obj/item/ammo_box/a357, /obj/item/ammo_box/a357, /obj/item/ammo_box/a357, /obj/item/ammo_box/a357, /obj/item/clothing/under/syndicate)
+	items_path = list(/obj/item/toy/russian_revolver/trick_revolver, /obj/item/ammo_box/a357, /obj/item/ammo_box/a357, /obj/item/ammo_box/a357, /obj/item/ammo_box/a357, /obj/item/clothing/under/syndicate)
 	spells_path = list(/obj/effect/proc_holder/spell/ethereal_jaunt, /obj/effect/proc_holder/spell/turf_teleport/blink, \
 		/obj/effect/proc_holder/spell/summonitem, /obj/effect/proc_holder/spell/noclothes, /obj/effect/proc_holder/spell/lichdom/gunslinger)
 	category = "Unique"

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -318,7 +318,7 @@
 		/obj/item/gun/projectile/automatic/sniper_rifle/syndicate = 1,
 		/obj/item/melee/energy/sword/saber = 1,
 		/obj/item/gun/energy/kinetic_accelerator/crossbow = 1,
-		/obj/item/gun/projectile/revolver = 1,
+		/obj/item/toy/russian_revolver/trick_revolver = 1,
 		/obj/item/clothing/gloves/color/yellow/power = 1,
 		/obj/item/twohanded/chainsaw = 1,
 		/obj/item/bee_briefcase = 1,

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -74,7 +74,7 @@
 		/obj/item/toy/balloon,
 		/obj/item/toy/blink,
 		/obj/item/gun/projectile/shotgun/toy/crossbow,
-		/obj/item/gun/projectile/revolver/capgun,
+		/obj/item/toy/russian_revolver/trick_revolver,
 		/obj/item/toy/katana,
 		/obj/random/mech,
 		/obj/item/toy/spinningtoy,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -67,7 +67,7 @@
 		/obj/item/encryptionkey/syndicate) // 2TC
 
 	var/static/list/payday = list( // 35TC
-		/obj/item/gun/projectile/revolver, // 13TC
+		/obj/item/toy/russian_revolver/trick_revolver, // 13TC
 		/obj/item/ammo_box/a357, // 3TC
 		/obj/item/ammo_box/a357, // 3TC
 		/obj/item/card/emag, // 6TC
@@ -237,7 +237,7 @@
 	name = "trick revolver kit"
 
 /obj/item/storage/box/syndie_kit/fake_revolver/populate_contents()
-	new /obj/item/toy/russian_revolver/trick_revolver(src)
+	new /obj/item/gun/projectile/revolver(src)
 
 /obj/item/storage/box/syndie_kit/mimery
 	name = "advanced mimery kit"
@@ -363,5 +363,5 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 	name = "\improper .357 revolver kit"
 
 /obj/item/storage/box/syndie_kit/revolver/populate_contents()
-	new /obj/item/gun/projectile/revolver(src)
+	new /obj/item/toy/russian_revolver/trick_revolver(src)
 	new /obj/item/ammo_box/a357(src)

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -133,7 +133,7 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 	equip_to_slot_or_del(new /obj/item/storage/backpack/security(src), slot_back)
 	equip_to_slot_or_del(new /obj/item/storage/box/survival_syndi(src), slot_in_backpack)
 
-	equip_to_slot_or_del(new /obj/item/gun/projectile/revolver(src), slot_in_backpack)
+	equip_to_slot_or_del(new /obj/item/toy/russian_revolver/trick_revolver(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/ammo_box/a357(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/combat/nanites(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/grenade/plastic/c4/x4(src), slot_in_backpack)

--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -242,7 +242,7 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 /datum/prize_item/capgun
 	name = "Capgun Revolver"
 	desc = "Do you feel lucky... punk?"
-	typepath = /obj/item/gun/projectile/revolver/capgun
+	typepath = /obj/item/toy/russian_revolver/trick_revolver
 	cost = 75
 
 /datum/prize_item/codex_gigas

--- a/code/modules/hydroponics/grown/misc_seeds.dm
+++ b/code/modules/hydroponics/grown/misc_seeds.dm
@@ -110,7 +110,7 @@
 	desc = "It smells like burning."
 	icon_state = "gatfruit"
 	origin_tech = "combat=6"
-	trash = /obj/item/gun/projectile/revolver
+	trash = /obj/item/toy/russian_revolver/trick_revolver
 	tastes = list("2nd amendment" = 1, "freedom" = 1)
 	bitesize_mod = 2
 	wine_power = 0.9 //It burns going down, too.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Balances the 357 revolver

## Why It's Good For The Game
Why did we put the higher damage version as a higher TC cost rather than the low damage version? This has been fixed, and should fix most issues people have with the 357 revolver. : )

## Testing
It works : )

## Changelog
:cl:
tweak: 357 revolver has been balanced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
