### PR TITLE
Fixes cult revive runes always giving up a persons body

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -621,7 +621,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		if(mob_to_revive.ghost_can_reenter())
 			mob_to_revive.grab_ghost()
 
-	if(!mob_to_revive.get_ghost() || mob_to_revive.client && mob_to_revive.client.is_afk())
+	if(!mob_to_revive.get_ghost() && !mob_to_revive.client || mob_to_revive.client.is_afk())
 		set waitfor = FALSE
 		to_chat(user, "<span class='cult'>[mob_to_revive] was revived, but their mind is lost! Seeking a lost soul to replace it.</span>")
 		var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Would you like to play as a revived Cultist?", ROLE_CULTIST, TRUE, poll_time = 20 SECONDS, source = /obj/item/melee/cultblade/dagger)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -621,7 +621,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		if(mob_to_revive.ghost_can_reenter())
 			mob_to_revive.grab_ghost()
 
-	if(!mob_to_revive.get_ghost() && !mob_to_revive.client || mob_to_revive.client.is_afk())
+	if(!mob_to_revive.get_ghost() && (!mob_to_revive.client || mob_to_revive.client.is_afk()))
 		set waitfor = FALSE
 		to_chat(user, "<span class='cult'>[mob_to_revive] was revived, but their mind is lost! Seeking a lost soul to replace it.</span>")
 		var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Would you like to play as a revived Cultist?", ROLE_CULTIST, TRUE, poll_time = 20 SECONDS, source = /obj/item/melee/cultblade/dagger)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #20832 
fixes #20806
Fixes a logic error that would cause people revived from a cult revive rune always getting their body given up

## Why It's Good For The Game
Bugs are bad

## Testing
Compiled and ran

## Changelog
:cl:
fix: You will no longer be given up to ghosts while in a valid revivable state by a revive rune
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
