### PR TITLE
Cultist teleportation now only works on the same Z-Level

### DIFF
--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -514,7 +514,7 @@
 	if(QDELETED(src) || !user || user.l_hand != src && user.r_hand != src || user.incapacitated() || !actual_selected_rune)
 		return
 
-	if(actual_selected_rune.z != src.z)
+	if(actual_selected_rune.z != user.z)
 		to_chat(user, "<span class='cultitalic'>You are too far away from the station to teleport!</span>")
 		log_game("Teleport rune failed - target rune not on the same Z-level")
 		return

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -514,6 +514,11 @@
 	if(QDELETED(src) || !user || user.l_hand != src && user.r_hand != src || user.incapacitated() || !actual_selected_rune)
 		return
 
+	if(actual_selected_rune.z != src.z)
+		to_chat(user, "<span class='cultitalic'>You are too far away from the station to teleport!</span>")
+		log_game("Teleport rune failed - target rune not on the same Z-level")
+		return
+
 	if(HAS_TRAIT(user, TRAIT_FLOORED))
 		to_chat(user, "<span class='cultitalic'>You cannot cast this spell while knocked down!</span>")
 		return

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -478,6 +478,7 @@
 	if(user.holy_check())
 		return
 	var/list/potential_runes = list()
+	var/list/filtered_runes = list()
 	var/list/teleportnames = list()
 	var/list/duplicaterunecount = list()
 	var/atom/movable/teleportee
@@ -500,7 +501,13 @@
 			duplicaterunecount[resultkey] = 1
 		potential_runes[resultkey] = T
 
-	if(!length(potential_runes))
+	// Filter out runes that are not on the same z-level
+	for(var/rune_key in potential_runes)
+		var/obj/effect/rune/teleport/rune_to_check = potential_runes[rune_key]
+		if(rune_to_check.z == user.z)
+			filtered_runes[rune_key] = rune_to_check
+
+	if(!length(filtered_runes))
 		to_chat(user, "<span class='warning'>There are no valid runes to teleport to!</span>")
 		log_game("Teleport spell failed - no other teleport runes")
 		return
@@ -509,8 +516,8 @@
 		log_game("Teleport spell failed - user in away mission")
 		return
 
-	var/input_rune_key = input(user, "Choose a rune to teleport to.", "Rune to Teleport to") as null|anything in potential_runes //we know what key they picked
-	var/obj/effect/rune/teleport/actual_selected_rune = potential_runes[input_rune_key] //what rune does that key correspond to?
+	var/input_rune_key = input(user, "Choose a rune to teleport to.", "Rune to Teleport to") as null|anything in filtered_runes //we know what key they picked
+	var/obj/effect/rune/teleport/actual_selected_rune = filtered_runes[input_rune_key] //what rune does that key correspond to?
 	if(QDELETED(src) || !user || user.l_hand != src && user.r_hand != src || user.incapacitated() || !actual_selected_rune)
 		return
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -487,6 +487,13 @@ structure_check() searches for nearby cultist structures required for the invoca
 		fail_invoke()
 		return
 
+	// Check if the target rune's Z-level is the same as the source rune's Z-level
+	if(actual_selected_rune.z != src.z)
+		to_chat(user, "<span class='cultitalic'>You are too far away from the station to teleport!</span>")
+		log_game("Teleport rune failed - target rune not on the same Z-level")
+		fail_invoke()
+		return
+
 	var/turf/T = get_turf(src)
 	var/turf/target = get_turf(actual_selected_rune)
 	var/movedsomething = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Does as the title says, teleportation now checks if the target rune is on the same Z-level. If the check fails it blocks the teleportation.

## Why It's Good For The Game
Cult teleportation from Z-level to Z-level is a balance nightmare. It encourages campy and stall bases on different areas of the world. It is common for cultists to make bases far away from the main station to avoid confrontation and deter anyone attempting to find them. This change is healthy as it now forces cult to rely less on their teleport ability and encourage the antagonist gameplay to focus more on the station instead of distant z-levels.

## Testing
tested, code works

## Changelog
:cl: Octus
add: Added new things
tweak: Cultist teleportation runes now only work on the same Z-level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
