### PR TITLE
Gas overlays ignore the turf's color

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -386,7 +386,7 @@ SUBSYSTEM_DEF(air)
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE  // should only appear in vis_contents, but to be safe
 	layer = FLY_LAYER
-	appearance_flags = TILE_BOUND | RESET_TRANSFORM
+	appearance_flags = TILE_BOUND | RESET_TRANSFORM | RESET_COLOR
 
 /obj/effect/overlay/turf/plasma
 	icon_state = "plasma"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes atmos overlays ignore the turf's set color.

## Why It's Good For The Game
Fixes #20688

## Images of changes
![OldSleepTight](https://user-images.githubusercontent.com/80771500/229525760-b1dc2992-5011-4a50-a12f-f973e47940c6.PNG)

## Testing
Used cerulean prints, opened a canister.

## Changelog
:cl:
fix: Visible gasses do not inherit the tile's color they occupy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
