### PR TITLE
Fixes Cargo Order Console reasons overflowing off screen

### DIFF
--- a/code/modules/supply/supply_console.dm
+++ b/code/modules/supply/supply_console.dm
@@ -265,7 +265,7 @@
 			if(world.time > timeout || !reason || (!is_public && !is_authorized(user)) || ..())
 				// Cancel if they take too long, they dont give a reason, they aint authed, or if they walked away
 				return
-			reason = sanitize(copytext(reason, 1, MAX_MESSAGE_LEN))
+			reason = sanitize(copytext(reason, 1, 75)) // very long reasons are bad
 
 			//===orderee identification information===
 			var/idname = "*None Provided*"


### PR DESCRIPTION
## What Does This PR Do
Significantly reduces the character limit on order reasons.

## Why It's Good For The Game
Prevents crates from having extremely long names or order reasons going off the TGUI menu

## Testing
Ran test server
Put in 1000 character reason and it was properly clamped.

## Changelog
:cl:
fix: Order TGUI will no longer overflow off screen
/:cl:

