### PR TITLE
Medical stacks

### DIFF
--- a/code/game/objects/items/stacks/medical_packs.dm
+++ b/code/game/objects/items/stacks/medical_packs.dm
@@ -167,6 +167,7 @@
 	singular_name = "improvised gauze"
 	desc = "A roll of cloth roughly cut from something that can stop bleeding, but does not heal wounds."
 	heal_brute = 0
+	stop_bleeding = 900
 
 /obj/item/stack/medical/bruise_pack/advanced
 	name = "advanced trauma kit"

--- a/code/game/objects/items/stacks/medical_packs.dm
+++ b/code/game/objects/items/stacks/medical_packs.dm
@@ -125,6 +125,7 @@
 	heal_brute = 10
 	stop_bleeding = 1800
 	dynamic_icon_state = TRUE
+	parent_stack = TRUE
 
 /obj/item/stack/medical/bruise_pack/attackby(obj/item/I, mob/user, params)
 	if(I.sharp)
@@ -166,7 +167,6 @@
 	singular_name = "improvised gauze"
 	desc = "A roll of cloth roughly cut from something that can stop bleeding, but does not heal wounds."
 	heal_brute = 0
-	stop_bleeding = 900
 
 /obj/item/stack/medical/bruise_pack/advanced
 	name = "advanced trauma kit"
@@ -201,6 +201,7 @@
 	healverb = "salve"
 	heal_burn = 10
 	dynamic_icon_state = TRUE
+	parent_stack = TRUE
 
 /obj/item/stack/medical/ointment/attack(mob/living/M, mob/user)
 	if(..())

--- a/code/game/objects/items/stacks/medical_packs.dm
+++ b/code/game/objects/items/stacks/medical_packs.dm
@@ -126,7 +126,6 @@
 	heal_brute = 10
 	stop_bleeding = 1800
 	dynamic_icon_state = TRUE
-	parent_stack = TRUE
 
 /obj/item/stack/medical/bruise_pack/attackby(obj/item/I, mob/user, params)
 	if(I.sharp)
@@ -203,7 +202,6 @@
 	healverb = "salve"
 	heal_burn = 10
 	dynamic_icon_state = TRUE
-	parent_stack = TRUE
 
 /obj/item/stack/medical/ointment/attack(mob/living/M, mob/user)
 	if(..())

--- a/code/game/objects/items/stacks/medical_packs.dm
+++ b/code/game/objects/items/stacks/medical_packs.dm
@@ -9,6 +9,7 @@
 	throw_range = 7
 	resistance_flags = FLAMMABLE
 	max_integrity = 40
+	parent_stack = TRUE
 	var/heal_brute = 0
 	var/heal_burn = 0
 	var/self_delay = 20

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -31,6 +31,8 @@
 	var/table_type
 	/// If this stack has a dynamic icon_state based on amount / max_amount
 	var/dynamic_icon_state = FALSE
+	/// if true, then this item can stack with children
+	var/parent_stack = FALSE
 
 /obj/item/stack/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()
@@ -355,7 +357,11 @@
 	use(amount)
 
 /obj/item/stack/attackby(obj/item/W, mob/user, params)
-	if(istype(W, merge_type))
+	if(!parent_stack && istype(W, merge_type))
+		var/obj/item/stack/S = W
+		merge(S)
+		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")
+	if(parent_stack==TRUE && W.type == type)
 		var/obj/item/stack/S = W
 		merge(S)
 		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -31,7 +31,7 @@
 	var/table_type
 	/// If this stack has a dynamic icon_state based on amount / max_amount
 	var/dynamic_icon_state = FALSE
-	/// if true, then this item can stack with children
+	/// if true, then this item can't stack with subtypes
 	var/parent_stack = FALSE
 
 /obj/item/stack/Initialize(mapload, new_amount, merge = TRUE)
@@ -357,7 +357,7 @@
 	use(amount)
 
 /obj/item/stack/attackby(obj/item/W, mob/user, params)
-	if(!parent_stack && istype(W, merge_type) || parent_stack && W.type == type)
+	if((!parent_stack && istype(W, merge_type)) || (parent_stack && W.type == type))
 		var/obj/item/stack/S = W
 		merge(S)
 		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -361,7 +361,7 @@
 		var/obj/item/stack/S = W
 		merge(S)
 		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")
-	if(parent_stack==TRUE && W.type == type)
+	if(parent_stack && W.type == type)
 		var/obj/item/stack/S = W
 		merge(S)
 		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -357,11 +357,7 @@
 	use(amount)
 
 /obj/item/stack/attackby(obj/item/W, mob/user, params)
-	if(!parent_stack && istype(W, merge_type))
-		var/obj/item/stack/S = W
-		merge(S)
-		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")
-	if(parent_stack && W.type == type)
+	if(!parent_stack && istype(W, merge_type) || parent_stack && W.type == type)
 		var/obj/item/stack/S = W
 		merge(S)
 		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #18173.
Prevents the upgrading of gauze and ointment into advanced trauma and burn kits through abuse of parent/child status in code. 
Adds the parent_stack flag to obj/item/stack allowing items flagged TRUE to be handled separately when stacks are merged.

## Why It's Good For The Game
Allows for parent items to not be merged with daughter items when picked up.

## Testing
Try to pick up advanced kits with gauze, and then gauze with advanced trauma kits
Repeat with ointment and burn kits.

## Changelog
:cl:
Fix: Prevents stacking gauze/ointment into advanced kits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
