### PR TITLE
Adds TD info to world/Topic?status

### DIFF
--- a/code/modules/world_topic/status.dm
+++ b/code/modules/world_topic/status.dm
@@ -30,6 +30,19 @@
 	status_info["map_name"] = SSmapping.map_datum.fluff_name
 	status_info["round_id"] = GLOB.round_id
 
+	// Export performance metrics
+	status_info["perfmetrics"] = list(
+		"td" = list(
+			"time_dilation_current" = SStime_track.time_dilation_current,
+			"time_dilation_avg_fast" = SStime_track.time_dilation_avg_fast,
+			"time_dilation_avg" = SStime_track.time_dilation_avg,
+			"time_dilation_avg_slow" = SStime_track.time_dilation_avg_slow
+		),
+		"mcpu" = world.map_cpu,
+		"cpu" = world.cpu
+	)
+
+
 	// Add more info if we are authed
 	if(key_valid)
 		if(SSticker.mode)


### PR DESCRIPTION
## What Does This PR Do
Adds performance metrics to the `world/Topic?status` export so we can get metrics outside of the game easier. These are queried via the world/Topic API and will allow me to put the info into `/status` on ALICE.

![image](https://user-images.githubusercontent.com/25063394/230776127-1be7c670-28f5-4167-8588-da3d9f313fa8.png)

Formatted:
![image](https://user-images.githubusercontent.com/25063394/230776134-bb726490-a3a3-48b8-a0ad-86accf8ad8ae.png)

## Why It's Good For The Game
Allows me to put perf metrics into ALICE.

## Images of changes
See above

## Testing
See above

## Changelog
NPFC 