### PR TITLE
Corrects cash input text for arcade machines

### DIFF
--- a/code/modules/arcade/arcade_base.dm
+++ b/code/modules/arcade/arcade_base.dm
@@ -61,7 +61,7 @@
 		return
 	if(!freeplay)
 		if(isspacecash(O))
-			insert_cash_arcade(O, user, token_price)
+			insert_cash(O, user, token_price)
 			if(pay_with_cash(token_price, "Arcade Token Purchase", "DonkBook Gaming", user, account_database.vendor_account))
 				tokens += 1
 			return

--- a/code/modules/arcade/arcade_base.dm
+++ b/code/modules/arcade/arcade_base.dm
@@ -61,7 +61,7 @@
 		return
 	if(!freeplay)
 		if(isspacecash(O))
-			insert_cash(O, user, token_price)
+			insert_cash_arcade(O, user, token_price)
 			if(pay_with_cash(token_price, "Arcade Token Purchase", "DonkBook Gaming", user, account_database.vendor_account))
 				tokens += 1
 			return

--- a/code/modules/economy/economy_machinery/economy_machinery.dm
+++ b/code/modules/economy/economy_machinery/economy_machinery.dm
@@ -83,6 +83,16 @@
 	cash_money.use(amount_to_insert)
 	return TRUE
 
+/obj/machinery/economy/proc/insert_cash_arcade(obj/item/stack/spacecash/cash_money, mob/user, amount)
+	if(amount > cash_money.amount)
+		return
+	var/amount_to_insert = amount ? amount : cash_money.amount
+	visible_message("<span class='info'>[user] inserts [amount] credits into [src].</span>")
+	cash_stored += amount_to_insert
+	cash_transaction += amount_to_insert
+	cash_money.use(amount_to_insert)
+	return TRUE
+
 /**
   * create the most effective combination of space cash piles to make up the requested amount
   *

--- a/code/modules/economy/economy_machinery/economy_machinery.dm
+++ b/code/modules/economy/economy_machinery/economy_machinery.dm
@@ -77,17 +77,7 @@
 	if(amount > cash_money.amount)
 		return
 	var/amount_to_insert = amount ? amount : cash_money.amount
-	visible_message("<span class='info'>[user] inserts [cash_money] into [src].</span>")
-	cash_stored += amount_to_insert
-	cash_transaction += amount_to_insert
-	cash_money.use(amount_to_insert)
-	return TRUE
-
-/obj/machinery/economy/proc/insert_cash_arcade(obj/item/stack/spacecash/cash_money, mob/user, amount)
-	if(amount > cash_money.amount)
-		return
-	var/amount_to_insert = amount ? amount : cash_money.amount
-	visible_message("<span class='info'>[user] inserts [amount] credits into [src].</span>")
+	visible_message("<span class='info'>[user] inserts [amount_to_insert] credits into [src].</span>")
 	cash_stored += amount_to_insert
 	cash_transaction += amount_to_insert
 	cash_money.use(amount_to_insert)

--- a/code/modules/economy/economy_machinery/economy_machinery.dm
+++ b/code/modules/economy/economy_machinery/economy_machinery.dm
@@ -77,7 +77,7 @@
 	if(amount > cash_money.amount)
 		return
 	var/amount_to_insert = amount ? amount : cash_money.amount
-	visible_message("<span class='info'>[user] inserts [amount_to_insert] credits into [src].</span>")
+	visible_message("<span class='info'>[user] inserts [amount_to_insert == 1 ? "[amount_to_insert] credit" : "[amount_to_insert] credits"]  into [src].</span>")
 	cash_stored += amount_to_insert
 	cash_transaction += amount_to_insert
 	cash_money.use(amount_to_insert)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20408 
Arcade machines now show the proper amount of space cash when cash is inserted.

## Why It's Good For The Game
Players should not panic thinking they sacrificed their life savings to THE CLAAAAWWWW.

## Testing
Insert cash into claw machine. VV edit claw machine to change token cost. Confirm cash inserted value is changed. 

## Changelog
:cl:
Fix: When inserting cash to arcade machines, the amount inserted is now properly shown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
