### PR TITLE
Adds ghost notification when the singularity is (likely) loose.

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -117,6 +117,9 @@
 /obj/singularity/narsie/singularity_act() //handled in /obj/singularity/proc/consume
 	return
 
+/obj/singularity/narsie/notify_dead()
+	return
+
 /obj/singularity/narsie/proc/pickcultist() //Narsie rewards his cultists with being devoured first, then picks a ghost to follow. --NEO
 	var/list/cultists = list()
 	var/list/noncultists = list()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -440,7 +440,6 @@
 		M.Stun(6 SECONDS)
 		M.visible_message("<span class='danger'>[M] stares blankly at [src]!</span>", \
 						"<span class='userdanger'>You look directly into [src] and feel weak.</span>")
-	return
 
 
 /obj/singularity/proc/emp_area()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -208,6 +208,7 @@
 				dissipate_strength = 10
 				if(!isnt_shutting_down)
 					notify_dead()
+					isnt_shutting_down = TRUE
 		if(STAGE_FIVE)//this one also lacks a check for gens because it eats everything
 			current_size = STAGE_FIVE
 			icon = 'icons/effects/288x288.dmi'
@@ -408,6 +409,8 @@
 	return
 
 /obj/singularity/proc/notify_dead()
+	if(!isnt_shutting_down)
+		return
 	notify_ghosts(
 		"IT'S LOOSE",
 		ghost_sound = 'sound/machines/warning-buzzer.ogg',

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -206,9 +206,7 @@
 				dissipate_delay = 10
 				dissipate_track = 0
 				dissipate_strength = 10
-				if(!isnt_shutting_down)
-					notify_dead()
-					isnt_shutting_down = TRUE
+				notify_dead()
 		if(STAGE_FIVE)//this one also lacks a check for gens because it eats everything
 			current_size = STAGE_FIVE
 			icon = 'icons/effects/288x288.dmi'

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -407,7 +407,7 @@
 	return
 
 /obj/singularity/proc/notify_dead()
-	if(!isnt_shutting_down)
+	if(isnt_shutting_down)
 		return
 	notify_ghosts(
 		"IT'S LOOSE",

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -27,6 +27,8 @@
 	var/consumedSupermatter = FALSE //If the singularity has eaten a supermatter shard and can go to stage six
 	var/warps_projectiles = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	/// Whether or not we've pinged ghosts
+	var/isnt_shutting_down = FALSE
 
 /obj/singularity/Initialize(mapload, starting_energy = 50)
 	. = ..()
@@ -204,6 +206,8 @@
 				dissipate_delay = 10
 				dissipate_track = 0
 				dissipate_strength = 10
+				if(!isnt_shutting_down)
+					notify_dead()
 		if(STAGE_FIVE)//this one also lacks a check for gens because it eats everything
 			current_size = STAGE_FIVE
 			icon = 'icons/effects/288x288.dmi'
@@ -403,6 +407,20 @@
 		C.IgniteMob()
 	return
 
+/obj/singularity/proc/notify_dead()
+	notify_ghosts(
+		"IT'S LOOSE",
+		ghost_sound = 'sound/machines/warning-buzzer.ogg',
+		source = src,
+		action = NOTIFY_FOLLOW,
+		flashwindow = FALSE,
+		title = "IT'S LOOSE",
+		alert_overlay = image(icon='icons/obj/singularity.dmi', icon_state="singularity_s1")
+	)
+
+	isnt_shutting_down = TRUE
+
+
 
 /obj/singularity/proc/mezzer()
 	for(var/mob/living/carbon/M in oviewers(8, src))
@@ -421,7 +439,7 @@
 		M.Stun(6 SECONDS)
 		M.visible_message("<span class='danger'>[M] stares blankly at [src]!</span>", \
 						"<span class='userdanger'>You look directly into [src] and feel weak.</span>")
-	return 
+	return
 
 
 /obj/singularity/proc/emp_area()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Pings ghosts when the singularity reaches stage four, at which point it's very likely not going to return to containment.
Inspired by /tg/.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Gives ghosts who aren't paying as much attention something to follow, and in the off-chance we do see a singulo, it's always fun to have a bit more flavor.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/89928798/230274802-749bca42-500e-4df3-8a5f-d6a07ddfcfe0.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: New ghost alert appears when a singularity reaches stage 4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
