### PR TITLE
buffs Potassium Iodide

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -416,8 +416,7 @@
 	taste_description = "cleansing"
 
 /datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/M)
-	if(prob(80))
-		M.radiation = max(0, M.radiation-10)
+	M.radiation = max(0, M.radiation - 25)
 	return ..()
 
 /datum/reagent/medicine/pen_acid


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Buffs Potassium Iodide, no longer has a 20% chance to not heal radiation, heals 25 radiation rather than 10 radiation. 

## Why It's Good For The Game
Potassium Iodide is rather awful in it's current state. The majority of people who come in with radiation to medbay will have a minimum of 2k+ radiation, which takes around 7 to 9 minutes to just fix the radiation with Potassium Iodide. Even though this is much quicker to produce in bulk then penetic, it's never used just due to the slow speed of it. This should let it actually do something instead of being a joke chemical you give someone while you scream at chem for Pentetic.

## Testing
Watched the rads go down

## Changelog
:cl:
tweak: Potassium Iodide no longer has a 20% chance not to heal radiation. Heals 25 radiation per cycle from 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
