### PR TITLE
Makes the Brand Intelligence event a bit more dangerous

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -149,6 +149,9 @@
 	/// How long to wait before resetting the warning cooldown
 	var/hit_warning_cooldown_length = 10 SECONDS
 
+	/// If the vendor should tip on anyone who walks by. Mainly used for brand intelligence
+	var/aggressive = FALSE
+
 /obj/machinery/economy/vending/Initialize(mapload)
 	. = ..()
 	var/build_inv = FALSE
@@ -427,6 +430,18 @@
 			new dump_path(get_turf(src))
 			R.amount--
 			break
+
+/obj/machinery/economy/vending/HasProximity(atom/movable/AM)
+	if(!aggressive)
+		return
+
+	if(isliving(AM))
+		AM.visible_message(
+			"<span class='danger'>[src] suddenly topples over onto [AM]!</span>",
+			"<span class='userdanger'>[src] topples over onto you without warning!</span>"
+		)
+		tilt(AM, prob(90), FALSE)
+		// yes, it stays aggressive. This means you better deal with it from a distance.
 
 /obj/machinery/economy/vending/crowbar_act(mob/user, obj/item/I)
 	if(!component_parts)
@@ -880,6 +895,9 @@
 	stat |= BROKEN
 	set_light(0)
 	update_icon(UPDATE_OVERLAYS)
+
+	if(aggressive)
+		aggressive = FALSE  // the evil is defeated
 
 	if(cash_transaction)
 		new /obj/item/stack/spacecash(get_turf(src), cash_transaction)

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -440,7 +440,7 @@
 			"<span class='danger'>[src] suddenly topples over onto [AM]!</span>",
 			"<span class='userdanger'>[src] topples over onto you without warning!</span>"
 		)
-		tilt(AM, prob(90), FALSE)
+		tilt(AM, prob(75), FALSE)
 		// yes, it stays aggressive. This means you better deal with it from a distance.
 
 /obj/machinery/economy/vending/crowbar_act(mob/user, obj/item/I)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -42,7 +42,7 @@
 		for(var/thing in infectedMachines)
 			var/obj/machinery/economy/vending/upriser = thing
 			if(prob(70))
-				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
+				var/mob/living/simple_animal/hostile/mimic/copy/vendor/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
 				M.faction = list("profit")
 				M.speak = rampant_speeches.Copy()
 				M.speak_chance = 15
@@ -59,6 +59,8 @@
 		infectedMachines.Add(rebel)
 		rebel.shut_up = FALSE
 		rebel.shoot_inventory = TRUE
+		rebel.aggressive = TRUE
+		rebel.AddComponent(/datum/component/proximity_monitor)
 
 		if(ISMULTIPLE(activeFor, 8))
 			originMachine.speak(pick(rampant_speeches))

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -45,7 +45,7 @@
 				// let them become "normal" after turning
 				upriser.shoot_inventory = FALSE
 				upriser.aggressive = FALSE
-				var/mob/living/simple_animal/hostile/mimic/copy/vendor/M = new(upriser.loc, upriser, null) // it will delete upriser on creation and override any machine checks
+				var/mob/living/simple_animal/hostile/mimic/copy/vendor/M = new(upriser.loc, upriser, null)
 				M.faction = list("profit")
 				M.speak = rampant_speeches.Copy()
 				M.speak_chance = 15

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -42,7 +42,10 @@
 		for(var/thing in infectedMachines)
 			var/obj/machinery/economy/vending/upriser = thing
 			if(prob(70))
-				var/mob/living/simple_animal/hostile/mimic/copy/vendor/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
+				// let them become "normal" after turning
+				upriser.shoot_inventory = FALSE
+				upriser.aggressive = FALSE
+				var/mob/living/simple_animal/hostile/mimic/copy/vendor/M = new(upriser.loc, upriser, null) // it will delete upriser on creation and override any machine checks
 				M.faction = list("profit")
 				M.speak = rampant_speeches.Copy()
 				M.speak_chance = 15
@@ -60,7 +63,9 @@
 		rebel.shut_up = FALSE
 		rebel.shoot_inventory = TRUE
 		rebel.aggressive = TRUE
-		rebel.AddComponent(/datum/component/proximity_monitor)
+		if(rebel.tiltable)
+			// add proximity monitor so they can tilt over
+			rebel.AddComponent(/datum/component/proximity_monitor)
 
 		if(ISMULTIPLE(activeFor, 8))
 			originMachine.speak(pick(rampant_speeches))
@@ -69,6 +74,9 @@
 	for(var/thing in infectedMachines)
 		var/obj/machinery/economy/vending/saved = thing
 		saved.shoot_inventory = FALSE
+		saved.aggressive = FALSE
+		if(saved.tiltable)
+			qdel(saved.GetComponent(/datum/component/proximity_monitor))
 	if(originMachine)
 		originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
 		originMachine.visible_message("[originMachine] beeps and seems lifeless.")

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -252,6 +252,8 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 		orig_vendor.forceMove(get_turf(src))
 		// tilt over in place
 		orig_vendor.tilt_over()
+		if(prob(70))
+			orig_vendor.obj_break()
 		orig_vendor = null
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -242,7 +242,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 	. = ..()
 	if(. && target && Adjacent(target))
 		visible_message("<span class='danger'>[src] throws itself on top of [target], crushing [target.p_them()]!</span>")
-		orig_vendor.forceMove(get_turf(loc))
+		orig_vendor.forceMove(get_turf(target))  // just to be sure it'll tilt onto them
 		orig_vendor.tilt(target, TRUE, FALSE)  // geeeeet dunked on
 		orig_vendor = null
 		qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -234,15 +234,14 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 
 	orig_vendor = base
 	orig_vendor.forceMove(src)
-
-
-	orig_vendor.aggressive = FALSE // just to be safe, in case this was turned
+	orig_vendor.aggressive = FALSE // just to be safe, in case this was converted
 
 	return ..(mapload, base, creator, destroy_original = FALSE)
 
 /mob/living/simple_animal/hostile/mimic/copy/vendor/AttackingTarget()
 	. = ..()
 	if(. && target && Adjacent(target))
+		visible_message("<span class='danger'>[src] throws itself on top of [target], crushing [target.p_them()]!</span>")
 		orig_vendor.forceMove(get_turf(loc))
 		orig_vendor.tilt(target, TRUE, FALSE)  // geeeeet dunked on
 		orig_vendor = null
@@ -251,6 +250,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 /mob/living/simple_animal/hostile/mimic/copy/vendor/death(gibbed)
 	if(!QDELETED(orig_vendor))
 		orig_vendor.forceMove(get_turf(src))
+		// tilt over in place
 		orig_vendor.tilt_over()
 		orig_vendor = null
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new degree of danger to the relatively lowkey brand intelligence event.
As the event currently works, machines will gradually become infected by an "origin machine", and if the origin machine isn't dealt with in time, they will eventually all become mimics. It isn't really that dangerous, just a bit annoying.

*Now, however, the vendors are a bit more...angry.*

Whenever a machine becomes infected, it will still shoot items out at you, but will *also* be watching the spaces around it for any new ~~victims~~customers. If you walk too close, it'll topple over onto you with a significant chance for a crit.

If you decide not to deal with the issue and wait until all machines are infected, they'll become mimics as before, with one notable change: The vendor mimics can now *tilt over onto you, **with 100% crit chance***. Good luck dealing with them from melee range!

As a little bonus feature that fell out of my re-implementation, vending machines that get mimicked will now actually revert to vending machine on death, instead of deleting the original. If it tilts over onto you, it'll revert to a normal vending machine (at the cost of it critting you, of course), but will be entirely intact. If you kill the mimics, though, you'll probably break the machines themselves, so you better hope you have an engineer around!
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This adds a bit more danger to an otherwise mostly inconsequential event. It encourages people to actually deal with the event instead of letting it slide, since people *will* get randomly crushed in the hallways if it isn't dealt with. And the very last thing you'll want to deal with will be insta-crit vendors, so people are *very* incentivized to not let it get that far. If it does, though, it'll sure be entertaining.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/233190807-68385d7f-e8e3-4a48-b824-bb6ca46ac04b.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Triggered the event, walked around, and got crushed by some pretty angry vending machines
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Brand Intelligence is now significantly more dangerous. Watch out!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
