### PR TITLE
[serious] Fixes buckling to operating tables

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -14,6 +14,7 @@
 	var/list/injected_reagents = list()
 	var/reagent_target_amount = 1
 	var/inject_amount = 1
+	can_buckle = TRUE					// you can buckle someone if they have cuffs
 
 /obj/machinery/optable/Initialize(mapload)
 	. = ..()
@@ -58,6 +59,8 @@
 		return
 	if(!ismob(O) || !iscarbon(O)) //Only Mobs and Carbons can go on this table (no syptic patches please)
 		return
+	if(user_buckle_mob(O, user, check_loc = FALSE))
+		return TRUE
 	take_patient(O, user)
 
 /**

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -7,14 +7,15 @@
 	anchored = TRUE
 	idle_power_consumption = 1
 	active_power_consumption = 5
+	can_buckle = TRUE // you can buckle someone if they have cuffs
+	buckle_lying = TRUE
 	var/mob/living/carbon/patient
 	var/obj/machinery/computer/operating/computer
-	buckle_lying = TRUE
 	var/no_icon_updates = FALSE //set this to TRUE if you don't want the icons ever changing
 	var/list/injected_reagents = list()
 	var/reagent_target_amount = 1
 	var/inject_amount = 1
-	can_buckle = TRUE // you can buckle someone if they have cuffs
+
 
 /obj/machinery/optable/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -14,8 +14,7 @@
 	var/list/injected_reagents = list()
 	var/reagent_target_amount = 1
 	var/inject_amount = 1
-	can_buckle = TRUE					// you can buckle someone if they have cuffs
-
+	can_buckle = TRUE // you can buckle someone if they have cuffs
 
 /obj/machinery/optable/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -1,5 +1,5 @@
 /obj/machinery/optable
-	name = "Operating Table"
+	name = "operating table"
 	desc = "Used for advanced medical procedures."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "table2-idle"
@@ -9,12 +9,13 @@
 	active_power_consumption = 5
 	var/mob/living/carbon/patient
 	var/obj/machinery/computer/operating/computer
-	buckle_lying = -1
+	buckle_lying = TRUE
 	var/no_icon_updates = FALSE //set this to TRUE if you don't want the icons ever changing
 	var/list/injected_reagents = list()
 	var/reagent_target_amount = 1
 	var/inject_amount = 1
 	can_buckle = TRUE					// you can buckle someone if they have cuffs
+
 
 /obj/machinery/optable/Initialize(mapload)
 	. = ..()
@@ -38,7 +39,7 @@
 /obj/machinery/optable/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)
 	if(user.a_intent == INTENT_HARM)
 		..(user, TRUE)
-		visible_message("<span class='warning'>[user] destroys the operating table!</span>")
+		visible_message("<span class='warning'>[user] destroys [src]!</span>")
 		qdel(src)
 		return TRUE
 
@@ -59,8 +60,8 @@
 		return
 	if(!ismob(O) || !iscarbon(O)) //Only Mobs and Carbons can go on this table (no syptic patches please)
 		return
-	if(user_buckle_mob(O, user, check_loc = FALSE))
-		return TRUE
+	if(!user_buckle_mob(O, user, check_loc = FALSE))
+		return
 	take_patient(O, user)
 
 /**
@@ -95,14 +96,10 @@
 
 /obj/machinery/optable/proc/take_patient(mob/living/carbon/new_patient, mob/living/carbon/user)
 	if(new_patient == user)
-		user.visible_message("[user] climbs on the operating table.","You climb on the operating table.")
+		user.visible_message("[user] climbs on [src].","You climb on [src].")
 	else
-		visible_message("<span class='alert'>[new_patient] has been laid on the operating table by [user].</span>")
+		visible_message("<span class='alert'>[new_patient] has been laid on [src] by [user].</span>")
 	new_patient.resting = TRUE
-	new_patient.lay_down()
-	new_patient.forceMove(loc)
-	if(user.pulling == new_patient)
-		user.stop_pulling()
 	if(new_patient.s_active) //Close the container opened
 		new_patient.s_active.close(new_patient)
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows you to properly buckle folks to operating tables, notably locking them in if they're handcuffed as you'd expect with a chair.
(also updates some messages while I'm here).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This is behavior that you'd really expect to be the default, but currently isn't. At least in my own experience, I've run up against this a *ton*, with prisoners or research subjects crawling off even if they're handcuffed. This should make operating tables a bit more secure and workable.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Buckled a monke to an optable, waited a bit.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can now actually buckle people to operating tables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
