### PR TITLE
Adds a funny little message if you focus too hard on a singulo/teslo

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -76,16 +76,17 @@
 	return 1
 
 /obj/singularity/attack_tk(mob/user)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
-		C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-		"<span class='userdanger'>As you mentally focus on the singularity, you feel your knowlage of the universe grow. So much raw information is there for the taking, and you won't waste a speck of it. within fractions of a millisecond you absorb as much information as possible, more than even an AI would have access to, you feel like a god. Suddenly, the gravity of this situation dawns on you. As you feel your skull begining to collapse, you think to yourself. That was a really dence idea, wasn't it? </span>")
-		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
-		C.ghostize(0)
-		if(B)
-			B.remove(C)
-			qdel(B)
+	if(!iscarbon(user))
+		return
+	var/mob/living/carbon/C = user
+	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
+	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
+	"<span class='userdanger'>As you mentally focus on the singularity, you feel your knowlage of the universe grow. So much raw information is there for the taking, and you won't waste a speck of it. Within fractions of a millisecond you absorb as much information as possible, more than even an AI would have access to, you feel like a god. Suddenly, the gravity of this situation dawns on you. As you feel your skull begining to collapse, you think to yourself. That was a really dense idea, wasn't it? </span>")
+	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
+	C.ghostize(0)
+	if(B)
+		B.remove(C)
+		qdel(B)
 
 /obj/singularity/Process_Spacemove() //The singularity stops drifting for no man!
 	return 0

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -81,7 +81,7 @@
 	var/mob/living/carbon/C = user
 	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
 	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-	"<span class='userdanger'>As you mentally focus on the singularity, you feel your knowlage of the universe grow. So much raw information is there for the taking, and you won't waste a speck of it. Within fractions of a millisecond you absorb as much information as possible, more than even an AI would have access to, you feel like a god. Suddenly, the gravity of this situation dawns on you. As you feel your skull begining to collapse, you think to yourself. That was a really dense idea, wasn't it? </span>")
+		"<span class='userdanger'>As you focus on the singularity, you feel your knowledge of the universe grow. So much raw information is there for the taking; you won't waste a speck of it. Within fractions of a millisecond you absorb as much information as possible, more than even an AI would have access to, and you feel like a god. Suddenly, the gravity of this situation dawns on you. As you feel your skull beginning to collapse, you think to yourself. That was a really dense idea, wasn't it?</span>")
 	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
 	C.ghostize(0)
 	if(B)
@@ -434,7 +434,6 @@
 		M.Stun(6 SECONDS)
 		M.visible_message("<span class='danger'>[M] stares blankly at [src]!</span>", \
 						"<span class='userdanger'>You look directly into [src] and feel weak.</span>")
-	return
 
 
 /obj/singularity/proc/emp_area()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -75,6 +75,18 @@
 	consume(user)
 	return 1
 
+/obj/singularity/attack_tk(mob/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
+		C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
+		"<span class='userdanger'>As you mentally focus on the endless void you feel your very consciousness and soul sucked into the void. That was a infinitely dense idea.</span>")
+		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
+		C.ghostize(0)
+		if(B)
+			B.remove(C)
+			qdel(B)
+
 /obj/singularity/Process_Spacemove() //The singularity stops drifting for no man!
 	return 0
 
@@ -421,7 +433,7 @@
 		M.Stun(6 SECONDS)
 		M.visible_message("<span class='danger'>[M] stares blankly at [src]!</span>", \
 						"<span class='userdanger'>You look directly into [src] and feel weak.</span>")
-	return 
+	return
 
 
 /obj/singularity/proc/emp_area()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -81,7 +81,7 @@
 	var/mob/living/carbon/C = user
 	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
 	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-		"<span class='userdanger'>As you focus on the singularity, you feel your knowledge of the universe grow. So much raw information is there for the taking; you won't waste a speck of it. Within fractions of a millisecond you absorb as much information as possible, more than even an AI would have access to, and you feel like a god. Suddenly, the gravity of this situation dawns on you. As you feel your skull beginning to collapse, you think to yourself. That was a really dense idea, wasn't it?</span>")
+		"<span class='userdanger'>As you concentrate on the singularity, your understanding of the cosmos expands exponentially. An immense wealth of raw information is at your fingertips, and you're determined not to squander a single morsel. Within mere microseconds, you absorb a staggering amount of information—more than any AI could ever hope to access—and you can't help but feel a godlike sense of power. However, the gravity of this situation swiftly sinks in. As you sense your skull starting to collapse under pressure, you can't help but admit to yourself: That was a really dense idea, wasn't it?</span>")
 	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
 	C.ghostize(0)
 	if(B)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -80,7 +80,7 @@
 		var/mob/living/carbon/C = user
 		investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
 		C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-		"<span class='userdanger'>As you mentally focus on the endless void you feel your very consciousness and soul get sucked into the singularity. That was an infinitely dense idea.</span>")
+		"<span class='userdanger'>As you mentally focus on the singularity, you feel your knowlage of the universe grow. So much raw information is there for the taking, and you won't waste a speck of it. within fractions of a millisecond you absorb as much information as possible, more than even an AI would have access to, you feel like a god. Suddenly, the gravity of this situation dawns on you. As you feel your skull begining to collapse, you think to yourself. That was a really dence idea, wasn't it? </span>")
 		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
 		C.ghostize(0)
 		if(B)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -80,7 +80,7 @@
 		var/mob/living/carbon/C = user
 		investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
 		C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-		"<span class='userdanger'>As you mentally focus on the endless void you feel your very consciousness and soul sucked into the void. That was a infinitely dense idea.</span>")
+		"<span class='userdanger'>As you mentally focus on the endless void you feel your very consciousness and soul get sucked into the singularity. That was an infinitely dense idea.</span>")
 		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
 		C.ghostize(0)
 		if(B)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -665,16 +665,17 @@
 			Consume(B)
 
 /obj/machinery/atmospherics/supermatter_crystal/attack_tk(mob/user)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "supermatter")
-		C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-		"<span class='userdanger'>As you mentally focus on the supermatter you feel the contents of your skull start melting away. That was a really dense idea.</span>")
-		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
-		C.ghostize(0)
-		if(B)
-			B.remove(C)
-			qdel(B)
+	if(!iscarbon(user))
+		return
+	var/mob/living/carbon/C = user
+	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "supermatter")
+	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
+	"<span class='userdanger'>As you mentally focus on the supermatter you feel the contents of your skull start melting away. That was a really dense idea.</span>")
+	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
+	C.ghostize(0)
+	if(B)
+		B.remove(C)
+		qdel(B)
 
 /obj/machinery/atmospherics/supermatter_crystal/attack_alien(mob/user)
 	dust_mob(user, cause = "alien attack")

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -670,7 +670,7 @@
 	var/mob/living/carbon/C = user
 	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "supermatter")
 	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-	"<span class='userdanger'>As you mentally focus on the supermatter you feel the contents of your skull start melting away. That was a really dense idea.</span>")
+		"<span class='userdanger'>As you mentally focus on the supermatter you feel the contents of your skull start melting away. That was a really dense idea.</span>")
 	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
 	C.ghostize(0)
 	if(B)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -162,7 +162,9 @@
 /obj/singularity/energy_ball/attack_tk(mob/user)
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
-		to_chat(C, "<span class='userdanger'>That was a shockingly dumb idea.</span>")
+		investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
+		C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
+		"<span class='userdanger'>As you mentally focus on the energy ball you feel the contents of your skull become overcharged. That was shockingly stupid.</span>")
 		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
 		C.ghostize(0)
 		if(B)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -160,16 +160,17 @@
 	dust_mobs(AM)
 
 /obj/singularity/energy_ball/attack_tk(mob/user)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
-		C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-		"<span class='userdanger'>As you mentally focus on the energy ball you feel the contents of your skull become overcharged. That was shockingly stupid.</span>")
-		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
-		C.ghostize(0)
-		if(B)
-			B.remove(C)
-			qdel(B)
+	if(!iscarbon(user))
+		return
+	var/mob/living/carbon/C = user
+	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
+	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
+	"<span class='userdanger'>As you mentally focus on the energy ball you feel the contents of your skull become overcharged. That was shockingly stupid.</span>")
+	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
+	C.ghostize(0)
+	if(B)
+		B.remove(C)
+		qdel(B)
 
 /// When we get orbited, add the orbiter to our tracked balls
 /obj/singularity/energy_ball/proc/on_start_orbit(atom/movable/this, atom/orbiter)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -165,7 +165,7 @@
 	var/mob/living/carbon/C = user
 	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
 	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
-	"<span class='userdanger'>As you mentally focus on the energy ball you feel the contents of your skull become overcharged. That was shockingly stupid.</span>")
+		"<span class='userdanger'>As you mentally focus on the energy ball you feel the contents of your skull become overcharged. That was shockingly stupid.</span>")
 	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
 	C.ghostize(0)
 	if(B)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds a interaction, and message if you try to use tele on a singulo, as well as updates the tesla interaction a little.

~~Singulo message: As you mentally focus on the endless void you feel your very consciousness and soul sucked into the void. That was a infinitely dense idea.~~

New message: As you mentally focus on the singularity, you feel your knowlage of the universe grow. So much raw information is there for the taking, and you won't waste a speck of it. Within fractions of a millisecond you absorb as much information as possible, more than even an AI would have access to, you feel like a god. Suddenly, the gravity of this situation dawns on you. As you feel your skull begining to collapse, you think to yourself. That was a really dense idea, wasn't it?

Teslo message: As you mentally focus on the energy ball you feel the contents of your skull become overcharged. That was shockingly stupid.

Oh and adds round object investigation logs for both, just like the SM has for tele deaths!
Double oh! removes a small bit of whitespace(?) because some vsc script did it automatically(lemme know if this isn't okay) 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Aside from the admin logging for both, its just a funny little interaction, and funny interactions are fun!

## Testing
<!-- How did you test the PR, if at all? -->
Booted up test server with changes, focused super hard on singulo and teslo, and got the messages, as well as admin logs for both.
## Changelog
:cl:
add: Adds two round object investigation logging to the related changes.
add: The singularity has a fun little interaction with telekinesis like the SM&teslo.
tweak: Updated the tesla interaction with telekinesis
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->

## Additional notes.
If any one has a better pun idea for the singulo message, im open to changing it, keep in mind that the SM ending message is "That was a really dense idea."
I'm not very good with puns