### PR TITLE
Add follow link to grey psionic communication

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -333,6 +333,7 @@
 	colour = "abductor"
 	key = "^"
 	flags = RESTRICTED | HIVEMIND
+	follow = TRUE
 
 /datum/language/grey/broadcast(mob/living/speaker, message, speaker_mask)
 	..(speaker,message,speaker.real_name)

--- a/code/modules/mob/mob_say_base.dm
+++ b/code/modules/mob/mob_say_base.dm
@@ -221,5 +221,4 @@
 		. += S.message + " "
 	. = trim_right(.)
 
-#undef USABLE_DEAD_EMOTES
 #undef ILLEGAL_CHARACTERS_LIST

--- a/code/modules/mob/mob_say_base.dm
+++ b/code/modules/mob/mob_say_base.dm
@@ -221,4 +221,5 @@
 		. += S.message + " "
 	. = trim_right(.)
 
+#undef USABLE_DEAD_EMOTES
 #undef ILLEGAL_CHARACTERS_LIST


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a following link for psionic communication, visible to ghosts.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This feels like something that should have been added, I have to wonder why it wasn't (beyond possibly an oversight).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://user-images.githubusercontent.com/89928798/232185354-9ab0a511-4182-45c3-a384-27a928802045.png)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Grey psionic communication now has a follow link
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
