### PR TITLE
Adds some crash reports to character loading

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -458,14 +458,14 @@
 	//Sanitize
 	var/datum/species/SP = GLOB.all_species[species]
 	if(!SP)
-		CRASH("Couldn't find a species matching [species], character name is [real_name].")
+		stack_trace("Couldn't find a species matching [species], character name is [real_name].")
 
 	metadata = sanitize_text(metadata, initial(metadata))
 	real_name = reject_bad_name(real_name, TRUE)
 
 	if(isnull(species))
 		species = "Human"
-		CRASH("Character doesn't have a species, character name is [real_name]. Defaulting to human.")
+		stack_trace("Character doesn't have a species, character name is [real_name]. Defaulting to human.")
 
 	if(isnull(language))
 		language = "None"

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -457,11 +457,15 @@
 
 	//Sanitize
 	var/datum/species/SP = GLOB.all_species[species]
+	if(!SP)
+		CRASH("Couldn't find a species matching [species], character name is [real_name].")
+
 	metadata = sanitize_text(metadata, initial(metadata))
 	real_name = reject_bad_name(real_name, TRUE)
 
 	if(isnull(species))
 		species = "Human"
+		CRASH("Character doesn't have a species, character name is [real_name]. Defaulting to human.")
 
 	if(isnull(language))
 		language = "None"

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -704,7 +704,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		return
 
 	if(href_list["track"])
-		var/mob/living/target = locate(href_list["track"]) in GLOB.mob_living_list
+		var/mob/living/target = locate(href_list["track"]) in GLOB.mob_list
 		if(target && target.can_track())
 			ai_actual_track(target)
 		else

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -704,7 +704,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		return
 
 	if(href_list["track"])
-		var/mob/living/target = locate(href_list["track"]) in GLOB.mob_list
+		var/mob/living/target = locate(href_list["track"]) in GLOB.mob_living_list
 		if(target && target.can_track())
 			ai_actual_track(target)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Adds some crash reports to character loading, because currently loading characters who can runtime
```
[2023-04-09T05:06:00] Runtime in character.dm,479: Cannot read null.has_gender
[2023-04-09T05:06:00]   proc name: load (/datum/character_save/proc/load)
[2023-04-09T05:06:00]   src: /datum/character_save (/datum/character_save)
[2023-04-09T05:06:00]   call stack:
[2023-04-09T05:06:00]   /datum/character_save (/datum/character_save): load
[2023-04-09T05:06:00]   /datum/client_login_processor/... (/datum/client_login_processor/load_characters): process_result
[2023-04-09T05:06:00]   *ADMIN* (/client): New
```
Unfortunately, the admins never know either what characters are runtiming because theres basically no data here. This adds some more that will hopefully help diagnose the problem.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Helps coders fix runtimes

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, unfortunately theres not much testing I can actually do locally. But there are no changes besides error logging

## Changelog
Nothing player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
