### PR TITLE
Removes a duplicate definition of Hot Chocolate

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
@@ -264,8 +264,8 @@
 /datum/reagent/consumable/drink/hot_coco
 	name = "Hot Chocolate"
 	id = "hot_coco"
-	description = "Made with love! And coco beans."
-	nutriment_factor = 3 * REAGENTS_METABOLISM
+	description = "Made with love! And cocoa beans."
+	nutriment_factor = 2 * REAGENTS_METABOLISM
 	color = "#401101"
 	drink_icon = "hot_coco"
 	drink_name = "Glass of hot coco"

--- a/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
@@ -272,6 +272,14 @@
 	drink_desc = "Delicious and cozy."
 	taste_description = "chocolate"
 
+/datum/reagent/consumable/drink/hot_coco/on_mob_life(mob/living/M)
+	if(M.bodytemperature < 310) // 310 is the normal bodytemp. 310.055
+		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
+	var/update_flags = STATUS_UPDATE_NONE
+	if(isvulpkanin(M) || istajaran(M) || isfarwa(M) || iswolpin(M))
+		update_flags |= M.adjustToxLoss(2, FALSE)
+	return ..() | update_flags
+
 /datum/reagent/consumable/drink/coffee
 	name = "Coffee"
 	id = "coffee"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -330,15 +330,6 @@
 	color = "#FEFEFE"
 	taste_description = "bitter vanilla"
 
-/datum/reagent/consumable/hot_coco
-	name = "Hot Chocolate"
-	id = "hot_coco"
-	description = "Made with love! And cocoa beans."
-	reagent_state = LIQUID
-	nutriment_factor = 2 * REAGENTS_METABOLISM
-	color = "#403010" // rgb: 64, 48, 16
-	taste_description = "chocolate"
-
 /datum/reagent/consumable/hot_coco/on_mob_life(mob/living/M)
 	if(M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -330,14 +330,6 @@
 	color = "#FEFEFE"
 	taste_description = "bitter vanilla"
 
-/datum/reagent/consumable/hot_coco/on_mob_life(mob/living/M)
-	if(M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
-		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
-	var/update_flags = STATUS_UPDATE_NONE
-	if(isvulpkanin(M) || istajaran(M) || isfarwa(M) || iswolpin(M))
-		update_flags |= M.adjustToxLoss(2, FALSE)
-	return ..() | update_flags
-
 /datum/reagent/consumable/garlic
 	name = "Garlic Juice"
 	id = "garlic"


### PR DESCRIPTION
## What Does This PR Do
Merges the defintion of Hot Chocolate reagent from `food_reagents.dm` into the one in `drinks_reagents.dm` (as well as the associated `on_mob_life()` proc definition).

## Why It's Good For The Game
Bar drinks using Hot Chocolate actually gain the proper sprite/name/description.
Less crimes against coders.

## Images of changes
![image](https://user-images.githubusercontent.com/100448493/230581660-6a2e11bc-bc2e-4466-8ec3-5efdccf15541.png)

## Testing
Grabbed a hot chocolate drink from the drinks vendor, extracted only the Hot Chocolate reagent, put in a bar glass - noted the correct drink sprite and name.
Fed the glass to a vulpkanin - noted it still raises their body temperature and poisons them.

## Changelog
:cl:
fix: Hot Chocolate bar drinks now have the correct sprite/name/description.
/:cl: