### PR TITLE
Staves Now Fit in Wizard Robes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,6 +73,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	/// Percentage armour reduction, happens before flat armour reduction.
 	var/armour_penetration_percentage = 0
 	var/list/allowed = null //suit storage stuff.
+	var/max_suit_w = WEIGHT_CLASS_BULKY //suit storage max weight
 	var/obj/item/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
 
 	var/needs_permit = FALSE			//Used by security bots to determine if this item is safe for public use.

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -90,6 +90,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, RAD = 10, FIRE = INFINITY, ACID = INFINITY)
 	allowed = list(/obj/item/teleportation_scroll, /obj/item/gun/magic/staff)
+	max_suit_w = WEIGHT_CLASS_HUGE
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 50
 	put_on_delay = 50

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -89,7 +89,7 @@
 	permeability_coefficient = 0.01
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, RAD = 10, FIRE = INFINITY, ACID = INFINITY)
-	allowed = list(/obj/item/teleportation_scroll)
+	allowed = list(/obj/item/teleportation_scroll, /obj/item/gun/magic/staff)
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 50
 	put_on_delay = 50

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -804,7 +804,7 @@
 				if(!disable_warning)
 					to_chat(H, "You somehow have a suit with no defined allowed items for suit storage, stop that.")
 				return FALSE
-			if(I.w_class > WEIGHT_CLASS_BULKY)
+			if(I.w_class > H.wear_suit.max_suit_w)
 				if(!disable_warning)
 					to_chat(H, "<span class='warning'>[I] is too big to attach.</span>")
 				return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -461,7 +461,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 					if(!disable_warning)
 						to_chat(usr, "You somehow have a suit with no defined allowed items for suit storage, stop that.")
 					return 0
-				if(src.w_class > WEIGHT_CLASS_BULKY)
+				if(src.w_class > H.wear_suit.max_suit_w)
 					if(!disable_warning)
 						to_chat(usr, "The [name] is too big to attach.")
 					return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Staves now fit in Wizard Robes.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Wizards have enough issues to deal with in a round. Giving them a way to store their stave, especially in the age of knockdown combat, is good in my opinion.

## Testing
<!-- How did you test the PR, if at all? -->
1. Spawn as Wiz.
2. Put a buncha magical sticks on my back.

## Changelog
:cl:
tweak: Tweaked wizard robes to be able to carry Magical Staffs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
