### PR TITLE
Makes reagents adjust their temperature towards your actual body temperature

### DIFF
--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -294,7 +294,7 @@
  */
 /datum/reagents/proc/metabolize(mob/living/M)
 	if(M)
-		temperature_reagents(M.bodytemperature - 30)
+		temperature_reagents(M.bodytemperature)
 		M.absorb_blood()
 
 	for(var/datum/reagent/R as anything in addiction_threshold_accumulated)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes an inexplicable `- 30` from the proc call that gradually shifts the temperature of carbon mobs' internal reagent holder towards their body temperature.

In practice, fixes water freezing into ice *inside your stomach* shortly after drinking (as well as Cider freezing into Applejack and one other alcoholic drink reaction).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
As someone who occasionally drinks water from the water coolers around the station for the miniscule RP value, it's.. kind of silly to eventually hear the magic fizz and get notified that the water has now frozen into ice *inside my body*, which should be fairly hot and definitely not at the freezing point of water.

I've done some research to make sure this wouldn't break something important, and discovered that basically only carbon mobs actually metabolize things, which triggers the specific case of reagent temperature adjustment in question. With that in mind, I cannot come up with any examples where the exact temperature of the reagents the stomach of a carbon mob would really matter, outside of some very fringe cases that would basically have to be set up intentionally, as most chemical reactions use reagents that are never commonly ingested, and/or require temperatures too high/low for this change to make a difference.

Just to be extra sure, I've checked the code surrounding chemical reactions that produce new chemicals, reactions of individual reagents to temperature, how body temperature affects the temperature of the internal reagent holder, the base body temperature of different species, as well as just about any use of `chem_temp` we have in the code that could reasonably be relevant to reagents inside a carbon mob.
If you know or can think of anything this could possibly break, be sure to mention it, I don't mind doing extra testing 👍
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Drank 20u of water, waited a while, rejoiced at no ice reaction fizz roughly at the 10u mark.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Water no longer freezes into ice inside your stomach.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
