### PR TITLE
Slightly refactors `adjustCloneLoss()` and `setCloneLoss()`

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -108,6 +108,7 @@
 /mob/living/carbon/human/proc/adjustBruteLossByPart(amount, organ_name, obj/damage_source = null, updating_health = TRUE)
 	if(dna.species && amount > 0)
 		amount *= dna.species.brute_mod
+
 	if(organ_name in bodyparts_by_name)
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
@@ -132,6 +133,12 @@
 			O.heal_damage(0, -amount, internal = 0, robo_repair = O.is_robotic(), updating_health = updating_health)
 	return STATUS_UPDATE_HEALTH
 
+/mob/living/carbon/human/unmutateAllBodyparts()
+	for(var/obj/item/organ/external/O in bodyparts)
+		if(O.status & ORGAN_MUTATED)
+			O.unmutate()
+			to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
+
 /mob/living/carbon/human/adjustCloneLoss(amount)
 	if(dna.species && amount > 0)
 		amount *= dna.species.clone_mod
@@ -144,10 +151,7 @@
 	var/heal_prob = max(0, 80 - getCloneLoss())
 
 	if(!getCloneLoss()) // All cloneloss was purged - fix all organs
-		for(var/obj/item/organ/external/O in bodyparts)
-			if(O.status & ORGAN_MUTATED)
-				O.unmutate()
-				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
+		unmutateAllBodyparts()
 		return
 
 	if(amount > 0) // Cloneloss was inflicted - chance to mutate an organ
@@ -180,10 +184,7 @@
 	. = ..()
 
 	if(!amount) // Cloneloss was set to 0 - fix all organs
-		for(var/obj/item/organ/external/O in bodyparts)
-			if(O.status & ORGAN_MUTATED)
-				O.unmutate()
-				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
+		unmutateAllBodyparts()
 
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/adjustOxyLoss(amount)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -133,7 +133,7 @@
 			O.heal_damage(0, -amount, internal = 0, robo_repair = O.is_robotic(), updating_health = updating_health)
 	return STATUS_UPDATE_HEALTH
 
-/mob/living/carbon/human/unmutateAllBodyparts()
+/mob/living/carbon/human/proc/unmutateAllBodyparts()
 	for(var/obj/item/organ/external/O in bodyparts)
 		if(O.status & ORGAN_MUTATED)
 			O.unmutate()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -139,7 +139,14 @@
 
 	var/heal_prob = max(0, 80 - getCloneLoss())
 	var/mut_prob = min(80, getCloneLoss() + 10)
-	if(amount > 0) //cloneloss is being added
+
+	if(getCloneLoss() == 0)  // All cloneloss was purged - fix all organs
+		for(var/obj/item/organ/external/O in bodyparts)
+			if(O.status & ORGAN_MUTATED)
+				O.unmutate()
+				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
+		return
+	else if(amount > 0) // Cloneloss was added
 		if(prob(mut_prob))
 			var/list/obj/item/organ/external/candidates = list() //TYPECASTED LISTS ARE NOT A FUCKING THING WHAT THE FUCK
 			for(var/obj/item/organ/external/O in bodyparts)
@@ -154,22 +161,13 @@
 				to_chat(src, "<span class='notice'>Something is not right with your [O.name]...</span>")
 				O.add_autopsy_data("Mutation", amount)
 				return
-
-	else //cloneloss is being subtracted
+	else if (amount < 0) // Cloneloss was subtracted
 		if(prob(heal_prob))
 			for(var/obj/item/organ/external/O in bodyparts)
 				if(O.status & ORGAN_MUTATED)
 					O.unmutate()
 					to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
 					return
-
-
-	if(getCloneLoss() < 1) //no cloneloss, fixes organs
-		for(var/obj/item/organ/external/O in bodyparts)
-			if(O.status & ORGAN_MUTATED)
-				O.unmutate()
-				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
-
 
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/adjustOxyLoss(amount)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -137,37 +137,37 @@
 		amount = amount * dna.species.clone_mod
 	. = ..()
 
-	var/heal_prob = max(0, 80 - getCloneLoss())
 	var/mut_prob = min(80, getCloneLoss() + 10)
+	var/heal_prob = max(0, 80 - getCloneLoss())
 
 	if(getCloneLoss() == 0)  // All cloneloss was purged - fix all organs
 		for(var/obj/item/organ/external/O in bodyparts)
 			if(O.status & ORGAN_MUTATED)
 				O.unmutate()
 				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
-		return
-	else if(amount > 0) // Cloneloss was added
-		if(prob(mut_prob))
-			var/list/obj/item/organ/external/candidates = list() //TYPECASTED LISTS ARE NOT A FUCKING THING WHAT THE FUCK
-			for(var/obj/item/organ/external/O in bodyparts)
-				if(O.is_robotic())
-					continue
-				if(!(O.status & ORGAN_MUTATED))
-					candidates |= O
+	else if(amount > 0) // Cloneloss was inflicted - chance to mutate an organ
+		if(!prob(mut_prob))
+			return
 
-			if(candidates.len)
-				var/obj/item/organ/external/O = pick(candidates)
-				O.mutate()
-				to_chat(src, "<span class='notice'>Something is not right with your [O.name]...</span>")
-				O.add_autopsy_data("Mutation", amount)
+		var/list/candidates = list()
+		for(var/obj/item/organ/external/O in bodyparts)
+			if(!O.is_robotic() && !(O.status & ORGAN_MUTATED))
+				candidates |= O
+
+		if(length(candidates))
+			var/obj/item/organ/external/O = pick(candidates)
+			O.mutate()
+			to_chat(src, "<span class='notice'>Something is not right with your [O.name]...</span>")
+			O.add_autopsy_data("Mutation", amount)
+	else if (amount < 0) // Cloneloss was healed - chance to unmutate an organ
+		if(!prob(heal_prob))
+			return
+
+		for(var/obj/item/organ/external/O in bodyparts)
+			if(O.status & ORGAN_MUTATED)
+				O.unmutate()
+				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
 				return
-	else if (amount < 0) // Cloneloss was subtracted
-		if(prob(heal_prob))
-			for(var/obj/item/organ/external/O in bodyparts)
-				if(O.status & ORGAN_MUTATED)
-					O.unmutate()
-					to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
-					return
 
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/adjustOxyLoss(amount)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -169,12 +169,18 @@
 				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
 				return
 
-// Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/setCloneLoss(amount)
 	if(dna.species && amount > 0)
 		amount = amount * dna.species.clone_mod
 	. = ..()
 
+	if(amount == 0) // Cloneloss was set to 0 - fix all organs
+		for(var/obj/item/organ/external/O in bodyparts)
+			if(O.status & ORGAN_MUTATED)
+				O.unmutate()
+				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
+
+// Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/adjustOxyLoss(amount)
 	if(dna.species && amount > 0)
 		amount = amount * dna.species.oxy_mod

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -28,7 +28,7 @@
 		if(sponge)
 			if(dna.species && amount > 0)
 				if(use_brain_mod)
-					amount = amount * dna.species.brain_mod
+					amount *= dna.species.brain_mod
 			sponge.damage = clamp(sponge.damage + amount, 0, 120)
 			if(sponge.damage >= 120)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
@@ -46,7 +46,7 @@
 		if(sponge)
 			if(dna.species && amount > 0)
 				if(use_brain_mod)
-					amount = amount * dna.species.brain_mod
+					amount *= dna.species.brain_mod
 			sponge.damage = clamp(amount, 0, 120)
 			if(sponge.damage >= 120)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
@@ -88,7 +88,7 @@
 /mob/living/carbon/human/adjustBruteLoss(amount, updating_health = TRUE, damage_source = null, robotic = FALSE)
 	if(amount > 0)
 		if(dna.species)
-			amount = amount * dna.species.brute_mod
+			amount *= dna.species.brute_mod
 		take_overall_damage(amount, 0, updating_health, used_weapon = damage_source)
 	else
 		heal_overall_damage(-amount, 0, updating_health, FALSE, robotic)
@@ -98,7 +98,7 @@
 /mob/living/carbon/human/adjustFireLoss(amount, updating_health = TRUE, damage_source = null, robotic = FALSE)
 	if(amount > 0)
 		if(dna.species)
-			amount = amount * dna.species.burn_mod
+			amount *= dna.species.burn_mod
 		take_overall_damage(0, amount, updating_health, used_weapon = damage_source)
 	else
 		heal_overall_damage(0, -amount, updating_health, FALSE, robotic)
@@ -107,7 +107,7 @@
 
 /mob/living/carbon/human/proc/adjustBruteLossByPart(amount, organ_name, obj/damage_source = null, updating_health = TRUE)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.brute_mod
+		amount *= dna.species.brute_mod
 	if(organ_name in bodyparts_by_name)
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
@@ -120,7 +120,7 @@
 
 /mob/living/carbon/human/proc/adjustFireLossByPart(amount, organ_name, obj/damage_source = null, updating_health = TRUE)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.burn_mod
+		amount *= dna.species.burn_mod
 
 	if(organ_name in bodyparts_by_name)
 		var/obj/item/organ/external/O = get_organ(organ_name)
@@ -134,7 +134,7 @@
 
 /mob/living/carbon/human/adjustCloneLoss(amount)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.clone_mod
+		amount *= dna.species.clone_mod
 	. = ..()
 
 	var/mut_prob = min(80, getCloneLoss() + 10)
@@ -171,7 +171,7 @@
 
 /mob/living/carbon/human/setCloneLoss(amount)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.clone_mod
+		amount *= dna.species.clone_mod
 	. = ..()
 
 	if(amount == 0) // Cloneloss was set to 0 - fix all organs
@@ -183,32 +183,32 @@
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/adjustOxyLoss(amount)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.oxy_mod
+		amount *= dna.species.oxy_mod
 	. = ..()
 
 /mob/living/carbon/human/setOxyLoss(amount)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.oxy_mod
+		amount *= dna.species.oxy_mod
 	. = ..()
 
 /mob/living/carbon/human/adjustToxLoss(amount)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.tox_mod
+		amount *= dna.species.tox_mod
 	. = ..()
 
 /mob/living/carbon/human/setToxLoss(amount)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.tox_mod
+		amount *= dna.species.tox_mod
 	. = ..()
 
 /mob/living/carbon/human/adjustStaminaLoss(amount, updating = TRUE)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.stamina_mod
+		amount *= dna.species.stamina_mod
 	. = ..()
 
 /mob/living/carbon/human/setStaminaLoss(amount, updating = TRUE)
 	if(dna.species && amount > 0)
-		amount = amount * dna.species.stamina_mod
+		amount *= dna.species.stamina_mod
 	. = ..()
 
 ////////////////////////////////////////////

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -137,15 +137,20 @@
 		amount *= dna.species.clone_mod
 	. = ..()
 
+	if(!amount)
+		return
+
 	var/mut_prob = min(80, getCloneLoss() + 10)
 	var/heal_prob = max(0, 80 - getCloneLoss())
 
-	if(getCloneLoss() == 0)  // All cloneloss was purged - fix all organs
+	if(!getCloneLoss()) // All cloneloss was purged - fix all organs
 		for(var/obj/item/organ/external/O in bodyparts)
 			if(O.status & ORGAN_MUTATED)
 				O.unmutate()
 				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
-	else if(amount > 0) // Cloneloss was inflicted - chance to mutate an organ
+		return
+
+	if(amount > 0) // Cloneloss was inflicted - chance to mutate an organ
 		if(!prob(mut_prob))
 			return
 
@@ -159,7 +164,7 @@
 			O.mutate()
 			to_chat(src, "<span class='notice'>Something is not right with your [O.name]...</span>")
 			O.add_autopsy_data("Mutation", amount)
-	else if (amount < 0) // Cloneloss was healed - chance to unmutate an organ
+	else // Cloneloss was partially healed - chance to unmutate an organ
 		if(!prob(heal_prob))
 			return
 
@@ -174,7 +179,7 @@
 		amount *= dna.species.clone_mod
 	. = ..()
 
-	if(amount == 0) // Cloneloss was set to 0 - fix all organs
+	if(!amount) // Cloneloss was set to 0 - fix all organs
 		for(var/obj/item/organ/external/O in bodyparts)
 			if(O.status & ORGAN_MUTATED)
 				O.unmutate()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -170,6 +170,11 @@
 				return
 
 // Defined here solely to take species flags into account without having to recast at mob/living level.
+/mob/living/carbon/human/setCloneLoss(amount)
+	if(dna.species && amount > 0)
+		amount = amount * dna.species.clone_mod
+	. = ..()
+
 /mob/living/carbon/human/adjustOxyLoss(amount)
 	if(dna.species && amount > 0)
 		amount = amount * dna.species.oxy_mod

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -156,10 +156,10 @@
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.setCloneLoss(0, FALSE) //Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
-	update_flags |= M.adjustCloneLoss(-1, FALSE) //What? We just set cloneloss to 0. Why? Simple; this is so external organs properly unmutate. // why don't you fix the code instead
+	update_flags |= M.setCloneLoss(0, FALSE) // Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
 	update_flags |= M.adjustBruteLoss(-1, FALSE)
 	update_flags |= M.adjustFireLoss(-1, FALSE)
+
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/head/head = H.get_organ("head")


### PR DESCRIPTION
## What Does This PR Do
Cleans up code around `adjustCloneLoss()` and adds a missing human `setCloneLoss()` proc override, fixing a couple bugs along the way.
Reaching a cloneloss of 0 through either proc will now unmutate all external organs, and `setCloneLoss()` now respects species cloneloss damage mod.

## Why It's Good For The Game
Less bugs and more sane code good

## Testing
1. Spawned in a Kidan and a decloner
2. Shot the poor sod several times
3. Swapped into the Kidan, confirmed it has multiple mutated limbs
4. Healed all the cellular damage away via Rezadone (`setCloneLoss(0)`) and VV-adjusting cloneloss to negative of current value
5. Confirmed that all limbs have been unmutated
6. Repeated several times for good measure
​
7. VV'd some toxin damage into the Kidan to confirm species damage mods still work

## Changelog
:cl:
fix: Lowering cellular damage to 0 will now always unmutate all your limbs.
fix: Cellular damage modifiers of certain species are no longer ignored in some cases.
/:cl: