### PR TITLE
fixes being unable to clean stuff with soap while targeting the mouth

### DIFF
--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -22,7 +22,7 @@
 /obj/item/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)
 		return
-	if(user.zone_selected == "mouth") // cleaning out someone's mouth is a different act
+	if(user.zone_selected == "mouth" && ishuman(target)) // cleaning out someone's mouth is a different act
 		return
 	if(target == user && user.a_intent == INTENT_GRAB && ishuman(target))
 		var/mob/living/carbon/human/muncher = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20661

## Why It's Good For The Game
This is a bug, you should be able to clean stuff regardless of your target

## Testing
Cleaned some stuff

## Changelog
:cl:
fix: Soap will still clean objects while targeting the mouth 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
