### PR TITLE
Walking over syringes without protection injects

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -178,6 +178,21 @@
 		M.update_inv_l_hand()
 		M.update_inv_r_hand()
 
+/obj/item/reagent_containers/syringe/Crossed(AM as mob|obj, oldloc)
+	var/mob/living/carbon/human/H = AM
+	if(ishuman(H) && H.reagents && !(HAS_TRAIT(H,TRAIT_PIERCEIMMUNE) || ismachineperson(H) || H.floating || H.flying || H.buckled || H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))))
+		H.visible_message("<span class='danger'>[H] is injected by \the [src].</span>", \
+					"<span class='userdanger'>You are injected by \the [src]!</span>")
+		if(IS_HORIZONTAL(H))
+			H.apply_damage(5, BRUTE,"chest")
+		else
+			H.apply_damage(5, BRUTE,(pick("l_foot", "r_foot")))
+		if(reagents.total_volume && H.reagents.total_volume < H.reagents.maximum_volume)
+			var/inject_amount = reagents.total_volume
+			reagents.reaction(H, REAGENT_INGEST, inject_amount)
+			reagents.trans_to(H, inject_amount)
+			update_icon()
+
 /obj/item/reagent_containers/syringe/antiviral
 	name = "syringe (spaceacillin)"
 	desc = "Contains antiviral agents."

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -185,7 +185,10 @@
 	if(H.floating || H.flying || H.buckled)
 		return
 
-	if(H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET)))
+	if(!IS_HORIZONTAL(H) && (H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))))
+		return
+
+	if(IS_HORIZONTAL(H) && ((H.wear_suit && (H.wear_suit.body_parts_covered & UPPER_TORSO)) || (H.w_uniform && (H.w_uniform.body_parts_covered & UPPER_TORSO))))
 		return
 
 	H.visible_message("<span class='danger'>[H] is injected by [src].</span>", \

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -179,18 +179,28 @@
 		M.update_inv_r_hand()
 
 /obj/item/reagent_containers/syringe/Crossed(mob/living/carbon/human/H, oldloc)
-	if(H.reagents && !(HAS_TRAIT(H,TRAIT_PIERCEIMMUNE) || ismachineperson(H) || H.floating || H.flying || H.buckled || H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))))
-		H.visible_message("<span class='danger'>[H] is injected by \the [src].</span>", \
-					"<span class='userdanger'>You are injected by \the [src]!</span>")
-		if(IS_HORIZONTAL(H))
-			H.apply_damage(5, BRUTE,"chest")
-		else
-			H.apply_damage(5, BRUTE,(pick("l_foot", "r_foot")))
-		if(reagents.total_volume && H.reagents.total_volume < H.reagents.maximum_volume)
-			var/inject_amount = reagents.total_volume
-			reagents.reaction(H, REAGENT_INGEST, inject_amount)
-			reagents.trans_to(H, inject_amount)
-			update_icon()
+	if(!istype(H) || !H.reagents || (HAS_TRAIT(H,TRAIT_PIERCEIMMUNE) || ismachineperson(H)))
+		return
+
+	if(H.floating || H.flying || H.buckled)
+		return
+
+	if(H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET)))
+		return
+
+	H.visible_message("<span class='danger'>[H] is injected by [src].</span>", \
+				"<span class='userdanger'>You are injected by [src]!</span>")
+
+	if(IS_HORIZONTAL(H))
+		H.apply_damage(5, BRUTE, BODY_ZONE_CHEST)
+	else
+		H.apply_damage(5, BRUTE,(pick(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT)))
+
+	if(reagents.total_volume && H.reagents.total_volume < H.reagents.maximum_volume)
+		var/inject_amount = reagents.total_volume
+		reagents.reaction(H, REAGENT_INGEST, inject_amount)
+		reagents.trans_to(H, inject_amount)
+		update_icon()
 
 /obj/item/reagent_containers/syringe/antiviral
 	name = "syringe (spaceacillin)"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -178,9 +178,8 @@
 		M.update_inv_l_hand()
 		M.update_inv_r_hand()
 
-/obj/item/reagent_containers/syringe/Crossed(AM as mob|obj, oldloc)
-	var/mob/living/carbon/human/H = AM
-	if(ishuman(H) && H.reagents && !(HAS_TRAIT(H,TRAIT_PIERCEIMMUNE) || ismachineperson(H) || H.floating || H.flying || H.buckled || H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))))
+/obj/item/reagent_containers/syringe/Crossed(mob/living/carbon/human/H, oldloc)
+	if(H.reagents && !(HAS_TRAIT(H,TRAIT_PIERCEIMMUNE) || ismachineperson(H) || H.floating || H.flying || H.buckled || H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))))
 		H.visible_message("<span class='danger'>[H] is injected by \the [src].</span>", \
 					"<span class='userdanger'>You are injected by \the [src]!</span>")
 		if(IS_HORIZONTAL(H))


### PR DESCRIPTION
## What Does This PR Do
Stepping over syringes without protection injects the chemicals in the syringe in you.
!!!doesn't apply to genetics dna injectors!!!
!!!you wont get injected if you have shoes/fly/float/are buckled/are an IPC/are wearing something that covers your feet like a hardsuit/are pierce immune!!!

## Why It's Good For The Game
Kinda funny.
Promotes managing your waste disposal well.

## Images of changes
https://user-images.githubusercontent.com/48032385/232134126-50767118-c958-40c5-9b61-cc1a60794740.mp4

## Testing
1. Waited for code to compile.
2. Stepped over a bunch of syringes.
3. Code finished compiling, tried it in-game.
4. Tested with golems, xenos, IPCs, humans, humans with shoes, humans with hardsuits, humans crawling.

## Changelog
:cl:
tweak: Stepping over syringes without protection injects you their chemicals.
/:cl: