### PR TITLE
Overdosed chemicals no longer do helpful effects when overdosed (generally)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -102,6 +102,7 @@
 	drink_name = "Glass of Absinthe"
 	drink_desc = "The green fairy is going to get you now!"
 	taste_description = "fucking pain"
+	allowed_overdose_process = TRUE
 
 //copy paste from LSD... shoot me
 /datum/reagent/consumable/ethanol/absinthe/on_mob_life(mob/living/M)
@@ -143,6 +144,7 @@
 	drink_name = "Glass of Rum"
 	drink_desc = "Now you want to Pray for a pirate suit, don't you?"
 	taste_description = "rum"
+	allowed_overdose_process = TRUE
 
 /datum/reagent/consumable/ethanol/rum/overdose_process(mob/living/M, severity)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -283,6 +283,7 @@
 	addiction_chance = 10
 	addiction_threshold = 10
 	taste_description = "very poor life choices"
+	allowed_overdose_process = TRUE
 
 
 /datum/reagent/krokodil/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -98,6 +98,7 @@
 	overdose_threshold = 200 // Hyperglycaemic shock
 	taste_description = "sweetness"
 	taste_mult = 1.5
+	allowed_overdose_process = TRUE
 
 /datum/reagent/consumable/sugar/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -717,6 +718,7 @@
 	overdose_threshold = 75
 	harmless = FALSE
 	taste_description = "oil"
+	allowed_overdose_process = TRUE
 
 /datum/reagent/consumable/hydrogenated_soybeanoil/on_mob_life(mob/living/M)
 	if(prob(15))

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -494,6 +494,7 @@
 	metabolization_rate = 0.2
 	overdose_threshold = 40
 	taste_mult = 0
+	allowed_overdose_process = TRUE
 
 /datum/reagent/histamine/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume) //dumping histamine on someone is VERY mean.
 	if(iscarbon(M))

--- a/code/modules/reagents/chemistry/reagents_datum.dm
+++ b/code/modules/reagents/chemistry/reagents_datum.dm
@@ -28,6 +28,8 @@
 	var/addiction_stage = 1
 	var/last_addiction_dose = 0
 	var/overdosed = FALSE // You fucked up and this is now triggering it's overdose effects, purge that shit quick.
+	///If this variable is true, chemicals will continue to process in mobs when overdosed.
+	var/allowed_overdose_process = FALSE
 	var/current_cycle = 1
 	var/drink_icon = null
 	var/drink_name = "Glass of ..what?"
@@ -98,6 +100,16 @@
 	return
 
 /datum/reagent/proc/on_mob_life(mob/living/M)
+	current_cycle++
+	var/total_depletion_rate = metabolization_rate * M.metabolism_efficiency // Cache it
+
+	handle_addiction(M, total_depletion_rate)
+	sate_addiction(M)
+
+	holder.remove_reagent(id, total_depletion_rate) //By default it slowly disappears.
+	return STATUS_UPDATE_NONE
+
+/datum/reagent/proc/on_mob_od_life(mob/living/M) //We want to drain reagents but not do the entire mob life.
 	current_cycle++
 	var/total_depletion_rate = metabolization_rate * M.metabolism_efficiency // Cache it
 

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -331,10 +331,13 @@
 				continue
 		//If you got this far, that means we can process whatever reagent this iteration is for. Handle things normally from here.
 		if(M && R)
-			update_flags |= R.on_mob_life(M)
 			if(R.volume >= R.overdose_threshold && !R.overdosed && R.overdose_threshold > 0)
 				R.overdosed = TRUE
 				R.overdose_start(M)
+			if((R.overdosed && R.allowed_overdose_process) || !R.overdosed)
+				update_flags |= R.on_mob_life(M)
+			else if(R.overdosed)
+				update_flags |= R.on_mob_od_life(M) //We want to drain reagents but not do the entire mob life.
 			if(R.volume < R.overdose_threshold && R.overdosed)
 				R.overdosed = FALSE
 			if(R.overdosed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Most chemicals no longer process their normal effects when overdosing. This means chemicals like omnizine no longer heal you when overdosing. Some chemicals still apply affects, like say rum.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If you are overdosing on a medicine, it should not be healing you.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed chemicals still worked.

## Changelog
:cl:
tweak: Most chemicals no longer heal you or provide beneficial effects when overdosing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
