### PR TITLE
Teleporters now use crossed over bump

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -329,6 +329,9 @@
 	name = "teleporter hub"
 	desc = "It's the hub of a teleporting machine."
 	icon_state = "tele0"
+	density = FALSE
+	layer = HOLOPAD_LAYER //Preventing mice and drones from sneaking under them.
+	plane = FLOOR_PLANE
 	var/accurate = 0
 	idle_power_consumption = 10
 	active_power_consumption = 2000
@@ -377,13 +380,13 @@
 			break
 	return power_station
 
-/obj/machinery/teleport/hub/Bumped(M as mob|obj)
+/obj/machinery/teleport/hub/Crossed(atom/movable/AM, oldloc)
 	if(!is_teleport_allowed(z) && !admin_usage)
-		if(ismob(M))
-			to_chat(M, "You can't use this here.")
+		if(ismob(AM))
+			to_chat(AM, "You can't use this here.")
 		return
-	if(power_station && power_station.engaged && !panel_open && !blockAI(M))
-		if(!teleport(M) && isliving(M)) // the isliving(M) is needed to avoid triggering errors if a spark bumps the telehub
+	if(power_station && power_station.engaged && !panel_open && !blockAI(AM))
+		if(!teleport(AM) && isliving(AM)) // the isliving(M) is needed to avoid triggering errors if a spark bumps the telehub
 			visible_message("<span class='warning'>[src] emits a loud buzz, as its teleport portal flickers and fails!</span>")
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 			power_station.toggle() // turn off the portal.
@@ -448,6 +451,9 @@
 	name = "permanent teleporter"
 	desc = "A teleporter with the target pre-set on the circuit board."
 	icon_state = "tele0"
+	density = FALSE
+	layer = HOLOPAD_LAYER
+	plane = FLOOR_PLANE
 	idle_power_consumption = 10
 	active_power_consumption = 2000
 
@@ -468,23 +474,23 @@
 	tele_delay = max(A, 0)
 	update_icon(UPDATE_ICON_STATE)
 
-/obj/machinery/teleport/perma/Bumped(atom/A)
+/obj/machinery/teleport/perma/Crossed(atom/movable/AM, oldloc)
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(!is_teleport_allowed(z))
-		to_chat(A, "You can't use this here.")
+		to_chat(AM, "You can't use this here.")
 		return
 
-	if(target && !recalibrating && !panel_open && !blockAI(A))
-		do_teleport(A, target)
+	if(target && !recalibrating && !panel_open && !blockAI(AM))
+		do_teleport(AM, target)
 		use_power(5000)
 		if(tele_delay)
 			recalibrating = TRUE
 			update_icon(UPDATE_ICON_STATE | UPDATE_OVERLAYS)
 			update_lighting()
-			addtimer(CALLBACK(src, PROC_REF(BumpedCallback)), tele_delay)
+			addtimer(CALLBACK(src, PROC_REF(CrossedCallback)), tele_delay)
 
-/obj/machinery/teleport/perma/proc/BumpedCallback()
+/obj/machinery/teleport/perma/proc/CrossedCallback()
 	recalibrating = FALSE
 	update_icon(UPDATE_ICON_STATE | UPDATE_OVERLAYS)
 	update_lighting()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Teleporters portal sections (be it the normal teleporter, or the permanent teleporter), now use crossed over bumped. This means thrown items no longer clang when you hit them, and will keep momentum going through the teleporter, similar to a portal. This also means that projectiles shot into a teleporter that is active acts like a portal, and will travel through them.

Teleporters are no longer dense.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Stuff banging on a teleporter / losing momentum through teleporters is bad.
Teleporters and portals acting more similar is good.
Being able to make funny deathtraps with teleporters and emitters is good.

## Testing
<!-- How did you test the PR, if at all? -->
Ensured teleporters still work.
Ensured they worked as expected.
Ensured teleporters no longer being dense was fine.

## Changelog
:cl:
tweak: Teleporters are no longer dense.
tweak: Teleporters are more similar to portals in practice, and no longer drain momentum of things thrown through them, or shot at.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
