### PR TITLE
Fixes a bug with early-finishing surgeries

### DIFF
--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -219,13 +219,15 @@
 		to_chat(user, "<span class='warning'>You need a [is_robotic ? "prying": "cauterizing"] tool in your inactive hand to stop the surgery!</span>")
 		return TRUE
 
-	if(skip_surgery || chosen_close_step.try_op(user, patient, selected_zone, close_tool, the_surgery))
+	if(skip_surgery || chosen_close_step.try_op(user, patient, selected_zone, close_tool, the_surgery) == SURGERY_INITIATE_SUCCESS)
 		// logging in case people wonder why they're cut up inside
 		log_attack(user, patient, "Prematurely finished \a [the_surgery] surgery.")
 		qdel(chosen_close_step)
 		patient.surgeries -= the_surgery
 		qdel(the_surgery)
-		return TRUE
+
+	// always return TRUE here so we don't continue the surgery chain and try to start a new surgery with our tool.
+	return TRUE
 
 /datum/component/surgery_initiator/proc/can_start_surgery(mob/user, mob/living/target)
 	if(!user.Adjacent(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug with early finishing surgeries (with a cautery or crowbar/screwdriver) where failing the surgery step would put you into a weird step. Now, as you'd expect, failing the step lets you try again immediately afterwards.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Better consistency across surgeries is always a net positive.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, threw a vulp onto a table, tried to fail surgeries, noted that I was able to retry the closing step after failing it.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Failing to interrupt a surgery should let you try again afterwards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
