### PR TITLE
Corrects the examine text of portable canisters to be correct to current mechanics

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -121,9 +121,9 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 
 /obj/machinery/atmospherics/portable/canister/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The canister can be connected to a connector port with a wrench. Tanks of gas (the kind you can hold in your hand) \
-			can be filled by the canister, by using the tank on the canister, increasing the release pressure, then opening the valve until it is full, and then eject it. \
-			A gas analyzer can be used to check the contents of the canister.</span>"
+	. += "<span class='notice'>Connect a canister to a connector port using a wrench. To fill a tank, attach it to the caniser, increase the \
+			release pressure, and open the valve. Alt-click to eject the tank, or use another to hot-swap. A gas analyzer can be used to check \
+			the contents of the canister.</span>"
 	if(isAntag(user))
 		. += "<span class='notice'>Canisters can be damaged, spilling their contents into the air, or you can just leave the release valve open.</span>"
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -122,8 +122,8 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 /obj/machinery/atmospherics/portable/canister/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>The canister can be connected to a connector port with a wrench. Tanks of gas (the kind you can hold in your hand) \
-			can be filled by the canister, by using the tank on the canister, increasing the release pressure, then opening the valve until it is full, and then close it. \
-			*DO NOT* remove the tank until the valve is closed. A gas analyzer can be used to check the contents of the canister.</span>"
+			can be filled by the canister, by using the tank on the canister, increasing the release pressure, then opening the valve until it is full, and then eject it. \
+			A gas analyzer can be used to check the contents of the canister.</span>"
 	if(isAntag(user))
 		. += "<span class='notice'>Canisters can be damaged, spilling their contents into the air, or you can just leave the release valve open.</span>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR corrects an oversight made with commit 8c24a36 where removing tank from a canister, it would not automatically close the canister, instead of flooding the room with plasma, or draining the oxygen canister. But the examine text was never updated to reflect these changes. As well as the changes brought on by #11377, as well as cutting down on the repetitive language

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Examine text should show correct information as well as being easy to read, describing the mechanics of today, and not how they worked 9 years ago, changes since then, such as the ability to alt-click and hot-swap tanks.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Before:
![image](https://user-images.githubusercontent.com/21987702/232592273-9f684ba1-f4c8-423d-a52d-2eec885a73ee.png)
After:
![image](https://user-images.githubusercontent.com/21987702/232599952-3845d60f-41a9-47e2-a2f3-7ac11232c901.png)

## Testing
<!-- How did you test the PR, if at all? -->
I made the changes, ran the server, found a plasma canister to examine, examined the plasma canister and took a screenshot of the updated text.

## Changelog
:cl: PPI
fix: Corrects the examine text of portable canisters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
