### PR TITLE
Carded AIs can now have their lawset directly changed by applying an AI module to them

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -37,7 +37,7 @@
 			to_chat(user, "<span class='danger'>Unable to establish a connection</span>: You're too far away from the target silicon!")
 			return
 		var/obj/item/aiModule/M = O
-		M.install(src)
+		M.install(src, user)
 		return
 	return ..()
 
@@ -80,7 +80,7 @@
 		if(!atoms_share_level(T, src))
 			to_chat(user, "<span class='danger'>Unable to establish a connection</span>: You're too far away from the target silicon!")
 			return
-		module.install(src)
+		module.install(src, user)
 		return
 	return ..()
 

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -10,6 +10,13 @@
 	var/flush = null
 	origin_tech = "programming=3;materials=3"
 
+/obj/item/aicard/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/aiModule))
+		var/obj/item/aiModule/module = I
+		module.install(src, user)
+		return
+	return ..()
+
 /obj/item/aicard/afterattack(atom/target, mob/user, proximity)
 	..()
 	if(!proximity || !target)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -30,55 +30,68 @@ AI MODULES
 			desc += current.law
 			desc += "<br>"
 
-/obj/item/aiModule/proc/install(obj/machinery/computer/C)
+/obj/item/aiModule/proc/install(obj/machinery/computer/C, mob/user)
 	if(istype(C, /obj/machinery/computer/aiupload))
 		var/obj/machinery/computer/aiupload/comp = C
 		if(comp.stat & NOPOWER)
-			to_chat(usr, "<span class='warning'>The upload computer has no power!</span>")
+			to_chat(user, "<span class='warning'>The upload computer has no power!</span>")
 			return
 		if(comp.stat & BROKEN)
-			to_chat(usr, "<span class='warning'>The upload computer is broken!</span>")
+			to_chat(user, "<span class='warning'>The upload computer is broken!</span>")
 			return
 		if(!comp.current)
-			to_chat(usr, "<span class='warning'>You haven't selected an AI to transmit laws to!</span>")
+			to_chat(user, "<span class='warning'>You haven't selected an AI to transmit laws to!</span>")
 			return
 
 		if(comp.current.stat == DEAD || comp.current.control_disabled)
-			to_chat(usr, "<span class='warning'>Upload failed. No signal is being detected from the AI.</span>")
+			to_chat(user, "<span class='warning'>Upload failed. No signal is being detected from the AI.</span>")
 		else if(comp.current.see_in_dark == 0)
-			to_chat(usr, "<span class='warning'>Upload failed. Only a faint signal is being detected from the AI, and it is not responding to our requests. It may be low on power.</span>")
+			to_chat(user, "<span class='warning'>Upload failed. Only a faint signal is being detected from the AI, and it is not responding to our requests. It may be low on power.</span>")
 		else
-			src.transmitInstructions(comp.current, usr)
+			src.transmitInstructions(comp.current, user)
 			to_chat(comp.current, "These are your laws now:")
 			comp.current.show_laws()
 			for(var/mob/living/silicon/robot/R in GLOB.mob_list)
 				if(R.lawupdate && (R.connected_ai == comp.current))
 					to_chat(R, "These are your laws now:")
 					R.show_laws()
-			to_chat(usr, "<span class='notice'>Upload complete. The AI's laws have been modified.</span>")
+			to_chat(user, "<span class='notice'>Upload complete. The AI's laws have been modified.</span>")
 
 	else if(istype(C, /obj/machinery/computer/borgupload))
 		var/obj/machinery/computer/borgupload/comp = C
 		if(comp.stat & NOPOWER)
-			to_chat(usr, "<span class='warning'>The upload computer has no power!</span>")
+			to_chat(user, "<span class='warning'>The upload computer has no power!</span>")
 			return
 		if(comp.stat & BROKEN)
-			to_chat(usr, "<span class='warning'>The upload computer is broken!</span>")
+			to_chat(user, "<span class='warning'>The upload computer is broken!</span>")
 			return
 		if(!comp.current)
-			to_chat(usr, "<span class='warning'>You haven't selected a robot to transmit laws to!</span>")
+			to_chat(user, "<span class='warning'>You haven't selected a robot to transmit laws to!</span>")
 			return
 
 		if(comp.current.stat == DEAD || comp.current.emagged)
-			to_chat(usr, "<span class='warning'>Upload failed. No signal is being detected from the robot.</span>")
+			to_chat(user, "<span class='warning'>Upload failed. No signal is being detected from the robot.</span>")
 		else if(comp.current.connected_ai)
-			to_chat(usr, "<span class='warning'>Upload failed. The robot is slaved to an AI.</span>")
+			to_chat(user, "<span class='warning'>Upload failed. The robot is slaved to an AI.</span>")
 		else
-			src.transmitInstructions(comp.current, usr)
+			transmitInstructions(comp.current, user)
 			to_chat(comp.current, "These are your laws now:")
 			comp.current.show_laws()
-			to_chat(usr, "<span class='notice'>Upload complete. The robot's laws have been modified.</span>")
-
+			to_chat(user, "<span class='notice'>Upload complete. The robot's laws have been modified.</span>")
+	if(istype(C, /obj/item/aicard))
+		var/mob/living/silicon/ai/ai_to_upload_to = locate(/mob/living/silicon/ai) in C
+		if(!ai_to_upload_to)
+			to_chat(user, "<span class='notice'>There is no AI in this intelicard.</span>")
+			return
+		if(ai_to_upload_to.stat == DEAD)
+			to_chat(user, "<span class='notice'>Corruption detected in lawset upload, throttling current service.</span>")
+			return
+		transmitInstructions(ai_to_upload_to, user)
+		for(var/mob/living/silicon/robot/R in GLOB.mob_list)
+			if(R.lawupdate && (R.connected_ai == ai_to_upload_to.current))
+				to_chat(R, "These are your laws now:")
+				R.show_laws()
+		to_chat(user, "<span class='notice'>Upload complete. The AI's laws have been modified.</span>")
 
 /obj/item/aiModule/proc/transmitInstructions(mob/living/silicon/ai/target, mob/sender)
 	log_law_changes(target, sender)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title, applying a AI module directly to the AI will change it's laws to that AI module

## Why It's Good For The Game
AI steal and AI kill aren't great objectives right now, and it generally sucks for the AI and the traitor who got it.
Because it's really hard to actually keep the AI on a lawset when its in a card the meta is to kill the AI then revive it later. This gives no advantage to the traitor and gives no advantage to the AI. This should encourage people to actually keep the AI around, and add a new dynamic to how sec has to deal someone who stole the AI rather than just chasing callouts from borgs.

## Testing
Compiled and ran in dream daemon
## Changelog
:cl:
tweak: Carded AIs can now have their lawset directly changed by applying an AI module to them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
